### PR TITLE
chore(dev): run backend compose service with daphne

### DIFF
--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -49,7 +49,7 @@ services:
       dockerfile: Containerfile
     image: backend:latest
     container_name: backend-goplan
-    command: bash -c "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
+    command: bash -c "python manage.py migrate && daphne -b 0.0.0.0 -p 8000 configs.asgi:application"
     ports:
       - "8000:8000"
     volumes:


### PR DESCRIPTION
## Summary

- Run the dev compose backend service with Daphne against `configs.asgi:application` instead of Django `runserver`.
- Keep all other local compose services unchanged.

## Validation

- `podman compose config`
- `podman compose up -d --no-deps --force-recreate backend`
- `podman logs --tail 80 backend-goplan`
- `podman inspect backend-goplan --format '{{range .Mounts}}{{println .Source "->" .Destination}}{{end}}'`
- `podman compose exec backend python manage.py check`
- `podman compose ps`
- HTTP smoke confirmed Daphne responded on port 8000; `/api/auth/me` showed app-level host/redirect behavior from the current local env, not a Daphne startup failure.

## Scope

This PR intentionally changes only `podman-compose.yml`. It excludes production compose cleanup, frontend Containerfile cleanup, domain hardcode cleanup, WebSocket auth/topology changes, and backend runtime settings cleanup.

Closes #30