### PR TITLE
fix(realtime): Redis throttle counters, minute windows, 429-aware WS client

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -25,6 +25,7 @@ DB_CONN_MAX_AGE=0
 
 # -------- Redis (Channel Layer) --------
 REDIS_URL=redis://redis-messaging:6379/0
+REDIS_CACHE_URL=redis://redis-messaging:6379/3
 
 # -------- Email --------
 # DEV (Mailpit): use the service name from podman-compose.yml (not

--- a/backend/configs/settings.py
+++ b/backend/configs/settings.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from datetime import timedelta
 from pathlib import Path
@@ -223,6 +224,30 @@ if not DEBUG:
     SECURE_HSTS_INCLUDE_SUBDOMAINS = True
     SECURE_HSTS_PRELOAD = True
 
+# -------- Cache (throttle counters, shared state) --------
+# DRF throttling stores its counters in the default cache. It must live in
+# Redis so counts are consistent across worker processes and survive restarts;
+# LocMemCache would silently reset on every autoreload/deploy.
+REDIS_CACHE_URL = os.environ.get('REDIS_CACHE_URL', 'redis://localhost:6379/3')
+
+TESTING = 'test' in sys.argv
+
+if TESTING:
+    # Tests must stay hermetic: no Redis dependency, and throttle counters
+    # must never leak between test runs.
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        }
+    }
+else:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+            'LOCATION': REDIS_CACHE_URL,
+        }
+    }
+
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # REST Framework Defaults
@@ -239,12 +264,12 @@ REST_FRAMEWORK = {
         'accounts.throttling.DevBypassScopedRateThrottle',
     ),
     'DEFAULT_THROTTLE_RATES': {
-        'anon': '100/hour',
-        'user': '1000/hour',
+        'anon': '30/minute',
+        'user': '60/minute',
         'auth_login': '20/hour',
         'auth_register': '10/hour',
-        'auth_refresh': '60/hour',
-        'auth_me': '300/hour',
+        'auth_refresh': '10/minute',
+        'auth_me': '30/minute',
         'auth_logout': '30/hour',
         'auth_profile_setup': '20/hour',
         'auth_profile_name': '60/hour',
@@ -254,7 +279,7 @@ REST_FRAMEWORK = {
         'auth_password_reset_confirm': '10/hour',
         'auth_avatar': '10/hour',
         'auth_password_change': '5/hour',
-        'realtime_ws_ticket': '120/hour',
+        'realtime_ws_ticket': '20/minute',
         'notifications_list': '120/hour',
         'notifications_unread_count': '300/hour',
         'notifications_mark_read': '120/hour',
@@ -316,6 +341,16 @@ REST_FRAMEWORK = {
         'ws_ticket_refresh': '20/minute',
     },
 }
+
+if TESTING:
+    # The anon bucket is keyed by REMOTE_ADDR, which is always 127.0.0.1 in
+    # tests, so the whole suite shares one bucket and would trip it. Scoped
+    # per-endpoint rates keep production values; dedicated throttle tests
+    # patch rates and clear the cache themselves.
+    REST_FRAMEWORK['DEFAULT_THROTTLE_RATES'] = {
+        **REST_FRAMEWORK['DEFAULT_THROTTLE_RATES'],
+        'anon': '1000/minute',
+    }
 
 if not DEBUG:
     REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] = (

--- a/backend/realtime/consumers.py
+++ b/backend/realtime/consumers.py
@@ -52,10 +52,13 @@ class BaseConsumer(AsyncJsonWebsocketConsumer):
     async def receive_json(self, content, **kwargs):
         if self.scope["user"].is_anonymous:
             return
-        if not await self._ensure_current_session():
-            return
+        # Heartbeat fast path: answer ping without the session DB check so a
+        # busy backend never stalls pong past the client timeout. Session
+        # validity is still enforced on business messages and push handlers.
         if content.get("type") == "ping":
             await self.send_json({"type": "pong"})
+            return
+        if not await self._ensure_current_session():
             return
         await self.handle_message(content)
 

--- a/backend/realtime/tests/test_consumers.py
+++ b/backend/realtime/tests/test_consumers.py
@@ -82,6 +82,29 @@ class RealtimeConsumerTests(TransactionTestCase):
 
         await communicator.disconnect()
 
+    async def test_ping_pong_skips_session_check_after_auth_revocation(self):
+        # Heartbeat must stay cheap: ping is answered without a session DB
+        # check, so a revoked session still gets pong. Revocation is enforced
+        # on business messages and push handlers instead.
+        user = await _create_user(email="ping-revoked@example.com")
+        ticket = await _issue_ws_ticket(user)
+
+        communicator = WebsocketCommunicator(
+            _build_application(),
+            "ws/realtime",
+            subprotocols=[settings.WS_SUBPROTOCOL, ticket],
+        )
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+
+        await _increment_auth_version(user)
+        await communicator.send_json_to({"type": "ping"})
+
+        response = await communicator.receive_json_from()
+        self.assertEqual(response, {"type": "pong"})
+
+        await communicator.disconnect()
+
     async def test_open_socket_closes_when_auth_version_is_revoked(self):
         user = await _create_user(email="open-revoked@example.com")
         ticket = await _issue_ws_ticket(user)
@@ -95,7 +118,7 @@ class RealtimeConsumerTests(TransactionTestCase):
         self.assertTrue(connected)
 
         await _increment_auth_version(user)
-        await communicator.send_json_to({"type": "ping"})
+        await communicator.send_json_to({"type": "chat.subscribe", "trip_id": ""})
 
         response = await communicator.receive_json_from()
         self.assertEqual(response, {"type": "auth_error", "code": "auth_failed"})

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,6 +10,9 @@ psycopg[binary]==3.2.9
 daphne==4.1.2
 channels==4.3.2
 channels-redis==4.3.0
+# Explicit pin: django.core.cache RedisCache (throttle counters) imports redis
+# directly; do not rely on it only as a transitive channels-redis dependency.
+redis==7.4.0
 PyJWT==2.12.1
 
 # -------- Async Task Worker --------

--- a/frontend/features/realtime/infrastructure/realtime-api.ts
+++ b/frontend/features/realtime/infrastructure/realtime-api.ts
@@ -5,11 +5,19 @@ type WsTicketResponse = {
 };
 
 export async function bffWsTicket(): Promise<WsTicketResponse> {
-  const res = await bff.post<WsTicketResponse>("/api/realtime/ws-ticket");
+  const res = await bff.post<WsTicketResponse>(
+    "/api/realtime/ws-ticket",
+    undefined,
+    { suppressThrottleToast: true },
+  );
   return res.data;
 }
 
 export async function bffRefreshWsTicket(): Promise<WsTicketResponse> {
-  const res = await bff.post<WsTicketResponse>("/api/realtime/ws-ticket/refresh");
+  const res = await bff.post<WsTicketResponse>(
+    "/api/realtime/ws-ticket/refresh",
+    undefined,
+    { suppressThrottleToast: true },
+  );
   return res.data;
 }

--- a/frontend/features/realtime/infrastructure/ws-manager.test.ts
+++ b/frontend/features/realtime/infrastructure/ws-manager.test.ts
@@ -1,10 +1,16 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { WsMessage } from "@/features/realtime/domain/types";
+import { bffWsTicket } from "@/features/realtime/infrastructure/realtime-api";
 import {
   WebSocketManager,
   resolveWebSocketBaseUrl,
 } from "@/features/realtime/infrastructure/ws-manager";
+
+vi.mock("@/features/realtime/infrastructure/realtime-api", () => ({
+  bffWsTicket: vi.fn(),
+  bffRefreshWsTicket: vi.fn(),
+}));
 
 type WebSocketManagerEmitter = {
   emit: (type: string, data: WsMessage) => void;
@@ -46,6 +52,66 @@ describe("WebSocketManager", () => {
     testManager.emit("notification", message);
 
     expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  describe("throttled ticket fetch", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      vi.mocked(bffWsTicket).mockReset();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    });
+
+    function throttleError(retryAfterSeconds?: string) {
+      return {
+        isAxiosError: true,
+        response: {
+          status: 429,
+          headers: retryAfterSeconds
+            ? { "retry-after": retryAfterSeconds }
+            : {},
+        },
+      };
+    }
+
+    it("waits for Retry-After before retrying and does not burn reconnect attempts", async () => {
+      const manager = new WebSocketManager();
+      vi.mocked(bffWsTicket).mockRejectedValue(throttleError("42"));
+
+      manager.connect();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(bffWsTicket).toHaveBeenCalledTimes(1);
+      expect(manager.getStatus()).toBe("reconnecting");
+
+      await vi.advanceTimersByTimeAsync(41_000);
+      expect(bffWsTicket).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(bffWsTicket).toHaveBeenCalledTimes(2);
+
+      const internals = manager as unknown as { reconnectAttempt: number };
+      expect(internals.reconnectAttempt).toBe(0);
+    });
+
+    it("falls back to a default delay when 429 carries no Retry-After", async () => {
+      const manager = new WebSocketManager();
+      vi.mocked(bffWsTicket).mockRejectedValue(throttleError());
+
+      manager.connect();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(bffWsTicket).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(29_000);
+      expect(bffWsTicket).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(bffWsTicket).toHaveBeenCalledTimes(2);
+    });
   });
 
   it("uses a browser-allowed close code during page unload", () => {

--- a/frontend/features/realtime/infrastructure/ws-manager.ts
+++ b/frontend/features/realtime/infrastructure/ws-manager.ts
@@ -9,9 +9,13 @@ import {
 const DEFAULT_WS_BASE_URL = "ws://localhost:8000";
 const WS_SUBPROTOCOL = "goplan.realtime.v1";
 const HEARTBEAT_INTERVAL_MS = 25_000;
-const HEARTBEAT_TIMEOUT_MS = 10_000;
+// Generous on purpose: a momentarily busy backend (or a proxied hop) must not
+// kill a healthy socket — every reconnect costs a one-time throttled ticket.
+const HEARTBEAT_TIMEOUT_MS = 30_000;
 const MAX_RECONNECT_ATTEMPTS = 10;
 const MAX_BACKOFF_MS = 30_000;
+const THROTTLE_FALLBACK_DELAY_MS = 30_000;
+const MAX_THROTTLE_DELAY_MS = 300_000;
 const SOFT_AUTH_ERROR_CODE = "refresh_auth_soft_failed";
 
 type MessageListener = (data: WsMessage) => void;
@@ -192,6 +196,11 @@ export class WebSocketManager {
         return;
       }
 
+      if (this.isThrottleError(error)) {
+        this.scheduleThrottledReconnect(error);
+        return;
+      }
+
       this.scheduleReconnect();
     }
   }
@@ -296,11 +305,50 @@ export class WebSocketManager {
         return;
       }
 
+      if (this.isThrottleError(error)) {
+        this.scheduleThrottledReconnect(error);
+        return;
+      }
+
       this.scheduleReconnect();
     }
   }
 
   // -------- Reconnect --------
+
+  /**
+   * 429 on a ticket endpoint is not a network failure: retrying early can
+   * never succeed and keeps the bucket full. Wait out Retry-After without
+   * consuming reconnect attempts so a throttled client always recovers.
+   */
+  private scheduleThrottledReconnect(error: unknown): void {
+    this.clearReconnectTimer();
+    this.setStatus("reconnecting");
+
+    const jitter = Math.random() * 1000;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, this.throttleRetryDelayMs(error) + jitter);
+  }
+
+  private isThrottleError(error: unknown): boolean {
+    return axios.isAxiosError(error) && error.response?.status === 429;
+  }
+
+  private throttleRetryDelayMs(error: unknown): number {
+    if (!axios.isAxiosError(error)) return THROTTLE_FALLBACK_DELAY_MS;
+
+    const rawHeader = (
+      error.response?.headers as Record<string, unknown> | undefined
+    )?.["retry-after"];
+    const seconds = Number.parseInt(String(rawHeader), 10);
+    if (!Number.isFinite(seconds) || seconds <= 0) {
+      return THROTTLE_FALLBACK_DELAY_MS;
+    }
+
+    return Math.min(seconds * 1000, MAX_THROTTLE_DELAY_MS);
+  }
 
   private scheduleReconnect(): void {
     if (this.reconnectAttempt >= MAX_RECONNECT_ATTEMPTS) {

--- a/frontend/shared/http/bff-client.test.ts
+++ b/frontend/shared/http/bff-client.test.ts
@@ -1,0 +1,53 @@
+import { AxiosError, AxiosHeaders, type InternalAxiosRequestConfig } from "axios";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { bff } from "@/shared/http/bff-client";
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn() },
+}));
+
+vi.mock("@/features/auth/infrastructure/token-manager", () => ({
+  tokenManager: { get: () => null, set: vi.fn() },
+}));
+
+function throttledAdapter(config: InternalAxiosRequestConfig) {
+  const headers = new AxiosHeaders({ "retry-after": "37" });
+  return Promise.reject(
+    new AxiosError("Too many requests", "ERR_BAD_REQUEST", config, null, {
+      status: 429,
+      statusText: "Too Many Requests",
+      data: {},
+      headers,
+      config,
+    }),
+  );
+}
+
+describe("bff client 429 toast", () => {
+  beforeEach(() => {
+    vi.mocked(toast.error).mockClear();
+  });
+
+  it("toasts the Retry-After message by default", async () => {
+    await expect(
+      bff.get("/api/anything", { adapter: throttledAdapter }),
+    ).rejects.toThrow();
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "Too many requests. Please try again in 37s.",
+    );
+  });
+
+  it("suppresses the toast when suppressThrottleToast is set", async () => {
+    await expect(
+      bff.get("/api/anything", {
+        adapter: throttledAdapter,
+        suppressThrottleToast: true,
+      }),
+    ).rejects.toThrow();
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/shared/http/bff-client.ts
+++ b/frontend/shared/http/bff-client.ts
@@ -3,6 +3,17 @@ import { toast } from "sonner";
 
 import { tokenManager } from "@/features/auth/infrastructure/token-manager";
 
+declare module "axios" {
+  export interface AxiosRequestConfig {
+    /**
+     * Skip the global "Too many requests" toast for this request. Use for
+     * background calls (e.g. WebSocket ticket fetches) whose failure is
+     * already surfaced elsewhere (connection banner).
+     */
+    suppressThrottleToast?: boolean;
+  }
+}
+
 const bff = axios.create({
   baseURL: "",
   timeout: 10_000,
@@ -58,6 +69,7 @@ bff.interceptors.response.use(
   (error: unknown) => {
     if (error && typeof error === "object" && "response" in error) {
       const axiosError = error as {
+        config?: { suppressThrottleToast?: boolean };
         response?: {
           headers?: Record<string, unknown>;
           status?: number;
@@ -66,7 +78,11 @@ bff.interceptors.response.use(
       if (axiosError.response?.headers) {
         captureAccessToken(axiosError.response.headers);
       }
-      if (axiosError.response?.status === 429 && axiosError.response.headers) {
+      if (
+        axiosError.response?.status === 429 &&
+        axiosError.response.headers &&
+        !axiosError.config?.suppressThrottleToast
+      ) {
         toast.error(getRetryAfterMessage(axiosError.response.headers));
       }
     }


### PR DESCRIPTION
Closes #41

## What changed

### Backend
- **Redis-backed throttle counters.** New `CACHES` default using `django.core.cache.backends.redis.RedisCache` on a dedicated Redis DB (`REDIS_CACHE_URL`, default `redis://localhost:6379/3`; `.env.example` updated). DRF throttle counts are now consistent across worker processes and survive restarts. Tests keep `LocMemCache` so they stay hermetic (no Redis dependency, no counter leakage between runs). `redis` is now pinned explicitly in `requirements.txt` instead of riding on `channels-redis`'s transitive dependency.
- **Operational scopes moved from hourly to minute windows** — worst-case `Retry-After` drops from ~3600s to ≤60s while keeping comparable effective ceilings:
  | scope | before | after |
  |---|---|---|
  | `anon` | 100/hour | 30/minute |
  | `user` | 1000/hour | 60/minute |
  | `auth_refresh` | 60/hour | 10/minute |
  | `auth_me` | 300/hour | 30/minute |
  | `realtime_ws_ticket` | 120/hour | 20/minute |

  Security scopes (`auth_login`, `auth_register`, password flows, email verification) are intentionally unchanged: hourly windows are the brute-force defense.
- **In test mode only**, the `anon` default rate is relaxed (the whole suite shares REMOTE_ADDR `127.0.0.1`, so suite-wide accumulation would trip the bucket). Scoped rates keep production values; dedicated throttle tests still patch rates and clear the cache themselves.
- **Realtime consumer heartbeat fast path**: `ping` is answered immediately without the per-ping session DB query. Session validity (`auth_version`) remains enforced on every business message and every push handler — the revocation test now exercises that path explicitly.

### Frontend
- **`ws-manager` understands 429**: a throttled ticket fetch now waits out `Retry-After` (fallback 30s, capped at 5min, jittered) before retrying, and no longer burns the 10 reconnect attempts — a throttled client always recovers instead of getting stuck on "Disconnected".
- **No more phantom toasts**: WS ticket calls opt out of the global "Too many requests" toast via a new `suppressThrottleToast` axios config flag; the connection banner already communicates the state.
- **Pong timeout 10s → 30s** so a momentarily busy backend (or proxied hop) doesn't kill a healthy socket — every reconnect costs a one-time throttled ticket.

## Tests
- TDD: new backend test `test_ping_pong_skips_session_check_after_auth_revocation` (RED→GREEN) and updated revocation test to use a business message; new vitest specs for the 429 reconnect path and the toast suppression flag (RED→GREEN).
- Backend: full suite 1099 tests — all pass except **5 pre-existing failures** in `trips.tests.test_timeline_reminders` (`RuntimeError: broker unavailable`), which fail identically on a clean `main` checkout and are unrelated to this change.
- Frontend: vitest 530/530 pass, `eslint` clean, `next build` succeeds.
- Runtime verified in dev containers: cache smoke key lands in Redis DB 3 (`:1:cache_smoke`).

## Risks
- Throttle counters now depend on Redis availability; Redis is already a hard dependency for Channels and Celery, so this adds no new failure domain.
- Ping no longer triggers session revocation checks: a revoked session can keep an idle socket alive slightly longer, but any pushed event or client message still enforces revocation immediately.
- Deploy note: `production` env needs `REDIS_CACHE_URL` added to `backend/.env` on the homelab (template updated in `.env.example`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)