### PR TITLE
feat(mobile): add trip editing and lifecycle controls

### DIFF
--- a/backend/trips/services.py
+++ b/backend/trips/services.py
@@ -319,6 +319,7 @@ def update_trip(trip, *, name=_UNSET, destination=_UNSET,
     """
     with transaction.atomic():
         trip = Trip.objects.select_for_update().get(pk=trip.pk)
+        _assert_not_terminal(trip)
         old_timezone = trip.timezone
 
         if name is not _UNSET:                       trip.name = name

--- a/backend/trips/tests/test_service_concurrency.py
+++ b/backend/trips/tests/test_service_concurrency.py
@@ -10,7 +10,14 @@ from django.test import TransactionTestCase
 from friends.models import Friendship
 from test_helpers import create_completed_user
 from trips.models import InvitationStatus, MemberStatus, Trip, TripInvitation, TripMember, TripRole, TripStatus
-from trips.services import InviteError, InvitationError, accept_invitation, send_trip_invitations
+from trips.services import (
+    InviteError,
+    InvitationError,
+    TripTerminalError,
+    accept_invitation,
+    send_trip_invitations,
+    update_trip,
+)
 
 
 def _make_friendship(user_a, user_b):
@@ -147,6 +154,45 @@ class TripServiceConcurrencyTests(TransactionTestCase):
         self.assertFalse(TripMember.objects.filter(trip=trip, user=invitee, status=MemberStatus.ACTIVE).exists())
         invitation.refresh_from_db()
         self.assertEqual(invitation.status, InvitationStatus.PENDING)
+
+    def test_update_trip_waits_for_terminal_trip_transition(self):
+        captain = create_completed_user("cap-edit@example.com", "captain_edit", "CAP004")
+        trip = _make_trip(captain, status=TripStatus.ONGOING)
+
+        transition_started = threading.Event()
+        allow_commit = threading.Event()
+
+        def close_trip_worker():
+            with transaction.atomic():
+                locked_trip = Trip.objects.select_for_update().get(pk=trip.pk)
+                locked_trip.status = TripStatus.COMPLETED
+                locked_trip.save(update_fields=["status"])
+                transition_started.set()
+                if not allow_commit.wait(timeout=5):
+                    raise AssertionError("Timed out waiting to commit terminal trip transition.")
+
+        close_thread, close_outcome = self._run_in_thread(close_trip_worker)
+        self.assertTrue(transition_started.wait(timeout=5))
+
+        update_thread, update_outcome = self._run_in_thread(
+            lambda: update_trip(trip, name="Edited after completion")
+        )
+
+        time.sleep(0.2)
+        self.assertTrue(update_thread.is_alive())
+
+        allow_commit.set()
+        update_thread.join(timeout=5)
+        close_thread.join(timeout=5)
+
+        self.assertFalse(close_thread.is_alive())
+        self.assertIsNone(close_outcome.get("error"))
+        self.assertFalse(update_thread.is_alive())
+        self.assertIsInstance(update_outcome.get("error"), TripTerminalError)
+
+        trip.refresh_from_db()
+        self.assertEqual(trip.status, TripStatus.COMPLETED)
+        self.assertEqual(trip.name, "T")
 
     def test_send_trip_invitations_converts_integrity_error_to_business_error(self):
         captain = create_completed_user("cap3@example.com", "captain3", "CAP003")

--- a/backend/trips/tests/test_update_trip.py
+++ b/backend/trips/tests/test_update_trip.py
@@ -4,7 +4,7 @@ from rest_framework.test import APITestCase
 from accounts.tokens import AccessToken
 from test_helpers import create_completed_user
 from trips.models import MemberStatus, Trip, TripMember, TripRole, TripStatus
-from trips.services import TimelineSectionDateConflictError
+from trips.services import TimelineSectionDateConflictError, TripTerminalError
 
 
 def _auth(user):
@@ -130,6 +130,22 @@ class UpdateTripTests(APITestCase):
 
         self.assertEqual(res.status_code, 409)
         self.assertEqual(res.data["error_code"], "SECTION_DATE_CONFLICT")
+
+    @patch("trips.views.update_trip")
+    def test_captain_update_maps_terminal_race_to_409(self, mock_update_trip):
+        mock_update_trip.side_effect = TripTerminalError(
+            "This trip is in a terminal state. No further changes are allowed."
+        )
+
+        res = self.client.patch(
+            self._url(),
+            {"name": "New Name"},
+            format="json",
+            **_auth(self.captain),
+        )
+
+        self.assertEqual(res.status_code, 409)
+        self.assertEqual(res.data["error_code"], "TRIP_TERMINAL")
 
     def test_trip_detail_response_includes_timezone(self):
         res = self.client.get(self._url(), **_auth(self.captain))

--- a/backend/trips/views.py
+++ b/backend/trips/views.py
@@ -208,6 +208,11 @@ class TripDetailUpdateAPIView(APIView):
                 {"detail": str(exc), "error_code": exc.error_code},
                 status=status.HTTP_409_CONFLICT,
             )
+        except TripTerminalError as exc:
+            return Response(
+                {"detail": str(exc), "error_code": exc.error_code},
+                status=status.HTTP_409_CONFLICT,
+            )
         return Response({"trip": TripDetailSerializer(updated).data})
 
 

--- a/mobile/src/app/trips/[tripId]/edit.tsx
+++ b/mobile/src/app/trips/[tripId]/edit.tsx
@@ -1,0 +1,3 @@
+import { EditTripScreen } from '@/features/trips/screens/EditTripScreen';
+
+export default EditTripScreen;

--- a/mobile/src/app/trips/__tests__/_layout.test.tsx
+++ b/mobile/src/app/trips/__tests__/_layout.test.tsx
@@ -1,8 +1,4 @@
-const mockRouter = {
-  canGoBack: jest.fn(),
-  back: jest.fn(),
-  replace: jest.fn(),
-};
+const mockRouter = { canGoBack: jest.fn(), back: jest.fn(), replace: jest.fn() };
 const mockUseSession = jest.fn();
 
 jest.mock('expo-router', () => {
@@ -14,11 +10,13 @@ jest.mock('expo-router', () => {
   }
 
   MockStack.Screen = function MockStackScreen({
+    name,
     options,
   }: {
-    options: { headerLeft?: () => import('react').ReactNode };
+    name: string;
+    options: { title: string; headerLeft?: () => import('react').ReactNode };
   }) {
-    return React.createElement(View, null, options.headerLeft?.());
+    return React.createElement(View, { testID: `screen-${name}` }, options.headerLeft?.());
   };
 
   return {
@@ -29,14 +27,8 @@ jest.mock('expo-router', () => {
 });
 
 jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
-
-jest.mock('@/features/auth/session', () => ({
-  useSession: () => mockUseSession(),
-}));
-
-jest.mock('@/shared/ui/LoadingScreen', () => ({
-  LoadingScreen: () => null,
-}));
+jest.mock('@/features/auth/session', () => ({ useSession: () => mockUseSession() }));
+jest.mock('@/shared/ui/LoadingScreen', () => ({ LoadingScreen: () => null }));
 
 // eslint-disable-next-line import/first
 import { fireEvent, render, screen } from '@testing-library/react-native';
@@ -49,45 +41,27 @@ describe('TripsLayout header actions', () => {
     mockUseSession.mockReturnValue({ status: 'signedIn', user: { requires_profile_setup: false } });
   });
 
+  it('registers the edit route as an Edit Trip modal with a cancel action', async () => {
+    await render(<TripsLayout />);
+    expect(screen.getByTestId('screen-[tripId]/edit')).toBeTruthy();
+    expect(screen.getByLabelText('Cancel trip editing')).toBeTruthy();
+  });
+
   it('returns to the previous route from the trip detail header when history exists', async () => {
     mockRouter.canGoBack.mockReturnValue(true);
-
     await render(<TripsLayout />);
     await fireEvent.press(screen.getByLabelText('Back to Trips'));
-
-    expect(screen.getByLabelText('Cancel trip creation')).toBeTruthy();
-    expect(mockRouter.canGoBack).toHaveBeenCalledTimes(1);
     expect(mockRouter.back).toHaveBeenCalledTimes(1);
     expect(mockRouter.replace).not.toHaveBeenCalled();
   });
 
-  it('returns to tabs from the create header when there is no navigation history', async () => {
+  it.each([
+    ['Cancel trip creation'],
+    ['Cancel trip editing'],
+  ])('returns to tabs from %s when there is no navigation history', async (label) => {
     mockRouter.canGoBack.mockReturnValue(false);
-
     await render(<TripsLayout />);
-    await fireEvent.press(screen.getByLabelText('Cancel trip creation'));
-
-    expect(mockRouter.canGoBack).toHaveBeenCalledTimes(1);
-    expect(mockRouter.back).not.toHaveBeenCalled();
-    expect(mockRouter.replace).toHaveBeenCalledWith('/(tabs)');
-  });
-
-  it('returns to the previous route from the create header when history exists', async () => {
-    mockRouter.canGoBack.mockReturnValue(true);
-
-    await render(<TripsLayout />);
-    await fireEvent.press(screen.getByLabelText('Cancel trip creation'));
-
-    expect(mockRouter.back).toHaveBeenCalledTimes(1);
-    expect(mockRouter.replace).not.toHaveBeenCalled();
-  });
-
-  it('returns to tabs from the trip detail header when there is no navigation history', async () => {
-    mockRouter.canGoBack.mockReturnValue(false);
-
-    await render(<TripsLayout />);
-    await fireEvent.press(screen.getByLabelText('Back to Trips'));
-
+    await fireEvent.press(screen.getByLabelText(label));
     expect(mockRouter.back).not.toHaveBeenCalled();
     expect(mockRouter.replace).toHaveBeenCalledWith('/(tabs)');
   });

--- a/mobile/src/app/trips/_layout.tsx
+++ b/mobile/src/app/trips/_layout.tsx
@@ -78,6 +78,20 @@ export default function TripsLayout() {
           ),
         }}
       />
+      <Stack.Screen
+        name="[tripId]/edit"
+        options={{
+          title: 'Edit Trip',
+          presentation: 'modal',
+          headerLeft: () => (
+            <HeaderAction
+              label="Cancel"
+              accessibilityLabel="Cancel trip editing"
+              onPress={leaveTripsRoute}
+            />
+          ),
+        }}
+      />
     </Stack>
   );
 }

--- a/mobile/src/features/trips/__tests__/EditTripScreen.test.tsx
+++ b/mobile/src/features/trips/__tests__/EditTripScreen.test.tsx
@@ -1,0 +1,198 @@
+import { Pressable, Text, View } from 'react-native';
+
+const mockParams = { tripId: 'trip-123' };
+const mockRouter = { dismissTo: jest.fn() };
+const mockUseTripDetail = jest.fn();
+const mockPublishTripEvent = jest.fn();
+
+jest.mock('expo-router', () => ({
+  Stack: { Screen: () => null },
+  useLocalSearchParams: () => mockParams,
+  useRouter: () => mockRouter,
+}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('../hooks/useTripDetail', () => ({ useTripDetail: (...args: unknown[]) => mockUseTripDetail(...args) }));
+jest.mock('../tripEvents', () => ({ publishTripEvent: (...args: unknown[]) => mockPublishTripEvent(...args) }));
+jest.mock('../api', () => ({ updateTrip: jest.fn() }));
+
+interface MockDateFieldProps {
+  label: string;
+  onChange: (date: Date) => void;
+  error?: string;
+}
+
+function MockDateField({ label, onChange, error }: MockDateFieldProps) {
+  return (
+    <View>
+      <Text>{label}</Text>
+      <Pressable accessibilityRole="button" accessibilityLabel={`Set ${label} to June 10`} onPress={() => onChange(new Date(2026, 5, 10))} />
+      {error ? <Text>{error}</Text> : null}
+    </View>
+  );
+}
+
+jest.mock('@/shared/ui/DateField', () => ({ DateField: MockDateField }));
+
+// eslint-disable-next-line import/first
+import { AxiosError, AxiosHeaders } from 'axios';
+// eslint-disable-next-line import/first
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { updateTrip } from '../api';
+// eslint-disable-next-line import/first
+import { EditTripScreen } from '../screens/EditTripScreen';
+// eslint-disable-next-line import/first
+import type { TripDetailResponse } from '../types';
+// eslint-disable-next-line import/first
+import type { ApiError } from '@/shared/api/errors';
+
+const mockUpdateTrip = updateTrip as jest.MockedFunction<typeof updateTrip>;
+const notFoundError: ApiError = { kind: 'message', message: 'Trip not found.', errorCode: 'TRIP_NOT_FOUND', status: 404 };
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, {}, {
+    status,
+    statusText: '',
+    headers: {},
+    config,
+    data,
+  });
+}
+
+const detail: TripDetailResponse = {
+  trip: {
+    id: 'trip-123',
+    name: 'Da Lat escape',
+    destination: 'Da Lat, Vietnam',
+    destination_provider: 'google',
+    destination_provider_id: 'place-123',
+    destination_lat: '11.9404',
+    destination_lng: '108.4583',
+    destination_country_code: 'VN',
+    cover_image_url: '/media/trip-covers/da-lat.jpg',
+    start_date: '2026-06-01',
+    end_date: '2026-06-03',
+    description: 'Mountain air',
+    status: 'PLANNING',
+    currency_code: 'VND',
+    timezone: 'Asia/Ho_Chi_Minh',
+    budget_estimate: '5000000.00',
+    cancelled_at: null,
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  my_membership: { role: 'CAPTAIN', status: 'ACTIVE', joined_at: '2026-01-01T00:00:00Z' },
+  members: [],
+};
+
+function readyHook(nextDetail: TripDetailResponse = detail) {
+  return {
+    detail: nextDetail,
+    status: 'ready' as const,
+    error: null,
+    refresh: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+async function save(): Promise<void> {
+  await fireEvent.press(screen.getByText('Save changes'));
+}
+
+describe('EditTripScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockParams.tripId = 'trip-123';
+    mockUseTripDetail.mockReturnValue(readyHook());
+  });
+
+  it('sends the normalized PATCH payload, clears stale destination metadata, publishes, and dismisses', async () => {
+    const updated = { ...detail.trip, name: 'Summer escape', destination: 'Nha Trang, Vietnam', description: '', budget_estimate: null };
+    mockUpdateTrip.mockResolvedValue(updated);
+    await render(<EditTripScreen />);
+    await fireEvent.changeText(screen.getByLabelText('Trip name'), '  Summer escape  ');
+    await fireEvent.changeText(screen.getByLabelText('Destination'), ' Nha Trang, Vietnam ');
+    await fireEvent.changeText(screen.getByLabelText('Description'), '   ');
+    await fireEvent.changeText(screen.getByLabelText('Budget estimate'), ' ');
+    await fireEvent.press(screen.getByLabelText('Currency USD'));
+    await fireEvent.press(screen.getByLabelText('Timezone Asia/Tokyo'));
+    await save();
+
+    await waitFor(() =>
+      expect(mockUpdateTrip).toHaveBeenCalledWith('trip-123', {
+        name: 'Summer escape',
+        destination: 'Nha Trang, Vietnam',
+        start_date: '2026-06-01',
+        end_date: '2026-06-03',
+        description: '',
+        budget_estimate: null,
+        currency_code: 'USD',
+        timezone: 'Asia/Tokyo',
+        destination_provider: '',
+        destination_provider_id: '',
+        destination_lat: null,
+        destination_lng: null,
+        destination_country_code: '',
+      }),
+    );
+    expect(mockPublishTripEvent).toHaveBeenCalledWith({ type: 'updated', trip: updated });
+    expect(mockRouter.dismissTo).toHaveBeenCalledWith('/trips/trip-123');
+  });
+
+  it('does not clear destination metadata when the destination is unchanged', async () => {
+    mockUpdateTrip.mockResolvedValue(detail.trip);
+    await render(<EditTripScreen />);
+    await save();
+
+    await waitFor(() => expect(mockUpdateTrip).toHaveBeenCalled());
+    expect(mockUpdateTrip.mock.calls[0]?.[1]).not.toHaveProperty('destination_provider');
+  });
+
+  it('blocks duplicate submission while the PATCH is pending', async () => {
+    mockUpdateTrip.mockImplementation(() => new Promise(() => undefined));
+    await render(<EditTripScreen />);
+
+    void fireEvent.press(screen.getByText('Save changes'));
+    await waitFor(() => expect(mockUpdateTrip).toHaveBeenCalledTimes(1));
+    const saveButton = screen.getByRole('button', { name: 'Save changes' });
+    expect(saveButton.props.accessibilityState).toEqual(expect.objectContaining({ disabled: true }));
+    await fireEvent.press(saveButton);
+    expect(mockUpdateTrip).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders backend field and business errors exactly as returned', async () => {
+    mockUpdateTrip.mockRejectedValueOnce(
+      axiosErrorWith(400, { destination: ['Choose a valid destination.'], timezone: ['Use a valid timezone.'] }),
+    );
+    await render(<EditTripScreen />);
+    await save();
+    expect(await screen.findByText('Choose a valid destination.')).toBeTruthy();
+    expect(await screen.findByText('Use a valid timezone.')).toBeTruthy();
+
+    mockUpdateTrip.mockRejectedValueOnce(axiosErrorWith(409, { detail: 'Trip has already been cancelled.' }));
+    await save();
+    expect(await screen.findByText('Trip has already been cancelled.')).toBeTruthy();
+  });
+
+  it('guards direct links for non-captains and terminal trips', async () => {
+    mockUseTripDetail.mockReturnValue(
+      readyHook({ ...detail, my_membership: { ...detail.my_membership, role: 'MEMBER' } }),
+    );
+    const { rerender } = await render(<EditTripScreen />);
+    expect(screen.getByText('Only the active trip captain can edit trip information.')).toBeTruthy();
+    await fireEvent.press(screen.getByText('Back to trip'));
+    expect(mockRouter.dismissTo).toHaveBeenCalledWith('/trips/trip-123');
+
+    mockUseTripDetail.mockReturnValue(readyHook({ ...detail, trip: { ...detail.trip, status: 'COMPLETED' } }));
+    await rerender(<EditTripScreen />);
+    expect(screen.getByText('Completed and cancelled trips can no longer be edited.')).toBeTruthy();
+  });
+
+  it('keeps the generic not-found response non-enumerating', async () => {
+    mockUseTripDetail.mockReturnValue({ ...readyHook(), detail: null, status: 'error', error: notFoundError });
+    await render(<EditTripScreen />);
+    expect(await screen.findByText('Trip not found')).toBeTruthy();
+    expect(screen.getByText('This trip does not exist or you are not a member of it.')).toBeTruthy();
+    expect(screen.queryByText('Try again')).toBeNull();
+  });
+});

--- a/mobile/src/features/trips/__tests__/TripActions.test.tsx
+++ b/mobile/src/features/trips/__tests__/TripActions.test.tsx
@@ -1,0 +1,87 @@
+import { Alert } from 'react-native';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { getTripDisplayActions, TripActions } from '../components/TripActions';
+import type { MyMembership, TripStatus } from '../types';
+
+const activeCaptain: Pick<MyMembership, 'role' | 'status'> = { role: 'CAPTAIN', status: 'ACTIVE' };
+const activeMember: Pick<MyMembership, 'role' | 'status'> = { role: 'MEMBER', status: 'ACTIVE' };
+
+function renderActions(
+  status: TripStatus,
+  membership: Pick<MyMembership, 'role' | 'status'> | null,
+  overrides: Partial<React.ComponentProps<typeof TripActions>> = {},
+) {
+  return render(
+    <TripActions
+      trip={{ status }}
+      membership={membership}
+      isMutating={false}
+      onAction={jest.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+describe('getTripDisplayActions', () => {
+  it.each([
+    ['PLANNING', activeCaptain, ['edit', 'start', 'cancel']],
+    ['ONGOING', activeCaptain, ['edit', 'complete', 'cancel']],
+    ['COMPLETED', activeCaptain, []],
+    ['CANCELLED', activeCaptain, []],
+    ['PLANNING', activeMember, ['leave']],
+    ['ONGOING', activeMember, ['leave']],
+    ['COMPLETED', activeMember, []],
+    ['CANCELLED', activeMember, []],
+  ] as const)('returns %p actions for %p', (status, membership, expected) => {
+    expect(getTripDisplayActions(status, membership)).toEqual(expected);
+  });
+
+  it('returns no actions for missing or inactive membership', () => {
+    expect(getTripDisplayActions('PLANNING', null)).toEqual([]);
+    expect(getTripDisplayActions('PLANNING', { role: 'MEMBER', status: 'LEFT' })).toEqual([]);
+  });
+});
+
+describe('TripActions', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('dispatches edit and start without a confirmation', async () => {
+    const onAction = jest.fn();
+    await renderActions('PLANNING', activeCaptain, { onAction });
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Edit trip' }));
+    expect(onAction).toHaveBeenCalledWith('edit');
+  });
+
+  it('confirms destructive lifecycle actions before dispatching', async () => {
+    const onAction = jest.fn();
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+    await renderActions('ONGOING', activeCaptain, { onAction });
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Complete trip' }));
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Complete this trip?',
+      expect.any(String),
+      expect.arrayContaining([expect.objectContaining({ text: 'Complete trip', style: 'destructive' })]),
+      expect.objectContaining({ cancelable: true }),
+    );
+    expect(onAction).not.toHaveBeenCalled();
+
+    const buttons = alertSpy.mock.calls[0]?.[2];
+    const confirm = buttons?.find((button) => button.text === 'Complete trip');
+    confirm?.onPress?.();
+    expect(onAction).toHaveBeenCalledWith('complete');
+  });
+
+  it('blocks all actions while a mutation is in flight', async () => {
+    const onAction = jest.fn();
+    await renderActions('PLANNING', activeCaptain, { isMutating: true, onAction });
+
+    expect(screen.getByRole('button', { name: 'Edit trip' }).props.accessibilityState).toEqual({ disabled: true });
+    await fireEvent.press(screen.getByRole('button', { name: 'Edit trip' }));
+    expect(onAction).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/features/trips/__tests__/TripDetailScreen.test.tsx
+++ b/mobile/src/features/trips/__tests__/TripDetailScreen.test.tsx
@@ -1,4 +1,10 @@
+import { Alert } from 'react-native';
+
 const mockParams = { tripId: 'trip-123' };
+const mockRouter = { push: jest.fn(), dismissTo: jest.fn() };
+const mockUseTripDetail = jest.fn();
+const mockPublishTripEvent = jest.fn();
+
 interface MockStackScreenProps {
   options: { title: string };
 }
@@ -8,30 +14,38 @@ const mockStackScreen = jest.fn((_props: MockStackScreenProps) => null);
 jest.mock('expo-router', () => ({
   Stack: { Screen: (props: MockStackScreenProps) => mockStackScreen(props) },
   useLocalSearchParams: () => mockParams,
+  useRouter: () => mockRouter,
 }));
 
-jest.mock('@expo/vector-icons', () => ({
-  Ionicons: () => null,
-}));
-
-jest.mock('expo-image', () => ({
-  Image: () => null,
-}));
-
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('expo-image', () => ({ Image: () => null }));
+jest.mock('../hooks/useTripDetail', () => ({ useTripDetail: (...args: unknown[]) => mockUseTripDetail(...args) }));
+jest.mock('../tripEvents', () => ({ publishTripEvent: (...args: unknown[]) => mockPublishTripEvent(...args) }));
 jest.mock('../api', () => ({
-  getTripDetail: jest.fn(),
+  startTrip: jest.fn(),
+  completeTrip: jest.fn(),
+  cancelTrip: jest.fn(),
+  leaveTrip: jest.fn(),
 }));
 
 // eslint-disable-next-line import/first
 import { AxiosError, AxiosHeaders } from 'axios';
 // eslint-disable-next-line import/first
-import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 // eslint-disable-next-line import/first
-import { getTripDetail } from '../api';
+import { cancelTrip, completeTrip, leaveTrip, startTrip } from '../api';
 // eslint-disable-next-line import/first
 import { TripDetailScreen } from '../screens/TripDetailScreen';
+// eslint-disable-next-line import/first
+import type { TripDetailResponse } from '../types';
+// eslint-disable-next-line import/first
+import type { ApiError } from '@/shared/api/errors';
 
-const mockGetTripDetail = getTripDetail as jest.MockedFunction<typeof getTripDetail>;
+const mockStartTrip = startTrip as jest.MockedFunction<typeof startTrip>;
+const mockCompleteTrip = completeTrip as jest.MockedFunction<typeof completeTrip>;
+const mockCancelTrip = cancelTrip as jest.MockedFunction<typeof cancelTrip>;
+const mockLeaveTrip = leaveTrip as jest.MockedFunction<typeof leaveTrip>;
+const notFoundError: ApiError = { kind: 'message', message: 'Trip not found.', errorCode: 'TRIP_NOT_FOUND', status: 404 };
 
 function axiosErrorWith(status: number, data: unknown): AxiosError {
   const config = { headers: new AxiosHeaders() };
@@ -44,7 +58,7 @@ function axiosErrorWith(status: number, data: unknown): AxiosError {
   });
 }
 
-const tripDetail = {
+const tripDetail: TripDetailResponse = {
   trip: {
     id: 'trip-123',
     name: 'Da Lat escape',
@@ -58,82 +72,156 @@ const tripDetail = {
     start_date: '2026-06-01',
     end_date: '2026-06-03',
     description: 'Mountain air and coffee.',
-    status: 'PLANNING' as const,
+    status: 'PLANNING',
     currency_code: 'VND',
     timezone: 'Asia/Ho_Chi_Minh',
     budget_estimate: '5000000.00',
     cancelled_at: null,
     created_at: '2026-01-01T00:00:00Z',
   },
-  my_membership: {
-    role: 'CAPTAIN' as const,
-    status: 'ACTIVE' as const,
-    joined_at: '2026-01-01T00:00:00Z',
-  },
+  my_membership: { role: 'CAPTAIN', status: 'ACTIVE', joined_at: '2026-01-01T00:00:00Z' },
   members: [
     {
       membership_id: 'membership-1',
       user: { id: 'user-1', display_name: 'Quang Minh', identify_tag: 'QUA001', avatar_url: null },
-      role: 'CAPTAIN' as const,
+      role: 'CAPTAIN',
       joined_at: '2026-01-01T00:00:00Z',
-    },
-    {
-      membership_id: 'membership-2',
-      user: { id: 'user-2', display_name: 'An Nguyen', identify_tag: 'ANG002', avatar_url: null },
-      role: 'MEMBER' as const,
-      joined_at: '2026-01-02T00:00:00Z',
     },
   ],
 };
+
+function readyHook(detail: TripDetailResponse = tripDetail) {
+  return {
+    detail,
+    status: 'ready' as const,
+    error: null,
+    refreshing: false,
+    refresh: jest.fn().mockResolvedValue(undefined),
+    applyStatus: jest.fn(),
+  };
+}
+
+async function confirmAlertAction(label: string): Promise<void> {
+  const buttons = jest.mocked(Alert.alert).mock.calls[0]?.[2];
+  const confirm = buttons?.find((button) => button.text === label);
+  await act(async () => {
+    confirm?.onPress?.();
+  });
+}
 
 describe('TripDetailScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockParams.tripId = 'trip-123';
+    mockUseTripDetail.mockReturnValue(readyHook());
   });
 
-  it('renders the trip overview and all members', async () => {
-    mockGetTripDetail.mockResolvedValue(tripDetail);
+  afterEach(() => jest.restoreAllMocks());
 
+  it('renders the trip overview and captain actions, then opens the edit route', async () => {
     await render(<TripDetailScreen />);
 
     expect(await screen.findByText('Overview')).toBeTruthy();
     expect(mockStackScreen.mock.calls.some(([props]) => props.options.title === 'Da Lat escape')).toBe(true);
     expect(screen.getByText('Planning')).toBeTruthy();
     expect(screen.getByText('Da Lat, Vietnam')).toBeTruthy();
-    expect(screen.getByText('Jun 1, 2026 – Jun 3, 2026')).toBeTruthy();
-    expect(screen.getByText('5,000,000 VND')).toBeTruthy();
-    expect(screen.getByText('Mountain air and coffee.')).toBeTruthy();
-    expect(screen.getByText('Members (2)')).toBeTruthy();
-    expect(screen.getByText('Quang Minh')).toBeTruthy();
-    expect(screen.getByText('An Nguyen')).toBeTruthy();
-    expect(mockGetTripDetail).toHaveBeenCalledWith('trip-123');
+    expect(screen.getByText('Members (1)')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Start trip' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Cancel trip' })).toBeTruthy();
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Edit trip' }));
+    expect(mockRouter.push).toHaveBeenCalledWith('/trips/trip-123/edit');
+  });
+
+  it('shows only leave for an active member and no actions for a terminal trip', async () => {
+    mockUseTripDetail.mockReturnValue(
+      readyHook({ ...tripDetail, my_membership: { ...tripDetail.my_membership, role: 'MEMBER' } }),
+    );
+    const { rerender } = await render(<TripDetailScreen />);
+    expect(screen.getByRole('button', { name: 'Leave trip' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Edit trip' })).toBeNull();
+
+    mockUseTripDetail.mockReturnValue(
+      readyHook({ ...tripDetail, trip: { ...tripDetail.trip, status: 'COMPLETED' } }),
+    );
+    await rerender(<TripDetailScreen />);
+    expect(screen.queryByLabelText('Trip actions')).toBeNull();
+  });
+
+  it('applies a successful start immediately, publishes it, and silently refreshes', async () => {
+    const hook = readyHook();
+    mockUseTripDetail.mockReturnValue(hook);
+    mockStartTrip.mockResolvedValue('ONGOING');
+    await render(<TripDetailScreen />);
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Start trip' }));
+
+    await waitFor(() => expect(mockStartTrip).toHaveBeenCalledWith('trip-123'));
+    expect(hook.applyStatus).toHaveBeenCalledWith('ONGOING');
+    expect(mockPublishTripEvent).toHaveBeenCalledWith({ type: 'statusChanged', tripId: 'trip-123', status: 'ONGOING' });
+    expect(hook.refresh).toHaveBeenCalledWith('silent');
+  });
+
+  it('confirms and completes an ongoing trip', async () => {
+    const hook = readyHook({ ...tripDetail, trip: { ...tripDetail.trip, status: 'ONGOING' } });
+    mockUseTripDetail.mockReturnValue(hook);
+    jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+    mockCompleteTrip.mockResolvedValue('COMPLETED');
+    await render(<TripDetailScreen />);
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Complete trip' }));
+    await confirmAlertAction('Complete trip');
+
+    await waitFor(() => expect(mockCompleteTrip).toHaveBeenCalledWith('trip-123'));
+    expect(hook.applyStatus).toHaveBeenCalledWith('COMPLETED');
+  });
+
+  it('confirms and cancels an ongoing trip', async () => {
+    const hook = readyHook({ ...tripDetail, trip: { ...tripDetail.trip, status: 'ONGOING' } });
+    mockUseTripDetail.mockReturnValue(hook);
+    jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+    mockCancelTrip.mockResolvedValue('CANCELLED');
+    await render(<TripDetailScreen />);
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Cancel trip' }));
+    await confirmAlertAction('Cancel trip');
+
+    await waitFor(() => expect(mockCancelTrip).toHaveBeenCalledWith('trip-123'));
+    expect(hook.applyStatus).toHaveBeenCalledWith('CANCELLED');
+  });
+
+  it('confirms leave, removes the trip from event consumers, and dismisses to tabs', async () => {
+    mockUseTripDetail.mockReturnValue(
+      readyHook({ ...tripDetail, my_membership: { ...tripDetail.my_membership, role: 'MEMBER' } }),
+    );
+    mockLeaveTrip.mockResolvedValue(undefined);
+    jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+    await render(<TripDetailScreen />);
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Leave trip' }));
+    await confirmAlertAction('Leave trip');
+
+    await waitFor(() => expect(mockLeaveTrip).toHaveBeenCalledWith('trip-123'));
+    expect(mockPublishTripEvent).toHaveBeenCalledWith({ type: 'removed', tripId: 'trip-123' });
+    expect(mockRouter.dismissTo).toHaveBeenCalledWith('/(tabs)');
+  });
+
+  it('renders the exact backend mutation error message', async () => {
+    mockStartTrip.mockRejectedValue(
+      axiosErrorWith(409, { detail: 'This trip cannot be started from its current status.', error_code: 'INVALID_STATUS_TRANSITION' }),
+    );
+    await render(<TripDetailScreen />);
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Start trip' }));
+    expect(await screen.findByText('This trip cannot be started from its current status.')).toBeTruthy();
   });
 
   it('shows one friendly not-found state for a 404 response', async () => {
-    mockGetTripDetail.mockRejectedValue(
-      axiosErrorWith(404, { detail: 'Trip not found.', error_code: 'TRIP_NOT_FOUND' }),
-    );
-
+    mockUseTripDetail.mockReturnValue({ ...readyHook(), detail: null, status: 'error', error: notFoundError });
     await render(<TripDetailScreen />);
 
     expect(await screen.findByText('Trip not found')).toBeTruthy();
     expect(screen.getByText('This trip does not exist or you are not a member of it.')).toBeTruthy();
     expect(screen.queryByText('Try again')).toBeNull();
-  });
-
-  it('retries a non-404 error and renders the recovered detail', async () => {
-    mockGetTripDetail
-      .mockRejectedValueOnce(axiosErrorWith(500, { detail: 'Service unavailable.' }))
-      .mockResolvedValueOnce(tripDetail);
-
-    await render(<TripDetailScreen />);
-
-    expect(await screen.findByText('Could not load trip')).toBeTruthy();
-    expect(screen.getByText('Service unavailable.')).toBeTruthy();
-    await fireEvent.press(screen.getByText('Try again'));
-
-    await waitFor(() => expect(mockGetTripDetail).toHaveBeenCalledTimes(2));
-    expect(await screen.findByText('Overview')).toBeTruthy();
   });
 });

--- a/mobile/src/features/trips/__tests__/api.test.ts
+++ b/mobile/src/features/trips/__tests__/api.test.ts
@@ -1,13 +1,24 @@
 jest.mock('@/shared/api/client', () => ({
-  apiClient: { get: jest.fn(), post: jest.fn() },
+  apiClient: { get: jest.fn(), patch: jest.fn(), post: jest.fn() },
 }));
 
 // eslint-disable-next-line import/first
 import { apiClient } from '@/shared/api/client';
 // eslint-disable-next-line import/first
-import { createTrip, extractCursor, getTripDetail, listTrips } from '../api';
+import {
+  cancelTrip,
+  completeTrip,
+  createTrip,
+  extractCursor,
+  getTripDetail,
+  leaveTrip,
+  listTrips,
+  startTrip,
+  updateTrip,
+} from '../api';
 
 const mockGet = apiClient.get as jest.MockedFunction<typeof apiClient.get>;
+const mockPatch = apiClient.patch as jest.MockedFunction<typeof apiClient.patch>;
 const mockPost = apiClient.post as jest.MockedFunction<typeof apiClient.post>;
 
 describe('extractCursor', () => {
@@ -72,5 +83,34 @@ describe('trips api', () => {
 
     expect(mockGet).toHaveBeenCalledWith('/trips/t1');
     expect(detail).toEqual(payload);
+  });
+
+  it('updateTrip patches the payload and unwraps trip', async () => {
+    mockPatch.mockResolvedValue({ data: { trip: { id: 't1', name: 'Updated trip' } } } as never);
+
+    const trip = await updateTrip('t1', { name: 'Updated trip', budget_estimate: null });
+
+    expect(mockPatch).toHaveBeenCalledWith('/trips/t1', { name: 'Updated trip', budget_estimate: null });
+    expect(trip).toEqual({ id: 't1', name: 'Updated trip' });
+  });
+
+  it.each([
+    ['start', startTrip, 'ONGOING'],
+    ['complete', completeTrip, 'COMPLETED'],
+    ['cancel', cancelTrip, 'CANCELLED'],
+  ] as const)('%sTrip posts to the lifecycle endpoint and unwraps status', async (action, request, status) => {
+    mockPost.mockResolvedValue({ data: { status } } as never);
+
+    await expect(request('t1')).resolves.toBe(status);
+
+    expect(mockPost).toHaveBeenCalledWith(`/trips/t1/${action}`);
+  });
+
+  it('leaveTrip posts to the leave endpoint', async () => {
+    mockPost.mockResolvedValue({ data: {} } as never);
+
+    await expect(leaveTrip('t1')).resolves.toBeUndefined();
+
+    expect(mockPost).toHaveBeenCalledWith('/trips/t1/leave');
   });
 });

--- a/mobile/src/features/trips/__tests__/options.test.ts
+++ b/mobile/src/features/trips/__tests__/options.test.ts
@@ -1,0 +1,13 @@
+import { CURATED_TIMEZONE_OPTIONS, getTimezoneOptions, TRIP_CURRENCY_CODES } from '../options';
+
+describe('trip options', () => {
+  it('keeps the currency choices aligned with the backend contract', () => {
+    expect(TRIP_CURRENCY_CODES).toEqual(['VND', 'USD', 'EUR', 'JPY', 'KRW', 'SGD', 'THB', 'AUD', 'GBP', 'CAD']);
+  });
+
+  it('uses curated timezones by default and retains an existing supported timezone outside the list', () => {
+    expect(getTimezoneOptions()).toBe(CURATED_TIMEZONE_OPTIONS);
+    expect(getTimezoneOptions('Pacific/Auckland')).toEqual(['Pacific/Auckland', ...CURATED_TIMEZONE_OPTIONS]);
+    expect(getTimezoneOptions('Asia/Ho_Chi_Minh')).toBe(CURATED_TIMEZONE_OPTIONS);
+  });
+});

--- a/mobile/src/features/trips/__tests__/useTripDetail.test.tsx
+++ b/mobile/src/features/trips/__tests__/useTripDetail.test.tsx
@@ -1,0 +1,185 @@
+const mockUseFocusEffect = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useFocusEffect: (effect: () => (() => void) | void) => mockUseFocusEffect(effect),
+}));
+
+jest.mock('../api', () => ({
+  getTripDetail: jest.fn(),
+}));
+
+// eslint-disable-next-line import/first
+import { AxiosError, AxiosHeaders } from 'axios';
+// eslint-disable-next-line import/first
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { getTripDetail } from '../api';
+// eslint-disable-next-line import/first
+import { useTripDetail } from '../hooks/useTripDetail';
+// eslint-disable-next-line import/first
+import { publishTripEvent } from '../tripEvents';
+
+const mockGetTripDetail = getTripDetail as jest.MockedFunction<typeof getTripDetail>;
+
+const trip = {
+  id: 'trip-1',
+  name: 'Da Lat escape',
+  destination: 'Da Lat, Vietnam',
+  destination_provider: '',
+  destination_provider_id: '',
+  destination_lat: null,
+  destination_lng: null,
+  destination_country_code: 'VN',
+  cover_image_url: '',
+  start_date: '2026-08-01',
+  end_date: '2026-08-03',
+  description: '',
+  status: 'PLANNING' as const,
+  currency_code: 'VND',
+  timezone: 'Asia/Ho_Chi_Minh',
+  budget_estimate: null,
+  cancelled_at: null,
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+const tripDetail = {
+  trip,
+  my_membership: { role: 'CAPTAIN' as const, status: 'ACTIVE' as const, joined_at: '2026-01-01T00:00:00Z' },
+  members: [],
+};
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, {}, {
+    status,
+    statusText: '',
+    headers: {},
+    config,
+    data,
+  });
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+function latestFocusCallback(): () => (() => void) | void {
+  const callback = mockUseFocusEffect.mock.calls.at(-1)?.[0] as (() => (() => void) | void) | undefined;
+  if (!callback) {
+    throw new Error('Expected useFocusEffect to register a callback.');
+  }
+  return callback;
+}
+
+describe('useTripDetail', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads on focus then silently refreshes while retaining the detail', async () => {
+    mockGetTripDetail.mockResolvedValue(tripDetail);
+    const { result, unmount } = await renderHook(() => useTripDetail('trip-1'));
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.detail).toEqual(tripDetail));
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+
+    expect(mockGetTripDetail).toHaveBeenCalledTimes(2);
+    expect(result.current.status).toBe('ready');
+    expect(result.current.refreshing).toBe(false);
+    unmount();
+  });
+
+  it('retains rendered detail after a non-404 silent refresh failure', async () => {
+    mockGetTripDetail
+      .mockResolvedValueOnce(tripDetail)
+      .mockRejectedValueOnce(axiosErrorWith(500, { detail: 'Service unavailable.' }));
+    const { result, unmount } = await renderHook(() => useTripDetail('trip-1'));
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.detail).toEqual(tripDetail));
+    await act(async () => {
+      latestFocusCallback()();
+    });
+
+    await waitFor(() => expect(result.current.error?.message).toBe('Service unavailable.'));
+    expect(result.current.detail).toEqual(tripDetail);
+    expect(result.current.status).toBe('ready');
+    unmount();
+  });
+
+  it('clears the detail for a generic not-found response without exposing membership state', async () => {
+    mockGetTripDetail.mockRejectedValue(
+      axiosErrorWith(404, { detail: 'Trip not found.', error_code: 'TRIP_NOT_FOUND' }),
+    );
+    const { result, unmount } = await renderHook(() => useTripDetail('trip-1'));
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+
+    await waitFor(() => expect(result.current.status).toBe('error'));
+    expect(result.current.detail).toBeNull();
+    expect(result.current.error).toMatchObject({
+      message: 'Trip not found.',
+      errorCode: 'TRIP_NOT_FOUND',
+      status: 404,
+    });
+    unmount();
+  });
+
+  it('ignores a request resolved after blur and only commits the latest focused request', async () => {
+    const first = deferred<typeof tripDetail>();
+    const second = deferred<typeof tripDetail>();
+    mockGetTripDetail.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const { result, unmount } = await renderHook(() => useTripDetail('trip-1'));
+
+    let cleanup: (() => void) | void = undefined;
+    await act(async () => {
+      cleanup = latestFocusCallback()();
+    });
+    await act(async () => {
+      cleanup?.();
+      latestFocusCallback()();
+    });
+    await act(async () => {
+      first.resolve({ ...tripDetail, trip: { ...trip, name: 'Stale response' } });
+    });
+    expect(result.current.detail).toBeNull();
+    await act(async () => {
+      second.resolve(tripDetail);
+    });
+
+    await waitFor(() => expect(result.current.detail?.trip.name).toBe('Da Lat escape'));
+    unmount();
+  });
+
+  it('patches rendered data immediately from update and status events', async () => {
+    mockGetTripDetail.mockResolvedValue(tripDetail);
+    const { result, unmount } = await renderHook(() => useTripDetail('trip-1'));
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.detail).toEqual(tripDetail));
+
+    await act(async () => {
+      publishTripEvent({ type: 'updated', trip: { ...trip, name: 'Updated Da Lat' } });
+      publishTripEvent({ type: 'statusChanged', tripId: 'trip-1', status: 'ONGOING' });
+    });
+
+    expect(result.current.detail?.trip).toMatchObject({ name: 'Updated Da Lat', status: 'ONGOING' });
+    unmount();
+  });
+});

--- a/mobile/src/features/trips/__tests__/useTripsList.test.tsx
+++ b/mobile/src/features/trips/__tests__/useTripsList.test.tsx
@@ -8,6 +8,8 @@ import { act, renderHook, waitFor } from '@testing-library/react-native';
 import { listTrips } from '../api';
 // eslint-disable-next-line import/first
 import { useTripsList } from '../hooks/useTripsList';
+// eslint-disable-next-line import/first
+import { publishTripEvent } from '../tripEvents';
 
 const mockListTrips = listTrips as jest.MockedFunction<typeof listTrips>;
 
@@ -26,6 +28,14 @@ const tripA = {
 };
 
 const tripB = { ...tripA, id: 'trip-b', name: 'Hoi An' };
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
 
 describe('useTripsList', () => {
   beforeEach(() => jest.clearAllMocks());
@@ -130,5 +140,142 @@ describe('useTripsList', () => {
     expect(result.current.status).toBe('ready');
     expect(result.current.error?.message).toBe('Something went wrong. Please try again.');
     expect(result.current.refreshing).toBe(false);
+  });
+
+  it('discards a pending cursor page when refresh starts a new list generation', async () => {
+    const cursorPage = deferred<{ items: typeof tripB[]; nextCursor: null }>();
+    mockListTrips
+      .mockResolvedValueOnce({ items: [tripA], nextCursor: 'cursor-1' })
+      .mockReturnValueOnce(cursorPage.promise)
+      .mockResolvedValueOnce({ items: [tripB], nextCursor: null });
+    const { result, unmount } = await renderHook(() => useTripsList());
+
+    await act(async () => {
+      await result.current.loadFirstPage('initial');
+    });
+    await act(async () => {
+      void result.current.loadMore();
+    });
+    await act(async () => {
+      await result.current.loadFirstPage('refresh');
+    });
+    await act(async () => {
+      cursorPage.resolve({ items: [{ ...tripA, id: 'stale-trip', name: 'Stale cursor result' }], nextCursor: null });
+    });
+
+    expect(result.current.items).toEqual([tripB]);
+    expect(result.current.loadingMore).toBe(false);
+    unmount();
+  });
+
+  it('does not paginate with the previous cursor while a first-page refresh is in flight', async () => {
+    const refreshPage = deferred<{ items: typeof tripB[]; nextCursor: string }>();
+    mockListTrips
+      .mockResolvedValueOnce({ items: [tripA], nextCursor: 'stale-cursor' })
+      .mockReturnValueOnce(refreshPage.promise)
+      .mockResolvedValueOnce({ items: [tripA], nextCursor: null });
+    const { result } = await renderHook(() => useTripsList());
+
+    await act(async () => {
+      await result.current.loadFirstPage('initial');
+    });
+    await act(async () => {
+      void result.current.loadFirstPage('refresh');
+    });
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    expect(mockListTrips).toHaveBeenCalledTimes(2);
+    expect(result.current.loadingMore).toBe(false);
+
+    await act(async () => {
+      refreshPage.resolve({ items: [tripB], nextCursor: 'fresh-cursor' });
+    });
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    expect(mockListTrips).toHaveBeenNthCalledWith(3, 'fresh-cursor');
+    expect(result.current.items).toEqual([tripB, tripA]);
+  });
+
+  it('applies update, status, and removal events immediately over a pending first-page response', async () => {
+    const refreshPage = deferred<{ items: typeof tripA[]; nextCursor: null }>();
+    mockListTrips
+      .mockResolvedValueOnce({ items: [tripA, tripB], nextCursor: null })
+      .mockReturnValueOnce(refreshPage.promise);
+    const { result, unmount } = await renderHook(() => useTripsList());
+
+    await act(async () => {
+      await result.current.loadFirstPage('initial');
+    });
+    await act(async () => {
+      void result.current.loadFirstPage('silent');
+    });
+    await act(async () => {
+      publishTripEvent({
+        type: 'updated',
+        trip: {
+          ...tripA,
+          destination_provider: '',
+          destination_provider_id: '',
+          destination_lat: null,
+          destination_lng: null,
+          destination_country_code: '',
+          description: '',
+          timezone: 'Asia/Ho_Chi_Minh',
+          cancelled_at: null,
+          created_at: '2026-01-01T00:00:00Z',
+          name: 'Updated Da Lat',
+        },
+      });
+      publishTripEvent({ type: 'statusChanged', tripId: 'trip-b', status: 'ONGOING' });
+      publishTripEvent({ type: 'removed', tripId: 'trip-b' });
+    });
+
+    expect(result.current.items).toEqual([{ ...tripA, name: 'Updated Da Lat' }]);
+    await act(async () => {
+      refreshPage.resolve({ items: [tripA, tripB], nextCursor: null });
+    });
+
+    expect(result.current.items).toEqual([{ ...tripA, name: 'Updated Da Lat' }]);
+    unmount();
+  });
+
+  it('lets a later focus refresh reconcile an older local event with server truth', async () => {
+    const serverTrip = { ...tripA, name: 'Newest server name' };
+    mockListTrips
+      .mockResolvedValueOnce({ items: [tripA], nextCursor: null })
+      .mockResolvedValueOnce({ items: [serverTrip], nextCursor: null });
+    const { result, unmount } = await renderHook(() => useTripsList());
+
+    await act(async () => {
+      await result.current.loadFirstPage('initial');
+      publishTripEvent({
+        type: 'updated',
+        trip: {
+          ...tripA,
+          destination_provider: '',
+          destination_provider_id: '',
+          destination_lat: null,
+          destination_lng: null,
+          destination_country_code: '',
+          description: '',
+          timezone: 'Asia/Ho_Chi_Minh',
+          cancelled_at: null,
+          created_at: '2026-01-01T00:00:00Z',
+          name: 'Local event name',
+        },
+      });
+    });
+    expect(result.current.items[0]?.name).toBe('Local event name');
+
+    await act(async () => {
+      await result.current.loadFirstPage('silent');
+    });
+
+    expect(result.current.items).toEqual([serverTrip]);
+    unmount();
   });
 });

--- a/mobile/src/features/trips/api.ts
+++ b/mobile/src/features/trips/api.ts
@@ -1,5 +1,13 @@
 import { apiClient } from '@/shared/api/client';
-import type { CreateTripInput, Trip, TripDetailResponse, TripListItem, TripListPage } from './types';
+import type {
+  CreateTripInput,
+  Trip,
+  TripDetailResponse,
+  TripListItem,
+  TripListPage,
+  TripStatus,
+  UpdateTripInput,
+} from './types';
 
 interface CursorPaginatedResponse {
   next: string | null;
@@ -31,4 +39,34 @@ export async function createTrip(input: CreateTripInput): Promise<Trip> {
 export async function getTripDetail(tripId: string): Promise<TripDetailResponse> {
   const { data } = await apiClient.get<TripDetailResponse>(`/trips/${tripId}`);
   return data;
+}
+
+export async function updateTrip(tripId: string, input: UpdateTripInput): Promise<Trip> {
+  const { data } = await apiClient.patch<{ trip: Trip }>(`/trips/${tripId}`, input);
+  return data.trip;
+}
+
+interface TripStatusResponse {
+  status: TripStatus;
+}
+
+async function postTripStatusAction(tripId: string, action: 'start' | 'complete' | 'cancel'): Promise<TripStatus> {
+  const { data } = await apiClient.post<TripStatusResponse>(`/trips/${tripId}/${action}`);
+  return data.status;
+}
+
+export function startTrip(tripId: string): Promise<TripStatus> {
+  return postTripStatusAction(tripId, 'start');
+}
+
+export function completeTrip(tripId: string): Promise<TripStatus> {
+  return postTripStatusAction(tripId, 'complete');
+}
+
+export function cancelTrip(tripId: string): Promise<TripStatus> {
+  return postTripStatusAction(tripId, 'cancel');
+}
+
+export async function leaveTrip(tripId: string): Promise<void> {
+  await apiClient.post(`/trips/${tripId}/leave`);
 }

--- a/mobile/src/features/trips/components/TripActions.tsx
+++ b/mobile/src/features/trips/components/TripActions.tsx
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { Alert, Pressable, StyleSheet, Text, View } from 'react-native';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import type { MyMembership, Trip, TripAction, TripStatus } from '../types';
+
+export type TripDisplayAction = TripAction | 'edit';
+
+interface TripActionsProps {
+  trip: Pick<Trip, 'status'>;
+  membership: Pick<MyMembership, 'role' | 'status'> | null;
+  isMutating: boolean;
+  onAction: (action: TripDisplayAction) => void | Promise<void>;
+}
+
+interface ActionMeta {
+  label: string;
+  tone: 'primary' | 'secondary' | 'danger';
+  confirmation?: { title: string; message: string; confirmLabel: string };
+}
+
+const ACTION_META: Record<TripDisplayAction, ActionMeta> = {
+  edit: { label: 'Edit trip', tone: 'secondary' },
+  start: { label: 'Start trip', tone: 'primary' },
+  complete: {
+    label: 'Complete trip',
+    tone: 'primary',
+    confirmation: {
+      title: 'Complete this trip?',
+      message: 'This marks the trip as completed. You cannot change it back.',
+      confirmLabel: 'Complete trip',
+    },
+  },
+  cancel: {
+    label: 'Cancel trip',
+    tone: 'danger',
+    confirmation: {
+      title: 'Cancel this trip?',
+      message: 'This cancels the trip for every member. You cannot change it back.',
+      confirmLabel: 'Cancel trip',
+    },
+  },
+  leave: {
+    label: 'Leave trip',
+    tone: 'danger',
+    confirmation: {
+      title: 'Leave this trip?',
+      message: 'You will no longer be able to access this trip unless you are invited again.',
+      confirmLabel: 'Leave trip',
+    },
+  },
+};
+
+export function getTripDisplayActions(
+  status: TripStatus,
+  membership: Pick<MyMembership, 'role' | 'status'> | null,
+): TripDisplayAction[] {
+  if (membership?.status !== 'ACTIVE') {
+    return [];
+  }
+
+  if (membership.role === 'CAPTAIN') {
+    if (status === 'PLANNING') {
+      return ['edit', 'start', 'cancel'];
+    }
+    if (status === 'ONGOING') {
+      return ['edit', 'complete', 'cancel'];
+    }
+    return [];
+  }
+
+  if (status === 'PLANNING' || status === 'ONGOING') {
+    return ['leave'];
+  }
+
+  return [];
+}
+
+export function TripActions({ trip, membership, isMutating, onAction }: TripActionsProps) {
+  const actionLockRef = useRef(false);
+  const actions = getTripDisplayActions(trip.status, membership);
+
+  useEffect(() => {
+    if (!isMutating) {
+      actionLockRef.current = false;
+    }
+  }, [isMutating]);
+
+  const releaseLock = useCallback(() => {
+    actionLockRef.current = false;
+  }, []);
+
+  const runAction = useCallback(
+    (action: TripDisplayAction) => {
+      try {
+        void Promise.resolve(onAction(action)).finally(releaseLock);
+      } catch (error) {
+        releaseLock();
+        throw error;
+      }
+    },
+    [onAction, releaseLock],
+  );
+
+  const dispatch = useCallback(
+    (action: TripDisplayAction) => {
+      if (isMutating || actionLockRef.current) {
+        return;
+      }
+
+      actionLockRef.current = true;
+      const confirmation = ACTION_META[action].confirmation;
+      if (confirmation) {
+        Alert.alert(
+          confirmation.title,
+          confirmation.message,
+          [
+            { text: 'Keep trip', style: 'cancel', onPress: releaseLock },
+            {
+              text: confirmation.confirmLabel,
+              style: 'destructive',
+              onPress: () => runAction(action),
+            },
+          ],
+          { cancelable: true, onDismiss: releaseLock },
+        );
+        return;
+      }
+
+      runAction(action);
+    },
+    [isMutating, releaseLock, runAction],
+  );
+
+  if (actions.length === 0) {
+    return null;
+  }
+
+  return (
+    <View accessibilityLabel="Trip actions" style={styles.container}>
+      {actions.map((action) => {
+        const meta = ACTION_META[action];
+        const disabled = isMutating;
+        return (
+          <Pressable
+            key={action}
+            accessibilityRole="button"
+            accessibilityLabel={meta.label}
+            accessibilityState={{ disabled }}
+            disabled={disabled}
+            onPress={() => dispatch(action)}
+            style={({ pressed }) => [
+              styles.button,
+              meta.tone === 'primary' && styles.primaryButton,
+              meta.tone === 'secondary' && styles.secondaryButton,
+              meta.tone === 'danger' && styles.dangerButton,
+              pressed && !disabled && styles.pressed,
+              disabled && styles.disabledButton,
+            ]}
+          >
+            <Text
+              style={[
+                styles.buttonText,
+                meta.tone === 'primary' && styles.primaryText,
+                meta.tone === 'secondary' && styles.secondaryText,
+                meta.tone === 'danger' && styles.dangerText,
+                disabled && styles.disabledText,
+              ]}
+            >
+              {meta.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { gap: spacing.sm },
+  button: {
+    minHeight: 48,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.md,
+    paddingHorizontal: spacing.md,
+  },
+  primaryButton: { backgroundColor: colors.primary },
+  secondaryButton: { backgroundColor: colors.surface, borderWidth: 1, borderColor: colors.border },
+  dangerButton: { backgroundColor: colors.dangerSoft, borderWidth: 1, borderColor: colors.dangerBorder },
+  pressed: { opacity: 0.82 },
+  disabledButton: { backgroundColor: colors.surface, borderColor: colors.border },
+  buttonText: { ...typography.body, fontWeight: '600' },
+  primaryText: { color: colors.background },
+  secondaryText: { color: colors.text },
+  dangerText: { color: colors.danger },
+  disabledText: { color: colors.textMuted },
+});

--- a/mobile/src/features/trips/hooks/useTripDetail.ts
+++ b/mobile/src/features/trips/hooks/useTripDetail.ts
@@ -1,0 +1,144 @@
+import { useFocusEffect } from 'expo-router';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { type ApiError, normalizeApiError } from '@/shared/api/errors';
+import { getTripDetail } from '../api';
+import { subscribeToTripEvents } from '../tripEvents';
+import type { Trip, TripDetailResponse, TripStatus } from '../types';
+
+export type TripDetailLoadStatus = 'loading' | 'ready' | 'error';
+export type TripDetailLoadMode = 'initial' | 'silent';
+
+const MISSING_TRIP_ERROR: ApiError = {
+  kind: 'message',
+  message: 'Trip not found.',
+  errorCode: 'TRIP_NOT_FOUND',
+  status: 404,
+};
+
+export function useTripDetail(tripId: string | undefined) {
+  const [detail, setDetail] = useState<TripDetailResponse | null>(null);
+  const [status, setStatus] = useState<TripDetailLoadStatus>('loading');
+  const [error, setError] = useState<ApiError | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [stateTripId, setStateTripId] = useState<string | undefined>(tripId);
+  const detailRef = useRef<TripDetailResponse | null>(null);
+  const requestIdRef = useRef(0);
+
+  const commitDetail = useCallback((nextDetail: TripDetailResponse) => {
+    setStateTripId(nextDetail.trip.id);
+    detailRef.current = nextDetail;
+    setDetail(nextDetail);
+    setError(null);
+    setStatus('ready');
+  }, []);
+
+  const refresh = useCallback(
+    async (mode: TripDetailLoadMode = 'silent') => {
+      const requestId = requestIdRef.current + 1;
+      requestIdRef.current = requestId;
+
+      if (!tripId) {
+        setStateTripId(tripId);
+        detailRef.current = null;
+        setDetail(null);
+        setError(MISSING_TRIP_ERROR);
+        setStatus('error');
+        return;
+      }
+
+      const hasDetail = detailRef.current?.trip.id === tripId;
+      setStateTripId(tripId);
+      if (!hasDetail) {
+        detailRef.current = null;
+        setError(null);
+        setStatus('loading');
+      } else if (mode === 'silent') {
+        setRefreshing(true);
+      }
+
+      try {
+        const nextDetail = await getTripDetail(tripId);
+        if (requestId === requestIdRef.current) {
+          commitDetail(nextDetail);
+        }
+      } catch (caught) {
+        if (requestId !== requestIdRef.current) {
+          return;
+        }
+        const nextError = normalizeApiError(caught);
+        setStateTripId(tripId);
+        if (nextError.status === 404 || !detailRef.current) {
+          detailRef.current = null;
+          setDetail(null);
+          setStatus('error');
+        } else {
+          setStatus('ready');
+        }
+        setError(nextError);
+      } finally {
+        if (requestId === requestIdRef.current) {
+          setRefreshing(false);
+        }
+      }
+    },
+    [commitDetail, tripId],
+  );
+
+  const applyTrip = useCallback(
+    (trip: Trip) => {
+      const current = detailRef.current;
+      if (!current || current.trip.id !== trip.id) {
+        return;
+      }
+      requestIdRef.current += 1;
+      commitDetail({ ...current, trip });
+      setRefreshing(false);
+    },
+    [commitDetail],
+  );
+
+  const applyStatus = useCallback(
+    (nextStatus: TripStatus) => {
+      const current = detailRef.current;
+      if (!current) {
+        return;
+      }
+      applyTrip({ ...current.trip, status: nextStatus });
+    },
+    [applyTrip],
+  );
+
+  useEffect(
+    () =>
+      subscribeToTripEvents((event) => {
+        if (event.type === 'updated' && event.trip.id === tripId) {
+          applyTrip(event.trip);
+        } else if (event.type === 'statusChanged' && event.tripId === tripId) {
+          applyStatus(event.status);
+        }
+      }),
+    [applyStatus, applyTrip, tripId],
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      void refresh(detailRef.current?.trip.id === tripId ? 'silent' : 'initial');
+      return () => {
+        requestIdRef.current += 1;
+      };
+    }, [refresh, tripId]),
+  );
+
+  const stateMatchesTrip = stateTripId === tripId;
+  const visibleDetail = stateMatchesTrip && detail?.trip.id === tripId ? detail : null;
+
+  return {
+    detail: visibleDetail,
+    status: stateMatchesTrip ? status : 'loading',
+    error: stateMatchesTrip ? error : null,
+    refreshing: stateMatchesTrip ? refreshing : false,
+    refresh,
+    applyTrip,
+    applyStatus,
+  };
+}

--- a/mobile/src/features/trips/hooks/useTripsList.ts
+++ b/mobile/src/features/trips/hooks/useTripsList.ts
@@ -1,9 +1,67 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { type ApiError, normalizeApiError } from '@/shared/api/errors';
 import { listTrips } from '../api';
-import type { TripListItem } from '../types';
+import { subscribeToTripEvents, type TripEvent } from '../tripEvents';
+import type { Trip, TripListItem, TripStatus } from '../types';
 
 export type TripsListStatus = 'loading' | 'ready' | 'error';
+
+interface TripListOverride {
+  version: number;
+  trip?: Trip;
+  status?: TripStatus;
+  removed?: boolean;
+}
+
+function applyUpdatedTrip(item: TripListItem, trip: Trip): TripListItem {
+  return {
+    ...item,
+    name: trip.name,
+    destination: trip.destination,
+    cover_image_url: trip.cover_image_url,
+    start_date: trip.start_date,
+    end_date: trip.end_date,
+    status: trip.status,
+    currency_code: trip.currency_code,
+    budget_estimate: trip.budget_estimate,
+  };
+}
+
+function applyOverride(item: TripListItem, override: TripListOverride | undefined): TripListItem | null {
+  if (!override) {
+    return item;
+  }
+  if (override.removed) {
+    return null;
+  }
+  let next = override.trip ? applyUpdatedTrip(item, override.trip) : item;
+  if (override.status) {
+    next = { ...next, status: override.status };
+  }
+  return next;
+}
+
+function applyOverrides(
+  items: TripListItem[],
+  overrides: Map<string, TripListOverride>,
+  requestEventVersion: number,
+): TripListItem[] {
+  return items.flatMap((item) => {
+    const override = overrides.get(item.id);
+    const next = applyOverride(item, override && override.version > requestEventVersion ? override : undefined);
+    return next ? [next] : [];
+  });
+}
+
+function overrideFromEvent(event: TripEvent, version: number, current?: TripListOverride): [string, TripListOverride] {
+  if (event.type === 'updated') {
+    return [event.trip.id, { ...current, version, trip: event.trip, status: event.trip.status, removed: false }];
+  }
+  if (event.type === 'statusChanged') {
+    return [event.tripId, { ...current, version, status: event.status }];
+  }
+  return [event.tripId, { ...current, version, removed: true }];
+}
 
 export function useTripsList() {
   const [items, setItems] = useState<TripListItem[]>([]);
@@ -12,13 +70,45 @@ export function useTripsList() {
   const [refreshing, setRefreshing] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const nextCursorRef = useRef<string | null>(null);
-  const inFlightRef = useRef(false);
+  const firstPageRequestRef = useRef(0);
+  const firstPageInFlightRef = useRef<number | null>(null);
+  const listGenerationRef = useRef(0);
+  const loadMoreInFlightRef = useRef(false);
+  const overridesRef = useRef(new Map<string, TripListOverride>());
+  const eventVersionRef = useRef(0);
+
+  useEffect(
+    () =>
+      subscribeToTripEvents((event) => {
+        const eventTripId = event.type === 'updated' ? event.trip.id : event.tripId;
+        eventVersionRef.current += 1;
+        const [tripId, override] = overrideFromEvent(
+          event,
+          eventVersionRef.current,
+          overridesRef.current.get(eventTripId),
+        );
+        overridesRef.current.set(tripId, override);
+        setItems((current) =>
+          current.flatMap((item) => {
+            if (item.id !== tripId) {
+              return [item];
+            }
+            const next = applyOverride(item, override);
+            return next ? [next] : [];
+          }),
+        );
+      }),
+    [],
+  );
 
   const loadFirstPage = useCallback(async (mode: 'initial' | 'refresh' | 'silent') => {
-    if (inFlightRef.current) {
-      return;
-    }
-    inFlightRef.current = true;
+    const requestId = firstPageRequestRef.current + 1;
+    firstPageRequestRef.current = requestId;
+    firstPageInFlightRef.current = requestId;
+    listGenerationRef.current += 1;
+    const requestEventVersion = eventVersionRef.current;
+    loadMoreInFlightRef.current = false;
+    setLoadingMore(false);
     if (mode === 'initial') {
       setStatus('loading');
     }
@@ -27,11 +117,17 @@ export function useTripsList() {
     }
     try {
       const page = await listTrips();
+      if (requestId !== firstPageRequestRef.current) {
+        return;
+      }
       nextCursorRef.current = page.nextCursor;
-      setItems(page.items);
+      setItems(applyOverrides(page.items, overridesRef.current, requestEventVersion));
       setError(null);
       setStatus('ready');
     } catch (err) {
+      if (requestId !== firstPageRequestRef.current) {
+        return;
+      }
       // A silent focus refresh must not blank out an already rendered list.
       if (mode === 'initial') {
         setError(normalizeApiError(err));
@@ -41,32 +137,47 @@ export function useTripsList() {
         setError(normalizeApiError(err));
       }
     } finally {
-      setRefreshing(false);
-      inFlightRef.current = false;
+      if (requestId === firstPageRequestRef.current) {
+        firstPageInFlightRef.current = null;
+        setRefreshing(false);
+      }
     }
   }, []);
 
   const loadMore = useCallback(async () => {
     const cursor = nextCursorRef.current;
-    if (inFlightRef.current || !cursor) {
+    if (firstPageInFlightRef.current !== null || loadMoreInFlightRef.current || !cursor) {
       return;
     }
-    inFlightRef.current = true;
+    const generation = listGenerationRef.current;
+    const requestEventVersion = eventVersionRef.current;
+    loadMoreInFlightRef.current = true;
     setLoadingMore(true);
     setError(null);
     try {
       const page = await listTrips(cursor);
+      if (generation !== listGenerationRef.current) {
+        return;
+      }
       nextCursorRef.current = page.nextCursor;
       setItems((prev) => {
         const seen = new Set(prev.map((t) => t.id));
-        return [...prev, ...page.items.filter((t) => !seen.has(t.id))];
+        const newItems = applyOverrides(page.items, overridesRef.current, requestEventVersion).filter(
+          (trip) => !seen.has(trip.id),
+        );
+        return [...prev, ...newItems];
       });
     } catch (err) {
+      if (generation !== listGenerationRef.current) {
+        return;
+      }
       // Keep the loaded pages; the next onEndReached retries from the same cursor.
       setError(normalizeApiError(err));
     } finally {
-      setLoadingMore(false);
-      inFlightRef.current = false;
+      if (generation === listGenerationRef.current) {
+        loadMoreInFlightRef.current = false;
+        setLoadingMore(false);
+      }
     }
   }, []);
 

--- a/mobile/src/features/trips/options.ts
+++ b/mobile/src/features/trips/options.ts
@@ -1,0 +1,24 @@
+export const TRIP_CURRENCY_CODES = ['VND', 'USD', 'EUR', 'JPY', 'KRW', 'SGD', 'THB', 'AUD', 'GBP', 'CAD'] as const;
+
+export const CURATED_TIMEZONE_OPTIONS = [
+  'Asia/Ho_Chi_Minh',
+  'Asia/Bangkok',
+  'Asia/Singapore',
+  'Asia/Tokyo',
+  'Asia/Seoul',
+  'Asia/Shanghai',
+  'Asia/Kolkata',
+  'Australia/Sydney',
+  'Europe/London',
+  'Europe/Paris',
+  'America/New_York',
+  'America/Los_Angeles',
+  'UTC',
+] as const;
+
+export function getTimezoneOptions(currentTimezone?: string): readonly string[] {
+  if (!currentTimezone || CURATED_TIMEZONE_OPTIONS.some((timezone) => timezone === currentTimezone)) {
+    return CURATED_TIMEZONE_OPTIONS;
+  }
+  return [currentTimezone, ...CURATED_TIMEZONE_OPTIONS];
+}

--- a/mobile/src/features/trips/screens/CreateTripScreen.tsx
+++ b/mobile/src/features/trips/screens/CreateTripScreen.tsx
@@ -10,10 +10,8 @@ import { Screen } from '@/shared/ui/Screen';
 import { TextField } from '@/shared/ui/TextField';
 import { createTrip } from '../api';
 import { formatDateParam } from '../dates';
+import { TRIP_CURRENCY_CODES } from '../options';
 import type { CreateTripInput } from '../types';
-
-// Mirrors SUPPORTED_TRIP_CURRENCY_CODES on the backend.
-const CURRENCIES = ['VND', 'USD', 'EUR', 'JPY', 'KRW', 'SGD', 'THB', 'AUD', 'GBP', 'CAD'];
 
 function FormSection({ title, children }: PropsWithChildren<{ title: string }>) {
   return (
@@ -166,7 +164,7 @@ export function CreateTripScreen() {
             <Text style={styles.currencyHint}>Swipe for more</Text>
           </View>
           <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.currencyRow}>
-            {CURRENCIES.map((code) => (
+            {TRIP_CURRENCY_CODES.map((code) => (
               <Pressable
                 key={code}
                 accessibilityRole="button"

--- a/mobile/src/features/trips/screens/EditTripScreen.tsx
+++ b/mobile/src/features/trips/screens/EditTripScreen.tsx
@@ -1,0 +1,296 @@
+import { Ionicons } from '@expo/vector-icons';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import { type PropsWithChildren, useRef, useState } from 'react';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { type ApiError, normalizeApiError } from '@/shared/api/errors';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { Button } from '@/shared/ui/Button';
+import { DateField } from '@/shared/ui/DateField';
+import { FormError } from '@/shared/ui/FormError';
+import { LoadingScreen } from '@/shared/ui/LoadingScreen';
+import { Screen } from '@/shared/ui/Screen';
+import { TextField } from '@/shared/ui/TextField';
+import { updateTrip } from '../api';
+import { formatDateParam, parseDateOnly } from '../dates';
+import { useTripDetail } from '../hooks/useTripDetail';
+import { getTimezoneOptions, TRIP_CURRENCY_CODES } from '../options';
+import { publishTripEvent } from '../tripEvents';
+import type { TripDetailResponse, UpdateTripInput } from '../types';
+
+function FormSection({ title, children }: PropsWithChildren<{ title: string }>) {
+  return (
+    <View style={styles.section}>
+      <Text accessibilityRole="header" style={styles.sectionTitle}>
+        {title}
+      </Text>
+      {children}
+    </View>
+  );
+}
+
+function EditUnavailable({ message, onBack }: { message: string; onBack: () => void }) {
+  return (
+    <SafeAreaView style={styles.safe}>
+      <View style={styles.centered}>
+        <Ionicons name="lock-closed-outline" size={44} color={colors.textMuted} />
+        <Text style={styles.sectionTitle}>Trip cannot be edited</Text>
+        <Text style={styles.centeredText}>{message}</Text>
+        <Button title="Back to trip" onPress={onBack} />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+function EditTripForm({ detail }: { detail: TripDetailResponse }) {
+  const router = useRouter();
+  const original = detail.trip;
+  const [name, setName] = useState(original.name);
+  const [destination, setDestination] = useState(original.destination);
+  const [startDate, setStartDate] = useState(() => parseDateOnly(original.start_date));
+  const [endDate, setEndDate] = useState(() => parseDateOnly(original.end_date));
+  const [description, setDescription] = useState(original.description);
+  const [budget, setBudget] = useState(original.budget_estimate ?? '');
+  const [currency, setCurrency] = useState(original.currency_code);
+  const [timezone, setTimezone] = useState(original.timezone);
+  const [dateError, setDateError] = useState<string | undefined>();
+  const [error, setError] = useState<ApiError | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const submitLockRef = useRef(false);
+  const timezoneOptions = getTimezoneOptions(original.timezone);
+  const canSubmit = Boolean(name.trim() && destination.trim());
+
+  function onStartDateChange(date: Date) {
+    setStartDate(date);
+    setDateError(undefined);
+    if (endDate < date) {
+      setEndDate(date);
+    }
+  }
+
+  async function onSubmit() {
+    if (submitLockRef.current) {
+      return;
+    }
+
+    setError(null);
+    setDateError(undefined);
+    const start = formatDateParam(startDate);
+    const end = formatDateParam(endDate);
+    if (end < start) {
+      setDateError('End date must be on or after the start date.');
+      return;
+    }
+
+    const trimmedDestination = destination.trim();
+    const trimmedBudget = budget.trim();
+    const input: UpdateTripInput = {
+      name: name.trim(),
+      destination: trimmedDestination,
+      start_date: start,
+      end_date: end,
+      description: description.trim(),
+      budget_estimate: trimmedBudget || null,
+      currency_code: currency,
+      timezone,
+    };
+    if (trimmedDestination !== original.destination) {
+      input.destination_provider = '';
+      input.destination_provider_id = '';
+      input.destination_lat = null;
+      input.destination_lng = null;
+      input.destination_country_code = '';
+    }
+
+    submitLockRef.current = true;
+    setSubmitting(true);
+    try {
+      const updated = await updateTrip(original.id, input);
+      publishTripEvent({ type: 'updated', trip: updated });
+      router.dismissTo(`/trips/${original.id}`);
+    } catch (caught) {
+      setError(normalizeApiError(caught));
+    } finally {
+      submitLockRef.current = false;
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Screen
+      scroll
+      edges={['left', 'right', 'bottom']}
+      footer={
+        <>
+          <FormError error={error} />
+          {!canSubmit ? <Text style={styles.submitHint}>Add a trip name and destination to continue.</Text> : null}
+          <Button title="Save changes" onPress={onSubmit} loading={submitting} disabled={!canSubmit} />
+        </>
+      }
+    >
+      <FormSection title="Basics">
+        <TextField
+          label="Trip name *"
+          accessibilityLabel="Trip name"
+          value={name}
+          onChangeText={setName}
+          maxLength={120}
+          error={error?.fieldErrors?.name}
+        />
+        <TextField
+          label="Destination *"
+          accessibilityLabel="Destination"
+          value={destination}
+          onChangeText={setDestination}
+          maxLength={200}
+          error={error?.fieldErrors?.destination}
+        />
+      </FormSection>
+
+      <FormSection title="Dates">
+        <DateField
+          label="Start date"
+          value={startDate}
+          onChange={onStartDateChange}
+          error={error?.fieldErrors?.start_date}
+        />
+        <DateField
+          label="End date"
+          value={endDate}
+          onChange={(date) => {
+            setEndDate(date);
+            setDateError(undefined);
+          }}
+          minimumDate={startDate}
+          error={dateError ?? error?.fieldErrors?.end_date}
+        />
+      </FormSection>
+
+      <FormSection title="Details">
+        <TextField
+          label="Description"
+          accessibilityLabel="Description"
+          value={description}
+          onChangeText={setDescription}
+          multiline
+          numberOfLines={3}
+          maxLength={180}
+          error={error?.fieldErrors?.description}
+        />
+        <TextField
+          label="Budget estimate"
+          accessibilityLabel="Budget estimate"
+          value={budget}
+          onChangeText={setBudget}
+          keyboardType="decimal-pad"
+          error={error?.fieldErrors?.budget_estimate}
+        />
+        <View style={styles.optionGroup}>
+          <Text style={styles.optionLabel}>Currency</Text>
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.optionRow}>
+            {TRIP_CURRENCY_CODES.map((code) => (
+              <Pressable
+                key={code}
+                accessibilityRole="button"
+                accessibilityLabel={`Currency ${code}`}
+                accessibilityState={{ selected: currency === code }}
+                onPress={() => setCurrency(code)}
+                style={[styles.chip, currency === code && styles.chipSelected]}
+              >
+                <Text style={[styles.chipText, currency === code && styles.chipTextSelected]}>{code}</Text>
+              </Pressable>
+            ))}
+          </ScrollView>
+          {error?.fieldErrors?.currency_code ? (
+            <Text style={styles.optionError}>{error.fieldErrors.currency_code}</Text>
+          ) : null}
+        </View>
+        <View style={styles.optionGroup}>
+          <Text style={styles.optionLabel}>Timezone</Text>
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.optionRow}>
+            {timezoneOptions.map((value) => (
+              <Pressable
+                key={value}
+                accessibilityRole="button"
+                accessibilityLabel={`Timezone ${value}`}
+                accessibilityState={{ selected: timezone === value }}
+                onPress={() => setTimezone(value)}
+                style={[styles.chip, timezone === value && styles.chipSelected]}
+              >
+                <Text style={[styles.chipText, timezone === value && styles.chipTextSelected]}>{value}</Text>
+              </Pressable>
+            ))}
+          </ScrollView>
+          {error?.fieldErrors?.timezone ? <Text style={styles.optionError}>{error.fieldErrors.timezone}</Text> : null}
+        </View>
+      </FormSection>
+    </Screen>
+  );
+}
+
+export function EditTripScreen() {
+  const { tripId } = useLocalSearchParams<{ tripId: string }>();
+  const router = useRouter();
+  const { detail, status, error, refresh } = useTripDetail(tripId);
+  const backToTrip = () => router.dismissTo(`/trips/${tripId}`);
+
+  if (status === 'loading') {
+    return <LoadingScreen />;
+  }
+
+  if (status === 'error' || !detail) {
+    const notFound = error?.status === 404;
+    return (
+      <SafeAreaView style={styles.safe}>
+        <View style={styles.centered}>
+          <Ionicons name={notFound ? 'help-circle-outline' : 'cloud-offline-outline'} size={44} color={colors.textMuted} />
+          <Text style={styles.sectionTitle}>{notFound ? 'Trip not found' : 'Could not load trip'}</Text>
+          <Text style={styles.centeredText}>
+            {notFound ? 'This trip does not exist or you are not a member of it.' : error?.message}
+          </Text>
+          {notFound ? null : <Button title="Try again" onPress={() => void refresh('initial')} />}
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const { trip, my_membership: membership } = detail;
+  if (membership.status !== 'ACTIVE' || membership.role !== 'CAPTAIN') {
+    return <EditUnavailable message="Only the active trip captain can edit trip information." onBack={backToTrip} />;
+  }
+  if (trip.status === 'COMPLETED' || trip.status === 'CANCELLED') {
+    return <EditUnavailable message="Completed and cancelled trips can no longer be edited." onBack={backToTrip} />;
+  }
+
+  return (
+    <>
+      <Stack.Screen options={{ title: 'Edit Trip' }} />
+      <EditTripForm key={trip.id} detail={detail} />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.background },
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: spacing.md, padding: spacing.lg },
+  centeredText: { ...typography.body, color: colors.textMuted, textAlign: 'center' },
+  section: { gap: spacing.md, padding: spacing.md, borderRadius: radii.lg, backgroundColor: colors.surface },
+  sectionTitle: { ...typography.heading, color: colors.text },
+  optionGroup: { gap: spacing.sm },
+  optionLabel: { ...typography.label, color: colors.text },
+  optionRow: { gap: spacing.sm },
+  chip: {
+    minHeight: 44,
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    paddingHorizontal: spacing.md,
+    backgroundColor: colors.background,
+  },
+  chipSelected: { borderColor: colors.primary, backgroundColor: colors.primarySoft },
+  chipText: { ...typography.label, color: colors.textMuted },
+  chipTextSelected: { color: colors.primary },
+  optionError: { ...typography.caption, color: colors.danger },
+  submitHint: { ...typography.caption, color: colors.textMuted, textAlign: 'center' },
+});

--- a/mobile/src/features/trips/screens/TripDetailScreen.tsx
+++ b/mobile/src/features/trips/screens/TripDetailScreen.tsx
@@ -1,19 +1,21 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Image } from 'expo-image';
-import { Stack, useLocalSearchParams } from 'expo-router';
-import { type ComponentProps, useCallback, useEffect, useState } from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import { type ComponentProps, useCallback, useRef, useState } from 'react';
+import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { resolveMediaUrl } from '@/shared/api/base-url';
 import { type ApiError, normalizeApiError } from '@/shared/api/errors';
 import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
 import { Button } from '@/shared/ui/Button';
 import { LoadingScreen } from '@/shared/ui/LoadingScreen';
-import { getTripDetail } from '../api';
+import { cancelTrip, completeTrip, leaveTrip, startTrip } from '../api';
 import { MemberRow } from '../components/MemberRow';
 import { StatusBadge } from '../components/StatusBadge';
+import { TripActions, type TripDisplayAction } from '../components/TripActions';
 import { formatDateRange } from '../dates';
-import type { TripDetailResponse } from '../types';
+import { useTripDetail } from '../hooks/useTripDetail';
+import { publishTripEvent } from '../tripEvents';
 
 const budgetFormatter = new Intl.NumberFormat('en-US');
 
@@ -24,11 +26,6 @@ function formatBudget(budget: string, currencyCode: string): string {
   }
   return `${budgetFormatter.format(amount)} ${currencyCode}`;
 }
-
-type TripDetailState =
-  | { status: 'loading' }
-  | { status: 'ready'; detail: TripDetailResponse }
-  | { status: 'error'; error: ApiError };
 
 interface DetailRowProps {
   icon: ComponentProps<typeof Ionicons>['name'];
@@ -47,65 +44,106 @@ function DetailRow({ icon, value, showDivider = false }: DetailRowProps) {
   );
 }
 
-async function fetchTripDetailState(tripId: string | undefined): Promise<TripDetailState> {
-  if (!tripId) {
-    return { status: 'error', error: normalizeApiError(new Error('Missing trip id.')) };
-  }
-  try {
-    return { status: 'ready', detail: await getTripDetail(tripId) };
-  } catch (error) {
-    return { status: 'error', error: normalizeApiError(error) };
-  }
-}
-
 export function TripDetailScreen() {
   const { tripId } = useLocalSearchParams<{ tripId: string }>();
-  const [state, setState] = useState<TripDetailState>({ status: 'loading' });
+  const router = useRouter();
+  const { detail, status, error, refreshing, refresh, applyStatus } = useTripDetail(tripId);
+  const [mutationError, setMutationError] = useState<ApiError | null>(null);
+  const [mutatingAction, setMutatingAction] = useState<TripDisplayAction | null>(null);
+  const mutationLockRef = useRef(false);
 
-  const retry = useCallback(() => {
-    setState({ status: 'loading' });
-    void fetchTripDetailState(tripId).then(setState);
-  }, [tripId]);
-
-  useEffect(() => {
-    let active = true;
-    void fetchTripDetailState(tripId).then((nextState) => {
-      if (active) {
-        setState(nextState);
+  const handleAction = useCallback(
+    async (action: TripDisplayAction) => {
+      if (action === 'edit') {
+        router.push(`/trips/${tripId}/edit`);
+        return;
       }
-    });
-    return () => {
-      active = false;
-    };
-  }, [tripId]);
+      if (!tripId || mutationLockRef.current) {
+        return;
+      }
 
-  if (state.status === 'loading') {
+      mutationLockRef.current = true;
+      setMutationError(null);
+      setMutatingAction(action);
+      try {
+        if (action === 'leave') {
+          await leaveTrip(tripId);
+          publishTripEvent({ type: 'removed', tripId });
+          router.dismissTo('/(tabs)');
+          return;
+        }
+
+        const nextStatus =
+          action === 'start'
+            ? await startTrip(tripId)
+            : action === 'complete'
+              ? await completeTrip(tripId)
+              : await cancelTrip(tripId);
+        applyStatus(nextStatus);
+        publishTripEvent({ type: 'statusChanged', tripId, status: nextStatus });
+        void refresh('silent');
+      } catch (caught) {
+        setMutationError(normalizeApiError(caught));
+      } finally {
+        mutationLockRef.current = false;
+        setMutatingAction(null);
+      }
+    },
+    [applyStatus, refresh, router, tripId],
+  );
+
+  if (status === 'loading') {
     return <LoadingScreen />;
   }
 
-  if (state.status === 'error') {
-    const notFound = state.error.status === 404;
+  if (status === 'error' || !detail) {
+    const displayError = error ?? normalizeApiError(new Error('Missing trip detail.'));
+    const notFound = displayError.status === 404;
     return (
       <SafeAreaView style={styles.safe}>
         <View style={styles.centered}>
           <Ionicons name={notFound ? 'help-circle-outline' : 'cloud-offline-outline'} size={44} color={colors.textMuted} />
           <Text style={styles.sectionTitle}>{notFound ? 'Trip not found' : 'Could not load trip'}</Text>
           <Text style={styles.muted}>
-            {notFound ? 'This trip does not exist or you are not a member of it.' : state.error.message}
+            {notFound ? 'This trip does not exist or you are not a member of it.' : displayError.message}
           </Text>
-          {notFound ? null : <Button title="Try again" onPress={retry} />}
+          {notFound ? null : <Button title="Try again" onPress={() => void refresh('initial')} />}
         </View>
       </SafeAreaView>
     );
   }
 
-  const { trip, members } = state.detail;
+  const { trip, members, my_membership: membership } = detail;
   const coverUrl = resolveMediaUrl(trip.cover_image_url || null);
+  const inlineError = mutationError ?? error;
 
   return (
     <SafeAreaView style={styles.safe} edges={['left', 'right', 'bottom']}>
       <Stack.Screen options={{ title: trip.name }} />
       <ScrollView contentContainerStyle={styles.content} contentInsetAdjustmentBehavior="automatic">
+        {inlineError ? (
+          <View accessibilityRole="alert" style={styles.inlineError}>
+            <Ionicons name="alert-circle-outline" size={20} color={colors.danger} />
+            <Text style={styles.inlineErrorText}>{inlineError.message}</Text>
+            {!mutationError ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Retry refreshing trip"
+                hitSlop={spacing.sm}
+                onPress={() => void refresh('silent')}
+                style={({ pressed }) => [styles.retryButton, pressed && styles.retryButtonPressed]}
+              >
+                <Text style={styles.retryText}>Retry</Text>
+              </Pressable>
+            ) : null}
+          </View>
+        ) : null}
+        {refreshing ? (
+          <View accessibilityLabel="Refreshing trip" style={styles.refreshingRow}>
+            <ActivityIndicator size="small" color={colors.primary} />
+            <Text style={styles.refreshingText}>Refreshing…</Text>
+          </View>
+        ) : null}
         {coverUrl ? (
           <Image source={{ uri: coverUrl }} style={styles.cover} contentFit="cover" transition={150} />
         ) : (
@@ -130,6 +168,18 @@ export function TripDetailScreen() {
             <DetailRow icon="wallet-outline" value={formatBudget(trip.budget_estimate, trip.currency_code)} />
           ) : null}
         </View>
+        <TripActions
+          trip={trip}
+          membership={membership}
+          isMutating={mutatingAction !== null}
+          onAction={handleAction}
+        />
+        {mutatingAction ? (
+          <View accessibilityLabel="Updating trip" style={styles.refreshingRow}>
+            <ActivityIndicator size="small" color={colors.primary} />
+            <Text style={styles.refreshingText}>Updating trip…</Text>
+          </View>
+        ) : null}
         {trip.description ? (
           <View style={styles.section}>
             <Text accessibilityRole="header" style={styles.sectionTitle}>
@@ -195,4 +245,21 @@ const styles = StyleSheet.create({
   sectionTitle: { ...typography.heading, color: colors.text },
   muted: { ...typography.body, color: colors.textMuted, textAlign: 'center' },
   membersCard: { paddingVertical: 0 },
+  inlineError: {
+    minHeight: 48,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.dangerBorder,
+    borderRadius: radii.md,
+    backgroundColor: colors.dangerSoft,
+  },
+  inlineErrorText: { ...typography.caption, color: colors.danger, flex: 1 },
+  retryButton: { minHeight: 44, justifyContent: 'center', paddingHorizontal: spacing.xs },
+  retryButtonPressed: { opacity: 0.55 },
+  retryText: { ...typography.label, color: colors.danger },
+  refreshingRow: { minHeight: 32, flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
+  refreshingText: { ...typography.caption, color: colors.textMuted },
 });

--- a/mobile/src/features/trips/tripEvents.ts
+++ b/mobile/src/features/trips/tripEvents.ts
@@ -1,0 +1,21 @@
+import type { Trip, TripStatus } from './types';
+
+export type TripEvent =
+  | { type: 'updated'; trip: Trip }
+  | { type: 'statusChanged'; tripId: string; status: TripStatus }
+  | { type: 'removed'; tripId: string };
+
+type TripEventListener = (event: TripEvent) => void;
+
+const listeners = new Set<TripEventListener>();
+
+export function publishTripEvent(event: TripEvent): void {
+  for (const listener of listeners) {
+    listener(event);
+  }
+}
+
+export function subscribeToTripEvents(listener: TripEventListener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/mobile/src/features/trips/types.ts
+++ b/mobile/src/features/trips/types.ts
@@ -77,3 +77,22 @@ export interface CreateTripInput {
   currency_code?: string;
   budget_estimate?: string;
 }
+
+export interface UpdateTripInput {
+  name?: string;
+  destination?: string;
+  destination_provider?: string;
+  destination_provider_id?: string;
+  destination_lat?: string | null;
+  destination_lng?: string | null;
+  destination_country_code?: string;
+  cover_image_url?: string;
+  start_date?: string;
+  end_date?: string;
+  description?: string;
+  currency_code?: string;
+  timezone?: string;
+  budget_estimate?: string | null;
+}
+
+export type TripAction = 'start' | 'complete' | 'cancel' | 'leave';

--- a/mobile/src/shared/ui/Button.tsx
+++ b/mobile/src/shared/ui/Button.tsx
@@ -16,7 +16,8 @@ export function Button({ title, onPress, loading = false, disabled = false, vari
     <Pressable
       testID="button-pressable"
       accessibilityRole="button"
-      accessibilityState={{ disabled: blocked }}
+      accessibilityLabel={title}
+      accessibilityState={{ disabled: blocked, busy: loading }}
       onPress={blocked ? () => undefined : onPress}
       style={({ pressed }) => [
         styles.base,


### PR DESCRIPTION
## Summary

- add captain-only trip editing for eligible mobile trips
- add role/status-aware start, complete, cancel, and leave actions with native confirmations
- synchronize trip detail and list state after mutations while protecting against stale refresh and pagination races
- harden backend trip updates so a terminal transition wins under concurrent edits

## Why

Issue #52 completes the core mobile Trips management flow. Users can now maintain trip details and perform only the lifecycle actions allowed by their membership and the persisted trip state.

The backend row-lock recheck closes a race where request-level validation could become stale while an edit waited behind a concurrent complete or cancel transaction.

## User impact

- Captains can edit active trips and start, complete, or cancel them.
- Active members can leave after confirmation.
- Detail and list views update immediately without an app relaunch.
- Inaccessible trips continue to use the existing non-enumerating not-found behavior.

## Validation

- `python manage.py test trips`: 205 passed
- `pnpm lint`: passed
- `pnpm typecheck`: passed
- `pnpm test --runInBand`: 21 suites, 111 tests passed
- iPhone 17 Pro Max dev-build QA:
  - captain edit → save → start
  - member leave confirmation and immediate list removal
  - relaunch preserved authentication
- `git diff --check`: passed

Closes #52
