### PR TITLE
fix(backend): exclude real env files from container image

### DIFF
--- a/backend/.containerignore
+++ b/backend/.containerignore
@@ -1,0 +1,9 @@
+.env
+*.env
+!*.env.example
+__pycache__
+**/__pycache__
+*.pyc
+.pytest_cache
+media_files
+.DS_Store

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,9 @@
+.env
+*.env
+!*.env.example
+__pycache__
+**/__pycache__
+*.pyc
+.pytest_cache
+media_files
+.DS_Store


### PR DESCRIPTION
Closes #34

## What changed

Add `backend/.containerignore` and `backend/.dockerignore` (identical content) so `COPY . .` in `backend/Containerfile` no longer bakes real local env files into image layers.

Excluded: `.env` / `*.env` (keeping `*.env.example`), `__pycache__` / `*.pyc` / `.pytest_cache`, `media_files` (runtime upload volume, mounted by compose), `.DS_Store`.

`media/` is intentionally **not** ignored — it is a Django app in `INSTALLED_APPS`; excluding it breaks startup with `ModuleNotFoundError: No module named 'media'` (hit and verified during testing).

## Why

Built backend images contained the real `backend/.env` and `backend/db.env` (Django secret key, DB password, SMTP and API credentials) — verified by listing `/app/.env` inside a built image. This violates the security baseline even though the files are gitignored, because the leak path is the image, not git.

## Verification

On this branch:

```
$ podman build -t backend-ignore-check:tmp -f backend/Containerfile backend/
$ podman run --rm --entrypoint sh backend-ignore-check:tmp -c 'ls /app/.env /app/db.env; ls /app/media/__init__.py'
ls: cannot access '/app/.env': No such file or directory
ls: cannot access '/app/db.env': No such file or directory
/app/media/__init__.py
```

A full production stack (7 containers) built with these ignore files is currently running and passing smoke tests (login page, BFF auth, WebSocket handshake) on the deploy lab machine.

## Risk

Low. No code or compose changes; runtime env continues to come from compose `env_file`. Dev compose mounts `./backend:/app`, so dev behavior is unchanged.