### PR TITLE
fix(auth): redirect email verification to public app origin

### DIFF
--- a/frontend/app/api/auth/verify-email/route.test.ts
+++ b/frontend/app/api/auth/verify-email/route.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const upstreamMock = vi.hoisted(() => ({
+  callAuthUpstream: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+  }),
+  headers: async () => new Headers(),
+}));
+
+vi.mock("@/app/api/auth/_lib/session-state", () => ({
+  clearRefreshAuthErrorMarker: vi.fn(),
+  setRefreshToken: vi.fn(),
+}));
+
+vi.mock("@/app/api/auth/_lib/upstream", () => {
+  function asObject(value: unknown) {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      return null;
+    }
+    return value as Record<string, unknown>;
+  }
+  function getString(value: unknown, key: string) {
+    const objectValue = asObject(value);
+    const candidate = objectValue?.[key];
+    return typeof candidate === "string" ? candidate : null;
+  }
+  function getBoolean(value: unknown, key: string) {
+    const objectValue = asObject(value);
+    const candidate = objectValue?.[key];
+    return typeof candidate === "boolean" ? candidate : null;
+  }
+  return {
+    asObject,
+    getString,
+    getBoolean,
+    callAuthUpstream: upstreamMock.callAuthUpstream,
+    extractUserPayload(user: Record<string, unknown> | null) {
+      return user;
+    },
+  };
+});
+
+const PUBLIC_APP_BASE_URL = "https://app.example.com";
+// Behind a tunnel/reverse proxy the Host header can be the internal service
+// address, so request.url must never be used as the redirect base.
+const INTERNAL_REQUEST_URL = "http://127.0.0.1:3000/api/auth/verify-email";
+
+function buildRequest(query: string) {
+  const url = new URL(`${INTERNAL_REQUEST_URL}${query}`);
+  return {
+    url: url.toString(),
+    nextUrl: url,
+    headers: new Headers(),
+  } as never;
+}
+
+describe("GET /api/auth/verify-email", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.stubEnv("NEXT_PUBLIC_APP_BASE_URL", PUBLIC_APP_BASE_URL);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("redirects to the public app origin after verification, not the request origin", async () => {
+    const { GET } = await import("@/app/api/auth/verify-email/route");
+
+    upstreamMock.callAuthUpstream.mockResolvedValue({
+      kind: "response",
+      ok: true,
+      status: 200,
+      data: {
+        user: {
+          id: "user-1",
+          email: "owner@example.com",
+          is_profile_completed: false,
+          requires_profile_setup: true,
+        },
+        tokens: { access: "access-token", refresh: "refresh-token" },
+      },
+    });
+
+    const response = await GET(buildRequest("?token=valid-token"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      `${PUBLIC_APP_BASE_URL}/setup-profile?verified=true`,
+    );
+  });
+
+  it("redirects invalid tokens to the public app origin login page", async () => {
+    const { GET } = await import("@/app/api/auth/verify-email/route");
+
+    const response = await GET(buildRequest(""));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      `${PUBLIC_APP_BASE_URL}/login?verify_error=invalid`,
+    );
+  });
+});

--- a/frontend/app/api/auth/verify-email/route.ts
+++ b/frontend/app/api/auth/verify-email/route.ts
@@ -9,11 +9,16 @@ import {
   getBoolean,
   getString,
 } from "@/app/api/auth/_lib/upstream";
+import { resolvePublicAppBaseUrl } from "@/shared/http/public-origin";
 
 export async function GET(request: NextRequest) {
+  // Behind a tunnel/reverse proxy the Host header may carry the internal
+  // service address, so request.url is not a safe base for browser redirects.
+  const appBaseUrl = await resolvePublicAppBaseUrl();
+
   const token = request.nextUrl.searchParams.get("token");
   if (!token) {
-    return NextResponse.redirect(new URL("/login?verify_error=invalid", request.url));
+    return NextResponse.redirect(new URL("/login?verify_error=invalid", appBaseUrl));
   }
 
   const upstream = await callAuthUpstream("/api/auth/verify-email", {
@@ -23,11 +28,11 @@ export async function GET(request: NextRequest) {
   }, request.headers);
 
   if (upstream.kind === "network_error") {
-    return NextResponse.redirect(new URL("/login?verify_error=invalid", request.url));
+    return NextResponse.redirect(new URL("/login?verify_error=invalid", appBaseUrl));
   }
 
   if (!upstream.ok) {
-    return NextResponse.redirect(new URL("/login?verify_error=invalid", request.url));
+    return NextResponse.redirect(new URL("/login?verify_error=invalid", appBaseUrl));
   }
 
   const payload = asObject(upstream.data);
@@ -38,7 +43,7 @@ export async function GET(request: NextRequest) {
   const refreshTokenValue = getString(tokens, "refresh");
 
   if (!userPayload || !accessToken || !refreshTokenValue) {
-    return NextResponse.redirect(new URL("/login?verify_error=invalid", request.url));
+    return NextResponse.redirect(new URL("/login?verify_error=invalid", appBaseUrl));
   }
 
   const jar = await cookies();
@@ -47,8 +52,8 @@ export async function GET(request: NextRequest) {
 
   const requiresProfileSetup = getBoolean(userObj, "requires_profile_setup");
   if (requiresProfileSetup) {
-    return NextResponse.redirect(new URL("/setup-profile?verified=true", request.url));
+    return NextResponse.redirect(new URL("/setup-profile?verified=true", appBaseUrl));
   }
 
-  return NextResponse.redirect(new URL("/?verified=true", request.url));
+  return NextResponse.redirect(new URL("/?verified=true", appBaseUrl));
 }


### PR DESCRIPTION
Closes #36

## What changed

`frontend/app/api/auth/verify-email/route.ts` now builds all six browser redirects from `resolvePublicAppBaseUrl()` (existing helper in `shared/http/public-origin.ts`) instead of `request.url`. Added `route.test.ts` with a regression test.

## Why

On production behind Cloudflare Tunnel, clicking the verification email link verified the account but redirected the browser to `https://127.0.0.1:3000/setup-profile?verified=true` — the Host header reaching the Next.js container carries the internal service address, so `request.url`-based absolute redirects leak the internal origin. Other flows are unaffected (`/` → `/login` is a relative redirect; other auth routes return JSON).

`resolvePublicAppBaseUrl()` prefers `NEXT_PUBLIC_APP_BASE_URL` (set in both dev `.env.local` and the production image build args), so dev behavior is unchanged and production redirects go to the public domain regardless of proxy Host handling.

## Verification

- TDD: regression test red on the old code (Location was `http://127.0.0.1:3000/...`), green after the fix.
- `npm run test`: 526 tests pass.
- `npm run lint`: pass.
- Production verification after deploy: register a fresh account, click the email link, expect `https://<app domain>/setup-profile?verified=true`.

## Risk

Low. Single route; helper falls back to `http://localhost:3000` outside production and to `x-forwarded-host`/`host` if the env var is ever missing in production.