### PR TITLE
fix(auth): send account-exists email on duplicate verified registration

### DIFF
--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -23,6 +23,7 @@ from accounts.tokens import RefreshToken
 from accounts.services import (
     complete_profile_identity,
     reset_user_password,
+    send_account_exists_email,
     send_password_reset_email,
     send_verification_email,
     update_display_name,
@@ -50,6 +51,13 @@ def send_verification_email_safely(user: User) -> None:
         send_verification_email(user)
     except (SMTPException, OSError):
         logger.exception("Failed to send verification email for user %s", user.pk)
+
+
+def send_account_exists_email_safely(user: User) -> None:
+    try:
+        send_account_exists_email(user)
+    except (SMTPException, OSError):
+        logger.exception("Failed to send account-exists email for user %s", user.pk)
 
 
 def normalize_whitespace(value: str) -> str:
@@ -137,7 +145,16 @@ class RegisterSerializer(serializers.Serializer):
             except User.DoesNotExist:
                 return User(email=validated_data["email"])
 
-            if user.email_verified or user.is_staff or user.is_superuser:
+            # Staff/superuser duplicates stay silent: anonymous requests must
+            # not be able to generate email to admin inboxes.
+            if user.is_staff or user.is_superuser:
+                return user
+
+            # Verified owner gets a "you already have an account" email so they
+            # are pointed to log in / reset password instead of waiting for a
+            # verification email that will never arrive. Response stays uniform.
+            if user.email_verified:
+                send_account_exists_email_safely(user)
                 return user
 
         send_verification_email_safely(user)

--- a/backend/accounts/services.py
+++ b/backend/accounts/services.py
@@ -190,6 +190,22 @@ def send_verification_email(user: User) -> None:
     )
 
 
+def send_account_exists_email(user: User) -> None:
+    body = render_to_string(
+        "accounts/account_exists.txt",
+        {
+            "login_url": f"{settings.FRONTEND_BASE_URL}/login",
+            "password_reset_url": f"{settings.FRONTEND_BASE_URL}/forgot-password",
+        },
+    )
+    send_mail(
+        subject="You already have a GoPlan account",
+        message=body,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        recipient_list=[user.email],
+    )
+
+
 def build_user_payload(user: User) -> dict:
     return {
         "id": str(user.id),

--- a/backend/accounts/templates/accounts/account_exists.txt
+++ b/backend/accounts/templates/accounts/account_exists.txt
@@ -1,0 +1,15 @@
+Hi,
+
+Someone (probably you) tried to create a GoPlan account with this email address, but you already have an account.
+
+Log in here:
+
+{{ login_url }}
+
+Forgot your password? Reset it here:
+
+{{ password_reset_url }}
+
+If this wasn't you, you can safely ignore this email.
+
+-- GoPlan

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -13,6 +13,8 @@ from django.contrib.auth.tokens import default_token_generator
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 
+from django.core.cache import cache
+
 from accounts.models import EmailVerificationToken
 from accounts.services import generate_email_verification_token
 from test_helpers import (
@@ -35,6 +37,11 @@ class AuthAPITestCase(APITestCase):
     password_reset_confirm_url = "/api/auth/password-reset/confirm"
     refresh_url = "/api/auth/refresh"
     logout_url = "/api/auth/logout"
+
+    def setUp(self) -> None:
+        # Throttle counters live in the cache and persist across tests;
+        # reset them so per-scope limits don't leak between test methods.
+        cache.clear()
 
     @staticmethod
     def issue_tokens_for_user(user):
@@ -135,6 +142,64 @@ class AuthAPITestCase(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         mock_send.assert_called_once_with(existing_user)
+
+    @patch("accounts.serializers.send_account_exists_email")
+    @patch("accounts.serializers.send_verification_email")
+    def test_register_duplicate_verified_email_sends_account_exists_email(
+        self, mock_send_verification, mock_send_account_exists
+    ):
+        existing_user = self.create_verified_user(
+            email="owner@example.com", password="StrongPass#2026"
+        )
+        payload = {"email": "OWNER@EXAMPLE.COM", "password": "StrongPass#2026"}
+
+        response = self.client.post(self.register_url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        mock_send_account_exists.assert_called_once_with(existing_user)
+        mock_send_verification.assert_not_called()
+
+    @patch("accounts.serializers.send_account_exists_email")
+    @patch("accounts.serializers.send_verification_email")
+    def test_register_duplicate_staff_or_superuser_sends_no_email(
+        self, mock_send_verification, mock_send_account_exists
+    ):
+        staff_user = User.objects.create_user(
+            email="staff@example.com", password="StrongPass#2026"
+        )
+        staff_user.is_staff = True
+        staff_user.save(update_fields=["is_staff"])
+        superuser = User.objects.create_superuser(
+            email="admin@example.com", password="StrongPass#2026"
+        )
+
+        for email in (staff_user.email, superuser.email):
+            with self.subTest(email=email):
+                payload = {"email": email, "password": "StrongPass#2026"}
+                response = self.client.post(self.register_url, payload, format="json")
+
+                self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+
+        mock_send_account_exists.assert_not_called()
+        mock_send_verification.assert_not_called()
+
+    def test_send_account_exists_email_contains_login_and_reset_links(self):
+        from django.core import mail
+
+        from accounts.services import send_account_exists_email
+
+        user = self.create_verified_user(
+            email="owner@example.com", password="StrongPass#2026"
+        )
+
+        send_account_exists_email(user)
+
+        self.assertEqual(len(mail.outbox), 1)
+        message = mail.outbox[0]
+        self.assertEqual(message.to, [user.email])
+        self.assertIn("already have", message.subject + message.body)
+        self.assertIn("/login", message.body)
+        self.assertIn("/forgot-password", message.body)
 
     @patch("accounts.serializers.send_verification_email")
     def test_register_normalizes_email_to_lowercase(self, mock_send):


### PR DESCRIPTION
Fixes #44

## What changed

`POST /api/auth/register` with an email that already belongs to an existing account kept returning the uniform `202 {"detail": "check your inbox..."}` but, for verified accounts, sent no email at all — the legitimate owner was stranded on the "Check your inbox" screen (mistaken for an SMTP outage in production).

- **Existing verified account** → now sends a "You already have a GoPlan account" email with login (`/login`) and password-reset (`/forgot-password`) links. New service `send_account_exists_email()` + template `accounts/account_exists.txt`, wrapped in a `_safely` helper so SMTP failures are logged, never surfaced (response stays uniform).
- **Existing unverified account** → unchanged: verification email re-sent (behavior from b1247fb).
- **Staff/superuser account** → intentionally stays silent, documented with a code comment: anonymous requests must not be able to generate email to admin inboxes.
- HTTP response is identical in all branches (202, same body) — no enumeration oracle. Throttling (`auth_register` scope) applies before the serializer in all branches.

## Tests

- `test_register_duplicate_verified_email_sends_account_exists_email`
- `test_register_duplicate_staff_or_superuser_sends_no_email`
- `test_send_account_exists_email_contains_login_and_reset_links`
- Existing duplicate/unverified and uniform-contract tests still pass.
- Added `cache.clear()` in `AuthAPITestCase.setUp` — throttle counters persist in cache across test methods and the new register requests pushed the class over the 10/hour `auth_register` limit.

`python manage.py test accounts` (in backend container): **254 tests, OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)