### PR TITLE
feat: forgiving image uploads via client-side preprocessing (avatar, photos, cover)

### DIFF
--- a/frontend/app/api/trips/[tripId]/photos/route.test.ts
+++ b/frontend/app/api/trips/[tripId]/photos/route.test.ts
@@ -222,7 +222,7 @@ describe("BFF /api/trips/[tripId]/photos", () => {
     });
   });
 
-  it("rejects HEIC with a clear unsupported-format payload", async () => {
+  it("rejects raw HEIC as a generic unsupported type (UI converts HEIC before upload)", async () => {
     const { POST } = await import("@/app/api/trips/[tripId]/photos/route");
     const formData = new FormData();
     formData.append("files", new File(["heic"], "photo.heic", { type: "image/heic" }));
@@ -234,8 +234,8 @@ describe("BFF /api/trips/[tripId]/photos", () => {
     expect(response.status).toBe(415);
     expect(fetch).not.toHaveBeenCalled();
     await expect(response.json()).resolves.toEqual({
-      detail: "HEIC images are not supported yet. Convert to JPEG, PNG, or WebP.",
-      error_code: "HEIC_UNSUPPORTED",
+      detail: "Unsupported image format. Use JPEG, PNG, or WebP.",
+      error_code: "UNSUPPORTED_IMAGE_TYPE",
     });
   });
 

--- a/frontend/app/api/trips/[tripId]/photos/route.ts
+++ b/frontend/app/api/trips/[tripId]/photos/route.ts
@@ -11,7 +11,6 @@ import {
   TRIP_PHOTO_MAX_FILES,
   TRIP_PHOTO_MAX_TOTAL_UPLOAD_BYTES,
   hasKnownUnsupportedTripPhotoMime,
-  isTripPhotoHeicFile,
   isTripPhotoSvgFile,
   totalTripPhotoFileBytes,
 } from "@/features/trips/domain/photo-constraints";
@@ -79,15 +78,6 @@ function validateFiles(files: File[]): NextResponse | null {
           error_code: "PHOTO_TOO_LARGE",
         },
         { status: 413 },
-      );
-    }
-    if (isTripPhotoHeicFile(file)) {
-      return NextResponse.json(
-        {
-          detail: "HEIC images are not supported yet. Convert to JPEG, PNG, or WebP.",
-          error_code: "HEIC_UNSUPPORTED",
-        },
-        { status: 415 },
       );
     }
     if (isTripPhotoSvgFile(file) || hasKnownUnsupportedTripPhotoMime(file)) {

--- a/frontend/features/account/presentation/avatar-edit-dialog.test.tsx
+++ b/frontend/features/account/presentation/avatar-edit-dialog.test.tsx
@@ -8,12 +8,17 @@ const avatarHookMock = vi.hoisted(() => ({
 }));
 
 const imageMock = vi.hoisted(() => ({
-  loadImageElement: vi.fn(),
   renderCroppedImageToWebP: vi.fn(),
+}));
+
+const imagePreprocessMock = vi.hoisted(() => ({
+  preprocessImageFile: vi.fn(),
+  IMAGE_INPUT_ACCEPT: "image/jpeg,image/png,image/webp,image/heic,.heic,.heif",
 }));
 
 vi.mock("@/features/account/application/use-update-avatar", () => avatarHookMock);
 vi.mock("@/shared/lib/image", () => imageMock);
+vi.mock("@/shared/lib/image-preprocess", () => imagePreprocessMock);
 vi.mock("react-easy-crop", () => ({
   default: (props: {
     onCropComplete: (
@@ -29,10 +34,6 @@ vi.mock("react-easy-crop", () => ({
   },
 }));
 
-function mockLoadedImage(width: number, height: number): HTMLImageElement {
-  return { naturalWidth: width, naturalHeight: height } as HTMLImageElement;
-}
-
 describe("AvatarEditDialog", () => {
   const upload = vi.fn();
 
@@ -43,7 +44,9 @@ describe("AvatarEditDialog", () => {
       uploading: false,
       error: null,
     });
-    imageMock.loadImageElement.mockResolvedValue(mockLoadedImage(512, 512));
+    imagePreprocessMock.preprocessImageFile.mockImplementation(
+      async (file: File) => ({ ok: true as const, file, wasProcessed: false }),
+    );
     imageMock.renderCroppedImageToWebP.mockResolvedValue(
       new Blob(["avatar"], { type: "image/webp" }),
     );
@@ -91,8 +94,11 @@ describe("AvatarEditDialog", () => {
     expect(upload).not.toHaveBeenCalled();
   });
 
-  it("rejects source images above the avatar dimension limit before cropping", async () => {
-    imageMock.loadImageElement.mockResolvedValue(mockLoadedImage(6000, 6000));
+  it("shows a local error when the file type is unsupported", async () => {
+    imagePreprocessMock.preprocessImageFile.mockResolvedValue({
+      ok: false,
+      code: "UNSUPPORTED",
+    });
 
     render(<AvatarEditDialog open onOpenChange={vi.fn()} />);
     const input = document.querySelector('input[type="file"]');
@@ -102,12 +108,14 @@ describe("AvatarEditDialog", () => {
 
     fireEvent.change(input, {
       target: {
-        files: [new File(["avatar"], "huge.png", { type: "image/png" })],
+        files: [new File(["avatar"], "image.bmp", { type: "image/bmp" })],
       },
     });
 
     expect(
-      await screen.findByText("Avatar image must be at most 1024x1024 pixels."),
+      await screen.findByText(
+        "Selected file must be a JPEG, PNG, WebP, or HEIC image.",
+      ),
     ).toBeInTheDocument();
     expect(screen.queryByTestId("cropper")).not.toBeInTheDocument();
     expect(upload).not.toHaveBeenCalled();
@@ -117,7 +125,9 @@ describe("AvatarEditDialog", () => {
     render(<AvatarEditDialog open onOpenChange={vi.fn()} />);
 
     expect(
-      screen.getByText("Choose a JPEG, PNG, or WebP image, then crop it into a square avatar."),
+      screen.getByText(
+        "Choose a JPEG, PNG, WebP, or HEIC image, then crop it into a square avatar.",
+      ),
     ).toBeInTheDocument();
   });
 });

--- a/frontend/features/account/presentation/avatar-edit-dialog.test.tsx
+++ b/frontend/features/account/presentation/avatar-edit-dialog.test.tsx
@@ -121,6 +121,69 @@ describe("AvatarEditDialog", () => {
     expect(upload).not.toHaveBeenCalled();
   });
 
+  it("shows a local error when the file cannot be decoded", async () => {
+    imagePreprocessMock.preprocessImageFile.mockResolvedValue({
+      ok: false,
+      code: "UNREADABLE",
+    });
+
+    render(<AvatarEditDialog open onOpenChange={vi.fn()} />);
+    const input = document.querySelector('input[type="file"]');
+    if (!(input instanceof HTMLInputElement)) {
+      throw new Error("Avatar file input was not rendered.");
+    }
+
+    fireEvent.change(input, {
+      target: {
+        files: [new File(["broken"], "broken.heic", { type: "image/heic" })],
+      },
+    });
+
+    expect(
+      await screen.findByText(
+        "Could not read this photo. Convert it to JPEG and try again.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("cropper")).not.toBeInTheDocument();
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it("ignores a preprocess result that resolves after the dialog closes", async () => {
+    let resolvePreprocess:
+      | ((value: { ok: true; file: File; wasProcessed: boolean }) => void)
+      | undefined;
+    imagePreprocessMock.preprocessImageFile.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePreprocess = resolve;
+        }),
+    );
+    const onOpenChange = vi.fn();
+    const { rerender } = render(
+      <AvatarEditDialog open onOpenChange={onOpenChange} />,
+    );
+    const input = document.querySelector('input[type="file"]');
+    if (!(input instanceof HTMLInputElement)) {
+      throw new Error("Avatar file input was not rendered.");
+    }
+
+    const file = new File(["avatar"], "avatar.png", { type: "image/png" });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    // Close the dialog while preprocessing is still in flight.
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    rerender(<AvatarEditDialog open={false} onOpenChange={onOpenChange} />);
+
+    resolvePreprocess?.({ ok: true, file, wasProcessed: false });
+    rerender(<AvatarEditDialog open onOpenChange={onOpenChange} />);
+
+    // Reopened dialog must show the empty picker, not a stale cropper.
+    expect(
+      await screen.findByText("Click to choose an image"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("cropper")).not.toBeInTheDocument();
+  });
+
   it("renders an accessible description for the avatar dialog", () => {
     render(<AvatarEditDialog open onOpenChange={vi.fn()} />);
 

--- a/frontend/features/account/presentation/avatar-edit-dialog.tsx
+++ b/frontend/features/account/presentation/avatar-edit-dialog.tsx
@@ -40,6 +40,9 @@ export function AvatarEditDialog({ open, onOpenChange }: Props) {
   // Render+upload spans an async gap before `uploading` flips on; this ref
   // blocks re-entry during that window so a double-click can't fire two encodes.
   const submittingRef = useRef(false);
+  // Bumped on dialog close and on every new pick; an in-flight preprocess
+  // whose token no longer matches must not commit state (stale-image guard).
+  const pickTokenRef = useRef(0);
 
   useEffect(() => {
     return () => {
@@ -56,8 +59,10 @@ export function AvatarEditDialog({ open, onOpenChange }: Props) {
     setLocalError(null);
     setProcessing(true);
 
+    const token = ++pickTokenRef.current;
     try {
       const result = await preprocessImageFile(file, AVATAR_SOURCE_TARGET);
+      if (pickTokenRef.current !== token) return; // dialog closed or pick superseded
       if (!result.ok) {
         setLocalError(
           result.code === "UNSUPPORTED"
@@ -75,6 +80,7 @@ export function AvatarEditDialog({ open, onOpenChange }: Props) {
   const handleOpenChange = useCallback(
     (next: boolean) => {
       if (!next) {
+        pickTokenRef.current += 1; // invalidate any in-flight preprocess
         if (fileUrl) URL.revokeObjectURL(fileUrl);
         setFileUrl(null);
         setCrop({ x: 0, y: 0 });

--- a/frontend/features/account/presentation/avatar-edit-dialog.tsx
+++ b/frontend/features/account/presentation/avatar-edit-dialog.tsx
@@ -5,10 +5,11 @@ import Cropper, { type Area } from "react-easy-crop";
 import { toast } from "sonner";
 
 import { useUpdateAvatar } from "@/features/account/application/use-update-avatar";
+import { renderCroppedImageToWebP } from "@/shared/lib/image";
 import {
-  loadImageElement,
-  renderCroppedImageToWebP,
-} from "@/shared/lib/image";
+  IMAGE_INPUT_ACCEPT,
+  preprocessImageFile,
+} from "@/shared/lib/image-preprocess";
 import { Button } from "@/shared/ui/button";
 import {
   Dialog,
@@ -24,8 +25,9 @@ type Props = {
 };
 
 const TARGET_PX = 512;
-const MAX_SOURCE_DIMENSION_PX = 1024;
-const ALLOWED_SOURCE_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
+// The preprocessed source only feeds the cropper locally (never uploaded);
+// these bounds keep huge camera photos workable in memory.
+const AVATAR_SOURCE_TARGET = { maxEdgePx: 2048, maxBytes: 10 * 1024 * 1024 };
 
 export function AvatarEditDialog({ open, onOpenChange }: Props) {
   const { upload, uploading, error } = useUpdateAvatar();
@@ -34,6 +36,7 @@ export function AvatarEditDialog({ open, onOpenChange }: Props) {
   const [zoom, setZoom] = useState(1);
   const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
   const [localError, setLocalError] = useState<string | null>(null);
+  const [processing, setProcessing] = useState(false);
   // Render+upload spans an async gap before `uploading` flips on; this ref
   // blocks re-entry during that window so a double-click can't fire two encodes.
   const submittingRef = useRef(false);
@@ -51,32 +54,22 @@ export function AvatarEditDialog({ open, onOpenChange }: Props) {
     setZoom(1);
     setCroppedAreaPixels(null);
     setLocalError(null);
+    setProcessing(true);
 
-    if (file.type && !ALLOWED_SOURCE_TYPES.has(file.type)) {
-      setLocalError("Selected file must be a JPEG, PNG, or WebP image.");
-      return;
-    }
-
-    const nextFileUrl = URL.createObjectURL(file);
     try {
-      const image = await loadImageElement(nextFileUrl);
-      if (
-        image.naturalWidth > MAX_SOURCE_DIMENSION_PX ||
-        image.naturalHeight > MAX_SOURCE_DIMENSION_PX
-      ) {
-        URL.revokeObjectURL(nextFileUrl);
+      const result = await preprocessImageFile(file, AVATAR_SOURCE_TARGET);
+      if (!result.ok) {
         setLocalError(
-          `Avatar image must be at most ${MAX_SOURCE_DIMENSION_PX}x${MAX_SOURCE_DIMENSION_PX} pixels.`,
+          result.code === "UNSUPPORTED"
+            ? "Selected file must be a JPEG, PNG, WebP, or HEIC image."
+            : "Could not read this photo. Convert it to JPEG and try again.",
         );
         return;
       }
-    } catch {
-      URL.revokeObjectURL(nextFileUrl);
-      setLocalError("Selected file could not be read as an image.");
-      return;
+      setFileUrl(URL.createObjectURL(result.file));
+    } finally {
+      setProcessing(false);
     }
-
-    setFileUrl(nextFileUrl);
   }, [fileUrl]);
 
   const handleOpenChange = useCallback(
@@ -128,18 +121,19 @@ export function AvatarEditDialog({ open, onOpenChange }: Props) {
         <DialogHeader>
           <DialogTitle>Change avatar</DialogTitle>
           <DialogDescription className="sr-only">
-            Choose a JPEG, PNG, or WebP image, then crop it into a square avatar.
+            Choose a JPEG, PNG, WebP, or HEIC image, then crop it into a square avatar.
           </DialogDescription>
         </DialogHeader>
 
         {!fileUrl ? (
           <>
             <label className="flex h-40 cursor-pointer items-center justify-center rounded-lg border-2 border-dashed border-border text-sm text-muted-foreground hover:border-primary">
-              Click to choose an image
+              {processing ? "Optimizing image…" : "Click to choose an image"}
               <input
                 type="file"
-                accept="image/jpeg,image/png,image/webp"
+                accept={IMAGE_INPUT_ACCEPT}
                 className="hidden"
+                disabled={processing}
                 onChange={(e) => {
                   const file = e.target.files?.[0];
                   if (file) void handleFile(file);

--- a/frontend/features/trips/domain/photo-constraints.ts
+++ b/frontend/features/trips/domain/photo-constraints.ts
@@ -6,22 +6,12 @@ export const TRIP_PHOTO_MAX_BODY_BYTES =
   TRIP_PHOTO_MAX_TOTAL_UPLOAD_BYTES + TRIP_PHOTO_MAX_MULTIPART_OVERHEAD_BYTES;
 
 export const TRIP_PHOTO_ALLOWED_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
-export const TRIP_PHOTO_HEIC_TYPES = new Set(["image/heic", "image/heif"]);
 export const TRIP_PHOTO_GENERIC_BINARY_TYPES = new Set([
   "application/octet-stream",
   "binary/octet-stream",
 ]);
 
 type PhotoFileLike = Pick<File, "name" | "size" | "type">;
-
-export function isTripPhotoHeicFile(file: PhotoFileLike): boolean {
-  const lowerName = file.name.toLowerCase();
-  return (
-    TRIP_PHOTO_HEIC_TYPES.has(file.type) ||
-    lowerName.endsWith(".heic") ||
-    lowerName.endsWith(".heif")
-  );
-}
 
 export function isTripPhotoSvgFile(file: PhotoFileLike): boolean {
   return file.type === "image/svg+xml" || file.name.toLowerCase().endsWith(".svg");

--- a/frontend/features/trips/domain/photo-errors.test.ts
+++ b/frontend/features/trips/domain/photo-errors.test.ts
@@ -23,6 +23,23 @@ describe("photo-errors", () => {
     );
   });
 
+  it("maps backend HEIC_UNSUPPORTED to the decode-failure copy", () => {
+    const error = {
+      isAxiosError: true,
+      response: {
+        status: 415,
+        data: {
+          detail: "HEIC images are not supported yet.",
+          error_code: "HEIC_UNSUPPORTED",
+        },
+      },
+    };
+
+    expect(getTripPhotoErrorMessage(error, "Upload failed.")).toBe(
+      "Could not read this photo. Convert it to JPEG and try again.",
+    );
+  });
+
   it("validates selected files before upload", () => {
     expect(validateTripPhotoFiles([])).toEqual({
       ok: false,

--- a/frontend/features/trips/domain/photo-errors.test.ts
+++ b/frontend/features/trips/domain/photo-errors.test.ts
@@ -6,20 +6,20 @@ import {
 } from "@/features/trips/domain/photo-errors";
 
 describe("photo-errors", () => {
-  it("maps HEIC_UNSUPPORTED to user-friendly copy", () => {
+  it("maps UNSUPPORTED_IMAGE_TYPE to user-friendly copy", () => {
     const error = {
       isAxiosError: true,
       response: {
         status: 415,
         data: {
-          detail: "HEIC images are not supported yet.",
-          error_code: "HEIC_UNSUPPORTED",
+          detail: "Unsupported image format.",
+          error_code: "UNSUPPORTED_IMAGE_TYPE",
         },
       },
     };
 
     expect(getTripPhotoErrorMessage(error, "Upload failed.")).toBe(
-      "HEIC photos are not supported yet. Convert them to JPEG, PNG, or WebP and try again.",
+      "Use JPEG, PNG, WebP, or HEIC photos. SVG and other formats are not supported.",
     );
   });
 
@@ -35,8 +35,7 @@ describe("photo-errors", () => {
       ]),
     ).toEqual({
       ok: false,
-      message:
-        "HEIC photos are not supported yet. Convert them to JPEG, PNG, or WebP and try again.",
+      message: "Use JPEG, PNG, WebP, or HEIC photos. SVG and other formats are not supported.",
     });
 
     expect(
@@ -45,7 +44,7 @@ describe("photo-errors", () => {
       ]),
     ).toEqual({
       ok: false,
-      message: "Use JPEG, PNG, or WebP photos. SVG and other formats are not supported.",
+      message: "Use JPEG, PNG, WebP, or HEIC photos. SVG and other formats are not supported.",
     });
 
     expect(

--- a/frontend/features/trips/domain/photo-errors.ts
+++ b/frontend/features/trips/domain/photo-errors.ts
@@ -8,7 +8,6 @@ import {
   TRIP_PHOTO_MAX_FILES,
   TRIP_PHOTO_MAX_TOTAL_UPLOAD_BYTES,
   hasKnownUnsupportedTripPhotoMime,
-  isTripPhotoHeicFile,
   isTripPhotoSvgFile,
   totalTripPhotoFileBytes,
 } from "@/features/trips/domain/photo-constraints";
@@ -18,8 +17,6 @@ type PhotoValidationResult =
   | { ok: false; message: string };
 
 const ERROR_MESSAGES: Record<string, string> = {
-  HEIC_UNSUPPORTED:
-    "HEIC photos are not supported yet. Convert them to JPEG, PNG, or WebP and try again.",
   NO_FILES: "Choose at least one photo.",
   PHOTO_DIMENSIONS_TOO_LARGE:
     "That photo is too large to process. Use an image under 45 megapixels.",
@@ -32,7 +29,7 @@ const ERROR_MESSAGES: Record<string, string> = {
   TOO_MANY_FILES: "Upload up to 20 photos at a time.",
   TRIP_TERMINAL: "Cancelled trips cannot change photos.",
   UNSUPPORTED_IMAGE_TYPE:
-    "Use JPEG, PNG, or WebP photos. SVG and other formats are not supported.",
+    "Use JPEG, PNG, WebP, or HEIC photos. SVG and other formats are not supported.",
 };
 
 export function getTripPhotoErrorMessage(error: unknown, fallback: string): string {
@@ -57,9 +54,6 @@ export function validateTripPhotoFiles(files: File[]): PhotoValidationResult {
   for (const file of files) {
     if (file.size > TRIP_PHOTO_MAX_FILE_BYTES) {
       return { ok: false, message: ERROR_MESSAGES.PHOTO_TOO_LARGE };
-    }
-    if (isTripPhotoHeicFile(file)) {
-      return { ok: false, message: ERROR_MESSAGES.HEIC_UNSUPPORTED };
     }
     if (isTripPhotoSvgFile(file) || hasKnownUnsupportedTripPhotoMime(file)) {
       return { ok: false, message: ERROR_MESSAGES.UNSUPPORTED_IMAGE_TYPE };

--- a/frontend/features/trips/domain/photo-errors.ts
+++ b/frontend/features/trips/domain/photo-errors.ts
@@ -17,6 +17,10 @@ type PhotoValidationResult =
   | { ok: false; message: string };
 
 const ERROR_MESSAGES: Record<string, string> = {
+  // Django still emits this code when raw HEIC bytes slip past the BFF MIME
+  // checks (e.g. empty/generic MIME); the UI converts HEIC client-side, so
+  // reaching this mapping means the photo could not be preprocessed.
+  HEIC_UNSUPPORTED: "Could not read this photo. Convert it to JPEG and try again.",
   NO_FILES: "Choose at least one photo.",
   PHOTO_DIMENSIONS_TOO_LARGE:
     "That photo is too large to process. Use an image under 45 megapixels.",

--- a/frontend/features/trips/domain/prepare-trip-photo-files.test.ts
+++ b/frontend/features/trips/domain/prepare-trip-photo-files.test.ts
@@ -74,4 +74,25 @@ describe("prepareTripPhotoFiles", () => {
 
     expect(result).toEqual({ ok: false, message: "Upload up to 20 photos at a time." });
   });
+
+  it("validates total upload size on the processed output, not the input", async () => {
+    const input = [
+      new File(["a"], "a.jpg", { type: "image/jpeg" }),
+      new File(["b"], "b.jpg", { type: "image/jpeg" }),
+    ];
+    // Small inputs grow past the 50 MiB total budget after processing; the
+    // total check runs before the per-file check, so this exercises it.
+    const bigChunk = new Uint8Array(26 * 1024 * 1024);
+    const preprocess = vi.fn().mockImplementation((file: File) =>
+      Promise.resolve({
+        ok: true,
+        file: new File([bigChunk], file.name, { type: "image/jpeg" }),
+        wasProcessed: true,
+      }),
+    );
+
+    const result = await prepareTripPhotoFiles(input, preprocess);
+
+    expect(result).toEqual({ ok: false, message: "Upload up to 50 MiB of photos at a time." });
+  });
 });

--- a/frontend/features/trips/domain/prepare-trip-photo-files.test.ts
+++ b/frontend/features/trips/domain/prepare-trip-photo-files.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  TRIP_PHOTO_PREPROCESS_TARGET,
+  prepareTripPhotoFiles,
+} from "@/features/trips/domain/prepare-trip-photo-files";
+import type { PreprocessResult } from "@/shared/lib/image-preprocess";
+
+function okResult(file: File): PreprocessResult {
+  return { ok: true, file, wasProcessed: true };
+}
+
+describe("prepareTripPhotoFiles", () => {
+  it("preprocesses every file with the trip photo target, then validates", async () => {
+    const input = [
+      new File(["a"], "a.heic", { type: "image/heic" }),
+      new File(["b"], "b.jpg", { type: "image/jpeg" }),
+    ];
+    const processed = [
+      new File(["a"], "a.webp", { type: "image/webp" }),
+      new File(["b"], "b.jpg", { type: "image/jpeg" }),
+    ];
+    const preprocess = vi
+      .fn()
+      .mockResolvedValueOnce(okResult(processed[0]))
+      .mockResolvedValueOnce({ ok: true, file: processed[1], wasProcessed: false });
+
+    const result = await prepareTripPhotoFiles(input, preprocess);
+
+    expect(preprocess).toHaveBeenCalledTimes(2);
+    expect(preprocess).toHaveBeenCalledWith(input[0], TRIP_PHOTO_PREPROCESS_TARGET);
+    expect(result).toEqual({ ok: true, files: processed });
+  });
+
+  it("maps UNSUPPORTED to a format message", async () => {
+    const preprocess = vi.fn().mockResolvedValue({ ok: false, code: "UNSUPPORTED" });
+
+    const result = await prepareTripPhotoFiles(
+      [new File(["x"], "x.svg", { type: "image/svg+xml" })],
+      preprocess,
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      message: "Use JPEG, PNG, WebP, or HEIC photos. SVG and other formats are not supported.",
+    });
+  });
+
+  it("maps UNREADABLE to a decode-failure message", async () => {
+    const preprocess = vi.fn().mockResolvedValue({ ok: false, code: "UNREADABLE" });
+
+    const result = await prepareTripPhotoFiles(
+      [new File(["x"], "broken.heic", { type: "image/heic" })],
+      preprocess,
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      message: "Could not read this photo. Convert it to JPEG and try again.",
+    });
+  });
+
+  it("still rejects more than 20 files after preprocessing", async () => {
+    const files = Array.from({ length: 21 }, (_, i) =>
+      new File(["x"], `p${i}.jpg`, { type: "image/jpeg" }),
+    );
+    const preprocess = vi
+      .fn()
+      .mockImplementation((file: File) =>
+        Promise.resolve({ ok: true, file, wasProcessed: false }),
+      );
+
+    const result = await prepareTripPhotoFiles(files, preprocess);
+
+    expect(result).toEqual({ ok: false, message: "Upload up to 20 photos at a time." });
+  });
+});

--- a/frontend/features/trips/domain/prepare-trip-photo-files.ts
+++ b/frontend/features/trips/domain/prepare-trip-photo-files.ts
@@ -1,0 +1,52 @@
+import {
+  preprocessImageFile,
+  type PreprocessResult,
+  type PreprocessTarget,
+} from "@/shared/lib/image-preprocess";
+
+import { TRIP_PHOTO_MAX_FILE_BYTES } from "@/features/trips/domain/photo-constraints";
+import { validateTripPhotoFiles } from "@/features/trips/domain/photo-errors";
+
+/** Mirrors backend TRIP_PHOTO_MEDIUM_MAX_EDGE — the largest variant the server keeps. */
+export const TRIP_PHOTO_PREPROCESS_TARGET: PreprocessTarget = {
+  maxEdgePx: 2560,
+  maxBytes: TRIP_PHOTO_MAX_FILE_BYTES,
+};
+
+export const PHOTO_UNREADABLE_MESSAGE =
+  "Could not read this photo. Convert it to JPEG and try again.";
+const PHOTO_UNSUPPORTED_MESSAGE =
+  "Use JPEG, PNG, WebP, or HEIC photos. SVG and other formats are not supported.";
+
+export type PrepareTripPhotosResult =
+  | { ok: true; files: File[] }
+  | { ok: false; message: string };
+
+type PreprocessFn = (file: File, target: PreprocessTarget) => Promise<PreprocessResult>;
+
+/**
+ * Normalize selected files (HEIC decode, downscale, WebP re-encode) one at a
+ * time to bound memory, then run the existing count/total-size validation on
+ * the processed output.
+ */
+export async function prepareTripPhotoFiles(
+  files: File[],
+  preprocess: PreprocessFn = preprocessImageFile,
+): Promise<PrepareTripPhotosResult> {
+  const processed: File[] = [];
+  for (const file of files) {
+    const result = await preprocess(file, TRIP_PHOTO_PREPROCESS_TARGET);
+    if (!result.ok) {
+      return {
+        ok: false,
+        message:
+          result.code === "UNSUPPORTED" ? PHOTO_UNSUPPORTED_MESSAGE : PHOTO_UNREADABLE_MESSAGE,
+      };
+    }
+    processed.push(result.file);
+  }
+
+  const validation = validateTripPhotoFiles(processed);
+  if (!validation.ok) return validation;
+  return { ok: true, files: processed };
+}

--- a/frontend/features/trips/presentation/cover-image-picker.tsx
+++ b/frontend/features/trips/presentation/cover-image-picker.tsx
@@ -7,8 +7,15 @@ import {
   bffUploadTripCover,
   extractBffErrorDetail,
 } from "@/features/trips/infrastructure/trips-api";
+import {
+  IMAGE_INPUT_ACCEPT,
+  preprocessImageFile,
+} from "@/shared/lib/image-preprocess";
 import { TripCoverImage } from "@/features/trips/presentation/trip-cover-image";
 import { Button } from "@/shared/ui/button";
+
+// Mirrors backend TRIP_COVER_MAX_EDGE / TRIP_COVER_MAX_BYTES.
+const COVER_PREPROCESS_TARGET = { maxEdgePx: 2560, maxBytes: 10 * 1024 * 1024 };
 
 type Props = {
   /** URL shown in the preview. Empty string falls back to app default placeholder. */
@@ -29,13 +36,22 @@ export function CoverImagePicker({ coverUrl, onChange }: Props) {
     setUploadError(null);
     setUploading(true);
     try {
-      const url = await bffUploadTripCover(file);
+      const result = await preprocessImageFile(file, COVER_PREPROCESS_TARGET);
+      if (!result.ok) {
+        setUploadError(
+          result.code === "UNSUPPORTED"
+            ? "Use a JPEG, PNG, WebP, or HEIC image."
+            : "Could not read this photo. Convert it to JPEG and try again.",
+        );
+        return;
+      }
+      const url = await bffUploadTripCover(result.file);
       onChange(url);
     } catch (error) {
       setUploadError(
         extractBffErrorDetail(
           error,
-          "Failed to upload. Try a different image (JPEG/PNG/WebP, max 10 MB).",
+          "Failed to upload. Try a different image (JPEG, PNG, WebP, or HEIC).",
         ),
       );
     } finally {
@@ -73,7 +89,7 @@ export function CoverImagePicker({ coverUrl, onChange }: Props) {
         <input
           ref={fileInputRef}
           type="file"
-          accept="image/jpeg,image/png,image/webp"
+          accept={IMAGE_INPUT_ACCEPT}
           className="hidden"
           onChange={handleFileChange}
         />

--- a/frontend/features/trips/presentation/photos-tab.test.tsx
+++ b/frontend/features/trips/presentation/photos-tab.test.tsx
@@ -21,6 +21,20 @@ vi.mock("@/features/trips/presentation/trip-context", () => ({
   }),
 }));
 
+// Keep real validation logic but stub preprocessing as identity (jsdom lacks createImageBitmap).
+vi.mock("@/features/trips/domain/prepare-trip-photo-files", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/features/trips/domain/prepare-trip-photo-files")>();
+  return {
+    ...original,
+    prepareTripPhotoFiles: vi.fn((files: File[]) =>
+      original.prepareTripPhotoFiles(files, (file) =>
+        Promise.resolve({ ok: true, file, wasProcessed: false }),
+      ),
+    ),
+  };
+});
+
+import { prepareTripPhotoFiles } from "@/features/trips/domain/prepare-trip-photo-files";
 import { PhotosTab } from "@/features/trips/presentation/photos-tab";
 
 const PHOTO: TripPhoto = {
@@ -291,11 +305,15 @@ describe("PhotosTab", () => {
     });
   });
 
-  it("rejects HEIC before upload with user-friendly copy", async () => {
+  it("surfaces preprocess failure copy when a photo cannot be read", async () => {
     photosApiMock.bffListTripPhotos.mockResolvedValueOnce({
       results: [],
       nextCursor: null,
       previousCursor: null,
+    });
+    vi.mocked(prepareTripPhotoFiles).mockResolvedValueOnce({
+      ok: false,
+      message: "Could not read this photo. Convert it to JPEG and try again.",
     });
 
     render(<PhotosTab />);
@@ -308,13 +326,13 @@ describe("PhotosTab", () => {
     }
     fireEvent.change(targetInput, {
       target: {
-        files: [new File(["heic"], "memory.heic", { type: "image/heic" })],
+        files: [new File(["bad"], "broken.jpg", { type: "image/jpeg" })],
       },
     });
 
     expect(
       await screen.findByText(
-        "Use JPEG, PNG, WebP, or HEIC photos. SVG and other formats are not supported.",
+        "Could not read this photo. Convert it to JPEG and try again.",
       ),
     ).toBeInTheDocument();
     expect(photosApiMock.bffUploadTripPhotos).not.toHaveBeenCalled();

--- a/frontend/features/trips/presentation/photos-tab.test.tsx
+++ b/frontend/features/trips/presentation/photos-tab.test.tsx
@@ -314,7 +314,7 @@ describe("PhotosTab", () => {
 
     expect(
       await screen.findByText(
-        "HEIC photos are not supported yet. Convert them to JPEG, PNG, or WebP and try again.",
+        "Use JPEG, PNG, WebP, or HEIC photos. SVG and other formats are not supported.",
       ),
     ).toBeInTheDocument();
     expect(photosApiMock.bffUploadTripPhotos).not.toHaveBeenCalled();

--- a/frontend/features/trips/presentation/photos-tab.tsx
+++ b/frontend/features/trips/presentation/photos-tab.tsx
@@ -13,6 +13,8 @@ import {
   getTripPhotoErrorMessage,
   validateTripPhotoFiles,
 } from "@/features/trips/domain/photo-errors";
+import { prepareTripPhotoFiles } from "@/features/trips/domain/prepare-trip-photo-files";
+import { IMAGE_INPUT_ACCEPT } from "@/shared/lib/image-preprocess";
 import {
   bffDeleteTripPhoto,
   bffDownloadTripPhoto,
@@ -61,6 +63,7 @@ export function PhotosTab() {
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [uploading, setUploading] = useState(false);
+  const [optimizing, setOptimizing] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [uploadError, setUploadError] = useState<string | null>(null);
@@ -168,31 +171,45 @@ export function PhotosTab() {
     }
   }
 
-  function handleFilesSelected(files: File[]) {
-    const validation = validateTripPhotoFiles(files);
+  async function handleFilesSelected(files: File[]) {
+    if (optimizing) return;
     setUploadError(null);
     setError(null);
-
-    if (!validation.ok) {
-      setUploadError(validation.message);
-      return;
+    setOptimizing(true);
+    try {
+      const result = await prepareTripPhotoFiles(files);
+      if (!result.ok) {
+        setUploadError(result.message);
+        return;
+      }
+      setStagedFiles(result.files);
+    } finally {
+      setOptimizing(false);
     }
-
-    setStagedFiles(files);
   }
 
-  function handleStageAddFiles(extra: File[]) {
-    setStagedFiles((current) => {
-      const base = current ?? [];
-      const next = [...base, ...extra];
-      const validation = validateTripPhotoFiles(next);
-      if (!validation.ok) {
-        setUploadError(validation.message);
-        return current;
+  async function handleStageAddFiles(extra: File[]) {
+    if (optimizing) return;
+    setOptimizing(true);
+    try {
+      const result = await prepareTripPhotoFiles(extra);
+      if (!result.ok) {
+        setUploadError(result.message);
+        return;
       }
-      setUploadError(null);
-      return next;
-    });
+      setStagedFiles((current) => {
+        const next = [...(current ?? []), ...result.files];
+        const validation = validateTripPhotoFiles(next);
+        if (!validation.ok) {
+          setUploadError(validation.message);
+          return current;
+        }
+        setUploadError(null);
+        return next;
+      });
+    } finally {
+      setOptimizing(false);
+    }
   }
 
   function handleStageRemove(index: number) {
@@ -208,7 +225,7 @@ export function PhotosTab() {
   }
 
   function handleStageCancel() {
-    if (uploading) return;
+    if (uploading || optimizing) return;
     setStagedFiles(null);
     setUploadError(null);
   }
@@ -378,15 +395,15 @@ export function PhotosTab() {
             type="button"
             className="mt-4"
             onClick={() => emptyStateInputRef.current?.click()}
-            disabled={uploading}
+            disabled={uploading || optimizing}
           >
             <Upload />
-            Upload photos
+            {optimizing ? "Optimizing…" : "Upload photos"}
           </Button>
           <input
             ref={emptyStateInputRef}
             type="file"
-            accept="image/jpeg,image/png,image/webp"
+            accept={IMAGE_INPUT_ACCEPT}
             multiple
             className="hidden"
             onChange={(event) => {
@@ -484,15 +501,20 @@ export function PhotosTab() {
           onCancel={handleExitSelection}
         />
       ) : (
-        <UploadFab onFilesSelected={handleFilesSelected} uploading={uploading} />
+        <UploadFab
+          onFilesSelected={(files) => void handleFilesSelected(files)}
+          uploading={uploading}
+          optimizing={optimizing}
+        />
       )}
 
       <UploadReviewDialog
         open={stagedFiles !== null}
         files={stagedFiles ?? []}
         uploading={uploading}
+        optimizing={optimizing}
         error={uploadError}
-        onAddFiles={handleStageAddFiles}
+        onAddFiles={(extra) => void handleStageAddFiles(extra)}
         onRemoveFile={handleStageRemove}
         onCancel={handleStageCancel}
         onConfirm={() => void handleStageConfirm()}

--- a/frontend/features/trips/presentation/upload-fab.tsx
+++ b/frontend/features/trips/presentation/upload-fab.tsx
@@ -3,22 +3,25 @@
 import { Loader2, Upload } from "lucide-react";
 import { useRef } from "react";
 
+import { IMAGE_INPUT_ACCEPT } from "@/shared/lib/image-preprocess";
 import { Button } from "@/shared/ui/button";
 
 export type UploadFabProps = {
   onFilesSelected: (files: File[]) => void;
   uploading: boolean;
+  optimizing: boolean;
 };
 
-export function UploadFab({ onFilesSelected, uploading }: UploadFabProps) {
+export function UploadFab({ onFilesSelected, uploading, optimizing }: UploadFabProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const busy = uploading || optimizing;
 
   return (
     <>
       <input
         ref={inputRef}
         type="file"
-        accept="image/jpeg,image/png,image/webp"
+        accept={IMAGE_INPUT_ACCEPT}
         multiple
         className="hidden"
         onChange={(event) => {
@@ -30,11 +33,11 @@ export function UploadFab({ onFilesSelected, uploading }: UploadFabProps) {
       <Button
         type="button"
         onClick={() => inputRef.current?.click()}
-        disabled={uploading}
+        disabled={busy}
         className="fixed bottom-6 right-6 z-30 h-12 rounded-full px-5 shadow-lg"
       >
-        {uploading ? <Loader2 className="animate-spin" /> : <Upload />}
-        {uploading ? "Uploading…" : "Upload"}
+        {busy ? <Loader2 className="animate-spin" /> : <Upload />}
+        {uploading ? "Uploading…" : optimizing ? "Optimizing…" : "Upload"}
       </Button>
     </>
   );

--- a/frontend/features/trips/presentation/upload-review-dialog.test.tsx
+++ b/frontend/features/trips/presentation/upload-review-dialog.test.tsx
@@ -35,6 +35,7 @@ describe("UploadReviewDialog", () => {
         open
         files={files}
         uploading={false}
+        optimizing={false}
         error={null}
         onAddFiles={vi.fn()}
         onRemoveFile={vi.fn()}
@@ -58,6 +59,7 @@ describe("UploadReviewDialog", () => {
         open
         files={files}
         uploading={false}
+        optimizing={false}
         error={null}
         onAddFiles={vi.fn()}
         onRemoveFile={onRemoveFile}
@@ -76,6 +78,7 @@ describe("UploadReviewDialog", () => {
         open
         files={[]}
         uploading={false}
+        optimizing={false}
         error={null}
         onAddFiles={vi.fn()}
         onRemoveFile={vi.fn()}
@@ -93,6 +96,7 @@ describe("UploadReviewDialog", () => {
         open
         files={[makeFile("a.jpg")]}
         uploading={false}
+        optimizing={false}
         error="Network error."
         onAddFiles={vi.fn()}
         onRemoveFile={vi.fn()}
@@ -113,6 +117,7 @@ describe("UploadReviewDialog", () => {
         open
         files={[makeFile("a.jpg")]}
         uploading={false}
+        optimizing={false}
         error={null}
         onAddFiles={vi.fn()}
         onRemoveFile={vi.fn()}
@@ -135,6 +140,7 @@ describe("UploadReviewDialog", () => {
         open
         files={[existing]}
         uploading={false}
+        optimizing={false}
         error={null}
         onAddFiles={onAddFiles}
         onRemoveFile={vi.fn()}
@@ -171,6 +177,7 @@ describe("UploadReviewDialog", () => {
         open
         files={[file]}
         uploading={false}
+        optimizing={false}
         error={null}
         onAddFiles={vi.fn()}
         onRemoveFile={vi.fn()}
@@ -186,6 +193,7 @@ describe("UploadReviewDialog", () => {
         open={false}
         files={[file]}
         uploading={false}
+        optimizing={false}
         error={null}
         onAddFiles={vi.fn()}
         onRemoveFile={vi.fn()}

--- a/frontend/features/trips/presentation/upload-review-dialog.test.tsx
+++ b/frontend/features/trips/presentation/upload-review-dialog.test.tsx
@@ -170,6 +170,28 @@ describe("UploadReviewDialog", () => {
     expect(onAddFiles.mock.calls[0][0][0].name).toBe("c.jpg");
   });
 
+  it("shows the optimizing status and disables actions while preprocessing", () => {
+    render(
+      <UploadReviewDialog
+        open
+        files={[makeFile("a.jpg")]}
+        uploading={false}
+        optimizing
+        error={null}
+        onAddFiles={vi.fn()}
+        onRemoveFile={vi.fn()}
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent("Optimizing photos…");
+    expect(screen.getByRole("button", { name: "Upload 1 photo" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Add more" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Remove a.jpg" })).toBeDisabled();
+  });
+
   it("revokes object URLs for staged files when the file list changes or the dialog closes", () => {
     const file = makeFile("a.jpg");
     const { rerender } = render(

--- a/frontend/features/trips/presentation/upload-review-dialog.tsx
+++ b/frontend/features/trips/presentation/upload-review-dialog.tsx
@@ -5,6 +5,7 @@
 import { Loader2, Plus, X } from "lucide-react";
 import { useEffect, useMemo, useRef } from "react";
 
+import { IMAGE_INPUT_ACCEPT } from "@/shared/lib/image-preprocess";
 import { Button } from "@/shared/ui/button";
 import {
   Dialog,
@@ -32,6 +33,7 @@ export type UploadReviewDialogProps = {
   open: boolean;
   files: File[];
   uploading: boolean;
+  optimizing: boolean;
   error: string | null;
   onAddFiles: (extra: File[]) => void;
   onRemoveFile: (index: number) => void;
@@ -43,6 +45,7 @@ export function UploadReviewDialog({
   open,
   files,
   uploading,
+  optimizing,
   error,
   onAddFiles,
   onRemoveFile,
@@ -74,7 +77,7 @@ export function UploadReviewDialog({
       : `${count} photos · ${formatBytes(totalBytes)}`;
 
   return (
-    <Dialog open={open} onOpenChange={(next) => !next && !uploading && onCancel()}>
+    <Dialog open={open} onOpenChange={(next) => !next && !uploading && !optimizing && onCancel()}>
       <DialogContent className="max-w-2xl">
         <DialogHeader>
           <DialogTitle>Review photos</DialogTitle>
@@ -96,7 +99,7 @@ export function UploadReviewDialog({
                 type="button"
                 aria-label={`Remove ${file.name}`}
                 onClick={() => onRemoveFile(index)}
-                disabled={uploading}
+                disabled={uploading || optimizing}
                 className="absolute right-1 top-1 flex size-6 items-center justify-center rounded-full bg-black/60 text-white transition-colors hover:bg-black/80 disabled:opacity-50"
               >
                 <X className="size-3.5" />
@@ -107,7 +110,7 @@ export function UploadReviewDialog({
             <input
               ref={addMoreInputRef}
               type="file"
-              accept="image/jpeg,image/png,image/webp"
+              accept={IMAGE_INPUT_ACCEPT}
               multiple
               className="hidden"
               onChange={(event) => {
@@ -124,7 +127,7 @@ export function UploadReviewDialog({
               type="button"
               aria-label="Add more"
               onClick={() => addMoreInputRef.current?.click()}
-              disabled={uploading}
+              disabled={uploading || optimizing}
               className="flex h-full w-full flex-col items-center justify-center gap-1 text-xs disabled:opacity-50"
             >
               <Plus className="size-5" />
@@ -132,6 +135,12 @@ export function UploadReviewDialog({
             </button>
           </div>
         </div>
+
+        {optimizing ? (
+          <p className="text-sm text-muted-foreground" role="status">
+            Optimizing photos…
+          </p>
+        ) : null}
 
         {error ? (
           <div
@@ -143,10 +152,10 @@ export function UploadReviewDialog({
         ) : null}
 
         <DialogFooter>
-          <Button type="button" variant="ghost" onClick={onCancel} disabled={uploading}>
+          <Button type="button" variant="ghost" onClick={onCancel} disabled={uploading || optimizing}>
             Cancel
           </Button>
-          <Button type="button" onClick={onConfirm} disabled={uploading || count === 0}>
+          <Button type="button" onClick={onConfirm} disabled={uploading || optimizing || count === 0}>
             {uploading ? <Loader2 className="animate-spin" /> : null}
             {uploadLabel}
           </Button>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "heic-to": "^1.5.2",
         "lucide-react": "^0.576.0",
         "next": "16.2.5",
         "radix-ui": "^1.4.3",
@@ -5055,6 +5056,7 @@
       "version": "19.2.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -5064,7 +5066,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -6871,6 +6873,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -9091,6 +9094,12 @@
       "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/heic-to": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/heic-to/-/heic-to-1.5.2.tgz",
+      "integrity": "sha512-8Fns+lZHAWmz5U5IUxDeXKwIf3foBoKNPLxxFY4B0MkLjNuomEIHCoDbDE+x/llFK3NCEO1cu4+n3iUKY+Svmw==",
+      "license": "LGPL-3.0"
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "heic-to": "^1.5.2",
     "lucide-react": "^0.576.0",
     "next": "16.2.5",
     "radix-ui": "^1.4.3",

--- a/frontend/shared/lib/image-preprocess.test.ts
+++ b/frontend/shared/lib/image-preprocess.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifySource,
+  scaledDimensions,
+  webpFileName,
+} from "@/shared/lib/image-preprocess";
+
+describe("classifySource", () => {
+  it("detects HEIC by MIME type and by extension", () => {
+    expect(classifySource({ name: "a.heic", type: "image/heic" })).toBe("heic");
+    expect(classifySource({ name: "b.HEIF", type: "" })).toBe("heic");
+    expect(classifySource({ name: "c.heic", type: "application/octet-stream" })).toBe("heic");
+  });
+
+  it("treats JPEG/PNG/WebP as standard", () => {
+    expect(classifySource({ name: "a.jpg", type: "image/jpeg" })).toBe("standard");
+    expect(classifySource({ name: "b.png", type: "image/png" })).toBe("standard");
+    expect(classifySource({ name: "c.webp", type: "image/webp" })).toBe("standard");
+  });
+
+  it("lets empty or generic binary MIME through as standard so decode decides", () => {
+    expect(classifySource({ name: "photo.jpg", type: "" })).toBe("standard");
+    expect(classifySource({ name: "photo.jpg", type: "application/octet-stream" })).toBe("standard");
+  });
+
+  it("rejects SVG and known non-image types", () => {
+    expect(classifySource({ name: "x.svg", type: "image/svg+xml" })).toBe("unsupported");
+    expect(classifySource({ name: "x.SVG", type: "" })).toBe("unsupported");
+    expect(classifySource({ name: "doc.pdf", type: "application/pdf" })).toBe("unsupported");
+  });
+});
+
+describe("scaledDimensions", () => {
+  it("returns input unchanged when the long edge fits", () => {
+    expect(scaledDimensions(2560, 1440, 2560)).toEqual({ width: 2560, height: 1440 });
+  });
+
+  it("scales the long edge down to the cap preserving aspect ratio", () => {
+    expect(scaledDimensions(4000, 3000, 2560)).toEqual({ width: 2560, height: 1920 });
+    expect(scaledDimensions(3000, 4000, 2560)).toEqual({ width: 1920, height: 2560 });
+  });
+
+  it("never returns dimensions below 1", () => {
+    expect(scaledDimensions(10000, 1, 2560)).toEqual({ width: 2560, height: 1 });
+  });
+});
+
+describe("webpFileName", () => {
+  it("swaps the extension for .webp", () => {
+    expect(webpFileName("IMG_0001.HEIC")).toBe("IMG_0001.webp");
+    expect(webpFileName("photo.jpeg")).toBe("photo.webp");
+  });
+
+  it("handles names without an extension", () => {
+    expect(webpFileName("photo")).toBe("photo.webp");
+    expect(webpFileName("")).toBe("photo.webp");
+  });
+});

--- a/frontend/shared/lib/image-preprocess.test.ts
+++ b/frontend/shared/lib/image-preprocess.test.ts
@@ -1,9 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   classifySource,
   scaledDimensions,
   webpFileName,
+  preprocessImageFile,
+  type DecodedBitmap,
+  type ImageCodec,
 } from "@/shared/lib/image-preprocess";
 
 describe("classifySource", () => {
@@ -55,5 +58,135 @@ describe("webpFileName", () => {
   it("handles names without an extension", () => {
     expect(webpFileName("photo")).toBe("photo.webp");
     expect(webpFileName("")).toBe("photo.webp");
+  });
+});
+
+function fakeBitmap(width: number, height: number): DecodedBitmap & { close: ReturnType<typeof vi.fn> } {
+  return { width, height, source: {}, close: vi.fn() };
+}
+
+function fakeCodec(overrides: Partial<ImageCodec> = {}): ImageCodec {
+  return {
+    decode: vi.fn().mockRejectedValue(new Error("decode not stubbed")),
+    encodeWebP: vi.fn().mockRejectedValue(new Error("encode not stubbed")),
+    decodeHeic: vi.fn().mockRejectedValue(new Error("heic not stubbed")),
+    ...overrides,
+  };
+}
+
+const TARGET = { maxEdgePx: 2560, maxBytes: 10 * 1024 * 1024 };
+
+describe("preprocessImageFile", () => {
+  it("passes small standard files through untouched", async () => {
+    const file = new File(["x"], "small.jpg", { type: "image/jpeg" });
+    const bitmap = fakeBitmap(1200, 800);
+    const codec = fakeCodec({ decode: vi.fn().mockResolvedValue(bitmap) });
+
+    const result = await preprocessImageFile(file, TARGET, codec);
+
+    expect(result).toEqual({ ok: true, file, wasProcessed: false });
+    expect(codec.encodeWebP).not.toHaveBeenCalled();
+    expect(bitmap.close).toHaveBeenCalled();
+  });
+
+  it("downscales and re-encodes oversized standard files to WebP", async () => {
+    const file = new File(["x"], "big.png", { type: "image/png" });
+    const bitmap = fakeBitmap(4000, 3000);
+    const encoded = new Blob(["webp"], { type: "image/webp" });
+    const codec = fakeCodec({
+      decode: vi.fn().mockResolvedValue(bitmap),
+      encodeWebP: vi.fn().mockResolvedValue(encoded),
+    });
+
+    const result = await preprocessImageFile(file, TARGET, codec);
+
+    expect(codec.encodeWebP).toHaveBeenCalledWith(bitmap, 2560, 1920, 0.9);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.wasProcessed).toBe(true);
+      expect(result.file.name).toBe("big.webp");
+      expect(result.file.type).toBe("image/webp");
+    }
+    expect(bitmap.close).toHaveBeenCalled();
+  });
+
+  it("re-encodes within-edge files that exceed the byte budget", async () => {
+    const big = new Uint8Array(11 * 1024 * 1024);
+    const file = new File([big], "huge.jpg", { type: "image/jpeg" });
+    const bitmap = fakeBitmap(2400, 1600);
+    const codec = fakeCodec({
+      decode: vi.fn().mockResolvedValue(bitmap),
+      encodeWebP: vi.fn().mockResolvedValue(new Blob(["small"], { type: "image/webp" })),
+    });
+
+    const result = await preprocessImageFile(file, TARGET, codec);
+
+    expect(codec.encodeWebP).toHaveBeenCalledWith(bitmap, 2400, 1600, 0.9);
+    expect(result.ok && result.wasProcessed).toBe(true);
+  });
+
+  it("steps quality down until the encoded size fits", async () => {
+    const file = new File(["x"], "big.jpg", { type: "image/jpeg" });
+    const bitmap = fakeBitmap(8000, 6000);
+    const tooBig = { size: TARGET.maxBytes + 1 } as Blob;
+    const fits = new Blob(["ok"], { type: "image/webp" });
+    const encodeWebP = vi.fn().mockResolvedValueOnce(tooBig).mockResolvedValueOnce(fits);
+    const codec = fakeCodec({
+      decode: vi.fn().mockResolvedValue(bitmap),
+      encodeWebP,
+    });
+
+    const result = await preprocessImageFile(file, TARGET, codec);
+
+    expect(encodeWebP).toHaveBeenNthCalledWith(1, bitmap, 2560, 1920, 0.9);
+    expect(encodeWebP).toHaveBeenNthCalledWith(2, bitmap, 2560, 1920, 0.8);
+    expect(result.ok).toBe(true);
+  });
+
+  it("decodes HEIC first, then re-encodes even when dimensions fit", async () => {
+    const file = new File(["x"], "IMG_0001.HEIC", { type: "image/heic" });
+    const intermediate = new Blob(["jpeg"], { type: "image/jpeg" });
+    const bitmap = fakeBitmap(2000, 1500);
+    const codec = fakeCodec({
+      decodeHeic: vi.fn().mockResolvedValue(intermediate),
+      decode: vi.fn().mockResolvedValue(bitmap),
+      encodeWebP: vi.fn().mockResolvedValue(new Blob(["webp"], { type: "image/webp" })),
+    });
+
+    const result = await preprocessImageFile(file, TARGET, codec);
+
+    expect(codec.decodeHeic).toHaveBeenCalledWith(file);
+    expect(codec.decode).toHaveBeenCalledWith(intermediate);
+    expect(codec.encodeWebP).toHaveBeenCalledWith(bitmap, 2000, 1500, 0.9);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.file.name).toBe("IMG_0001.webp");
+  });
+
+  it("returns UNSUPPORTED for SVG without touching the codec", async () => {
+    const file = new File(["<svg/>"], "x.svg", { type: "image/svg+xml" });
+    const codec = fakeCodec();
+
+    const result = await preprocessImageFile(file, TARGET, codec);
+
+    expect(result).toEqual({ ok: false, code: "UNSUPPORTED" });
+    expect(codec.decode).not.toHaveBeenCalled();
+  });
+
+  it("returns UNREADABLE when HEIC decoding fails", async () => {
+    const file = new File(["x"], "broken.heic", { type: "image/heic" });
+    const codec = fakeCodec({ decodeHeic: vi.fn().mockRejectedValue(new Error("boom")) });
+
+    const result = await preprocessImageFile(file, TARGET, codec);
+
+    expect(result).toEqual({ ok: false, code: "UNREADABLE" });
+  });
+
+  it("returns UNREADABLE when bitmap decoding fails", async () => {
+    const file = new File(["x"], "corrupt.jpg", { type: "image/jpeg" });
+    const codec = fakeCodec({ decode: vi.fn().mockRejectedValue(new Error("boom")) });
+
+    const result = await preprocessImageFile(file, TARGET, codec);
+
+    expect(result).toEqual({ ok: false, code: "UNREADABLE" });
   });
 });

--- a/frontend/shared/lib/image-preprocess.ts
+++ b/frontend/shared/lib/image-preprocess.ts
@@ -145,6 +145,9 @@ export async function preprocessImageFile(
       if (encoded.size <= target.maxBytes) break;
     }
     if (!encoded || encoded.size > target.maxBytes) {
+      // Budget exhausted even at the lowest quality step. Practically
+      // unreachable at 2560px WebP except when the encoder ignores quality
+      // (e.g. old Safari falls back to lossless PNG bytes for toBlob WebP).
       return { ok: false, code: "UNREADABLE" };
     }
     return {

--- a/frontend/shared/lib/image-preprocess.ts
+++ b/frontend/shared/lib/image-preprocess.ts
@@ -1,0 +1,48 @@
+/**
+ * Client-side image preprocessing: downscale oversized images and decode HEIC
+ * before validation/upload, instead of hard-rejecting them. Targets mirror what
+ * the server keeps (it never stores originals), so nothing of value is lost.
+ */
+
+export const IMAGE_INPUT_ACCEPT =
+  "image/jpeg,image/png,image/webp,image/heic,image/heif,.heic,.heif";
+
+const STANDARD_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
+const HEIC_TYPES = new Set(["image/heic", "image/heif"]);
+const GENERIC_BINARY_TYPES = new Set([
+  "application/octet-stream",
+  "binary/octet-stream",
+]);
+
+export type SourceKind = "standard" | "heic" | "unsupported";
+
+export function classifySource(file: Pick<File, "name" | "type">): SourceKind {
+  const name = file.name.toLowerCase();
+  if (HEIC_TYPES.has(file.type) || name.endsWith(".heic") || name.endsWith(".heif")) {
+    return "heic";
+  }
+  if (file.type === "image/svg+xml" || name.endsWith(".svg")) return "unsupported";
+  if (STANDARD_TYPES.has(file.type)) return "standard";
+  // Empty/generic MIME happens on some platforms; let decoding decide.
+  if (file.type === "" || GENERIC_BINARY_TYPES.has(file.type)) return "standard";
+  return "unsupported";
+}
+
+export function scaledDimensions(
+  width: number,
+  height: number,
+  maxEdgePx: number,
+): { width: number; height: number } {
+  const longEdge = Math.max(width, height);
+  if (longEdge <= maxEdgePx) return { width, height };
+  const scale = maxEdgePx / longEdge;
+  return {
+    width: Math.max(1, Math.round(width * scale)),
+    height: Math.max(1, Math.round(height * scale)),
+  };
+}
+
+export function webpFileName(name: string): string {
+  const base = name.replace(/\.[^.]+$/, "");
+  return `${base || "photo"}.webp`;
+}

--- a/frontend/shared/lib/image-preprocess.ts
+++ b/frontend/shared/lib/image-preprocess.ts
@@ -4,6 +4,8 @@
  * the server keeps (it never stores originals), so nothing of value is lost.
  */
 
+import { compressImageToWebP } from "@/shared/lib/image";
+
 export const IMAGE_INPUT_ACCEPT =
   "image/jpeg,image/png,image/webp,image/heic,image/heif,.heic,.heif";
 
@@ -13,6 +15,7 @@ const GENERIC_BINARY_TYPES = new Set([
   "application/octet-stream",
   "binary/octet-stream",
 ]);
+const QUALITY_STEPS = [0.9, 0.8, 0.7];
 
 export type SourceKind = "standard" | "heic" | "unsupported";
 
@@ -45,4 +48,113 @@ export function scaledDimensions(
 export function webpFileName(name: string): string {
   const base = name.replace(/\.[^.]+$/, "");
   return `${base || "photo"}.webp`;
+}
+
+export type PreprocessTarget = {
+  /** Max long edge after processing, in pixels. */
+  maxEdgePx: number;
+  /** Max encoded size, in bytes. */
+  maxBytes: number;
+};
+
+export type PreprocessResult =
+  | { ok: true; file: File; wasProcessed: boolean }
+  | { ok: false; code: "UNSUPPORTED" | "UNREADABLE" };
+
+export type DecodedBitmap = {
+  width: number;
+  height: number;
+  source: unknown;
+  close(): void;
+};
+
+export type ImageCodec = {
+  decode(blob: Blob): Promise<DecodedBitmap>;
+  encodeWebP(
+    bitmap: DecodedBitmap,
+    width: number,
+    height: number,
+    quality: number,
+  ): Promise<Blob>;
+  /** Decode HEIC/HEIF into a JPEG blob; lazy-loads the WASM decoder. */
+  decodeHeic(file: File): Promise<Blob>;
+};
+
+export const browserImageCodec: ImageCodec = {
+  async decode(blob) {
+    // createImageBitmap applies EXIF orientation by default ("from-image").
+    const bitmap = await createImageBitmap(blob);
+    return {
+      width: bitmap.width,
+      height: bitmap.height,
+      source: bitmap,
+      close: () => bitmap.close(),
+    };
+  },
+  async encodeWebP(decoded, width, height, quality) {
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("Canvas 2D context unavailable.");
+    ctx.imageSmoothingQuality = "high";
+    ctx.drawImage(decoded.source as ImageBitmap, 0, 0, width, height);
+    return compressImageToWebP(canvas, quality);
+  },
+  async decodeHeic(file) {
+    const { heicTo } = await import("heic-to");
+    return heicTo({ blob: file, type: "image/jpeg", quality: 0.92 });
+  },
+};
+
+export async function preprocessImageFile(
+  file: File,
+  target: PreprocessTarget,
+  codec: ImageCodec = browserImageCodec,
+): Promise<PreprocessResult> {
+  const kind = classifySource(file);
+  if (kind === "unsupported") return { ok: false, code: "UNSUPPORTED" };
+
+  let sourceBlob: Blob = file;
+  if (kind === "heic") {
+    try {
+      sourceBlob = await codec.decodeHeic(file);
+    } catch {
+      return { ok: false, code: "UNREADABLE" };
+    }
+  }
+
+  let bitmap: DecodedBitmap;
+  try {
+    bitmap = await codec.decode(sourceBlob);
+  } catch {
+    return { ok: false, code: "UNREADABLE" };
+  }
+
+  try {
+    const fitsAsIs =
+      kind === "standard" &&
+      file.size <= target.maxBytes &&
+      Math.max(bitmap.width, bitmap.height) <= target.maxEdgePx;
+    if (fitsAsIs) return { ok: true, file, wasProcessed: false };
+
+    const { width, height } = scaledDimensions(bitmap.width, bitmap.height, target.maxEdgePx);
+    let encoded: Blob | null = null;
+    for (const quality of QUALITY_STEPS) {
+      encoded = await codec.encodeWebP(bitmap, width, height, quality);
+      if (encoded.size <= target.maxBytes) break;
+    }
+    if (!encoded || encoded.size > target.maxBytes) {
+      return { ok: false, code: "UNREADABLE" };
+    }
+    return {
+      ok: true,
+      file: new File([encoded], webpFileName(file.name), { type: "image/webp" }),
+      wasProcessed: true,
+    };
+  } catch {
+    return { ok: false, code: "UNREADABLE" };
+  } finally {
+    bitmap.close();
+  }
 }


### PR DESCRIPTION
Closes #46

## What changed

Instead of hard-rejecting oversized/HEIC images, the frontend now normalizes them client-side before validation/upload:

- **New shared module `shared/lib/image-preprocess.ts`** — classify source (JPEG/PNG/WebP vs HEIC vs unsupported), decode HEIC via lazy-loaded `heic-to` (WASM, dynamic-import-only chunk, verified absent from main bundle), downscale to a max long edge with canvas, re-encode WebP q0.9→0.8→0.7. Injectable `ImageCodec` seam keeps logic unit-testable in jsdom. Fast path: already-valid files pass through untouched (zero re-encode, no quality loss).
- **Avatar dialog** — the old 1024×1024 source rejection is gone; sources are downscaled to 2048px for the cropper (final output is still 512px WebP). HEIC accepted. Stale-result guard ignores preprocess results that resolve after the dialog closes.
- **Photos tab** — files are preprocessed (2560px = server `TRIP_PHOTO_MEDIUM_MAX_EDGE`, 10 MiB) before staging, with an "Optimizing…" state across FAB/empty state/review dialog. 20-file and 50 MiB-total limits still enforced on processed output.
- **Cover picker** — preprocess (2560px = `TRIP_COVER_MAX_EDGE`) before upload, HEIC accepted.
- **HEIC-specific rejects removed** from `validateTripPhotoFiles` and the photos BFF route — raw HEIC at the BFF now falls into the generic `UNSUPPORTED_IMAGE_TYPE` reject.

**No server or BFF limit changed** — Django remains the authoritative safety net (magic-byte/PIL probing unchanged).

## Known accepted trade-offs

- The review-dialog "Add more" dedupe compares raw picks against processed staged files, so re-picking the same photo can stage it twice (user can remove it).
- The BFF no longer extension-rejects `.heic` files carrying a generic/empty MIME; they are forwarded and rejected by Django's byte probe. Net effect unchanged (no raw HEIC is ever stored); the reject just happens one layer deeper.
- Django still emits `HEIC_UNSUPPORTED` for that path; the frontend keeps a defensive mapping for it (decode-failure copy).
- Cover button shows "Uploading…" during the preprocess phase (single busy state).
- The decode-failure copy string is duplicated across three modules (kept in sync by tests); candidate for a shared constant if it grows.

## Verification

- `npm run test`: 556/556 passing (98 files)
- `npm run lint`: clean
- `npm run build`: succeeds
- `tsc --noEmit`: no new errors (two pre-existing errors in `use-trip-chat.test.tsx` / `use-in-view.test.tsx` are untouched by this branch)
- Manual verification with real photos (large JPEG, EXIF-rotated portrait, iPhone HEIC) still recommended before merge — see checklist in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)