### PR TITLE
fix(ai): stop GoPlanAI replies showing raw \uXXXX escape sequences

### DIFF
--- a/backend/ai/agent/runner.py
+++ b/backend/ai/agent/runner.py
@@ -16,6 +16,7 @@ from ai.agent.intent import (
     prompt_requests_timeline_activity_creation,
     timeline_activity_repair_arguments,
 )
+from ai.agent.text import decode_unicode_escapes
 from ai.agent.tools import openai_tool_params, resolve_tool
 from ai.deepseek import (
     DeepSeekProviderError,
@@ -240,7 +241,11 @@ def run_goplan_ai_agent(*, interaction) -> AgentRunResult:
 
     messages = [
         {"role": "system", "content": _v2_system_prompt()},
-        {"role": "system", "content": "CONTEXT:\n" + json.dumps(context, default=str)},
+        {
+            "role": "system",
+            "content": "CONTEXT:\n"
+            + json.dumps(context, ensure_ascii=False, default=str),
+        },
         {"role": "user", "content": interaction.prompt},
     ]
     tools = openai_tool_params()
@@ -355,6 +360,8 @@ def run_goplan_ai_agent(*, interaction) -> AgentRunResult:
         interaction_id=interaction_id,
         drafts_created=drafts_created,
     )
+    if message_text is not None:
+        message_text = decode_unicode_escapes(message_text)
     return AgentRunResult(
         drafts_created=drafts_created,
         message_text=message_text,

--- a/backend/ai/agent/text.py
+++ b/backend/ai/agent/text.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import re
+
+# The model sometimes emits literal "\uXXXX" sequences as plain text instead
+# of the character itself (mimicking ASCII-escaped JSON it saw in context).
+_SURROGATE_PAIR_RE = re.compile(
+    r"\\u([dD][89abAB][0-9a-fA-F]{2})\\u([dD][c-fC-F][0-9a-fA-F]{2})"
+)
+_BMP_ESCAPE_RE = re.compile(r"\\u([0-9a-fA-F]{4})")
+
+
+def _decode_surrogate_pair(match: re.Match[str]) -> str:
+    high = int(match.group(1), 16)
+    low = int(match.group(2), 16)
+    return chr(0x10000 + ((high - 0xD800) << 10) + (low - 0xDC00))
+
+
+def _decode_bmp_escape(match: re.Match[str]) -> str:
+    code_point = int(match.group(1), 16)
+    if 0xD800 <= code_point <= 0xDFFF:
+        # Lone surrogate: not a valid character on its own, keep the raw text.
+        return match.group(0)
+    return chr(code_point)
+
+
+def decode_unicode_escapes(text: str) -> str:
+    """Decode literal \\uXXXX escape sequences left in model output."""
+    if "\\u" not in text:
+        return text
+    text = _SURROGATE_PAIR_RE.sub(_decode_surrogate_pair, text)
+    return _BMP_ESCAPE_RE.sub(_decode_bmp_escape, text)

--- a/backend/ai/tests/test_agent_runner.py
+++ b/backend/ai/tests/test_agent_runner.py
@@ -92,6 +92,56 @@ class RunnerTests(TestCase):
         self.assertEqual(draft.required_confirmation, "CAPTAIN")
 
     @patch("ai.agent.runner.complete_with_tools")
+    def test_context_message_keeps_non_ascii_characters_raw(self, mock_complete):
+        self.trip.name = "Chuyến đi \N{SMILING FACE WITH SMILING EYES}"
+        self.trip.save(update_fields=["name"])
+        mock_complete.return_value = DeepSeekToolResult(
+            text=None,
+            tool_calls=[
+                ToolCallParsed(
+                    id="c1",
+                    name="respond_to_user",
+                    arguments_json='{"message":"Hi."}',
+                ),
+            ],
+            usage=DeepSeekUsage(1, 1, 2),
+            finish_reason="tool_calls",
+        )
+
+        run_goplan_ai_agent(interaction=self.interaction)
+
+        context_content = mock_complete.call_args.kwargs["messages"][1]["content"]
+        self.assertIn(self.trip.name, context_content)
+        self.assertNotIn("\\u", context_content)
+
+    @patch("ai.agent.runner.complete_with_tools")
+    def test_message_text_decodes_literal_unicode_escapes(self, mock_complete):
+        # JSON string "Hi \\ud83d\\ude0a" -> tool arg text with literal
+        # escape sequences, as emitted by the model when it mimics
+        # ASCII-escaped context instead of writing the emoji itself.
+        bs = "\\"
+        escaped_message = f"Hi {bs}{bs}ud83d{bs}{bs}ude0a"
+        mock_complete.return_value = DeepSeekToolResult(
+            text=None,
+            tool_calls=[
+                ToolCallParsed(
+                    id="c1",
+                    name="respond_to_user",
+                    arguments_json='{"message":"' + escaped_message + '"}',
+                ),
+            ],
+            usage=DeepSeekUsage(1, 1, 2),
+            finish_reason="tool_calls",
+        )
+
+        result = run_goplan_ai_agent(interaction=self.interaction)
+
+        self.assertEqual(
+            result.message_text,
+            "Hi \N{SMILING FACE WITH SMILING EYES}",
+        )
+
+    @patch("ai.agent.runner.complete_with_tools")
     def test_unknown_tool_returns_tool_unknown_error(self, mock_complete):
         mock_complete.return_value = DeepSeekToolResult(
             text=None,

--- a/backend/ai/tests/test_agent_text.py
+++ b/backend/ai/tests/test_agent_text.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from django.test import SimpleTestCase
+
+from ai.agent.text import decode_unicode_escapes
+
+# Escape sequences are assembled from fragments so no tooling between the
+# repo and an editor can collapse them into real characters.
+BS = "\\"
+WAVE_ESCAPE = BS + "ud83d" + BS + "udc4b"  # escaped form of U+1F44B waving hand
+SMILE_ESCAPE = BS + "ud83d" + BS + "ude0a"  # escaped form of U+1F60A smiling face
+A_GRAVE_ESCAPE = BS + "u00e0"  # escaped form of U+00E0 a-grave
+LONE_SURROGATE_ESCAPE = BS + "ud83d"  # high surrogate with no pair
+
+
+class DecodeUnicodeEscapesTests(SimpleTestCase):
+    def test_decodes_surrogate_pair_escape_to_emoji(self):
+        self.assertEqual(
+            decode_unicode_escapes(f"Hello {WAVE_ESCAPE}"),
+            "Hello \N{WAVING HAND SIGN}",
+        )
+
+    def test_decodes_bmp_escapes_and_surrogate_pairs_in_mixed_text(self):
+        self.assertEqual(
+            decode_unicode_escapes(f"Ch{A_GRAVE_ESCAPE}o {SMILE_ESCAPE}!"),
+            "Chào \N{SMILING FACE WITH SMILING EYES}!",
+        )
+
+    def test_leaves_plain_text_and_real_emoji_untouched(self):
+        text = "Chào bạn \N{SMILING FACE WITH SMILING EYES}"
+        self.assertEqual(decode_unicode_escapes(text), text)
+
+    def test_leaves_lone_surrogate_escape_untouched(self):
+        text = f"bad {LONE_SURROGATE_ESCAPE} end"
+        self.assertEqual(decode_unicode_escapes(text), text)
+
+    def test_leaves_text_without_escapes_untouched(self):
+        self.assertEqual(decode_unicode_escapes("no escapes here"), "no escapes here")


### PR DESCRIPTION
## Problem

GoPlanAI replies sometimes contained literal `\ud83d\udc4b` / `\ud83d\ude0a` strings instead of the 👋 / 😊 emoji. This was not a frontend rendering bug: the escape sequences were present in the stored message text itself.

Root cause: the agent context was serialized with `json.dumps(context)` using the default `ensure_ascii=True`, so all Vietnamese text and emoji in the context (trip name, recent chat, activities) were sent to DeepSeek as `\uXXXX` escapes. The model sometimes mimicked that style and emitted literal escape sequences in its replies. It also wasted input tokens (6 ASCII chars per non-ASCII character).

## Fix

- Serialize agent context with `ensure_ascii=False` so the model sees real UTF-8 text (`backend/ai/agent/runner.py`).
- Safety net: new `decode_unicode_escapes()` in `backend/ai/agent/text.py` decodes any literal escape sequences (surrogate pairs and BMP escapes) left in the final message text before it is returned; lone surrogates are kept as-is to avoid producing invalid characters.

## Tests

- 5 unit tests for `decode_unicode_escapes` (surrogate pairs, BMP escapes, plain text, lone surrogates).
- 2 runner tests: context message keeps non-ASCII characters raw; message text with model-emitted escapes is decoded.
- Full `ai` app suite: 186 tests, all passing.

## Notes

- Existing AI messages already stored with escape sequences are not rewritten; only new messages are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
