### PR TITLE
chore(mobile): add expo-dev-client for network-flexible dev builds

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^1.18.1",
         "expo": "~57.0.2",
         "expo-constants": "~57.0.3",
+        "expo-dev-client": "~57.0.5",
         "expo-device": "~57.0.0",
         "expo-font": "~57.0.0",
         "expo-glass-effect": "~57.0.0",
@@ -7539,6 +7540,59 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-dev-client": {
+      "version": "57.0.5",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-57.0.5.tgz",
+      "integrity": "sha512-OOQJHb4Cf403AhZAbcZg0OOVJKLc1HArVck92LHd9PO2HuTadj/6YAlWIyXXYfeYYdjoVgLd/cAXnaEAwp6HKg==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-launcher": "~57.0.5",
+        "expo-dev-menu": "~57.0.5",
+        "expo-dev-menu-interface": "~57.0.0",
+        "expo-manifests": "~57.0.0",
+        "expo-updates-interface": "~57.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-launcher": {
+      "version": "57.0.5",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-57.0.5.tgz",
+      "integrity": "sha512-f76DIU/mF3YdDZOgwLL3A5gwb3NVIySLE5ot+gy1T0pFo6VPW3Ew7h8oyG9fQdYum58v/3LoB1uWAIhhkHhsqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/schema-utils": "^57.0.1",
+        "expo-dev-menu": "~57.0.5",
+        "expo-manifests": "~57.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-dev-menu": {
+      "version": "57.0.5",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-57.0.5.tgz",
+      "integrity": "sha512-ITQdZBawOe7Z9aB9erLNKIM/0X1iL6VvTrC5By6ECQqTptiRLJmpeqCt1vCJ72Wz+8YeHk+n2GY5V+1yzXf5OA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-menu-interface": "~57.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-dev-menu-interface": {
+      "version": "57.0.0",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-57.0.0.tgz",
+      "integrity": "sha512-F47VdzOHYc19FhI/jBgctpO8a5UskTIxG6a1E5t3W5gF8VImuvBQffdXXfLHhsuCl7dS3v3U0R45cleeVXO1Zg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-device": {
       "version": "57.0.0",
       "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-57.0.0.tgz",
@@ -7606,6 +7660,12 @@
         }
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "57.0.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-57.0.0.tgz",
+      "integrity": "sha512-GJMjJlS3ZRTXWkKJPXY9OjscEEyPxbvNURBJ9Gkd3KxS4Hzof+EdK8pF+3Ty4ec435ciYm9ll+IWznuVHYMiow==",
+      "license": "MIT"
+    },
     "node_modules/expo-keep-awake": {
       "version": "57.0.0",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-57.0.0.tgz",
@@ -7628,6 +7688,18 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "57.0.0",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-57.0.0.tgz",
+      "integrity": "sha512-JDKDuF1gd3wPywhu+VzH+qFNDlu91Unqpcre6R9b14MEMq5L3mG6XL9LOySChiWlLJAoObeNPdVV7Od6P++49g==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-json-utils": "~57.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -7826,6 +7898,15 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "57.0.0",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-57.0.0.tgz",
+      "integrity": "sha512-AQASxPDpUjHG55R4WXZ5mLu0rE4F2T/JfHOsXLfZPS1A268ynHHFv+MnZ99/Gb0xWvg3ZjNTgXPEWoRCShSJJg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-web-browser": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -8,6 +8,7 @@
     "axios": "^1.18.1",
     "expo": "~57.0.2",
     "expo-constants": "~57.0.3",
+    "expo-dev-client": "~57.0.5",
     "expo-device": "~57.0.0",
     "expo-font": "~57.0.0",
     "expo-glass-effect": "~57.0.0",


### PR DESCRIPTION
## Summary
- Add `expo-dev-client` (~57.0.5) to the mobile app so the development build includes the Expo dev launcher.
- The dev launcher lets the app pick or enter a Metro server URL at runtime, so switching Wi-Fi networks no longer requires a full rebuild.

## Notes
- Dependency has native code: one rebuild via `npx expo run:ios --device` is required for the installed dev build to pick it up. After that, the normal Wi-Fi + `npx expo start` workflow applies.
- No runtime/production impact — dev-client only affects development builds.

## Verification
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` ✅ (37/37 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)