### PR TITLE
chore(config): make backend runtime settings env-driven

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,16 +21,33 @@ DB_USER=goplan_user
 DB_PASSWORD=replace-with-your-own-db-password
 DB_HOST=postgresql-goplan
 DB_PORT=5432
+DB_CONN_MAX_AGE=0
 
 # -------- Redis (Channel Layer) --------
 REDIS_URL=redis://redis-messaging:6379/0
 
-# -------- Email (Mailpit Dev) --------
-# Use the service name from podman-compose.yml (not container_name) as the
-# hostname — Compose DNS resolves service names on the internal network.
+# -------- Email --------
+# DEV (Mailpit): use the service name from podman-compose.yml (not
+# container_name) as the hostname — Compose DNS resolves service names on the
+# internal network. Mailpit needs no auth, so leave USER/PASSWORD empty.
 EMAIL_HOST=mailpit
 EMAIL_PORT=1025
 EMAIL_USE_TLS=0
+EMAIL_USE_SSL=0
+EMAIL_HOST_USER=
+EMAIL_HOST_PASSWORD=
+DEFAULT_FROM_EMAIL=noreply@goplan.app
+#
+# PRODUCTION SMTP example — replace the values above on the deploy host:
+#   EMAIL_HOST=smtp.example.com
+#   EMAIL_PORT=587
+#   EMAIL_USE_TLS=1
+#   EMAIL_USE_SSL=0
+#   EMAIL_HOST_USER=<smtp-username>
+#   EMAIL_HOST_PASSWORD=<smtp-app-password-or-token>
+#   DEFAULT_FROM_EMAIL=GoPlan <noreply@example.com>
+# Use EMAIL_PORT=465 with EMAIL_USE_SSL=1 and EMAIL_USE_TLS=0 only if your
+# provider requires implicit TLS.
 
 # -------- Frontend --------
 FRONTEND_BASE_URL=http://localhost:3000

--- a/backend/configs/settings.py
+++ b/backend/configs/settings.py
@@ -3,6 +3,7 @@ import os
 from datetime import timedelta
 from pathlib import Path
 
+from django.core.exceptions import ImproperlyConfigured
 from PIL import Image as _PILImage
 
 # Process-wide hard guard for extreme decompression bombs. Every Image.open path
@@ -24,6 +25,17 @@ def env_bool(name: str, default: bool = False) -> bool:
 def env_list(name: str) -> tuple[str, ...]:
     raw = os.environ.get(name, "")
     return tuple(item.strip() for item in raw.split(",") if item.strip())
+
+
+def env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default
+
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise ImproperlyConfigured(f"{name} must be an integer.") from exc
 
 
 # -------- Core Flags --------
@@ -118,7 +130,7 @@ DATABASES = {
         'PASSWORD': os.environ['DB_PASSWORD'],
         'HOST': os.environ['DB_HOST'],
         'PORT': os.environ['DB_PORT'],
-        'CONN_MAX_AGE': 600,
+        'CONN_MAX_AGE': env_int('DB_CONN_MAX_AGE', 0),
     }
 }
 
@@ -326,7 +338,10 @@ EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = os.environ.get('EMAIL_HOST', 'localhost')
 EMAIL_PORT = int(os.environ.get('EMAIL_PORT', '1025'))
 EMAIL_USE_TLS = os.environ.get('EMAIL_USE_TLS', '0') == '1'
-DEFAULT_FROM_EMAIL = 'noreply@goplan.app'
+EMAIL_USE_SSL = os.environ.get('EMAIL_USE_SSL', '0') == '1'
+EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER', '')
+EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD', '')
+DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', 'noreply@goplan.app')
 
 # -------- Password Reset --------
 PASSWORD_RESET_TIMEOUT = 3600  # 1 hour

--- a/backend/configs/tests.py
+++ b/backend/configs/tests.py
@@ -1,0 +1,22 @@
+import os
+from unittest.mock import patch
+
+from django.core.exceptions import ImproperlyConfigured
+from django.test import SimpleTestCase
+
+from configs.settings import env_int
+
+
+class SettingsEnvironmentTests(SimpleTestCase):
+    def test_env_int_uses_default_when_variable_is_missing(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(env_int("DB_CONN_MAX_AGE", 0), 0)
+
+    def test_env_int_parses_integer_value(self):
+        with patch.dict(os.environ, {"DB_CONN_MAX_AGE": "60"}):
+            self.assertEqual(env_int("DB_CONN_MAX_AGE", 0), 60)
+
+    def test_env_int_rejects_non_integer_value(self):
+        with patch.dict(os.environ, {"DB_CONN_MAX_AGE": "not-an-int"}):
+            with self.assertRaises(ImproperlyConfigured):
+                env_int("DB_CONN_MAX_AGE", 0)


### PR DESCRIPTION
## Summary

- Add `env_int` for typed integer env parsing in Django settings.
- Make `DB_CONN_MAX_AGE` configurable through env.
- Make SMTP auth/runtime settings configurable through env while keeping Mailpit as the dev example.
- Add focused tests for integer env parsing.

## Validation

- `podman run --rm -v /Users/quangminh/Home/Python/Website/GoPlan/backend:/app --env-file /Users/quangminh/Home/Python/Website/GoPlan/backend/.env localhost/backend:latest python manage.py test configs`
- `podman run --rm -v /Users/quangminh/Home/Python/Website/GoPlan/backend:/app --env-file /Users/quangminh/Home/Python/Website/GoPlan/backend/.env localhost/backend:latest python manage.py check`
- `git diff --check`

## Scope

This PR intentionally excludes Cloudflare-specific SSL redirect behavior, production domain hardcoding, production compose cleanup, frontend Containerfile cleanup, WebSocket topology, and real env values/secrets.

Closes #28