### PR TITLE
fix(chat): restore composer focus after send

### DIFF
--- a/frontend/features/chat/presentation/rich-composer.test.tsx
+++ b/frontend/features/chat/presentation/rich-composer.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { RichComposer } from "@/features/chat/presentation/rich-composer";
@@ -41,6 +41,19 @@ describe("RichComposer", () => {
     fireEvent.keyDown(getEditor(), { key: "Enter" });
 
     expect(onSend).toHaveBeenCalledWith("@GoPlanAI plan day 1");
+  });
+
+  it("returns focus to the message editor after sending with the button", async () => {
+    const onSend = vi.fn().mockResolvedValue("ok");
+    render(<RichComposer disabled={false} isSending={false} onSend={onSend} />);
+
+    inputText("hello");
+    const sendButton = screen.getByRole("button", { name: "Send message" });
+    sendButton.focus();
+    fireEvent.click(sendButton);
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledWith("hello"));
+    await waitFor(() => expect(getEditor()).toHaveFocus());
   });
 
   it("keeps the AI prompt in the composer when the send is blocked", async () => {

--- a/frontend/features/chat/presentation/rich-composer.tsx
+++ b/frontend/features/chat/presentation/rich-composer.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { ArrowUp, Loader2 } from "lucide-react";
-import { useState, type ChangeEvent, type KeyboardEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type KeyboardEvent,
+} from "react";
 
 import {
   GOPLAN_AI_MENTION,
@@ -41,6 +48,8 @@ function limitDraftForMode(value: string, hasAIMention: boolean): string {
 }
 
 export function RichComposer({ disabled, isSending, placeholder, onSend }: Props) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const shouldRestoreFocusRef = useRef(false);
   const [hasMention, setHasMention] = useState(false);
   const [draft, setDraft] = useState("");
   const [menuOpen, setMenuOpen] = useState(false);
@@ -51,6 +60,28 @@ export function RichComposer({ disabled, isSending, placeholder, onSend }: Props
   const sending = isSending || localSending;
   const canSubmit =
     !disabled && !sending && (hasMention || normalizedDraft.length > 0);
+
+  const restoreEditorFocus = useCallback((): void => {
+    const focusEditor = () => {
+      const textarea = textareaRef.current;
+      if (!textarea || disabled || textarea.disabled) return;
+      textarea.focus({ preventScroll: true });
+    };
+
+    window.requestAnimationFrame(() => {
+      focusEditor();
+      window.setTimeout(focusEditor, 0);
+    });
+  }, [disabled]);
+
+  useEffect(() => {
+    if (sending || !shouldRestoreFocusRef.current) return;
+
+    shouldRestoreFocusRef.current = false;
+    if (!disabled) {
+      restoreEditorFocus();
+    }
+  }, [disabled, restoreEditorFocus, sending]);
 
   function applyInput(rawValue: string): void {
     const parsed = parseGoPlanAIMention(rawValue);
@@ -90,6 +121,7 @@ export function RichComposer({ disabled, isSending, placeholder, onSend }: Props
       : normalizedDraft;
 
     setLocalSending(true);
+    shouldRestoreFocusRef.current = true;
     setMenuOpen(false);
     setError(null);
     try {
@@ -152,6 +184,7 @@ export function RichComposer({ disabled, isSending, placeholder, onSend }: Props
         <div className="flex min-h-[40px] min-w-0 flex-1 items-center gap-2 rounded-md border border-input bg-background px-3 py-2 focus-within:ring-2 focus-within:ring-ring">
           {hasMention && <AIMentionToken />}
           <Textarea
+            ref={textareaRef}
             value={draft}
             rows={1}
             maxLength={hasMention ? MAX_AI_PROMPT_LENGTH : MAX_CONTENT_LENGTH}
@@ -161,7 +194,7 @@ export function RichComposer({ disabled, isSending, placeholder, onSend }: Props
             disabled={disabled || sending}
             onChange={handleChange}
             onKeyDown={handleKeyDown}
-            className="min-h-6 min-w-0 flex-1 resize-none border-0 bg-transparent p-0 shadow-none focus-visible:ring-0"
+            className="min-h-6 min-w-0 flex-1 resize-none border-0 bg-transparent p-0 leading-6 shadow-none focus-visible:ring-0"
             aria-label="Message"
           />
         </div>


### PR DESCRIPTION
## Summary

- Restore focus to the chat message editor after sending with the button.
- Align the composer textarea line height so the caret matches the visible input height.
- Add a regression test for button-send focus restoration.

## Validation

- `cd frontend && npm run test -- rich-composer`
- `cd frontend && npm run lint`

## Scope

This PR only contains the chat composer UI bugfix. It intentionally excludes deploy config, BFF trusted IP changes, backend settings, compose changes, and `frontend/package-lock.json`.