### PR TITLE
feat(mobile): add friends management

### DIFF
--- a/mobile/src/app/(tabs)/_layout.tsx
+++ b/mobile/src/app/(tabs)/_layout.tsx
@@ -29,6 +29,7 @@ export default function TabsLayout() {
         name="friends"
         options={{
           title: 'Friends',
+          headerShown: false,
           tabBarIcon: ({ color, size }) => <Ionicons name="people-outline" color={color} size={size} />,
         }}
       />

--- a/mobile/src/app/(tabs)/friends.tsx
+++ b/mobile/src/app/(tabs)/friends.tsx
@@ -1,15 +1,3 @@
-import { StyleSheet, Text } from 'react-native';
-import { colors, typography } from '@/shared/theme/tokens';
-import { Screen } from '@/shared/ui/Screen';
+import { FriendsScreen } from '@/features/friends/screens/FriendsScreen';
 
-export default function FriendsScreen() {
-  return (
-    <Screen>
-      <Text style={styles.placeholder}>Friends will live here.</Text>
-    </Screen>
-  );
-}
-
-const styles = StyleSheet.create({
-  placeholder: { ...typography.body, color: colors.textMuted },
-});
+export default FriendsScreen;

--- a/mobile/src/app/__tests__/_layout.test.tsx
+++ b/mobile/src/app/__tests__/_layout.test.tsx
@@ -1,0 +1,34 @@
+const mockStackScreen = jest.fn();
+
+jest.mock('expo-router', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+
+  function MockStack({ children }: { children: import('react').ReactNode }) {
+    return React.createElement(View, null, children);
+  }
+
+  MockStack.Screen = function MockStackScreen({ name }: { name: string }) {
+    mockStackScreen(name);
+    return null;
+  };
+
+  return { Stack: MockStack };
+});
+
+jest.mock('@/features/auth/session', () => ({
+  SessionProvider: ({ children }: { children: import('react').ReactNode }) => children,
+}));
+
+// eslint-disable-next-line import/first
+import { render } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import RootLayout from '../_layout';
+
+describe('RootLayout', () => {
+  it('registers the guarded Friends native stack', async () => {
+    await render(<RootLayout />);
+
+    expect(mockStackScreen).toHaveBeenCalledWith('friends');
+  });
+});

--- a/mobile/src/app/_layout.tsx
+++ b/mobile/src/app/_layout.tsx
@@ -8,6 +8,7 @@ export default function RootLayout() {
         <Stack.Screen name="(auth)" />
         <Stack.Screen name="(tabs)" />
         <Stack.Screen name="trips" />
+        <Stack.Screen name="friends" />
       </Stack>
     </SessionProvider>
   );

--- a/mobile/src/app/friends/__tests__/_layout.test.tsx
+++ b/mobile/src/app/friends/__tests__/_layout.test.tsx
@@ -1,0 +1,128 @@
+const mockRouter = { canGoBack: jest.fn(), back: jest.fn(), replace: jest.fn() };
+const mockUseSession = jest.fn();
+const mockStackScreen = jest.fn();
+
+jest.mock('expo-router', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+
+  function MockStack({ children }: { children: import('react').ReactNode }) {
+    return React.createElement(View, null, children);
+  }
+
+  MockStack.Screen = function MockStackScreen({
+    name,
+    options,
+  }: {
+    name: string;
+    options: {
+      title: string;
+      presentation?: string;
+      headerLeft?: () => import('react').ReactNode;
+    };
+  }) {
+    mockStackScreen({ name, options });
+    return React.createElement(View, { testID: `screen-${name}` }, options.headerLeft?.());
+  };
+
+  return {
+    Redirect: ({ href }: { href: string }) => React.createElement(View, { testID: `redirect-${href}` }),
+    Stack: MockStack,
+    useRouter: () => mockRouter,
+  };
+});
+
+jest.mock('@/features/auth/session', () => ({ useSession: () => mockUseSession() }));
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('@/shared/ui/LoadingScreen', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+  return { LoadingScreen: () => React.createElement(View, { testID: 'loading-session' }) };
+});
+
+// eslint-disable-next-line import/first
+import { fireEvent, render, screen } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import FriendsLayout from '../_layout';
+
+describe('FriendsLayout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSession.mockReturnValue({ status: 'signedIn', user: { requires_profile_setup: false } });
+  });
+
+  it('registers Add Friend as a native modal and Requests as a pushed screen', async () => {
+    await render(<FriendsLayout />);
+
+    expect(screen.getByTestId('screen-add')).toBeTruthy();
+    expect(screen.getByTestId('screen-requests')).toBeTruthy();
+    const registrations = mockStackScreen.mock.calls.map(([registration]) => registration);
+    expect(registrations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'add', options: expect.objectContaining({ presentation: 'modal' }) }),
+        expect.objectContaining({ name: 'requests', options: expect.objectContaining({ title: 'Friend Requests' }) }),
+      ]),
+    );
+  });
+
+  it('dismisses Add Friend through native history when available', async () => {
+    mockRouter.canGoBack.mockReturnValue(true);
+    await render(<FriendsLayout />);
+
+    await fireEvent.press(screen.getByLabelText('Cancel adding a friend'));
+
+    expect(mockRouter.back).toHaveBeenCalledTimes(1);
+    expect(mockRouter.replace).not.toHaveBeenCalled();
+  });
+
+  it('returns a history-less Add Friend deep link to the Friends tab', async () => {
+    mockRouter.canGoBack.mockReturnValue(false);
+    await render(<FriendsLayout />);
+
+    await fireEvent.press(screen.getByLabelText('Cancel adding a friend'));
+
+    expect(mockRouter.back).not.toHaveBeenCalled();
+    expect(mockRouter.replace).toHaveBeenCalledWith('/(tabs)/friends');
+  });
+
+  it('provides a native-header path back from the initial Requests route', async () => {
+    mockRouter.canGoBack.mockReturnValue(true);
+    await render(<FriendsLayout />);
+
+    await fireEvent.press(screen.getByLabelText('Back to Friends'));
+
+    expect(mockRouter.back).toHaveBeenCalledTimes(1);
+    expect(mockRouter.replace).not.toHaveBeenCalled();
+  });
+
+  it('returns a history-less Requests deep link to the Friends tab', async () => {
+    mockRouter.canGoBack.mockReturnValue(false);
+    await render(<FriendsLayout />);
+
+    await fireEvent.press(screen.getByLabelText('Back to Friends'));
+
+    expect(mockRouter.back).not.toHaveBeenCalled();
+    expect(mockRouter.replace).toHaveBeenCalledWith('/(tabs)/friends');
+  });
+
+  it('shows the session restoration fallback', async () => {
+    mockUseSession.mockReturnValue({ status: 'restoring', user: null });
+    await render(<FriendsLayout />);
+
+    expect(screen.getByTestId('loading-session')).toBeTruthy();
+  });
+
+  it('redirects signed-out users to login', async () => {
+    mockUseSession.mockReturnValue({ status: 'signedOut', user: null });
+    await render(<FriendsLayout />);
+
+    expect(screen.getByTestId('redirect-/(auth)/login')).toBeTruthy();
+  });
+
+  it('redirects incomplete profiles to profile setup', async () => {
+    mockUseSession.mockReturnValue({ status: 'signedIn', user: { requires_profile_setup: true } });
+    await render(<FriendsLayout />);
+
+    expect(screen.getByTestId('redirect-/(auth)/profile-setup')).toBeTruthy();
+  });
+});

--- a/mobile/src/app/friends/_layout.tsx
+++ b/mobile/src/app/friends/_layout.tsx
@@ -1,0 +1,91 @@
+import { Ionicons } from '@expo/vector-icons';
+import { Redirect, Stack, useRouter } from 'expo-router';
+import { Pressable, StyleSheet, Text } from 'react-native';
+import { useSession } from '@/features/auth/session';
+import { colors, spacing, typography } from '@/shared/theme/tokens';
+import { LoadingScreen } from '@/shared/ui/LoadingScreen';
+
+function HeaderCancelAction({ onPress }: { onPress: () => void }) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel="Cancel adding a friend"
+      hitSlop={spacing.sm}
+      onPress={onPress}
+      style={({ pressed }) => [styles.headerAction, pressed && styles.headerActionPressed]}
+    >
+      <Text style={styles.headerActionText}>Cancel</Text>
+    </Pressable>
+  );
+}
+
+function HeaderBackAction({ onPress }: { onPress: () => void }) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel="Back to Friends"
+      hitSlop={spacing.sm}
+      onPress={onPress}
+      style={({ pressed }) => [styles.headerAction, pressed && styles.headerActionPressed]}
+    >
+      <Ionicons name="chevron-back" size={22} color={colors.primary} />
+      <Text style={styles.headerActionText}>Friends</Text>
+    </Pressable>
+  );
+}
+
+export default function FriendsLayout() {
+  const router = useRouter();
+  const { status, user } = useSession();
+
+  if (status === 'restoring') {
+    return <LoadingScreen />;
+  }
+  if (status === 'signedOut') {
+    return <Redirect href="/(auth)/login" />;
+  }
+  if (user?.requires_profile_setup) {
+    return <Redirect href="/(auth)/profile-setup" />;
+  }
+
+  const leaveFriendsRoute = () => {
+    if (router.canGoBack()) {
+      router.back();
+      return;
+    }
+    router.replace('/(tabs)/friends');
+  };
+
+  return (
+    <Stack screenOptions={{ headerShown: true }}>
+      <Stack.Screen
+        name="add"
+        options={{
+          title: 'Add Friend',
+          presentation: 'modal',
+          headerLeft: () => <HeaderCancelAction onPress={leaveFriendsRoute} />,
+        }}
+      />
+      <Stack.Screen
+        name="requests"
+        options={{
+          title: 'Friend Requests',
+          headerLeft: () => <HeaderBackAction onPress={leaveFriendsRoute} />,
+        }}
+      />
+    </Stack>
+  );
+}
+
+const styles = StyleSheet.create({
+  headerAction: {
+    minHeight: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginLeft: -spacing.sm,
+    paddingHorizontal: spacing.sm,
+  },
+  headerActionPressed: { opacity: 0.55 },
+  headerActionText: { ...typography.body, color: colors.primary },
+});

--- a/mobile/src/app/friends/add.tsx
+++ b/mobile/src/app/friends/add.tsx
@@ -1,0 +1,3 @@
+import { AddFriendScreen } from '@/features/friends/screens/AddFriendScreen';
+
+export default AddFriendScreen;

--- a/mobile/src/app/friends/requests.tsx
+++ b/mobile/src/app/friends/requests.tsx
@@ -1,0 +1,3 @@
+import { FriendRequestsScreen } from '@/features/friends/screens/FriendRequestsScreen';
+
+export default FriendRequestsScreen;

--- a/mobile/src/features/friends/__tests__/AddFriendScreen.test.tsx
+++ b/mobile/src/features/friends/__tests__/AddFriendScreen.test.tsx
@@ -1,0 +1,146 @@
+const mockUseFriendSearch = jest.fn();
+
+jest.mock('../hooks/useFriendSearch', () => ({
+  useFriendSearch: () => mockUseFriendSearch(),
+}));
+
+jest.mock('expo-image', () => ({ Image: () => null }));
+
+// eslint-disable-next-line import/first
+import { fireEvent, render, screen } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { AddFriendScreen } from '../screens/AddFriendScreen';
+// eslint-disable-next-line import/first
+import type { useFriendSearch } from '../hooks/useFriendSearch';
+// eslint-disable-next-line import/first
+import type { FriendUser } from '../types';
+
+type FriendSearchState = ReturnType<typeof useFriendSearch>;
+
+const user: FriendUser = {
+  id: 'user-2',
+  display_name: 'Minh Anh',
+  identify_tag: 'minhanh#AB12',
+  avatar_url: null,
+};
+
+function createState(overrides: Partial<FriendSearchState> = {}): FriendSearchState {
+  return {
+    query: '',
+    setQuery: jest.fn(),
+    user: null,
+    searchStatus: 'idle',
+    searchError: null,
+    search: jest.fn(async () => {}),
+    sendStatus: 'idle',
+    sendError: null,
+    friendRequest: null,
+    sendRequest: jest.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+describe('AddFriendScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates the identify tag and starts an exact search', async () => {
+    const setQuery = jest.fn();
+    const search = jest.fn(async () => {});
+    mockUseFriendSearch.mockReturnValue(createState({ query: 'minhanh#AB12', setQuery, search }));
+
+    await render(<AddFriendScreen />);
+    await fireEvent.changeText(screen.getByLabelText('Identify tag'), 'other#CD34');
+    await fireEvent.press(screen.getByRole('button', { name: 'Search' }));
+
+    expect(setQuery).toHaveBeenCalledWith('other#CD34');
+    expect(search).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows one neutral state when search returns no user', async () => {
+    mockUseFriendSearch.mockReturnValue(createState({ query: 'unknown#NONE', searchStatus: 'notFound' }));
+
+    await render(<AddFriendScreen />);
+
+    expect(screen.getByText('No user found')).toBeTruthy();
+    expect(screen.getByText('Check the identify tag and try again.')).toBeTruthy();
+    expect(screen.queryByText(/yourself/i)).toBeNull();
+  });
+
+  it('renders the found user, sends a request, and shows the completed state', async () => {
+    const sendRequest = jest.fn(async () => {});
+    mockUseFriendSearch.mockReturnValue(
+      createState({ query: user.identify_tag, user, searchStatus: 'found', sendRequest }),
+    );
+
+    const { rerender } = await render(<AddFriendScreen />);
+    expect(screen.getByText('Minh Anh')).toBeTruthy();
+    expect(screen.getByText('minhanh#AB12')).toBeTruthy();
+    expect(screen.getByText('MA')).toBeTruthy();
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Send friend request' }));
+    expect(sendRequest).toHaveBeenCalledTimes(1);
+
+    mockUseFriendSearch.mockReturnValue(
+      createState({ query: user.identify_tag, user, searchStatus: 'found', sendStatus: 'sent' }),
+    );
+    await rerender(<AddFriendScreen />);
+
+    expect(screen.getByText('Friend request sent.')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Send friend request' })).toBeNull();
+  });
+
+  it('displays malformed-query detail and field errors through the normalized error shape', async () => {
+    mockUseFriendSearch.mockReturnValue(
+      createState({
+        query: 'malformed',
+        searchStatus: 'error',
+        searchError: {
+          kind: 'message',
+          message: 'Enter an identify tag in name#CODE format.',
+          errorCode: 'INVALID_SEARCH_QUERY',
+          status: 400,
+        },
+      }),
+    );
+    const { rerender } = await render(<AddFriendScreen />);
+    expect(screen.getByText('Enter an identify tag in name#CODE format.')).toBeTruthy();
+
+    mockUseFriendSearch.mockReturnValue(
+      createState({
+        query: 'malformed',
+        searchStatus: 'error',
+        searchError: {
+          kind: 'field',
+          message: 'Please fix the highlighted fields.',
+          fieldErrors: { q: 'Use the name#CODE format.' },
+          status: 400,
+        },
+      }),
+    );
+    await rerender(<AddFriendScreen />);
+
+    expect(screen.getByText('Use the name#CODE format.')).toBeTruthy();
+  });
+
+  it('shows backend friend-request business errors exactly as returned', async () => {
+    mockUseFriendSearch.mockReturnValue(
+      createState({
+        query: user.identify_tag,
+        user,
+        searchStatus: 'found',
+        sendError: {
+          kind: 'message',
+          message: 'A friend request is already pending.',
+          errorCode: 'DUPLICATE_PENDING',
+          status: 409,
+        },
+      }),
+    );
+
+    await render(<AddFriendScreen />);
+
+    expect(screen.getByText('A friend request is already pending.')).toBeTruthy();
+  });
+});

--- a/mobile/src/features/friends/__tests__/FriendRequestsScreen.test.tsx
+++ b/mobile/src/features/friends/__tests__/FriendRequestsScreen.test.tsx
@@ -1,0 +1,382 @@
+const mockUseFocusEffect = jest.fn();
+const mockUseFriendRequests = jest.fn();
+const mockFlatListProps = jest.fn();
+
+jest.mock('react-native/Libraries/Lists/FlatList', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+
+  interface MockItem {
+    id: string;
+  }
+
+  interface MockFlatListProps {
+    data: MockItem[];
+    renderItem: (info: { item: MockItem }) => import('react').ReactNode;
+    onRefresh: () => void;
+    onEndReached: () => void;
+    refreshing: boolean;
+    ListEmptyComponent: import('react').ReactNode;
+    ListFooterComponent: import('react').ReactNode;
+  }
+
+  function MockFlatList(props: MockFlatListProps) {
+    mockFlatListProps(props);
+    return React.createElement(
+      View,
+      null,
+      props.data.length > 0
+        ? props.data.map((item) =>
+            React.createElement(React.Fragment, { key: item.id }, props.renderItem({ item })),
+          )
+        : props.ListEmptyComponent,
+      props.ListFooterComponent,
+    );
+  }
+
+  return { __esModule: true, default: MockFlatList };
+});
+
+jest.mock('expo-router', () => ({
+  useFocusEffect: (effect: () => void) => mockUseFocusEffect(effect),
+}));
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('expo-image', () => ({ Image: () => null }));
+jest.mock('@/shared/ui/LoadingScreen', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+  return { LoadingScreen: () => React.createElement(View, { testID: 'requests-loading' }) };
+});
+jest.mock('../hooks/useFriendRequests', () => ({ useFriendRequests: () => mockUseFriendRequests() }));
+
+// eslint-disable-next-line import/first
+import { fireEvent, render, screen } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { FriendRequestsScreen } from '../screens/FriendRequestsScreen';
+// eslint-disable-next-line import/first
+import type { useFriendRequests } from '../hooks/useFriendRequests';
+// eslint-disable-next-line import/first
+import type { FriendRequest } from '../types';
+
+type FriendRequestsState = ReturnType<typeof useFriendRequests>;
+type RequestListState = FriendRequestsState['incoming'];
+
+const incomingRequest: FriendRequest = {
+  id: 'incoming-1',
+  sender: {
+    id: 'alice-id',
+    display_name: 'Alice Sender',
+    identify_tag: 'alice#ABC123',
+    avatar_url: null,
+  },
+  receiver: {
+    id: 'current-id',
+    display_name: 'Current User',
+    identify_tag: 'current#CUR123',
+    avatar_url: null,
+  },
+  status: 'PENDING',
+  resolved_at: null,
+  created_at: '2026-07-20T10:00:00Z',
+};
+
+const outgoingRequest: FriendRequest = {
+  id: 'outgoing-1',
+  sender: incomingRequest.receiver,
+  receiver: {
+    id: 'bob-id',
+    display_name: 'Bob Receiver',
+    identify_tag: 'bob#DEF456',
+    avatar_url: null,
+  },
+  status: 'PENDING',
+  resolved_at: null,
+  created_at: '2026-07-21T10:00:00Z',
+};
+
+function createListState(overrides: Partial<RequestListState> = {}): RequestListState {
+  return {
+    items: [],
+    status: 'ready',
+    error: null,
+    errorSource: null,
+    refreshing: false,
+    loadingMore: false,
+    hasNextPage: false,
+    loadFirstPage: jest.fn(async (_mode: 'initial' | 'refresh' | 'silent') => {}),
+    loadMore: jest.fn(async () => {}),
+    upsertLocalItem: jest.fn(),
+    removeLocalItem: jest.fn(),
+    ...overrides,
+  };
+}
+
+function createState(overrides: Partial<FriendRequestsState> = {}): FriendRequestsState {
+  return {
+    incoming: createListState(),
+    outgoing: createListState(),
+    pendingActions: new Map(),
+    mutationError: null,
+    performAction: jest.fn(async (_requestId: string, _action: 'accept' | 'decline' | 'cancel') => true),
+    loadFirstPages: jest.fn(async (_mode: 'initial' | 'refresh' | 'silent') => {}),
+    clearMutationError: jest.fn(),
+    ...overrides,
+  };
+}
+
+function latestListProps(): {
+  onRefresh: () => void;
+  onEndReached: () => void;
+  refreshing: boolean;
+} {
+  const props = mockFlatListProps.mock.calls.at(-1)?.[0];
+  if (!props) {
+    throw new Error('Expected FriendRequestsScreen to render a FlatList.');
+  }
+  return props;
+}
+
+describe('FriendRequestsScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseFriendRequests.mockReturnValue(createState());
+  });
+
+  it('loads both request lists initially and silently on later focus', async () => {
+    const loadFirstPages = jest.fn(async (_mode: 'initial' | 'refresh' | 'silent') => {});
+    mockUseFriendRequests.mockReturnValue(createState({ loadFirstPages }));
+    await render(<FriendRequestsScreen />);
+
+    const focusCallback = mockUseFocusEffect.mock.calls.at(0)?.[0];
+    expect(focusCallback).toBeDefined();
+    focusCallback?.();
+    focusCallback?.();
+
+    expect(loadFirstPages).toHaveBeenNthCalledWith(1, 'initial');
+    expect(loadFirstPages).toHaveBeenNthCalledWith(2, 'silent');
+  });
+
+  it('shows the current tab loading state independently', async () => {
+    mockUseFriendRequests.mockReturnValue(
+      createState({
+        incoming: createListState({ items: [incomingRequest] }),
+        outgoing: createListState({ status: 'loading' }),
+      }),
+    );
+    await render(<FriendRequestsScreen />);
+
+    expect(screen.getByText('Alice Sender')).toBeTruthy();
+    await fireEvent.press(screen.getByText('Outgoing'));
+    expect(screen.getByTestId('requests-loading')).toBeTruthy();
+  });
+
+  it('switches between incoming sender and outgoing receiver without inventing counts', async () => {
+    mockUseFriendRequests.mockReturnValue(
+      createState({
+        incoming: createListState({ items: [incomingRequest] }),
+        outgoing: createListState({ items: [outgoingRequest] }),
+      }),
+    );
+    await render(<FriendRequestsScreen />);
+
+    expect(screen.getByText('Alice Sender')).toBeTruthy();
+    expect(screen.queryByText('Bob Receiver')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Incoming requests' }).props.accessibilityState).toEqual({ selected: true });
+    expect(screen.getByRole('button', { name: 'Outgoing requests' }).props.accessibilityState).toEqual({ selected: false });
+    expect(screen.getByText('Incoming')).toBeTruthy();
+    expect(screen.queryByText(/Incoming \(/)).toBeNull();
+    expect(screen.queryByText(/Outgoing \(/)).toBeNull();
+
+    await fireEvent.press(screen.getByText('Outgoing'));
+
+    expect(screen.getByRole('button', { name: 'Outgoing requests' }).props.accessibilityState).toEqual({ selected: true });
+    expect(screen.getByText('Bob Receiver')).toBeTruthy();
+    expect(screen.queryByText('Alice Sender')).toBeNull();
+  });
+
+  it('shows the active tab initial error and retries only that tab', async () => {
+    const outgoingLoadFirstPage = jest.fn(async (_mode: 'initial' | 'refresh' | 'silent') => {});
+    const incomingLoadFirstPage = jest.fn(async (_mode: 'initial' | 'refresh' | 'silent') => {});
+    mockUseFriendRequests.mockReturnValue(
+      createState({
+        incoming: createListState({ items: [incomingRequest], loadFirstPage: incomingLoadFirstPage }),
+        outgoing: createListState({
+          status: 'error',
+          error: { kind: 'network', message: 'Outgoing requests failed.' },
+          errorSource: 'initial',
+          loadFirstPage: outgoingLoadFirstPage,
+        }),
+      }),
+    );
+    await render(<FriendRequestsScreen />);
+
+    await fireEvent.press(screen.getByText('Outgoing'));
+    expect(screen.getByText('Could not load requests')).toBeTruthy();
+    expect(screen.getByText('Outgoing requests failed.')).toBeTruthy();
+    await fireEvent.press(screen.getByText('Try again'));
+
+    expect(outgoingLoadFirstPage).toHaveBeenCalledWith('initial');
+    expect(incomingLoadFirstPage).not.toHaveBeenCalled();
+  });
+
+  it('dispatches incoming and outgoing actions with their request IDs', async () => {
+    const performAction = jest.fn(async (_requestId: string, _action: 'accept' | 'decline' | 'cancel') => true);
+    mockUseFriendRequests.mockReturnValue(
+      createState({
+        incoming: createListState({ items: [incomingRequest] }),
+        outgoing: createListState({ items: [outgoingRequest] }),
+        performAction,
+      }),
+    );
+    await render(<FriendRequestsScreen />);
+
+    await fireEvent.press(screen.getByLabelText('Accept Alice Sender'));
+    await fireEvent.press(screen.getByLabelText('Decline Alice Sender'));
+    await fireEvent.press(screen.getByText('Outgoing'));
+    await fireEvent.press(screen.getByLabelText('Cancel request to Bob Receiver'));
+
+    expect(performAction).toHaveBeenNthCalledWith(1, 'incoming-1', 'accept');
+    expect(performAction).toHaveBeenNthCalledWith(2, 'incoming-1', 'decline');
+    expect(performAction).toHaveBeenNthCalledWith(3, 'outgoing-1', 'cancel');
+  });
+
+  it('retains the row, displays mutation errors, and disables duplicate actions', async () => {
+    mockUseFriendRequests.mockReturnValue(
+      createState({
+        incoming: createListState({ items: [incomingRequest] }),
+        pendingActions: new Map([['incoming-1', 'accept']]),
+        mutationError: { kind: 'message', message: 'Request is no longer pending.', errorCode: 'INVALID_REQUEST_STATE' },
+      }),
+    );
+    await render(<FriendRequestsScreen />);
+
+    expect(screen.getByText('Alice Sender')).toBeTruthy();
+    expect(screen.getByText('Request is no longer pending.')).toBeTruthy();
+    expect(screen.getByLabelText('Accept Alice Sender').props.accessibilityState).toEqual({
+      disabled: true,
+      busy: true,
+    });
+    expect(screen.getByLabelText('Decline Alice Sender').props.accessibilityState).toEqual({
+      disabled: true,
+      busy: false,
+    });
+    expect(screen.queryByLabelText('Retry refreshing incoming requests')).toBeNull();
+  });
+
+  it('delegates pull-to-refresh and pagination to the active tab', async () => {
+    const incomingLoadFirstPage = jest.fn(async (_mode: 'initial' | 'refresh' | 'silent') => {});
+    const incomingLoadMore = jest.fn(async () => {});
+    const outgoingLoadFirstPage = jest.fn(async (_mode: 'initial' | 'refresh' | 'silent') => {});
+    const outgoingLoadMore = jest.fn(async () => {});
+    mockUseFriendRequests.mockReturnValue(
+      createState({
+        incoming: createListState({
+          items: [incomingRequest],
+          refreshing: true,
+          loadFirstPage: incomingLoadFirstPage,
+          loadMore: incomingLoadMore,
+        }),
+        outgoing: createListState({
+          items: [outgoingRequest],
+          loadFirstPage: outgoingLoadFirstPage,
+          loadMore: outgoingLoadMore,
+        }),
+      }),
+    );
+    await render(<FriendRequestsScreen />);
+
+    const incomingProps = latestListProps();
+    await incomingProps.onRefresh();
+    await incomingProps.onEndReached();
+    expect(incomingProps.refreshing).toBe(true);
+
+    await fireEvent.press(screen.getByText('Outgoing'));
+    const outgoingProps = latestListProps();
+    await outgoingProps.onRefresh();
+    await outgoingProps.onEndReached();
+
+    expect(incomingLoadFirstPage).toHaveBeenCalledWith('refresh');
+    expect(incomingLoadMore).toHaveBeenCalledTimes(1);
+    expect(outgoingLoadFirstPage).toHaveBeenCalledWith('refresh');
+    expect(outgoingLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries load-more errors through each tab cursor function', async () => {
+    const incomingLoadFirstPage = jest.fn(async (_mode: 'initial' | 'refresh' | 'silent') => {});
+    const incomingLoadMore = jest.fn(async () => {});
+    const outgoingLoadFirstPage = jest.fn(async (_mode: 'initial' | 'refresh' | 'silent') => {});
+    const outgoingLoadMore = jest.fn(async () => {});
+    mockUseFriendRequests.mockReturnValue(
+      createState({
+        incoming: createListState({
+          items: [incomingRequest],
+          error: { kind: 'network', message: 'More incoming failed.' },
+          errorSource: 'loadMore',
+          loadFirstPage: incomingLoadFirstPage,
+          loadMore: incomingLoadMore,
+        }),
+        outgoing: createListState({
+          items: [outgoingRequest],
+          error: { kind: 'network', message: 'More outgoing failed.' },
+          errorSource: 'loadMore',
+          loadFirstPage: outgoingLoadFirstPage,
+          loadMore: outgoingLoadMore,
+        }),
+      }),
+    );
+    await render(<FriendRequestsScreen />);
+
+    await latestListProps().onEndReached();
+    expect(incomingLoadMore).not.toHaveBeenCalled();
+    await fireEvent.press(screen.getByLabelText('Retry loading more incoming requests'));
+    await fireEvent.press(screen.getByText('Outgoing'));
+    await latestListProps().onEndReached();
+    expect(outgoingLoadMore).not.toHaveBeenCalled();
+    await fireEvent.press(screen.getByLabelText('Retry loading more outgoing requests'));
+
+    expect(incomingLoadMore).toHaveBeenCalledTimes(1);
+    expect(outgoingLoadMore).toHaveBeenCalledTimes(1);
+    expect(incomingLoadFirstPage).not.toHaveBeenCalled();
+    expect(outgoingLoadFirstPage).not.toHaveBeenCalled();
+  });
+
+  it('keeps each tab data during refresh errors and retries that first page', async () => {
+    const incomingLoadFirstPage = jest.fn(async (_mode: 'initial' | 'refresh' | 'silent') => {});
+    const outgoingLoadFirstPage = jest.fn(async (_mode: 'initial' | 'refresh' | 'silent') => {});
+    mockUseFriendRequests.mockReturnValue(
+      createState({
+        incoming: createListState({
+          items: [incomingRequest],
+          error: { kind: 'network', message: 'Incoming refresh failed.' },
+          errorSource: 'refresh',
+          loadFirstPage: incomingLoadFirstPage,
+        }),
+        outgoing: createListState({
+          items: [outgoingRequest],
+          error: { kind: 'network', message: 'Outgoing refresh failed.' },
+          errorSource: 'refresh',
+          loadFirstPage: outgoingLoadFirstPage,
+        }),
+      }),
+    );
+    await render(<FriendRequestsScreen />);
+
+    expect(screen.getByText('Alice Sender')).toBeTruthy();
+    await fireEvent.press(screen.getByLabelText('Retry refreshing incoming requests'));
+    await fireEvent.press(screen.getByText('Outgoing'));
+    expect(screen.getByText('Bob Receiver')).toBeTruthy();
+    await fireEvent.press(screen.getByLabelText('Retry refreshing outgoing requests'));
+
+    expect(incomingLoadFirstPage).toHaveBeenCalledWith('refresh');
+    expect(outgoingLoadFirstPage).toHaveBeenCalledWith('refresh');
+  });
+
+  it('shows distinct empty messages without total-count placeholders', async () => {
+    await render(<FriendRequestsScreen />);
+
+    expect(screen.getByText('No incoming requests')).toBeTruthy();
+    await fireEvent.press(screen.getByText('Outgoing'));
+    expect(screen.getByText('No outgoing requests')).toBeTruthy();
+    expect(screen.queryByText(/\d+ requests/)).toBeNull();
+  });
+});

--- a/mobile/src/features/friends/__tests__/FriendsScreen.test.tsx
+++ b/mobile/src/features/friends/__tests__/FriendsScreen.test.tsx
@@ -1,0 +1,274 @@
+import { Alert } from 'react-native';
+
+const mockRouter = { push: jest.fn() };
+const mockUseFocusEffect = jest.fn();
+const mockUseFriendsList = jest.fn();
+const mockFlatListProps = jest.fn();
+
+jest.mock('react-native/Libraries/Lists/FlatList', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+
+  interface MockItem {
+    friendship_id: string;
+  }
+
+  interface MockFlatListProps {
+    data: MockItem[];
+    renderItem: (info: { item: MockItem }) => import('react').ReactNode;
+    onRefresh: () => void;
+    onEndReached: () => void;
+    refreshing: boolean;
+    ListEmptyComponent: import('react').ReactNode;
+    ListFooterComponent: import('react').ReactNode;
+  }
+
+  function MockFlatList(props: MockFlatListProps) {
+    mockFlatListProps(props);
+    return React.createElement(
+      View,
+      null,
+      props.data.length > 0
+        ? props.data.map((item) =>
+            React.createElement(React.Fragment, { key: item.friendship_id }, props.renderItem({ item })),
+          )
+        : props.ListEmptyComponent,
+      props.ListFooterComponent,
+    );
+  }
+
+  return { __esModule: true, default: MockFlatList };
+});
+
+jest.mock('expo-router', () => ({
+  useFocusEffect: (effect: () => void) => mockUseFocusEffect(effect),
+  useRouter: () => mockRouter,
+}));
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('expo-image', () => ({ Image: () => null }));
+jest.mock('@/shared/ui/LoadingScreen', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+  return { LoadingScreen: () => React.createElement(View, { testID: 'friends-loading' }) };
+});
+jest.mock('../hooks/useFriendsList', () => ({ useFriendsList: () => mockUseFriendsList() }));
+
+// eslint-disable-next-line import/first
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { FriendsScreen } from '../screens/FriendsScreen';
+// eslint-disable-next-line import/first
+import type { useFriendsList } from '../hooks/useFriendsList';
+// eslint-disable-next-line import/first
+import type { Friend } from '../types';
+
+type FriendsListState = ReturnType<typeof useFriendsList>;
+
+const friend: Friend = {
+  friendship_id: 'friendship-1',
+  user: {
+    id: 'user-1',
+    display_name: 'Alice Nguyen',
+    identify_tag: 'alice#ABC123',
+    avatar_url: null,
+  },
+  created_at: '2026-07-20T10:00:00Z',
+};
+
+function createState(overrides: Partial<FriendsListState> = {}): FriendsListState {
+  return {
+    items: [],
+    status: 'ready',
+    error: null,
+    errorSource: null,
+    refreshing: false,
+    loadingMore: false,
+    hasNextPage: false,
+    loadFirstPage: jest.fn(async (_mode: 'initial' | 'refresh' | 'silent') => {}),
+    loadMore: jest.fn(async () => {}),
+    upsertLocalItem: jest.fn(),
+    removeLocalItem: jest.fn(),
+    removingIds: new Set<string>(),
+    mutationError: null,
+    removeFriend: jest.fn(async (_friendshipId: string) => true),
+    clearMutationError: jest.fn(),
+    ...overrides,
+  };
+}
+
+function latestListProps(): {
+  onRefresh: () => void;
+  onEndReached: () => void;
+  refreshing: boolean;
+} {
+  const props = mockFlatListProps.mock.calls.at(-1)?.[0];
+  if (!props) {
+    throw new Error('Expected FriendsScreen to render a FlatList.');
+  }
+  return props;
+}
+
+describe('FriendsScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseFriendsList.mockReturnValue(createState());
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('shows a full loading state before the first page resolves', async () => {
+    mockUseFriendsList.mockReturnValue(createState({ status: 'loading' }));
+
+    await render(<FriendsScreen />);
+
+    expect(screen.getByTestId('friends-loading')).toBeTruthy();
+    expect(screen.queryByText('No friends yet')).toBeNull();
+  });
+
+  it('shows the empty state and routes to Add Friend and Requests', async () => {
+    await render(<FriendsScreen />);
+
+    expect(screen.getByText('No friends yet')).toBeTruthy();
+    await fireEvent.press(screen.getByLabelText('Add Friend'));
+    await fireEvent.press(screen.getByLabelText('Requests'));
+    await fireEvent.press(screen.getByText('Add your first friend'));
+
+    expect(mockRouter.push).toHaveBeenNthCalledWith(1, '/friends/add');
+    expect(mockRouter.push).toHaveBeenNthCalledWith(2, '/friends/requests');
+    expect(mockRouter.push).toHaveBeenNthCalledWith(3, '/friends/add');
+  });
+
+  it('renders a friend and refreshes initially, then silently on later focus', async () => {
+    const loadFirstPage = jest.fn(async (_mode: 'initial' | 'refresh' | 'silent') => {});
+    mockUseFriendsList.mockReturnValue(createState({ items: [friend], loadFirstPage }));
+    await render(<FriendsScreen />);
+
+    expect(screen.getByText('Alice Nguyen')).toBeTruthy();
+    expect(screen.getByText('alice#ABC123')).toBeTruthy();
+    const focusCallback = mockUseFocusEffect.mock.calls.at(0)?.[0];
+    expect(focusCallback).toBeDefined();
+
+    focusCallback?.();
+    focusCallback?.();
+
+    expect(loadFirstPage).toHaveBeenNthCalledWith(1, 'initial');
+    expect(loadFirstPage).toHaveBeenNthCalledWith(2, 'silent');
+  });
+
+  it('shows an initial error and retries the first page', async () => {
+    const loadFirstPage = jest.fn(async (_mode: 'initial' | 'refresh' | 'silent') => {});
+    mockUseFriendsList.mockReturnValue(
+      createState({
+        status: 'error',
+        error: { kind: 'network', message: 'Cannot reach the server. Check your connection.' },
+        errorSource: 'initial',
+        loadFirstPage,
+      }),
+    );
+
+    await render(<FriendsScreen />);
+    await fireEvent.press(screen.getByText('Try again'));
+
+    expect(screen.getByText('Could not load friends')).toBeTruthy();
+    expect(loadFirstPage).toHaveBeenCalledWith('initial');
+  });
+
+  it('delegates pull-to-refresh and end-reached pagination', async () => {
+    const loadFirstPage = jest.fn(async (_mode: 'initial' | 'refresh' | 'silent') => {});
+    const loadMore = jest.fn(async () => {});
+    mockUseFriendsList.mockReturnValue(
+      createState({ items: [friend], refreshing: true, loadFirstPage, loadMore }),
+    );
+    await render(<FriendsScreen />);
+
+    const listProps = latestListProps();
+    await listProps.onRefresh();
+    await listProps.onEndReached();
+
+    expect(listProps.refreshing).toBe(true);
+    expect(loadFirstPage).toHaveBeenCalledWith('refresh');
+    expect(loadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a load-more error with the same pagination function', async () => {
+    const loadFirstPage = jest.fn(async (_mode: 'initial' | 'refresh' | 'silent') => {});
+    const loadMore = jest.fn(async () => {});
+    mockUseFriendsList.mockReturnValue(
+      createState({
+        items: [friend],
+        error: { kind: 'network', message: 'Could not load another page.' },
+        errorSource: 'loadMore',
+        loadFirstPage,
+        loadMore,
+      }),
+    );
+    await render(<FriendsScreen />);
+
+    await latestListProps().onEndReached();
+    expect(loadMore).not.toHaveBeenCalled();
+    await fireEvent.press(screen.getByLabelText('Retry loading more friends'));
+
+    expect(screen.getByText('Alice Nguyen')).toBeTruthy();
+    expect(loadMore).toHaveBeenCalledTimes(1);
+    expect(loadFirstPage).not.toHaveBeenCalled();
+  });
+
+  it('keeps the list during a refresh error and retries the first page as refresh', async () => {
+    const loadFirstPage = jest.fn(async (_mode: 'initial' | 'refresh' | 'silent') => {});
+    mockUseFriendsList.mockReturnValue(
+      createState({
+        items: [friend],
+        error: { kind: 'network', message: 'Refresh failed.' },
+        errorSource: 'refresh',
+        loadFirstPage,
+      }),
+    );
+    await render(<FriendsScreen />);
+
+    expect(screen.getByText('Alice Nguyen')).toBeTruthy();
+    await fireEvent.press(screen.getByLabelText('Retry refreshing friends'));
+    expect(loadFirstPage).toHaveBeenCalledWith('refresh');
+  });
+
+  it('only removes after the destructive native confirmation action', async () => {
+    const removeFriend = jest.fn(async (_friendshipId: string) => true);
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+    mockUseFriendsList.mockReturnValue(createState({ items: [friend], removeFriend }));
+    await render(<FriendsScreen />);
+
+    await fireEvent.press(screen.getByLabelText('Remove Alice Nguyen'));
+    expect(removeFriend).not.toHaveBeenCalled();
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Remove friend',
+      'Remove Alice Nguyen from your friends?',
+      expect.any(Array),
+    );
+
+    const buttons = alertSpy.mock.calls[0]?.[2];
+    const destructive = buttons?.find((button) => button.text === 'Remove');
+    expect(destructive?.style).toBe('destructive');
+    await act(async () => {
+      destructive?.onPress?.();
+    });
+    expect(removeFriend).toHaveBeenCalledWith('friendship-1');
+  });
+
+  it('keeps rendered data, displays mutation errors, and disables duplicate removal UI', async () => {
+    mockUseFriendsList.mockReturnValue(
+      createState({
+        items: [friend],
+        removingIds: new Set(['friendship-1']),
+        mutationError: { kind: 'message', message: 'Friendship not found.', errorCode: 'FRIENDSHIP_NOT_FOUND' },
+      }),
+    );
+    await render(<FriendsScreen />);
+
+    expect(screen.getByText('Alice Nguyen')).toBeTruthy();
+    expect(screen.getByText('Friendship not found.')).toBeTruthy();
+    expect(screen.queryByLabelText('Retry refreshing friends')).toBeNull();
+    expect(screen.getByLabelText('Remove Alice Nguyen').props.accessibilityState).toEqual({
+      disabled: true,
+      busy: true,
+    });
+  });
+});

--- a/mobile/src/features/friends/__tests__/api.test.ts
+++ b/mobile/src/features/friends/__tests__/api.test.ts
@@ -1,0 +1,162 @@
+jest.mock('@/shared/api/client', () => ({
+  apiClient: { delete: jest.fn(), get: jest.fn(), post: jest.fn() },
+}));
+
+// eslint-disable-next-line import/first
+import { apiClient } from '@/shared/api/client';
+// eslint-disable-next-line import/first
+import {
+  acceptFriendRequest,
+  cancelFriendRequest,
+  declineFriendRequest,
+  listFriends,
+  listIncomingFriendRequests,
+  listOutgoingFriendRequests,
+  removeFriend,
+  searchFriendUser,
+  sendFriendRequest,
+} from '../api';
+
+const mockDelete = apiClient.delete as jest.MockedFunction<typeof apiClient.delete>;
+const mockGet = apiClient.get as jest.MockedFunction<typeof apiClient.get>;
+const mockPost = apiClient.post as jest.MockedFunction<typeof apiClient.post>;
+
+const friendUser = {
+  id: 'user-2',
+  display_name: 'Bob Example',
+  identify_tag: 'bob#DEF456',
+  avatar_url: '/media/avatars/bob.webp',
+};
+
+const friendship = {
+  friendship_id: 'friendship-1',
+  user: friendUser,
+  created_at: '2026-07-22T01:00:00Z',
+};
+
+const friendRequest = {
+  id: 'request-1',
+  sender: friendUser,
+  receiver: {
+    id: 'user-1',
+    display_name: 'Alice Example',
+    identify_tag: 'alice#ABC123',
+    avatar_url: null,
+  },
+  status: 'PENDING' as const,
+  resolved_at: null,
+  created_at: '2026-07-22T01:00:00Z',
+};
+
+describe('friends api', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('lists friends and normalizes the DRF cursor page', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        next: 'http://testserver/api/friends/?cursor=next%3D%3D',
+        previous: null,
+        results: [friendship],
+      },
+    } as never);
+
+    await expect(listFriends()).resolves.toEqual({
+      items: [friendship],
+      nextCursor: 'next==',
+    });
+    expect(mockGet).toHaveBeenCalledWith('/friends/', { params: undefined });
+  });
+
+  it('passes an opaque cursor when listing a subsequent friends page', async () => {
+    mockGet.mockResolvedValue({
+      data: { next: null, previous: null, results: [] },
+    } as never);
+
+    await expect(listFriends('opaque-cursor')).resolves.toEqual({
+      items: [],
+      nextCursor: null,
+    });
+    expect(mockGet).toHaveBeenCalledWith('/friends/', {
+      params: { cursor: 'opaque-cursor' },
+    });
+  });
+
+  it('searches by identify tag with cancellation support and unwraps the user', async () => {
+    const controller = new AbortController();
+    mockGet.mockResolvedValue({ data: { user: friendUser } } as never);
+
+    await expect(searchFriendUser('bob#DEF456', controller.signal)).resolves.toEqual(friendUser);
+    expect(mockGet).toHaveBeenCalledWith('/friends/search', {
+      params: { q: 'bob#DEF456' },
+      signal: controller.signal,
+    });
+  });
+
+  it('preserves the backend neutral not-found search result', async () => {
+    mockGet.mockResolvedValue({ data: { user: null } } as never);
+
+    await expect(searchFriendUser('nobody#ZZZ999')).resolves.toBeNull();
+  });
+
+  it('sends an identify tag and unwraps the friend request', async () => {
+    mockPost.mockResolvedValue({ data: { friend_request: friendRequest } } as never);
+
+    await expect(sendFriendRequest('bob#DEF456')).resolves.toEqual(friendRequest);
+    expect(mockPost).toHaveBeenCalledWith('/friends/requests', {
+      identify_tag: 'bob#DEF456',
+    });
+  });
+
+  it.each([
+    ['incoming', listIncomingFriendRequests],
+    ['outgoing', listOutgoingFriendRequests],
+  ] as const)('lists %s requests with cursor pagination', async (direction, request) => {
+    mockGet.mockResolvedValue({
+      data: { next: null, previous: null, results: [friendRequest] },
+    } as never);
+
+    await expect(request('request-cursor')).resolves.toEqual({
+      items: [friendRequest],
+      nextCursor: null,
+    });
+    expect(mockGet).toHaveBeenCalledWith(`/friends/requests/${direction}`, {
+      params: { cursor: 'request-cursor' },
+    });
+  });
+
+  it('accepts a request and normalizes the response keys', async () => {
+    mockPost.mockResolvedValue({
+      data: { friendship, friend_request_id: friendRequest.id },
+    } as never);
+
+    await expect(acceptFriendRequest(friendRequest.id)).resolves.toEqual({
+      friendship,
+      friendRequestId: friendRequest.id,
+    });
+    expect(mockPost).toHaveBeenCalledWith(
+      `/friends/requests/${friendRequest.id}/accept`,
+    );
+  });
+
+  it.each([
+    ['decline', declineFriendRequest],
+    ['cancel', cancelFriendRequest],
+  ] as const)('%ss a request and unwraps the terminal request', async (action, request) => {
+    const terminalRequest = {
+      ...friendRequest,
+      status: action === 'decline' ? ('DECLINED' as const) : ('CANCELLED' as const),
+      resolved_at: '2026-07-22T02:00:00Z',
+    };
+    mockPost.mockResolvedValue({ data: { friend_request: terminalRequest } } as never);
+
+    await expect(request(friendRequest.id)).resolves.toEqual(terminalRequest);
+    expect(mockPost).toHaveBeenCalledWith(`/friends/requests/${friendRequest.id}/${action}`);
+  });
+
+  it('removes a friendship through the exact backend URL', async () => {
+    mockDelete.mockResolvedValue({ data: undefined } as never);
+
+    await expect(removeFriend(friendship.friendship_id)).resolves.toBeUndefined();
+    expect(mockDelete).toHaveBeenCalledWith(`/friends/${friendship.friendship_id}`);
+  });
+});

--- a/mobile/src/features/friends/__tests__/friendComponents.test.tsx
+++ b/mobile/src/features/friends/__tests__/friendComponents.test.tsx
@@ -1,0 +1,113 @@
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+
+// eslint-disable-next-line import/first
+import { fireEvent, render, screen } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { FriendAvatar } from '../components/FriendAvatar';
+// eslint-disable-next-line import/first
+import { FriendRequestRow } from '../components/FriendRequestRow';
+// eslint-disable-next-line import/first
+import { FriendRow } from '../components/FriendRow';
+
+describe('friend presentation components', () => {
+  it('renders accessible fallback initials and identity fields', async () => {
+    await render(
+      <FriendRow
+        friendshipId="friendship-1"
+        displayName="Alice Nguyen"
+        identifyTag="alice#ABC123"
+        avatarUrl={null}
+        removing={false}
+        onRemoveRequest={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText('Avatar for Alice Nguyen, alice#ABC123')).toBeTruthy();
+    expect(screen.getByText('AN')).toBeTruthy();
+    expect(screen.getByText('Alice Nguyen')).toBeTruthy();
+    expect(screen.getByText('alice#ABC123')).toBeTruthy();
+  });
+
+  it('resolves a relative avatar URL through the API media endpoint', async () => {
+    await render(
+      <FriendAvatar displayName="Alice" identifyTag="alice#ABC123" avatarUrl="/media/avatars/alice.jpg" />,
+    );
+
+    const avatar = screen.getByLabelText('Avatar for Alice, alice#ABC123');
+    const image = avatar.props.children;
+    expect(image.props.source).toEqual({ uri: 'http://testserver:8000/api/media/files/avatars/alice.jpg' });
+  });
+
+  it('requests confirmation with friendship identity and disables duplicate removal', async () => {
+    const onRemoveRequest = jest.fn();
+    const view = await render(
+      <FriendRow
+        friendshipId="friendship-1"
+        displayName="Alice Nguyen"
+        identifyTag="alice#ABC123"
+        avatarUrl={null}
+        removing={false}
+        onRemoveRequest={onRemoveRequest}
+      />,
+    );
+
+    await fireEvent.press(screen.getByLabelText('Remove Alice Nguyen'));
+    expect(onRemoveRequest).toHaveBeenCalledWith('friendship-1', 'Alice Nguyen');
+
+    await view.rerender(
+      <FriendRow
+        friendshipId="friendship-1"
+        displayName="Alice Nguyen"
+        identifyTag="alice#ABC123"
+        avatarUrl={null}
+        removing
+        onRemoveRequest={onRemoveRequest}
+      />,
+    );
+    const removeButton = screen.getByLabelText('Remove Alice Nguyen');
+    expect(removeButton.props.accessibilityState).toEqual({ disabled: true, busy: true });
+    await fireEvent.press(removeButton);
+    expect(onRemoveRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes incoming request actions with the request ID', async () => {
+    const onAction = jest.fn();
+    await render(
+      <FriendRequestRow
+        requestId="request-1"
+        displayName="Bob Tran"
+        identifyTag="bob#DEF456"
+        avatarUrl={null}
+        direction="incoming"
+        pendingAction={null}
+        onAction={onAction}
+      />,
+    );
+
+    await fireEvent.press(screen.getByLabelText('Accept Bob Tran'));
+    await fireEvent.press(screen.getByLabelText('Decline Bob Tran'));
+
+    expect(onAction).toHaveBeenNthCalledWith(1, 'request-1', 'accept');
+    expect(onAction).toHaveBeenNthCalledWith(2, 'request-1', 'decline');
+    expect(screen.queryByLabelText('Cancel request to Bob Tran')).toBeNull();
+  });
+
+  it('shows only Cancel for outgoing requests and exposes the pending mutation state', async () => {
+    await render(
+      <FriendRequestRow
+        requestId="request-2"
+        displayName="Carol Le"
+        identifyTag="carol#GHI789"
+        avatarUrl={null}
+        direction="outgoing"
+        pendingAction="cancel"
+        onAction={jest.fn()}
+      />,
+    );
+
+    const cancelButton = screen.getByLabelText('Cancel request to Carol Le');
+    expect(cancelButton.props.accessibilityState).toEqual({ disabled: true, busy: true });
+    expect(screen.queryByLabelText('Accept Carol Le')).toBeNull();
+    expect(screen.queryByLabelText('Decline Carol Le')).toBeNull();
+  });
+});

--- a/mobile/src/features/friends/__tests__/useFriendRequests.test.tsx
+++ b/mobile/src/features/friends/__tests__/useFriendRequests.test.tsx
@@ -1,0 +1,355 @@
+jest.mock('../api', () => ({
+  acceptFriendRequest: jest.fn(),
+  cancelFriendRequest: jest.fn(),
+  declineFriendRequest: jest.fn(),
+  listIncomingFriendRequests: jest.fn(),
+  listOutgoingFriendRequests: jest.fn(),
+}));
+
+jest.mock('@/features/auth/session', () => ({
+  useSession: () => ({ user: { id: 'user-current' } }),
+}));
+
+// eslint-disable-next-line import/first
+import { AxiosError, AxiosHeaders } from 'axios';
+// eslint-disable-next-line import/first
+import { act, renderHook } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import {
+  acceptFriendRequest,
+  cancelFriendRequest,
+  declineFriendRequest,
+  listIncomingFriendRequests,
+  listOutgoingFriendRequests,
+} from '../api';
+// eslint-disable-next-line import/first
+import { subscribeToFriendEvents, type FriendEvent } from '../friendEvents';
+// eslint-disable-next-line import/first
+import { useFriendRequests } from '../hooks/useFriendRequests';
+// eslint-disable-next-line import/first
+import type { Friend, FriendRequest, FriendUser } from '../types';
+
+const mockAcceptFriendRequest = acceptFriendRequest as jest.MockedFunction<typeof acceptFriendRequest>;
+const mockCancelFriendRequest = cancelFriendRequest as jest.MockedFunction<typeof cancelFriendRequest>;
+const mockDeclineFriendRequest = declineFriendRequest as jest.MockedFunction<typeof declineFriendRequest>;
+const mockListIncoming = listIncomingFriendRequests as jest.MockedFunction<typeof listIncomingFriendRequests>;
+const mockListOutgoing = listOutgoingFriendRequests as jest.MockedFunction<typeof listOutgoingFriendRequests>;
+
+const currentUser: FriendUser = {
+  id: 'user-current',
+  display_name: 'Quang Minh',
+  identify_tag: 'quangminh#QM01',
+  avatar_url: null,
+};
+
+const friendUser: FriendUser = {
+  id: 'user-friend',
+  display_name: 'Minh Anh',
+  identify_tag: 'minhanh#MA02',
+  avatar_url: null,
+};
+
+const otherUser: FriendUser = {
+  id: 'user-other',
+  display_name: 'Lan Anh',
+  identify_tag: 'lananh#LA03',
+  avatar_url: null,
+};
+
+const friendship: Friend = {
+  friendship_id: 'friendship-1',
+  user: friendUser,
+  created_at: '2026-07-22T01:00:00Z',
+};
+
+function incomingRequest(id: string, sender: FriendUser = friendUser): FriendRequest {
+  return {
+    id,
+    sender,
+    receiver: currentUser,
+    status: 'PENDING',
+    resolved_at: null,
+    created_at: '2026-07-22T00:00:00Z',
+  };
+}
+
+function outgoingRequest(id: string, receiver: FriendUser = friendUser): FriendRequest {
+  return {
+    id,
+    sender: currentUser,
+    receiver,
+    status: 'PENDING',
+    resolved_at: null,
+    created_at: '2026-07-22T00:00:00Z',
+  };
+}
+
+function resolvedRequest(request: FriendRequest, status: 'DECLINED' | 'CANCELLED'): FriendRequest {
+  return { ...request, status, resolved_at: '2026-07-22T02:00:00Z' };
+}
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, {}, {
+    status,
+    statusText: '',
+    headers: {},
+    config,
+    data,
+  });
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('useFriendRequests', () => {
+  beforeEach(() => {
+    mockAcceptFriendRequest.mockReset();
+    mockCancelFriendRequest.mockReset();
+    mockDeclineFriendRequest.mockReset();
+    mockListIncoming.mockReset();
+    mockListOutgoing.mockReset();
+  });
+
+  it('loads and paginates incoming and outgoing requests independently with cursor de-duplication', async () => {
+    const incomingA = incomingRequest('incoming-a');
+    const incomingB = incomingRequest('incoming-b', otherUser);
+    const outgoingA = outgoingRequest('outgoing-a');
+    const outgoingB = outgoingRequest('outgoing-b', otherUser);
+    mockListIncoming
+      .mockResolvedValueOnce({ items: [incomingA], nextCursor: 'incoming-cursor' })
+      .mockResolvedValueOnce({ items: [incomingA, incomingB], nextCursor: null });
+    mockListOutgoing
+      .mockResolvedValueOnce({ items: [outgoingA], nextCursor: 'outgoing-cursor' })
+      .mockResolvedValueOnce({ items: [outgoingA, outgoingB], nextCursor: null });
+    const { result } = await renderHook(() => useFriendRequests());
+
+    await act(async () => {
+      await result.current.incoming.loadFirstPage('initial');
+    });
+    expect(mockListOutgoing).not.toHaveBeenCalled();
+    expect(result.current.incoming.items).toEqual([incomingA]);
+    expect(result.current.outgoing.items).toEqual([]);
+
+    await act(async () => {
+      await result.current.outgoing.loadFirstPage('initial');
+    });
+    await act(async () => {
+      await Promise.all([result.current.incoming.loadMore(), result.current.outgoing.loadMore()]);
+    });
+
+    expect(mockListIncoming).toHaveBeenNthCalledWith(1);
+    expect(mockListIncoming).toHaveBeenNthCalledWith(2, 'incoming-cursor');
+    expect(mockListOutgoing).toHaveBeenNthCalledWith(1);
+    expect(mockListOutgoing).toHaveBeenNthCalledWith(2, 'outgoing-cursor');
+    expect(result.current.incoming.items).toEqual([incomingA, incomingB]);
+    expect(result.current.outgoing.items).toEqual([outgoingA, outgoingB]);
+    expect(result.current.incoming.hasNextPage).toBe(false);
+    expect(result.current.outgoing.hasNextPage).toBe(false);
+  });
+
+  it('loads both first pages through the shared focus-refresh entry point', async () => {
+    const incoming = incomingRequest('incoming-1');
+    const outgoing = outgoingRequest('outgoing-1');
+    mockListIncoming.mockResolvedValue({ items: [incoming], nextCursor: null });
+    mockListOutgoing.mockResolvedValue({ items: [outgoing], nextCursor: null });
+    const { result } = await renderHook(() => useFriendRequests());
+
+    await act(async () => {
+      await result.current.loadFirstPages('initial');
+    });
+
+    expect(result.current.incoming.items).toEqual([incoming]);
+    expect(result.current.outgoing.items).toEqual([outgoing]);
+    expect(mockListIncoming).toHaveBeenCalledTimes(1);
+    expect(mockListOutgoing).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes accepted, declined, and cancelled requests and publishes the accepted friendship', async () => {
+    const accepted = incomingRequest('incoming-accept');
+    const declined = incomingRequest('incoming-decline', otherUser);
+    const cancelled = outgoingRequest('outgoing-cancel');
+    mockListIncoming.mockResolvedValue({ items: [accepted, declined], nextCursor: null });
+    mockListOutgoing.mockResolvedValue({ items: [cancelled], nextCursor: null });
+    mockAcceptFriendRequest.mockResolvedValue({ friendship, friendRequestId: accepted.id });
+    mockDeclineFriendRequest.mockResolvedValue(resolvedRequest(declined, 'DECLINED'));
+    mockCancelFriendRequest.mockResolvedValue(resolvedRequest(cancelled, 'CANCELLED'));
+    const events: FriendEvent[] = [];
+    const unsubscribe = subscribeToFriendEvents(currentUser.id, (event) => events.push(event));
+    const { result } = await renderHook(() => useFriendRequests());
+
+    try {
+      await act(async () => {
+        await result.current.loadFirstPages('initial');
+      });
+      await act(async () => {
+        await expect(result.current.performAction(accepted.id, 'accept')).resolves.toBe(true);
+        await expect(result.current.performAction(declined.id, 'decline')).resolves.toBe(true);
+        await expect(result.current.performAction(cancelled.id, 'cancel')).resolves.toBe(true);
+      });
+    } finally {
+      unsubscribe();
+    }
+
+    expect(result.current.incoming.items).toEqual([]);
+    expect(result.current.outgoing.items).toEqual([]);
+    expect(mockAcceptFriendRequest).toHaveBeenCalledWith(accepted.id);
+    expect(mockDeclineFriendRequest).toHaveBeenCalledWith(declined.id);
+    expect(mockCancelFriendRequest).toHaveBeenCalledWith(cancelled.id);
+    expect(events).toEqual([{ type: 'friendshipAdded', friendship }]);
+  });
+
+  it('locks duplicate actions by request ID while allowing different IDs concurrently', async () => {
+    const firstRequest = incomingRequest('incoming-1');
+    const secondRequest = incomingRequest('incoming-2', otherUser);
+    const first = deferred<FriendRequest>();
+    const second = deferred<FriendRequest>();
+    mockDeclineFriendRequest.mockImplementation((requestId) => {
+      return requestId === firstRequest.id ? first.promise : second.promise;
+    });
+    const { result } = await renderHook(() => useFriendRequests());
+    let firstAction: Promise<boolean> = Promise.resolve(false);
+    let duplicateAction: Promise<boolean> = Promise.resolve(true);
+    let secondAction: Promise<boolean> = Promise.resolve(false);
+
+    await act(async () => {
+      firstAction = result.current.performAction(firstRequest.id, 'decline');
+      duplicateAction = result.current.performAction(firstRequest.id, 'accept');
+      secondAction = result.current.performAction(secondRequest.id, 'decline');
+      await expect(duplicateAction).resolves.toBe(false);
+    });
+
+    expect(mockDeclineFriendRequest).toHaveBeenCalledTimes(2);
+    expect(mockAcceptFriendRequest).not.toHaveBeenCalled();
+    expect(result.current.pendingActions).toEqual(
+      new Map([
+        [firstRequest.id, 'decline'],
+        [secondRequest.id, 'decline'],
+      ]),
+    );
+
+    let outcomes: boolean[] = [];
+    await act(async () => {
+      first.resolve(resolvedRequest(firstRequest, 'DECLINED'));
+      second.resolve(resolvedRequest(secondRequest, 'DECLINED'));
+      outcomes = await Promise.all([firstAction, duplicateAction, secondAction]);
+    });
+
+    expect(outcomes).toEqual([true, false, true]);
+    expect(result.current.pendingActions.size).toBe(0);
+  });
+
+  it('normalizes a mutation error and keeps the unresolved request visible', async () => {
+    const request = incomingRequest('incoming-error');
+    mockListIncoming.mockResolvedValue({ items: [request], nextCursor: null });
+    mockAcceptFriendRequest.mockRejectedValue(
+      axiosErrorWith(409, { detail: 'You have reached the friend limit.', error_code: 'FRIEND_LIMIT_REACHED' }),
+    );
+    const { result } = await renderHook(() => useFriendRequests());
+
+    await act(async () => {
+      await result.current.incoming.loadFirstPage('initial');
+    });
+    await act(async () => {
+      await expect(result.current.performAction(request.id, 'accept')).resolves.toBe(false);
+    });
+
+    expect(result.current.incoming.items).toEqual([request]);
+    expect(result.current.pendingActions.size).toBe(0);
+    expect(result.current.mutationError).toMatchObject({
+      message: 'You have reached the friend limit.',
+      errorCode: 'FRIEND_LIMIT_REACHED',
+      status: 409,
+    });
+  });
+
+  it('keeps a resolved-request tombstone over a first-page response that started before the mutation', async () => {
+    const request = incomingRequest('incoming-stale');
+    const staleRefresh = deferred<{ items: FriendRequest[]; nextCursor: null }>();
+    mockListIncoming
+      .mockResolvedValueOnce({ items: [request], nextCursor: null })
+      .mockReturnValueOnce(staleRefresh.promise);
+    mockDeclineFriendRequest.mockResolvedValue(resolvedRequest(request, 'DECLINED'));
+    const { result } = await renderHook(() => useFriendRequests());
+
+    await act(async () => {
+      await result.current.incoming.loadFirstPage('initial');
+    });
+    let refreshPromise: Promise<void> = Promise.resolve();
+    await act(async () => {
+      refreshPromise = result.current.incoming.loadFirstPage('refresh');
+    });
+    await act(async () => {
+      await result.current.performAction(request.id, 'decline');
+    });
+    expect(result.current.incoming.items).toEqual([]);
+
+    await act(async () => {
+      staleRefresh.resolve({ items: [request], nextCursor: null });
+      await refreshPromise;
+    });
+
+    expect(result.current.incoming.items).toEqual([]);
+    expect(result.current.incoming.status).toBe('ready');
+  });
+
+  it('lets a first-page request started after the mutation reconcile server truth', async () => {
+    const request = incomingRequest('incoming-reconcile');
+    mockListIncoming
+      .mockResolvedValueOnce({ items: [request], nextCursor: null })
+      .mockResolvedValueOnce({ items: [request], nextCursor: null });
+    mockDeclineFriendRequest.mockResolvedValue(resolvedRequest(request, 'DECLINED'));
+    const { result } = await renderHook(() => useFriendRequests());
+
+    await act(async () => {
+      await result.current.incoming.loadFirstPage('initial');
+      await result.current.performAction(request.id, 'decline');
+    });
+    expect(result.current.incoming.items).toEqual([]);
+
+    await act(async () => {
+      await result.current.incoming.loadFirstPage('silent');
+    });
+
+    expect(result.current.incoming.items).toEqual([request]);
+  });
+
+  it('keeps the loaded page and cursor after a load-more error, then retries the same cursor', async () => {
+    const firstRequest = incomingRequest('incoming-first');
+    const secondRequest = incomingRequest('incoming-second', otherUser);
+    mockListIncoming
+      .mockResolvedValueOnce({ items: [firstRequest], nextCursor: 'cursor-retry' })
+      .mockRejectedValueOnce(axiosErrorWith(503, { detail: 'Could not load more requests.' }))
+      .mockResolvedValueOnce({ items: [firstRequest, secondRequest], nextCursor: null });
+    const { result } = await renderHook(() => useFriendRequests());
+
+    await act(async () => {
+      await result.current.incoming.loadFirstPage('initial');
+      await result.current.incoming.loadMore();
+    });
+
+    expect(result.current.incoming.items).toEqual([firstRequest]);
+    expect(result.current.incoming.errorSource).toBe('loadMore');
+    expect(result.current.incoming.error?.message).toBe('Could not load more requests.');
+    expect(result.current.incoming.hasNextPage).toBe(true);
+
+    await act(async () => {
+      await result.current.incoming.loadMore();
+    });
+
+    expect(mockListIncoming).toHaveBeenNthCalledWith(1);
+    expect(mockListIncoming).toHaveBeenNthCalledWith(2, 'cursor-retry');
+    expect(mockListIncoming).toHaveBeenNthCalledWith(3, 'cursor-retry');
+    expect(result.current.incoming.items).toEqual([firstRequest, secondRequest]);
+    expect(result.current.incoming.error).toBeNull();
+    expect(result.current.incoming.errorSource).toBeNull();
+    expect(result.current.incoming.hasNextPage).toBe(false);
+  });
+});

--- a/mobile/src/features/friends/__tests__/useFriendSearch.test.tsx
+++ b/mobile/src/features/friends/__tests__/useFriendSearch.test.tsx
@@ -1,0 +1,283 @@
+const mockUseFocusEffect = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useFocusEffect: (effect: () => (() => void) | void) => mockUseFocusEffect(effect),
+}));
+
+jest.mock('../api', () => ({
+  searchFriendUser: jest.fn(),
+  sendFriendRequest: jest.fn(),
+}));
+
+// eslint-disable-next-line import/first
+import { AxiosError, AxiosHeaders } from 'axios';
+// eslint-disable-next-line import/first
+import { act, renderHook } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { searchFriendUser, sendFriendRequest } from '../api';
+// eslint-disable-next-line import/first
+import { useFriendSearch } from '../hooks/useFriendSearch';
+// eslint-disable-next-line import/first
+import type { FriendRequest, FriendUser } from '../types';
+
+const mockSearchFriendUser = searchFriendUser as jest.MockedFunction<typeof searchFriendUser>;
+const mockSendFriendRequest = sendFriendRequest as jest.MockedFunction<typeof sendFriendRequest>;
+
+const foundUser: FriendUser = {
+  id: 'user-2',
+  display_name: 'Minh Anh',
+  identify_tag: 'minhanh#AB12',
+  avatar_url: null,
+};
+
+const sender: FriendUser = {
+  id: 'user-1',
+  display_name: 'Quang Minh',
+  identify_tag: 'quangminh#CD34',
+  avatar_url: null,
+};
+
+const createdRequest: FriendRequest = {
+  id: 'request-1',
+  sender,
+  receiver: foundUser,
+  status: 'PENDING',
+  resolved_at: null,
+  created_at: '2026-07-22T00:00:00Z',
+};
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, {}, {
+    status,
+    statusText: '',
+    headers: {},
+    config,
+    data,
+  });
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+async function setQuery(result: { current: ReturnType<typeof useFriendSearch> }, query: string) {
+  await act(async () => {
+    result.current.setQuery(query);
+  });
+}
+
+async function runSearch(result: { current: ReturnType<typeof useFriendSearch> }) {
+  await act(async () => {
+    await result.current.search();
+  });
+}
+
+describe('useFriendSearch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('finds an exact identify tag and resets stale results when the query changes', async () => {
+    mockSearchFriendUser.mockResolvedValue(foundUser);
+    const { result } = await renderHook(() => useFriendSearch());
+
+    await setQuery(result, '  minhanh#AB12  ');
+    await runSearch(result);
+
+    expect(mockSearchFriendUser).toHaveBeenCalledWith('minhanh#AB12', expect.any(AbortSignal));
+    expect(result.current.user).toEqual(foundUser);
+    expect(result.current.searchStatus).toBe('found');
+
+    await setQuery(result, 'someone#ZZ99');
+
+    expect(result.current.user).toBeNull();
+    expect(result.current.searchStatus).toBe('idle');
+  });
+
+  it('uses the same neutral not-found state for a null search result', async () => {
+    mockSearchFriendUser.mockResolvedValue(null);
+    const { result } = await renderHook(() => useFriendSearch());
+
+    await setQuery(result, 'unknown#NONE');
+    await runSearch(result);
+
+    expect(result.current.user).toBeNull();
+    expect(result.current.searchStatus).toBe('notFound');
+    expect(result.current.searchError).toBeNull();
+  });
+
+  it('normalizes malformed-query errors from the backend', async () => {
+    mockSearchFriendUser.mockRejectedValue(
+      axiosErrorWith(400, { detail: 'Enter an identify tag in name#CODE format.', error_code: 'INVALID_SEARCH_QUERY' }),
+    );
+    const { result } = await renderHook(() => useFriendSearch());
+
+    await setQuery(result, 'malformed');
+    await runSearch(result);
+
+    expect(result.current.searchStatus).toBe('error');
+    expect(result.current.searchError).toMatchObject({
+      message: 'Enter an identify tag in name#CODE format.',
+      errorCode: 'INVALID_SEARCH_QUERY',
+      status: 400,
+    });
+  });
+
+  it('keeps the latest search result when an older request resolves last', async () => {
+    const first = deferred<FriendUser | null>();
+    const second = deferred<FriendUser | null>();
+    mockSearchFriendUser.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const { result } = await renderHook(() => useFriendSearch());
+
+    await setQuery(result, 'first#AA11');
+    let firstSearch: Promise<void> = Promise.resolve();
+    await act(async () => {
+      firstSearch = result.current.search();
+    });
+    const firstSignal = mockSearchFriendUser.mock.calls[0]?.[1];
+
+    await setQuery(result, 'second#BB22');
+    expect(firstSignal?.aborted).toBe(true);
+    let secondSearch: Promise<void> = Promise.resolve();
+    await act(async () => {
+      secondSearch = result.current.search();
+    });
+
+    const newestUser = { ...foundUser, id: 'user-newest', identify_tag: 'second#BB22' };
+    await act(async () => {
+      second.resolve(newestUser);
+      await secondSearch;
+    });
+    await act(async () => {
+      first.resolve({ ...foundUser, id: 'user-stale', identify_tag: 'first#AA11' });
+      await firstSearch;
+    });
+
+    expect(result.current.user).toEqual(newestUser);
+    expect(result.current.searchStatus).toBe('found');
+  });
+
+  it('aborts and ignores a pending search when the screen loses focus', async () => {
+    const pending = deferred<FriendUser | null>();
+    mockSearchFriendUser.mockReturnValue(pending.promise);
+    const { result } = await renderHook(() => useFriendSearch());
+    const focusCallback = mockUseFocusEffect.mock.calls.at(-1)?.[0] as (() => (() => void) | void) | undefined;
+    const cleanup = focusCallback?.();
+
+    await setQuery(result, 'minhanh#AB12');
+    let searchPromise: Promise<void> = Promise.resolve();
+    await act(async () => {
+      searchPromise = result.current.search();
+    });
+    const signal = mockSearchFriendUser.mock.calls[0]?.[1];
+
+    cleanup?.();
+    expect(signal?.aborted).toBe(true);
+
+    await act(async () => {
+      pending.resolve(foundUser);
+      await searchPromise;
+    });
+    expect(result.current.user).toBeNull();
+  });
+
+  it('sends the server-returned identify tag and stores the created request', async () => {
+    mockSearchFriendUser.mockResolvedValue(foundUser);
+    mockSendFriendRequest.mockResolvedValue(createdRequest);
+    const { result } = await renderHook(() => useFriendSearch());
+
+    await setQuery(result, '  MINHANH#ab12  ');
+    await runSearch(result);
+    await act(async () => {
+      await result.current.sendRequest();
+    });
+
+    expect(mockSendFriendRequest).toHaveBeenCalledWith(foundUser.identify_tag);
+    expect(result.current.friendRequest).toEqual(createdRequest);
+    expect(result.current.sendStatus).toBe('sent');
+  });
+
+  it('blocks duplicate sends synchronously while the mutation is pending', async () => {
+    const pending = deferred<FriendRequest>();
+    mockSearchFriendUser.mockResolvedValue(foundUser);
+    mockSendFriendRequest.mockReturnValue(pending.promise);
+    const { result } = await renderHook(() => useFriendSearch());
+
+    await setQuery(result, foundUser.identify_tag);
+    await runSearch(result);
+    let firstSend: Promise<void> = Promise.resolve();
+    await act(async () => {
+      firstSend = result.current.sendRequest();
+      await result.current.sendRequest();
+    });
+
+    expect(mockSendFriendRequest).toHaveBeenCalledTimes(1);
+    expect(result.current.sendStatus).toBe('sending');
+
+    await act(async () => {
+      pending.resolve(createdRequest);
+      await firstSend;
+    });
+    expect(result.current.sendStatus).toBe('sent');
+  });
+
+  it('keeps a pending send locked across blur and commits its result after refocus', async () => {
+    const pending = deferred<FriendRequest>();
+    mockSearchFriendUser.mockResolvedValue(foundUser);
+    mockSendFriendRequest.mockReturnValue(pending.promise);
+    const { result } = await renderHook(() => useFriendSearch());
+    const focusCallback = mockUseFocusEffect.mock.calls.at(-1)?.[0] as (() => (() => void) | void) | undefined;
+    const cleanup = focusCallback?.();
+
+    await setQuery(result, foundUser.identify_tag);
+    await runSearch(result);
+    let sendPromise: Promise<void> = Promise.resolve();
+    await act(async () => {
+      sendPromise = result.current.sendRequest();
+    });
+    expect(result.current.sendStatus).toBe('sending');
+
+    cleanup?.();
+    await act(async () => {
+      focusCallback?.();
+    });
+    expect(result.current.sendStatus).toBe('sending');
+    await act(async () => {
+      await result.current.sendRequest();
+    });
+    expect(mockSendFriendRequest).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      pending.resolve(createdRequest);
+      await sendPromise;
+    });
+    expect(result.current.friendRequest).toEqual(createdRequest);
+    expect(result.current.sendStatus).toBe('sent');
+  });
+
+  it.each([
+    ['SELF_REQUEST', 'You cannot send a friend request to yourself.'],
+    ['USER_NOT_FOUND', 'User not found.'],
+    ['DUPLICATE_PENDING', 'A friend request is already pending.'],
+    ['ALREADY_FRIENDS', 'You are already friends.'],
+    ['FRIEND_LIMIT_REACHED', 'One of you has reached the friend limit.'],
+  ])('normalizes the %s business error without replacing its message', async (errorCode, message) => {
+    mockSearchFriendUser.mockResolvedValue(foundUser);
+    mockSendFriendRequest.mockRejectedValue(axiosErrorWith(409, { detail: message, error_code: errorCode }));
+    const { result } = await renderHook(() => useFriendSearch());
+
+    await setQuery(result, foundUser.identify_tag);
+    await runSearch(result);
+    await act(async () => {
+      await result.current.sendRequest();
+    });
+
+    expect(result.current.sendStatus).toBe('idle');
+    expect(result.current.sendError).toMatchObject({ message, errorCode, status: 409 });
+  });
+});

--- a/mobile/src/features/friends/__tests__/useFriendsList.test.tsx
+++ b/mobile/src/features/friends/__tests__/useFriendsList.test.tsx
@@ -1,0 +1,367 @@
+jest.mock('../api', () => ({
+  listFriends: jest.fn(),
+  removeFriend: jest.fn(),
+}));
+
+jest.mock('@/features/auth/session', () => ({
+  useSession: () => ({ user: { id: 'owner-user' } }),
+}));
+
+// eslint-disable-next-line import/first
+import { AxiosError, AxiosHeaders } from 'axios';
+// eslint-disable-next-line import/first
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { listFriends, removeFriend } from '../api';
+// eslint-disable-next-line import/first
+import { publishFriendEvent } from '../friendEvents';
+// eslint-disable-next-line import/first
+import { useFriendsList } from '../hooks/useFriendsList';
+// eslint-disable-next-line import/first
+import type { Friend } from '../types';
+
+const mockListFriends = listFriends as jest.MockedFunction<typeof listFriends>;
+const mockRemoveFriend = removeFriend as jest.MockedFunction<typeof removeFriend>;
+
+function makeFriend(id: string, displayName: string): Friend {
+  return {
+    friendship_id: id,
+    user: {
+      id: `user-${id}`,
+      display_name: displayName,
+      identify_tag: `${displayName.toLowerCase().replaceAll(' ', '')}#ABC123`,
+      avatar_url: null,
+    },
+    created_at: '2026-07-22T00:00:00Z',
+  };
+}
+
+const friendA = makeFriend('friend-a', 'Alice Example');
+const friendB = makeFriend('friend-b', 'Bob Example');
+const friendC = makeFriend('friend-c', 'Charlie Example');
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, {}, {
+    status,
+    statusText: '',
+    headers: {},
+    config,
+    data,
+  });
+}
+
+describe('useFriendsList', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('loads, paginates with de-duplication, then replaces all pages on refresh', async () => {
+    mockListFriends
+      .mockResolvedValueOnce({ items: [friendA], nextCursor: 'cursor-1' })
+      .mockResolvedValueOnce({ items: [friendA, friendB], nextCursor: 'cursor-2' })
+      .mockResolvedValueOnce({ items: [friendC], nextCursor: null });
+    const { result, unmount } = await renderHook(() => useFriendsList());
+
+    await act(async () => {
+      await result.current.loadFirstPage('initial');
+    });
+    expect(result.current.items).toEqual([friendA]);
+    expect(result.current.status).toBe('ready');
+    expect(result.current.hasNextPage).toBe(true);
+
+    await act(async () => {
+      await result.current.loadMore();
+    });
+    expect(result.current.items).toEqual([friendA, friendB]);
+    expect(mockListFriends).toHaveBeenNthCalledWith(2, 'cursor-1');
+
+    await act(async () => {
+      await result.current.loadFirstPage('refresh');
+    });
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    expect(result.current.items).toEqual([friendC]);
+    expect(result.current.refreshing).toBe(false);
+    expect(result.current.hasNextPage).toBe(false);
+    expect(mockListFriends).toHaveBeenCalledTimes(3);
+    unmount();
+  });
+
+  it('retains the failed load-more cursor and retries it without dropping rendered items', async () => {
+    mockListFriends
+      .mockResolvedValueOnce({ items: [friendA], nextCursor: 'retry-cursor' })
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce({ items: [friendB], nextCursor: null });
+    const { result, unmount } = await renderHook(() => useFriendsList());
+
+    await act(async () => {
+      await result.current.loadFirstPage('initial');
+    });
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    expect(result.current.items).toEqual([friendA]);
+    expect(result.current.errorSource).toBe('loadMore');
+    expect(result.current.error?.message).toBe('Something went wrong. Please try again.');
+    expect(result.current.hasNextPage).toBe(true);
+
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    expect(mockListFriends).toHaveBeenNthCalledWith(2, 'retry-cursor');
+    expect(mockListFriends).toHaveBeenNthCalledWith(3, 'retry-cursor');
+    expect(result.current.items).toEqual([friendA, friendB]);
+    expect(result.current.error).toBeNull();
+    expect(result.current.errorSource).toBeNull();
+    expect(result.current.hasNextPage).toBe(false);
+    unmount();
+  });
+
+  it('invalidates an older cursor page when a refresh starts a new list generation', async () => {
+    const staleCursorPage = deferred<{ items: Friend[]; nextCursor: null }>();
+    mockListFriends
+      .mockResolvedValueOnce({ items: [friendA], nextCursor: 'cursor-1' })
+      .mockReturnValueOnce(staleCursorPage.promise)
+      .mockResolvedValueOnce({ items: [friendB], nextCursor: null });
+    const { result, unmount } = await renderHook(() => useFriendsList());
+
+    await act(async () => {
+      await result.current.loadFirstPage('initial');
+    });
+    let staleLoadMore: Promise<void> = Promise.resolve();
+    await act(async () => {
+      staleLoadMore = result.current.loadMore();
+    });
+    await act(async () => {
+      await result.current.loadFirstPage('refresh');
+    });
+    await act(async () => {
+      staleCursorPage.resolve({ items: [friendC], nextCursor: null });
+      await staleLoadMore;
+    });
+
+    expect(result.current.items).toEqual([friendB]);
+    expect(result.current.loadingMore).toBe(false);
+    unmount();
+  });
+
+  it('exposes retry instead of staying loading when an early silent focus request fails', async () => {
+    const supersededInitialPage = deferred<{ items: Friend[]; nextCursor: null }>();
+    mockListFriends
+      .mockReturnValueOnce(supersededInitialPage.promise)
+      .mockRejectedValueOnce(new Error('offline'));
+    const { result, unmount } = await renderHook(() => useFriendsList());
+
+    let initialRequest: Promise<void> = Promise.resolve();
+    await act(async () => {
+      initialRequest = result.current.loadFirstPage('initial');
+    });
+    await act(async () => {
+      await result.current.loadFirstPage('silent');
+    });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.errorSource).toBe('initial');
+    expect(result.current.error?.message).toBe('Something went wrong. Please try again.');
+
+    await act(async () => {
+      supersededInitialPage.resolve({ items: [friendA], nextCursor: null });
+      await initialRequest;
+    });
+    expect(result.current.status).toBe('error');
+    expect(result.current.items).toEqual([]);
+    unmount();
+  });
+
+  it('keeps a friendshipAdded upsert over a first-page response that started earlier', async () => {
+    const staleFirstPage = deferred<{ items: Friend[]; nextCursor: null }>();
+    const locallyAcceptedFriend = {
+      ...friendA,
+      user: { ...friendA.user, display_name: 'Alice Accepted Locally' },
+    };
+    mockListFriends.mockReturnValueOnce(staleFirstPage.promise);
+    const { result, unmount } = await renderHook(() => useFriendsList());
+
+    let firstPageRequest: Promise<void> = Promise.resolve();
+    await act(async () => {
+      firstPageRequest = result.current.loadFirstPage('initial');
+    });
+    await act(async () => {
+      publishFriendEvent('owner-user', { type: 'friendshipAdded', friendship: locallyAcceptedFriend });
+    });
+    expect(result.current.items).toEqual([locallyAcceptedFriend]);
+
+    await act(async () => {
+      staleFirstPage.resolve({ items: [friendA, friendB], nextCursor: null });
+      await firstPageRequest;
+    });
+
+    expect(result.current.items).toEqual([locallyAcceptedFriend, friendB]);
+    unmount();
+  });
+
+  it('keeps a removal tombstone over a first-page response that started earlier', async () => {
+    const staleRefresh = deferred<{ items: Friend[]; nextCursor: null }>();
+    mockListFriends
+      .mockResolvedValueOnce({ items: [friendA, friendB], nextCursor: null })
+      .mockReturnValueOnce(staleRefresh.promise);
+    const { result, unmount } = await renderHook(() => useFriendsList());
+
+    await act(async () => {
+      await result.current.loadFirstPage('initial');
+    });
+    let refreshRequest: Promise<void> = Promise.resolve();
+    await act(async () => {
+      refreshRequest = result.current.loadFirstPage('silent');
+    });
+    await act(async () => {
+      publishFriendEvent('owner-user', { type: 'friendshipRemoved', friendshipId: friendA.friendship_id });
+    });
+    expect(result.current.items).toEqual([friendB]);
+
+    await act(async () => {
+      staleRefresh.resolve({ items: [friendA, friendB], nextCursor: null });
+      await refreshRequest;
+    });
+
+    expect(result.current.items).toEqual([friendB]);
+    unmount();
+  });
+
+  it('lets a first-page request started after a mutation reconcile with server truth', async () => {
+    mockListFriends
+      .mockResolvedValueOnce({ items: [friendA], nextCursor: null })
+      .mockResolvedValueOnce({ items: [friendA, friendB], nextCursor: null });
+    const { result, unmount } = await renderHook(() => useFriendsList());
+
+    await act(async () => {
+      await result.current.loadFirstPage('initial');
+    });
+    await act(async () => {
+      publishFriendEvent('owner-user', { type: 'friendshipRemoved', friendshipId: friendA.friendship_id });
+    });
+    expect(result.current.items).toEqual([]);
+
+    await act(async () => {
+      await result.current.loadFirstPage('silent');
+    });
+
+    expect(result.current.items).toEqual([friendA, friendB]);
+    unmount();
+  });
+
+  it('ignores friendship events published for a different authenticated user', async () => {
+    mockListFriends.mockResolvedValueOnce({ items: [friendA], nextCursor: null });
+    const { result, unmount } = await renderHook(() => useFriendsList());
+
+    await act(async () => {
+      await result.current.loadFirstPage('initial');
+      publishFriendEvent('another-user', { type: 'friendshipAdded', friendship: friendB });
+      publishFriendEvent('another-user', { type: 'friendshipRemoved', friendshipId: friendA.friendship_id });
+    });
+
+    expect(result.current.items).toEqual([friendA]);
+    unmount();
+  });
+
+  it('removes locally after backend success and clears the pending marker', async () => {
+    mockListFriends.mockResolvedValueOnce({ items: [friendA], nextCursor: null });
+    mockRemoveFriend.mockResolvedValueOnce(undefined);
+    const { result, unmount } = await renderHook(() => useFriendsList());
+
+    await act(async () => {
+      await result.current.loadFirstPage('initial');
+    });
+    let didRemove = false;
+    await act(async () => {
+      didRemove = await result.current.removeFriend(friendA.friendship_id);
+    });
+
+    expect(didRemove).toBe(true);
+    expect(mockRemoveFriend).toHaveBeenCalledWith(friendA.friendship_id);
+    expect(result.current.items).toEqual([]);
+    expect(result.current.removingIds.has(friendA.friendship_id)).toBe(false);
+    expect(result.current.mutationError).toBeNull();
+    unmount();
+  });
+
+  it('normalizes a backend removal error while preserving the friendship', async () => {
+    mockListFriends.mockResolvedValueOnce({ items: [friendA], nextCursor: null });
+    mockRemoveFriend.mockRejectedValueOnce(
+      axiosErrorWith(404, {
+        detail: 'Friendship not found.',
+        error_code: 'FRIENDSHIP_NOT_FOUND',
+      }),
+    );
+    const { result, unmount } = await renderHook(() => useFriendsList());
+
+    await act(async () => {
+      await result.current.loadFirstPage('initial');
+    });
+    let didRemove = true;
+    await act(async () => {
+      didRemove = await result.current.removeFriend(friendA.friendship_id);
+    });
+
+    expect(didRemove).toBe(false);
+    expect(result.current.items).toEqual([friendA]);
+    expect(result.current.removingIds.has(friendA.friendship_id)).toBe(false);
+    expect(result.current.mutationError).toMatchObject({
+      message: 'Friendship not found.',
+      errorCode: 'FRIENDSHIP_NOT_FOUND',
+      status: 404,
+    });
+
+    await act(async () => {
+      result.current.clearMutationError();
+    });
+    expect(result.current.mutationError).toBeNull();
+    unmount();
+  });
+
+  it('uses a synchronous lock to block duplicate removals before React state commits', async () => {
+    const pendingRemoval = deferred<void>();
+    mockListFriends.mockResolvedValueOnce({ items: [friendA], nextCursor: null });
+    mockRemoveFriend.mockReturnValueOnce(pendingRemoval.promise);
+    const { result, unmount } = await renderHook(() => useFriendsList());
+
+    await act(async () => {
+      await result.current.loadFirstPage('initial');
+    });
+
+    let firstRemoval: Promise<boolean> = Promise.resolve(false);
+    let duplicateResult = true;
+    await act(async () => {
+      firstRemoval = result.current.removeFriend(friendA.friendship_id);
+      duplicateResult = await result.current.removeFriend(friendA.friendship_id);
+    });
+
+    expect(duplicateResult).toBe(false);
+    expect(mockRemoveFriend).toHaveBeenCalledTimes(1);
+    expect(result.current.removingIds.has(friendA.friendship_id)).toBe(true);
+
+    let firstResult = false;
+    await act(async () => {
+      pendingRemoval.resolve();
+      firstResult = await firstRemoval;
+    });
+
+    expect(firstResult).toBe(true);
+    await waitFor(() => {
+      expect(result.current.removingIds.has(friendA.friendship_id)).toBe(false);
+    });
+    expect(result.current.items).toEqual([]);
+    unmount();
+  });
+});

--- a/mobile/src/features/friends/api.ts
+++ b/mobile/src/features/friends/api.ts
@@ -1,0 +1,94 @@
+import { apiClient } from '@/shared/api/client';
+import {
+  type CursorPage,
+  type CursorPaginatedResponse,
+  toCursorPage,
+} from '@/shared/api/pagination';
+import type {
+  AcceptFriendRequestResult,
+  Friend,
+  FriendRequest,
+  FriendUser,
+} from './types';
+
+interface FriendUserResponse {
+  user: FriendUser | null;
+}
+
+interface FriendRequestResponse {
+  friend_request: FriendRequest;
+}
+
+interface AcceptFriendRequestResponse {
+  friendship: Friend;
+  friend_request_id: string;
+}
+
+async function listFriendPage<T>(path: string, cursor?: string | null): Promise<CursorPage<T>> {
+  const { data } = await apiClient.get<CursorPaginatedResponse<T>>(path, {
+    params: cursor ? { cursor } : undefined,
+  });
+  return toCursorPage(data);
+}
+
+export function listFriends(cursor?: string | null): Promise<CursorPage<Friend>> {
+  return listFriendPage('/friends/', cursor);
+}
+
+export async function searchFriendUser(
+  query: string,
+  signal?: AbortSignal,
+): Promise<FriendUser | null> {
+  const { data } = await apiClient.get<FriendUserResponse>('/friends/search', {
+    params: { q: query },
+    signal,
+  });
+  return data.user;
+}
+
+export async function sendFriendRequest(identifyTag: string): Promise<FriendRequest> {
+  const { data } = await apiClient.post<FriendRequestResponse>('/friends/requests', {
+    identify_tag: identifyTag,
+  });
+  return data.friend_request;
+}
+
+export function listIncomingFriendRequests(
+  cursor?: string | null,
+): Promise<CursorPage<FriendRequest>> {
+  return listFriendPage('/friends/requests/incoming', cursor);
+}
+
+export function listOutgoingFriendRequests(
+  cursor?: string | null,
+): Promise<CursorPage<FriendRequest>> {
+  return listFriendPage('/friends/requests/outgoing', cursor);
+}
+
+export async function acceptFriendRequest(id: string): Promise<AcceptFriendRequestResult> {
+  const { data } = await apiClient.post<AcceptFriendRequestResponse>(
+    `/friends/requests/${id}/accept`,
+  );
+  return {
+    friendship: data.friendship,
+    friendRequestId: data.friend_request_id,
+  };
+}
+
+export async function declineFriendRequest(id: string): Promise<FriendRequest> {
+  const { data } = await apiClient.post<FriendRequestResponse>(
+    `/friends/requests/${id}/decline`,
+  );
+  return data.friend_request;
+}
+
+export async function cancelFriendRequest(id: string): Promise<FriendRequest> {
+  const { data } = await apiClient.post<FriendRequestResponse>(
+    `/friends/requests/${id}/cancel`,
+  );
+  return data.friend_request;
+}
+
+export async function removeFriend(friendshipId: string): Promise<void> {
+  await apiClient.delete(`/friends/${friendshipId}`);
+}

--- a/mobile/src/features/friends/components/FriendAvatar.tsx
+++ b/mobile/src/features/friends/components/FriendAvatar.tsx
@@ -1,0 +1,69 @@
+import { Image } from 'expo-image';
+import { memo, useMemo } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { resolveMediaUrl } from '@/shared/api/base-url';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+
+export interface FriendAvatarProps {
+  displayName: string;
+  identifyTag: string;
+  avatarUrl: string | null;
+}
+
+function getInitials(displayName: string): string {
+  const names = displayName.trim().split(/\s+/).filter(Boolean);
+  if (names.length === 0) {
+    return '?';
+  }
+  const first = Array.from(names[0])[0] ?? '';
+  const last = names.length > 1 ? (Array.from(names[names.length - 1])[0] ?? '') : '';
+  return `${first}${last}`.toLocaleUpperCase();
+}
+
+export const FriendAvatar = memo(function FriendAvatar({
+  displayName,
+  identifyTag,
+  avatarUrl,
+}: FriendAvatarProps) {
+  const resolvedAvatarUrl = resolveMediaUrl(avatarUrl);
+  const imageSource = useMemo(
+    () => (resolvedAvatarUrl ? { uri: resolvedAvatarUrl } : null),
+    [resolvedAvatarUrl],
+  );
+
+  return (
+    <View
+      accessible
+      accessibilityRole="image"
+      accessibilityLabel={`Avatar for ${displayName}, ${identifyTag}`}
+      style={styles.avatar}
+    >
+      {imageSource ? (
+        <Image
+          source={imageSource}
+          recyclingKey={identifyTag}
+          style={styles.image}
+          contentFit="cover"
+          transition={150}
+        />
+      ) : (
+        <Text style={styles.initials}>{getInitials(displayName)}</Text>
+      )}
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  avatar: {
+    width: spacing.lg * 2,
+    height: spacing.lg * 2,
+    borderRadius: radii.full,
+    borderCurve: 'continuous',
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+    backgroundColor: colors.primarySoft,
+  },
+  image: { width: '100%', height: '100%' },
+  initials: { ...typography.body, color: colors.primary, fontWeight: '700' },
+});

--- a/mobile/src/features/friends/components/FriendRequestRow.tsx
+++ b/mobile/src/features/friends/components/FriendRequestRow.tsx
@@ -1,0 +1,163 @@
+import { memo, useCallback } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { FriendAvatar } from './FriendAvatar';
+
+export type FriendRequestDirection = 'incoming' | 'outgoing';
+export type FriendRequestAction = 'accept' | 'decline' | 'cancel';
+
+export interface FriendRequestRowProps {
+  requestId: string;
+  displayName: string;
+  identifyTag: string;
+  avatarUrl: string | null;
+  direction: FriendRequestDirection;
+  pendingAction: FriendRequestAction | null;
+  onAction: (requestId: string, action: FriendRequestAction) => void;
+}
+
+interface RequestActionButtonProps {
+  requestId: string;
+  action: FriendRequestAction;
+  title: string;
+  accessibilityLabel: string;
+  primary?: boolean;
+  loading: boolean;
+  disabled: boolean;
+  onAction: (requestId: string, action: FriendRequestAction) => void;
+}
+
+const RequestActionButton = memo(function RequestActionButton({
+  requestId,
+  action,
+  title,
+  accessibilityLabel,
+  primary = false,
+  loading,
+  disabled,
+  onAction,
+}: RequestActionButtonProps) {
+  const pressAction = useCallback(() => {
+    onAction(requestId, action);
+  }, [action, onAction, requestId]);
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      accessibilityState={{ disabled, busy: loading }}
+      disabled={disabled}
+      onPress={pressAction}
+      style={({ pressed }) => [
+        styles.actionButton,
+        primary ? styles.primaryAction : styles.secondaryAction,
+        pressed && !disabled && styles.actionPressed,
+        disabled && !loading && styles.actionDisabled,
+      ]}
+    >
+      {loading ? (
+        <ActivityIndicator color={primary ? colors.background : colors.primary} />
+      ) : (
+        <Text style={[styles.actionText, primary ? styles.primaryActionText : styles.secondaryActionText]}>
+          {title}
+        </Text>
+      )}
+    </Pressable>
+  );
+});
+
+export const FriendRequestRow = memo(function FriendRequestRow({
+  requestId,
+  displayName,
+  identifyTag,
+  avatarUrl,
+  direction,
+  pendingAction,
+  onAction,
+}: FriendRequestRowProps) {
+  const blocked = pendingAction !== null;
+
+  return (
+    <View style={styles.row}>
+      <View style={styles.identityRow}>
+        <FriendAvatar displayName={displayName} identifyTag={identifyTag} avatarUrl={avatarUrl} />
+        <View style={styles.identity}>
+          <Text style={styles.name} numberOfLines={1}>
+            {displayName}
+          </Text>
+          <Text style={styles.identifyTag} numberOfLines={1}>
+            {identifyTag}
+          </Text>
+        </View>
+      </View>
+      <View style={styles.actions}>
+        {direction === 'incoming' ? (
+          <>
+            <RequestActionButton
+              requestId={requestId}
+              action="accept"
+              title="Accept"
+              accessibilityLabel={`Accept ${displayName}`}
+              primary
+              loading={pendingAction === 'accept'}
+              disabled={blocked}
+              onAction={onAction}
+            />
+            <RequestActionButton
+              requestId={requestId}
+              action="decline"
+              title="Decline"
+              accessibilityLabel={`Decline ${displayName}`}
+              loading={pendingAction === 'decline'}
+              disabled={blocked}
+              onAction={onAction}
+            />
+          </>
+        ) : (
+          <RequestActionButton
+            requestId={requestId}
+            action="cancel"
+            title="Cancel Request"
+            accessibilityLabel={`Cancel request to ${displayName}`}
+            loading={pendingAction === 'cancel'}
+            disabled={blocked}
+            onAction={onAction}
+          />
+        )}
+      </View>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  row: {
+    gap: spacing.md,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.lg,
+    borderCurve: 'continuous',
+    backgroundColor: colors.background,
+  },
+  identityRow: { flexDirection: 'row', alignItems: 'center', gap: spacing.md },
+  identity: { flex: 1, minWidth: 0, gap: spacing.xs },
+  name: { ...typography.body, color: colors.text, fontWeight: '600' },
+  identifyTag: { ...typography.caption, color: colors.textMuted },
+  actions: { flexDirection: 'row', justifyContent: 'flex-end', gap: spacing.sm },
+  actionButton: {
+    minHeight: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.md,
+    borderWidth: 1,
+    borderRadius: radii.md,
+    borderCurve: 'continuous',
+  },
+  primaryAction: { borderColor: colors.primary, backgroundColor: colors.primary },
+  secondaryAction: { borderColor: colors.border, backgroundColor: colors.background },
+  actionPressed: { opacity: 0.65 },
+  actionDisabled: { opacity: 0.45 },
+  actionText: { ...typography.label },
+  primaryActionText: { color: colors.background },
+  secondaryActionText: { color: colors.text },
+});

--- a/mobile/src/features/friends/components/FriendRow.tsx
+++ b/mobile/src/features/friends/components/FriendRow.tsx
@@ -1,0 +1,84 @@
+import { Ionicons } from '@expo/vector-icons';
+import { memo, useCallback } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { FriendAvatar } from './FriendAvatar';
+
+export interface FriendRowProps {
+  friendshipId: string;
+  displayName: string;
+  identifyTag: string;
+  avatarUrl: string | null;
+  removing: boolean;
+  onRemoveRequest: (friendshipId: string, displayName: string) => void;
+}
+
+export const FriendRow = memo(function FriendRow({
+  friendshipId,
+  displayName,
+  identifyTag,
+  avatarUrl,
+  removing,
+  onRemoveRequest,
+}: FriendRowProps) {
+  const requestRemoval = useCallback(() => {
+    onRemoveRequest(friendshipId, displayName);
+  }, [displayName, friendshipId, onRemoveRequest]);
+
+  return (
+    <View style={styles.row}>
+      <FriendAvatar displayName={displayName} identifyTag={identifyTag} avatarUrl={avatarUrl} />
+      <View style={styles.identity}>
+        <Text style={styles.name} numberOfLines={1}>
+          {displayName}
+        </Text>
+        <Text style={styles.identifyTag} numberOfLines={1}>
+          {identifyTag}
+        </Text>
+      </View>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`Remove ${displayName}`}
+        accessibilityState={{ disabled: removing, busy: removing }}
+        disabled={removing}
+        hitSlop={spacing.xs}
+        onPress={requestRemoval}
+        style={({ pressed }) => [styles.removeButton, pressed && !removing && styles.removeButtonPressed]}
+      >
+        {removing ? (
+          <ActivityIndicator color={colors.danger} />
+        ) : (
+          <Ionicons name="person-remove-outline" size={22} color={colors.danger} />
+        )}
+      </Pressable>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  row: {
+    minHeight: spacing.xl * 2,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.lg,
+    borderCurve: 'continuous',
+    backgroundColor: colors.background,
+  },
+  identity: { flex: 1, minWidth: 0, gap: spacing.xs },
+  name: { ...typography.body, color: colors.text, fontWeight: '600' },
+  identifyTag: { ...typography.caption, color: colors.textMuted },
+  removeButton: {
+    width: 44,
+    height: 44,
+    borderRadius: radii.full,
+    borderCurve: 'continuous',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.dangerSoft,
+  },
+  removeButtonPressed: { opacity: 0.55 },
+});

--- a/mobile/src/features/friends/friendEvents.ts
+++ b/mobile/src/features/friends/friendEvents.ts
@@ -1,0 +1,28 @@
+import type { Friend } from './types';
+
+export type FriendEvent =
+  | { type: 'friendshipAdded'; friendship: Friend }
+  | { type: 'friendshipRemoved'; friendshipId: string };
+
+type FriendEventListener = (event: FriendEvent) => void;
+
+interface OwnedFriendEventListener {
+  ownerUserId: string;
+  listener: FriendEventListener;
+}
+
+const listeners = new Set<OwnedFriendEventListener>();
+
+export function publishFriendEvent(ownerUserId: string, event: FriendEvent): void {
+  for (const subscription of listeners) {
+    if (subscription.ownerUserId === ownerUserId) {
+      subscription.listener(event);
+    }
+  }
+}
+
+export function subscribeToFriendEvents(ownerUserId: string, listener: FriendEventListener): () => void {
+  const subscription = { ownerUserId, listener };
+  listeners.add(subscription);
+  return () => listeners.delete(subscription);
+}

--- a/mobile/src/features/friends/hooks/useCursorList.ts
+++ b/mobile/src/features/friends/hooks/useCursorList.ts
@@ -1,0 +1,215 @@
+import { useCallback, useRef, useState } from 'react';
+import type { ApiError } from '@/shared/api/errors';
+import { normalizeApiError } from '@/shared/api/errors';
+import type { CursorPage } from '@/shared/api/pagination';
+
+export type CursorListStatus = 'loading' | 'ready' | 'error';
+export type CursorListLoadMode = 'initial' | 'refresh' | 'silent';
+export type CursorListErrorSource = 'initial' | 'refresh' | 'loadMore' | null;
+
+interface ItemOverride<T> {
+  version: number;
+  item?: T;
+  removed: boolean;
+}
+
+interface CursorListOptions<T> {
+  getKey: (item: T) => string;
+  loadPage: (cursor?: string | null) => Promise<CursorPage<T>>;
+}
+
+function applyOverrides<T>(
+  serverItems: T[],
+  overrides: Map<string, ItemOverride<T>>,
+  requestOverrideVersion: number,
+  getKey: (item: T) => string,
+  includeMissingAdditions: boolean,
+): T[] {
+  const seen = new Set<string>();
+  const reconciled: T[] = [];
+
+  for (const serverItem of serverItems) {
+    const key = getKey(serverItem);
+    const override = overrides.get(key);
+    const activeOverride = override && override.version > requestOverrideVersion ? override : undefined;
+    if (activeOverride?.removed) {
+      continue;
+    }
+    const item = activeOverride?.item ?? serverItem;
+    seen.add(key);
+    reconciled.push(item);
+  }
+
+  if (!includeMissingAdditions) {
+    return reconciled;
+  }
+
+  const additions: T[] = [];
+  for (const [key, override] of overrides) {
+    if (
+      override.version > requestOverrideVersion &&
+      !override.removed &&
+      override.item &&
+      !seen.has(key)
+    ) {
+      additions.push(override.item);
+      seen.add(key);
+    }
+  }
+  return [...additions.reverse(), ...reconciled];
+}
+
+export function useCursorList<T>({ getKey, loadPage }: CursorListOptions<T>) {
+  const [items, setItems] = useState<T[]>([]);
+  const [status, setStatus] = useState<CursorListStatus>('loading');
+  const [error, setError] = useState<ApiError | null>(null);
+  const [errorSource, setErrorSource] = useState<CursorListErrorSource>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasNextPage, setHasNextPage] = useState(false);
+  const nextCursorRef = useRef<string | null>(null);
+  const firstPageRequestRef = useRef(0);
+  const firstPageInFlightRef = useRef<number | null>(null);
+  const listGenerationRef = useRef(0);
+  const loadMoreInFlightRef = useRef(false);
+  const hasUsablePageRef = useRef(false);
+  const overridesRef = useRef(new Map<string, ItemOverride<T>>());
+  const overrideVersionRef = useRef(0);
+
+  const loadFirstPage = useCallback(
+    async (mode: CursorListLoadMode) => {
+      const requestId = firstPageRequestRef.current + 1;
+      firstPageRequestRef.current = requestId;
+      firstPageInFlightRef.current = requestId;
+      listGenerationRef.current += 1;
+      const requestOverrideVersion = overrideVersionRef.current;
+      loadMoreInFlightRef.current = false;
+      setLoadingMore(false);
+      setError(null);
+      setErrorSource(null);
+      if (mode === 'initial') {
+        setStatus('loading');
+      } else if (mode === 'refresh') {
+        setRefreshing(true);
+      }
+
+      try {
+        const page = await loadPage();
+        if (requestId !== firstPageRequestRef.current) {
+          return;
+        }
+        nextCursorRef.current = page.nextCursor;
+        setHasNextPage(page.nextCursor !== null);
+        setItems(
+          applyOverrides(
+            page.items,
+            overridesRef.current,
+            requestOverrideVersion,
+            getKey,
+            true,
+          ),
+        );
+        hasUsablePageRef.current = true;
+        setStatus('ready');
+      } catch (caught) {
+        if (requestId !== firstPageRequestRef.current) {
+          return;
+        }
+        setError(normalizeApiError(caught));
+        if (mode === 'initial' || !hasUsablePageRef.current) {
+          setErrorSource('initial');
+          setStatus('error');
+        } else {
+          setErrorSource('refresh');
+        }
+      } finally {
+        if (requestId === firstPageRequestRef.current) {
+          firstPageInFlightRef.current = null;
+          setRefreshing(false);
+        }
+      }
+    },
+    [getKey, loadPage],
+  );
+
+  const loadMore = useCallback(async () => {
+    const cursor = nextCursorRef.current;
+    if (firstPageInFlightRef.current !== null || loadMoreInFlightRef.current || !cursor) {
+      return;
+    }
+
+    const generation = listGenerationRef.current;
+    const requestOverrideVersion = overrideVersionRef.current;
+    loadMoreInFlightRef.current = true;
+    setLoadingMore(true);
+    setError(null);
+    setErrorSource(null);
+    try {
+      const page = await loadPage(cursor);
+      if (generation !== listGenerationRef.current) {
+        return;
+      }
+      nextCursorRef.current = page.nextCursor;
+      setHasNextPage(page.nextCursor !== null);
+      setItems((current) => {
+        const seen = new Set(current.map(getKey));
+        const nextItems = applyOverrides(
+          page.items,
+          overridesRef.current,
+          requestOverrideVersion,
+          getKey,
+          false,
+        ).filter((item) => !seen.has(getKey(item)));
+        return [...current, ...nextItems];
+      });
+    } catch (caught) {
+      if (generation !== listGenerationRef.current) {
+        return;
+      }
+      setError(normalizeApiError(caught));
+      setErrorSource('loadMore');
+    } finally {
+      if (generation === listGenerationRef.current) {
+        loadMoreInFlightRef.current = false;
+        setLoadingMore(false);
+      }
+    }
+  }, [getKey, loadPage]);
+
+  const upsertLocalItem = useCallback(
+    (item: T) => {
+      const key = getKey(item);
+      overrideVersionRef.current += 1;
+      overridesRef.current.set(key, {
+        version: overrideVersionRef.current,
+        item,
+        removed: false,
+      });
+      setItems((current) => [item, ...current.filter((candidate) => getKey(candidate) !== key)]);
+    },
+    [getKey],
+  );
+
+  const removeLocalItem = useCallback((key: string) => {
+    overrideVersionRef.current += 1;
+    overridesRef.current.set(key, {
+      version: overrideVersionRef.current,
+      removed: true,
+    });
+    setItems((current) => current.filter((item) => getKey(item) !== key));
+  }, [getKey]);
+
+  return {
+    items,
+    status,
+    error,
+    errorSource,
+    refreshing,
+    loadingMore,
+    hasNextPage,
+    loadFirstPage,
+    loadMore,
+    upsertLocalItem,
+    removeLocalItem,
+  };
+}

--- a/mobile/src/features/friends/hooks/useFriendRequests.ts
+++ b/mobile/src/features/friends/hooks/useFriendRequests.ts
@@ -1,0 +1,91 @@
+import { useCallback, useRef, useState } from 'react';
+import { useSession } from '@/features/auth/session';
+import { type ApiError, normalizeApiError } from '@/shared/api/errors';
+import {
+  acceptFriendRequest as acceptFriendRequestApi,
+  cancelFriendRequest as cancelFriendRequestApi,
+  declineFriendRequest as declineFriendRequestApi,
+  listIncomingFriendRequests,
+  listOutgoingFriendRequests,
+} from '../api';
+import { publishFriendEvent } from '../friendEvents';
+import type { FriendRequest } from '../types';
+import { type CursorListLoadMode, useCursorList } from './useCursorList';
+
+export type FriendRequestAction = 'accept' | 'decline' | 'cancel';
+
+const getRequestKey = (request: FriendRequest) => request.id;
+
+export function useFriendRequests() {
+  const { user } = useSession();
+  const ownerUserId = user?.id;
+  const incoming = useCursorList({
+    getKey: getRequestKey,
+    loadPage: listIncomingFriendRequests,
+  });
+  const outgoing = useCursorList({
+    getKey: getRequestKey,
+    loadPage: listOutgoingFriendRequests,
+  });
+  const removeIncomingRequest = incoming.removeLocalItem;
+  const removeOutgoingRequest = outgoing.removeLocalItem;
+  const loadIncomingFirstPage = incoming.loadFirstPage;
+  const loadOutgoingFirstPage = outgoing.loadFirstPage;
+  const [pendingActions, setPendingActions] = useState<ReadonlyMap<string, FriendRequestAction>>(new Map());
+  const [mutationError, setMutationError] = useState<ApiError | null>(null);
+  const pendingActionsRef = useRef(new Map<string, FriendRequestAction>());
+
+  const performAction = useCallback(
+    async (requestId: string, action: FriendRequestAction): Promise<boolean> => {
+      if (pendingActionsRef.current.has(requestId)) {
+        return false;
+      }
+
+      pendingActionsRef.current.set(requestId, action);
+      setPendingActions(new Map(pendingActionsRef.current));
+      setMutationError(null);
+      try {
+        if (action === 'accept') {
+          const result = await acceptFriendRequestApi(requestId);
+          removeIncomingRequest(result.friendRequestId);
+          if (ownerUserId) {
+            publishFriendEvent(ownerUserId, { type: 'friendshipAdded', friendship: result.friendship });
+          }
+        } else if (action === 'decline') {
+          await declineFriendRequestApi(requestId);
+          removeIncomingRequest(requestId);
+        } else {
+          await cancelFriendRequestApi(requestId);
+          removeOutgoingRequest(requestId);
+        }
+        return true;
+      } catch (caught) {
+        setMutationError(normalizeApiError(caught));
+        return false;
+      } finally {
+        pendingActionsRef.current.delete(requestId);
+        setPendingActions(new Map(pendingActionsRef.current));
+      }
+    },
+    [ownerUserId, removeIncomingRequest, removeOutgoingRequest],
+  );
+
+  const loadFirstPages = useCallback(
+    async (mode: CursorListLoadMode) => {
+      await Promise.all([loadIncomingFirstPage(mode), loadOutgoingFirstPage(mode)]);
+    },
+    [loadIncomingFirstPage, loadOutgoingFirstPage],
+  );
+
+  const clearMutationError = useCallback(() => setMutationError(null), []);
+
+  return {
+    incoming,
+    outgoing,
+    pendingActions,
+    mutationError,
+    performAction,
+    loadFirstPages,
+    clearMutationError,
+  };
+}

--- a/mobile/src/features/friends/hooks/useFriendSearch.ts
+++ b/mobile/src/features/friends/hooks/useFriendSearch.ts
@@ -1,0 +1,147 @@
+import { useFocusEffect } from 'expo-router';
+import { useCallback, useRef, useState } from 'react';
+import { type ApiError, normalizeApiError } from '@/shared/api/errors';
+import { searchFriendUser, sendFriendRequest } from '../api';
+import type { FriendRequest, FriendUser } from '../types';
+
+export type FriendSearchStatus = 'idle' | 'searching' | 'found' | 'notFound' | 'error';
+export type FriendRequestSendStatus = 'idle' | 'sending' | 'sent';
+
+export function useFriendSearch() {
+  const [query, setQueryValue] = useState('');
+  const [user, setUser] = useState<FriendUser | null>(null);
+  const [searchStatus, setSearchStatus] = useState<FriendSearchStatus>('idle');
+  const [searchError, setSearchError] = useState<ApiError | null>(null);
+  const [sendStatus, setSendStatus] = useState<FriendRequestSendStatus>('idle');
+  const [sendError, setSendError] = useState<ApiError | null>(null);
+  const [friendRequest, setFriendRequest] = useState<FriendRequest | null>(null);
+
+  const activeRef = useRef(true);
+  const searchGenerationRef = useRef(0);
+  const queryVersionRef = useRef(0);
+  const searchControllerRef = useRef<AbortController | null>(null);
+  const sendLockRef = useRef(false);
+
+  const cancelPendingSearch = useCallback(() => {
+    searchGenerationRef.current += 1;
+    searchControllerRef.current?.abort();
+    searchControllerRef.current = null;
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      activeRef.current = true;
+      setSearchStatus((current) => (current === 'searching' ? 'idle' : current));
+
+      return () => {
+        activeRef.current = false;
+        cancelPendingSearch();
+      };
+    }, [cancelPendingSearch]),
+  );
+
+  const setQuery = useCallback(
+    (nextQuery: string) => {
+      cancelPendingSearch();
+      queryVersionRef.current += 1;
+      setQueryValue(nextQuery);
+      setUser(null);
+      setSearchStatus('idle');
+      setSearchError(null);
+      setSendStatus('idle');
+      setSendError(null);
+      setFriendRequest(null);
+    },
+    [cancelPendingSearch],
+  );
+
+  const search = useCallback(async () => {
+    const normalizedQuery = query.trim();
+    if (!normalizedQuery) {
+      cancelPendingSearch();
+      setUser(null);
+      setSearchStatus('idle');
+      setSearchError(null);
+      return;
+    }
+
+    searchControllerRef.current?.abort();
+    const controller = new AbortController();
+    searchControllerRef.current = controller;
+    const generation = searchGenerationRef.current + 1;
+    searchGenerationRef.current = generation;
+
+    setUser(null);
+    setSearchStatus('searching');
+    setSearchError(null);
+    setSendStatus('idle');
+    setSendError(null);
+    setFriendRequest(null);
+
+    try {
+      const foundUser = await searchFriendUser(normalizedQuery, controller.signal);
+      if (!activeRef.current || controller.signal.aborted || generation !== searchGenerationRef.current) {
+        return;
+      }
+
+      setUser(foundUser);
+      setSearchStatus(foundUser ? 'found' : 'notFound');
+    } catch (caught) {
+      if (!activeRef.current || controller.signal.aborted || generation !== searchGenerationRef.current) {
+        return;
+      }
+
+      setUser(null);
+      setSearchError(normalizeApiError(caught));
+      setSearchStatus('error');
+    } finally {
+      if (searchControllerRef.current === controller) {
+        searchControllerRef.current = null;
+      }
+    }
+  }, [cancelPendingSearch, query]);
+
+  const sendRequest = useCallback(async () => {
+    if (!user || sendLockRef.current) {
+      return;
+    }
+
+    sendLockRef.current = true;
+    const queryVersion = queryVersionRef.current;
+    setSendStatus('sending');
+    setSendError(null);
+
+    try {
+      // Use the server-returned tag instead of the user's raw search input.
+      const createdRequest = await sendFriendRequest(user.identify_tag);
+      if (queryVersion !== queryVersionRef.current) {
+        return;
+      }
+
+      setFriendRequest(createdRequest);
+      setSendStatus('sent');
+    } catch (caught) {
+      if (queryVersion !== queryVersionRef.current) {
+        return;
+      }
+
+      setSendError(normalizeApiError(caught));
+      setSendStatus('idle');
+    } finally {
+      sendLockRef.current = false;
+    }
+  }, [user]);
+
+  return {
+    query,
+    setQuery,
+    user,
+    searchStatus,
+    searchError,
+    search,
+    sendStatus,
+    sendError,
+    friendRequest,
+    sendRequest,
+  };
+}

--- a/mobile/src/features/friends/hooks/useFriendsList.ts
+++ b/mobile/src/features/friends/hooks/useFriendsList.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSession } from '@/features/auth/session';
+import { type ApiError, normalizeApiError } from '@/shared/api/errors';
+import { listFriends, removeFriend as removeFriendApi } from '../api';
+import { publishFriendEvent, subscribeToFriendEvents } from '../friendEvents';
+import type { Friend } from '../types';
+import { useCursorList } from './useCursorList';
+
+const getFriendKey = (friend: Friend) => friend.friendship_id;
+
+export function useFriendsList() {
+  const { user } = useSession();
+  const ownerUserId = user?.id;
+  const list = useCursorList({ getKey: getFriendKey, loadPage: listFriends });
+  const [removingIds, setRemovingIds] = useState<ReadonlySet<string>>(new Set());
+  const [mutationError, setMutationError] = useState<ApiError | null>(null);
+  const removingIdsRef = useRef(new Set<string>());
+  const { removeLocalItem, upsertLocalItem } = list;
+
+  useEffect(
+    () => {
+      if (!ownerUserId) {
+        return;
+      }
+      return subscribeToFriendEvents(ownerUserId, (event) => {
+        if (event.type === 'friendshipAdded') {
+          upsertLocalItem(event.friendship);
+        } else {
+          removeLocalItem(event.friendshipId);
+        }
+      });
+    },
+    [ownerUserId, removeLocalItem, upsertLocalItem],
+  );
+
+  const removeFriend = useCallback(async (friendshipId: string): Promise<boolean> => {
+    if (removingIdsRef.current.has(friendshipId)) {
+      return false;
+    }
+
+    removingIdsRef.current.add(friendshipId);
+    setRemovingIds(new Set(removingIdsRef.current));
+    setMutationError(null);
+    try {
+      await removeFriendApi(friendshipId);
+      if (ownerUserId) {
+        publishFriendEvent(ownerUserId, { type: 'friendshipRemoved', friendshipId });
+      }
+      return true;
+    } catch (caught) {
+      setMutationError(normalizeApiError(caught));
+      return false;
+    } finally {
+      removingIdsRef.current.delete(friendshipId);
+      setRemovingIds(new Set(removingIdsRef.current));
+    }
+  }, [ownerUserId]);
+
+  const clearMutationError = useCallback(() => setMutationError(null), []);
+
+  return { ...list, removingIds, mutationError, removeFriend, clearMutationError };
+}

--- a/mobile/src/features/friends/screens/AddFriendScreen.tsx
+++ b/mobile/src/features/friends/screens/AddFriendScreen.tsx
@@ -1,0 +1,154 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { Button } from '@/shared/ui/Button';
+import { FormError } from '@/shared/ui/FormError';
+import { Screen } from '@/shared/ui/Screen';
+import { TextField } from '@/shared/ui/TextField';
+import { FriendAvatar } from '../components/FriendAvatar';
+import { useFriendSearch } from '../hooks/useFriendSearch';
+import type { FriendUser } from '../types';
+
+function FriendSearchResult({ user, sending, sent, onSend }: {
+  user: FriendUser;
+  sending: boolean;
+  sent: boolean;
+  onSend: () => void;
+}) {
+  return (
+    <View style={styles.resultCard}>
+      <View style={styles.userRow}>
+        <FriendAvatar
+          displayName={user.display_name}
+          identifyTag={user.identify_tag}
+          avatarUrl={user.avatar_url}
+        />
+        <View style={styles.userInfo}>
+          <Text style={styles.displayName} numberOfLines={1}>
+            {user.display_name}
+          </Text>
+          <Text style={styles.identifyTag} numberOfLines={1}>
+            {user.identify_tag}
+          </Text>
+        </View>
+      </View>
+
+      {sent ? (
+        <View accessibilityRole="alert" style={styles.sentNotice}>
+          <Text style={styles.sentText}>Friend request sent.</Text>
+        </View>
+      ) : (
+        <Button title="Send friend request" onPress={onSend} loading={sending} />
+      )}
+    </View>
+  );
+}
+
+export function AddFriendScreen() {
+  const {
+    query,
+    setQuery,
+    user,
+    searchStatus,
+    searchError,
+    search,
+    sendStatus,
+    sendError,
+    sendRequest,
+  } = useFriendSearch();
+
+  const isSearching = searchStatus === 'searching';
+  const isSending = sendStatus === 'sending';
+  const queryFieldError =
+    searchError?.fieldErrors?.identify_tag ??
+    searchError?.fieldErrors?.q ??
+    sendError?.fieldErrors?.identify_tag ??
+    sendError?.fieldErrors?.q;
+
+  return (
+    <Screen scroll edges={['left', 'right', 'bottom']}>
+      <View style={styles.intro}>
+        <Text accessibilityRole="header" style={styles.title}>
+          Find a friend
+        </Text>
+        <Text style={styles.subtitle}>Enter their exact identify tag, including the name and code.</Text>
+      </View>
+
+      <TextField
+        label="Identify tag"
+        accessibilityLabel="Identify tag"
+        placeholder="name#CODE"
+        autoCapitalize="none"
+        autoCorrect={false}
+        returnKeyType="search"
+        value={query}
+        onChangeText={setQuery}
+        onSubmitEditing={() => {
+          if (query.trim() && !isSearching) {
+            void search();
+          }
+        }}
+        error={queryFieldError}
+      />
+      <FormError error={searchError} />
+      <Button title="Search" onPress={() => void search()} loading={isSearching} disabled={!query.trim()} />
+
+      {searchStatus === 'notFound' ? (
+        <View accessibilityRole="alert" style={styles.neutralState}>
+          <Text style={styles.stateTitle}>No user found</Text>
+          <Text style={styles.stateBody}>Check the identify tag and try again.</Text>
+        </View>
+      ) : null}
+
+      {searchStatus === 'found' && user ? (
+        <>
+          <FriendSearchResult
+            user={user}
+            sending={isSending}
+            sent={sendStatus === 'sent'}
+            onSend={() => void sendRequest()}
+          />
+          <FormError error={sendError} />
+        </>
+      ) : null}
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  intro: { gap: spacing.sm, marginTop: spacing.md },
+  title: { ...typography.title, color: colors.text },
+  subtitle: { ...typography.body, color: colors.textMuted },
+  neutralState: {
+    alignItems: 'center',
+    gap: spacing.sm,
+    padding: spacing.lg,
+    borderRadius: radii.lg,
+    borderCurve: 'continuous',
+    backgroundColor: colors.surface,
+  },
+  stateTitle: { ...typography.heading, color: colors.text },
+  stateBody: { ...typography.body, color: colors.textMuted, textAlign: 'center' },
+  resultCard: {
+    gap: spacing.md,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.lg,
+    borderCurve: 'continuous',
+    backgroundColor: colors.background,
+  },
+  userRow: { flexDirection: 'row', alignItems: 'center', gap: spacing.md },
+  userInfo: { flex: 1, minWidth: 0, gap: spacing.xs },
+  displayName: { ...typography.body, color: colors.text, fontWeight: '600' },
+  identifyTag: { ...typography.caption, color: colors.textMuted },
+  sentNotice: {
+    minHeight: 48,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.md,
+    borderRadius: radii.md,
+    borderCurve: 'continuous',
+    backgroundColor: colors.successSoft,
+  },
+  sentText: { ...typography.body, color: colors.success, fontWeight: '600' },
+});

--- a/mobile/src/features/friends/screens/FriendRequestsScreen.tsx
+++ b/mobile/src/features/friends/screens/FriendRequestsScreen.tsx
@@ -1,0 +1,247 @@
+import { Ionicons } from '@expo/vector-icons';
+import { useFocusEffect } from 'expo-router';
+import { useCallback, useRef, useState } from 'react';
+import { ActivityIndicator, FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { Button } from '@/shared/ui/Button';
+import { LoadingScreen } from '@/shared/ui/LoadingScreen';
+import { FriendRequestRow } from '../components/FriendRequestRow';
+import { useFriendRequests } from '../hooks/useFriendRequests';
+import type { FriendRequest } from '../types';
+
+type RequestTab = 'incoming' | 'outgoing';
+
+export function FriendRequestsScreen() {
+  const {
+    incoming,
+    outgoing,
+    pendingActions,
+    mutationError,
+    performAction,
+    loadFirstPages,
+    clearMutationError,
+  } = useFriendRequests();
+  const [tab, setTab] = useState<RequestTab>('incoming');
+  const loadedOnceRef = useRef(false);
+
+  useFocusEffect(
+    useCallback(() => {
+      clearMutationError();
+      void loadFirstPages(loadedOnceRef.current ? 'silent' : 'initial');
+      loadedOnceRef.current = true;
+    }, [clearMutationError, loadFirstPages]),
+  );
+
+  const current = tab === 'incoming' ? incoming : outgoing;
+  const loadCurrentFirstPage = current.loadFirstPage;
+  const loadCurrentMore = current.loadMore;
+  const currentErrorSource = current.errorSource;
+  const changeTab = useCallback(
+    (nextTab: RequestTab) => {
+      clearMutationError();
+      setTab(nextTab);
+    },
+    [clearMutationError],
+  );
+  const refreshCurrent = useCallback(() => {
+    clearMutationError();
+    void loadCurrentFirstPage('refresh');
+  }, [clearMutationError, loadCurrentFirstPage]);
+  const retryInitial = useCallback(() => {
+    clearMutationError();
+    void loadCurrentFirstPage('initial');
+  }, [clearMutationError, loadCurrentFirstPage]);
+  const autoLoadCurrentMore = useCallback(() => {
+    if (currentErrorSource !== 'loadMore') {
+      void loadCurrentMore();
+    }
+  }, [currentErrorSource, loadCurrentMore]);
+
+  const renderItem = useCallback(
+    ({ item }: { item: FriendRequest }) => {
+      const user = tab === 'incoming' ? item.sender : item.receiver;
+      return (
+        <FriendRequestRow
+          requestId={item.id}
+          displayName={user.display_name}
+          identifyTag={user.identify_tag}
+          avatarUrl={user.avatar_url}
+          direction={tab}
+          pendingAction={pendingActions.get(item.id) ?? null}
+          onAction={performAction}
+        />
+      );
+    },
+    [pendingActions, performAction, tab],
+  );
+
+  if (current.status === 'loading') {
+    return (
+      <SafeAreaView style={styles.safe} edges={['left', 'right', 'bottom']}>
+        <RequestTabs tab={tab} onChange={changeTab} />
+        <LoadingScreen />
+      </SafeAreaView>
+    );
+  }
+
+  if (current.status === 'error') {
+    return (
+      <SafeAreaView style={styles.safe} edges={['left', 'right', 'bottom']}>
+        <RequestTabs tab={tab} onChange={changeTab} />
+        <View style={styles.centered}>
+          <Ionicons name="cloud-offline-outline" size={44} color={colors.textMuted} />
+          <Text style={styles.stateTitle}>Could not load requests</Text>
+          <Text style={styles.stateBody}>{current.error?.message}</Text>
+          <Button title="Try again" onPress={retryInitial} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const refreshError = current.errorSource === 'refresh' ? current.error : null;
+  const inlineError = mutationError ?? refreshError;
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['left', 'right', 'bottom']}>
+      <RequestTabs tab={tab} onChange={changeTab} />
+      {inlineError ? (
+        <View accessibilityRole="alert" style={styles.inlineError}>
+          <Ionicons name="alert-circle-outline" size={20} color={colors.danger} />
+          <Text style={styles.inlineErrorText}>{inlineError.message}</Text>
+          {!mutationError ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={`Retry refreshing ${tab} requests`}
+              onPress={refreshCurrent}
+              style={({ pressed }) => [styles.retryButton, pressed && styles.pressed]}
+            >
+              <Text style={styles.retryText}>Retry</Text>
+            </Pressable>
+          ) : null}
+        </View>
+      ) : null}
+      <FlatList
+        key={tab}
+        style={styles.list}
+        data={current.items}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        contentContainerStyle={current.items.length === 0 ? styles.emptyContainer : styles.listContent}
+        onRefresh={refreshCurrent}
+        refreshing={current.refreshing}
+        onEndReached={autoLoadCurrentMore}
+        onEndReachedThreshold={0.4}
+        ListEmptyComponent={
+          <View style={styles.emptyState}>
+            <Ionicons name="mail-open-outline" size={44} color={colors.textMuted} />
+            <Text style={styles.stateTitle}>No {tab} requests</Text>
+            <Text style={styles.stateBody}>
+              {tab === 'incoming'
+                ? 'New requests from other people will appear here.'
+                : 'Friend requests you send will appear here.'}
+            </Text>
+          </View>
+        }
+        ListFooterComponent={
+          current.errorSource === 'loadMore' && current.error ? (
+            <View accessibilityRole="alert" style={styles.footerError}>
+              <Text style={styles.footerErrorText}>{current.error.message}</Text>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={`Retry loading more ${tab} requests`}
+                onPress={() => void loadCurrentMore()}
+                style={({ pressed }) => [styles.retryButton, pressed && styles.pressed]}
+              >
+                <Text style={styles.retryText}>Try again</Text>
+              </Pressable>
+            </View>
+          ) : current.loadingMore ? (
+            <ActivityIndicator style={styles.footerSpinner} color={colors.primary} />
+          ) : null
+        }
+      />
+    </SafeAreaView>
+  );
+}
+
+function RequestTabs({ tab, onChange }: { tab: RequestTab; onChange: (tab: RequestTab) => void }) {
+  return (
+    <View style={styles.tabs}>
+      {(['incoming', 'outgoing'] as const).map((value) => {
+        const selected = tab === value;
+        const label = value === 'incoming' ? 'Incoming' : 'Outgoing';
+        return (
+          <Pressable
+            key={value}
+            accessibilityRole="button"
+            accessibilityLabel={`${label} requests`}
+            accessibilityState={{ selected }}
+            onPress={() => onChange(value)}
+            style={({ pressed }) => [styles.tab, selected && styles.tabSelected, pressed && styles.pressed]}
+          >
+            <Text style={[styles.tabText, selected && styles.tabTextSelected]}>{label}</Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.background },
+  tabs: {
+    flexDirection: 'row',
+    gap: spacing.xs,
+    margin: spacing.md,
+    padding: spacing.xs,
+    borderRadius: radii.md,
+    borderCurve: 'continuous',
+    backgroundColor: colors.surface,
+  },
+  tab: {
+    minHeight: 44,
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.sm,
+    borderCurve: 'continuous',
+  },
+  tabSelected: { backgroundColor: colors.background },
+  tabText: { ...typography.label, color: colors.textMuted },
+  tabTextSelected: { color: colors.primary },
+  pressed: { opacity: 0.55 },
+  list: { flex: 1 },
+  listContent: { paddingHorizontal: spacing.md, paddingBottom: spacing.xl, gap: spacing.sm },
+  emptyContainer: { flexGrow: 1, justifyContent: 'center', padding: spacing.lg },
+  emptyState: { alignItems: 'center', gap: spacing.md },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.md,
+    padding: spacing.lg,
+  },
+  stateTitle: { ...typography.heading, color: colors.text, textTransform: 'none' },
+  stateBody: { ...typography.body, color: colors.textMuted, textAlign: 'center' },
+  inlineError: {
+    minHeight: 48,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    marginHorizontal: spacing.md,
+    marginBottom: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.dangerBorder,
+    borderRadius: radii.md,
+    borderCurve: 'continuous',
+    backgroundColor: colors.dangerSoft,
+  },
+  inlineErrorText: { ...typography.caption, color: colors.danger, flex: 1 },
+  retryButton: { minHeight: 44, justifyContent: 'center', paddingHorizontal: spacing.xs },
+  retryText: { ...typography.label, color: colors.danger },
+  footerSpinner: { marginVertical: spacing.md },
+  footerError: { alignItems: 'center', gap: spacing.xs, paddingVertical: spacing.md },
+  footerErrorText: { ...typography.caption, color: colors.danger, textAlign: 'center' },
+});

--- a/mobile/src/features/friends/screens/FriendsScreen.tsx
+++ b/mobile/src/features/friends/screens/FriendsScreen.tsx
@@ -1,0 +1,269 @@
+import { Ionicons } from '@expo/vector-icons';
+import { useFocusEffect, useRouter } from 'expo-router';
+import { useCallback, useRef } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { Button } from '@/shared/ui/Button';
+import { LoadingScreen } from '@/shared/ui/LoadingScreen';
+import { FriendRow } from '../components/FriendRow';
+import { useFriendsList } from '../hooks/useFriendsList';
+import type { Friend } from '../types';
+
+interface HeaderActionProps {
+  icon: 'person-add-outline' | 'mail-outline';
+  label: string;
+  onPress: () => void;
+}
+
+function HeaderAction({ icon, label, onPress }: HeaderActionProps) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      hitSlop={spacing.xs}
+      onPress={onPress}
+      style={({ pressed }) => [styles.headerAction, pressed && styles.pressed]}
+    >
+      <Ionicons name={icon} size={21} color={colors.primary} />
+      <Text style={styles.headerActionText}>{label}</Text>
+    </Pressable>
+  );
+}
+
+function FriendsHeader({ onAdd, onRequests }: { onAdd: () => void; onRequests: () => void }) {
+  return (
+    <View style={styles.screenHeader}>
+      <Text accessibilityRole="header" style={styles.screenTitle}>
+        Friends
+      </Text>
+      <View style={styles.headerActions}>
+        <HeaderAction icon="person-add-outline" label="Add Friend" onPress={onAdd} />
+        <HeaderAction icon="mail-outline" label="Requests" onPress={onRequests} />
+      </View>
+    </View>
+  );
+}
+
+export function FriendsScreen() {
+  const router = useRouter();
+  const {
+    items,
+    status,
+    error,
+    errorSource,
+    refreshing,
+    loadingMore,
+    loadFirstPage,
+    loadMore,
+    removingIds,
+    mutationError,
+    removeFriend,
+    clearMutationError,
+  } = useFriendsList();
+  const loadedOnceRef = useRef(false);
+
+  useFocusEffect(
+    useCallback(() => {
+      clearMutationError();
+      void loadFirstPage(loadedOnceRef.current ? 'silent' : 'initial');
+      loadedOnceRef.current = true;
+    }, [clearMutationError, loadFirstPage]),
+  );
+
+  const openAddFriend = useCallback(() => router.push('/friends/add'), [router]);
+  const openRequests = useCallback(() => router.push('/friends/requests'), [router]);
+  const refreshFriends = useCallback(() => {
+    clearMutationError();
+    void loadFirstPage('refresh');
+  }, [clearMutationError, loadFirstPage]);
+  const autoLoadMore = useCallback(() => {
+    if (errorSource !== 'loadMore') {
+      void loadMore();
+    }
+  }, [errorSource, loadMore]);
+
+  const confirmRemove = useCallback(
+    (friendshipId: string, displayName: string) => {
+      Alert.alert(
+        'Remove friend',
+        `Remove ${displayName} from your friends?`,
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Remove',
+            style: 'destructive',
+            onPress: () => {
+              void removeFriend(friendshipId);
+            },
+          },
+        ],
+      );
+    },
+    [removeFriend],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: Friend }) => (
+      <FriendRow
+        friendshipId={item.friendship_id}
+        displayName={item.user.display_name}
+        identifyTag={item.user.identify_tag}
+        avatarUrl={item.user.avatar_url}
+        removing={removingIds.has(item.friendship_id)}
+        onRemoveRequest={confirmRemove}
+      />
+    ),
+    [confirmRemove, removingIds],
+  );
+
+  const header = <FriendsHeader onAdd={openAddFriend} onRequests={openRequests} />;
+
+  if (status === 'loading') {
+    return (
+      <SafeAreaView style={styles.safe}>
+        {header}
+        <LoadingScreen />
+      </SafeAreaView>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <SafeAreaView style={styles.safe}>
+        {header}
+        <View style={styles.centered}>
+          <Ionicons name="cloud-offline-outline" size={44} color={colors.textMuted} />
+          <Text style={styles.stateTitle}>Could not load friends</Text>
+          <Text style={styles.stateBody}>{error?.message}</Text>
+          <Button title="Try again" onPress={() => void loadFirstPage('initial')} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const inlineError = mutationError ?? (errorSource === 'refresh' ? error : null);
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+      {header}
+      {inlineError ? (
+        <View accessibilityRole="alert" style={styles.inlineError}>
+          <Ionicons name="alert-circle-outline" size={20} color={colors.danger} />
+          <Text style={styles.inlineErrorText}>{inlineError.message}</Text>
+          {!mutationError ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Retry refreshing friends"
+              onPress={refreshFriends}
+              style={({ pressed }) => [styles.retryButton, pressed && styles.pressed]}
+            >
+              <Text style={styles.retryText}>Retry</Text>
+            </Pressable>
+          ) : null}
+        </View>
+      ) : null}
+      <FlatList
+        style={styles.list}
+        data={items}
+        keyExtractor={(item) => item.friendship_id}
+        renderItem={renderItem}
+        contentContainerStyle={items.length === 0 ? styles.emptyContainer : styles.listContent}
+        onRefresh={refreshFriends}
+        refreshing={refreshing}
+        onEndReached={autoLoadMore}
+        onEndReachedThreshold={0.4}
+        ListEmptyComponent={
+          <View style={styles.emptyState}>
+            <Ionicons name="people-outline" size={44} color={colors.textMuted} />
+            <Text style={styles.stateTitle}>No friends yet</Text>
+            <Text style={styles.stateBody}>Find someone by their identify tag to start planning together.</Text>
+            <Button title="Add your first friend" onPress={openAddFriend} />
+          </View>
+        }
+        ListFooterComponent={
+          errorSource === 'loadMore' && error ? (
+            <View accessibilityRole="alert" style={styles.footerError}>
+              <Text style={styles.footerErrorText}>{error.message}</Text>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Retry loading more friends"
+                onPress={() => void loadMore()}
+                style={({ pressed }) => [styles.retryButton, pressed && styles.pressed]}
+              >
+                <Text style={styles.retryText}>Try again</Text>
+              </Pressable>
+            </View>
+          ) : loadingMore ? (
+            <ActivityIndicator style={styles.footerSpinner} color={colors.primary} />
+          ) : null
+        }
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.background },
+  screenHeader: {
+    minHeight: 66,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    gap: spacing.sm,
+  },
+  screenTitle: { ...typography.largeTitle, color: colors.text },
+  headerActions: { flexDirection: 'row', gap: spacing.sm },
+  headerAction: {
+    minHeight: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    borderRadius: radii.md,
+    borderCurve: 'continuous',
+    backgroundColor: colors.primarySoft,
+  },
+  headerActionText: { ...typography.label, color: colors.primary },
+  pressed: { opacity: 0.55 },
+  list: { flex: 1 },
+  listContent: { paddingHorizontal: spacing.md, paddingBottom: spacing.xl, gap: spacing.sm },
+  emptyContainer: { flexGrow: 1, justifyContent: 'center', padding: spacing.lg },
+  emptyState: { alignItems: 'center', gap: spacing.md },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.md,
+    padding: spacing.lg,
+  },
+  stateTitle: { ...typography.heading, color: colors.text },
+  stateBody: { ...typography.body, color: colors.textMuted, textAlign: 'center' },
+  inlineError: {
+    minHeight: 48,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    marginHorizontal: spacing.md,
+    marginBottom: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.dangerBorder,
+    borderRadius: radii.md,
+    borderCurve: 'continuous',
+    backgroundColor: colors.dangerSoft,
+  },
+  inlineErrorText: { ...typography.caption, color: colors.danger, flex: 1 },
+  retryButton: { minHeight: 44, justifyContent: 'center', paddingHorizontal: spacing.xs },
+  retryText: { ...typography.label, color: colors.danger },
+  footerSpinner: { marginVertical: spacing.md },
+  footerError: { alignItems: 'center', gap: spacing.xs, paddingVertical: spacing.md },
+  footerErrorText: { ...typography.caption, color: colors.danger, textAlign: 'center' },
+});

--- a/mobile/src/features/friends/types.ts
+++ b/mobile/src/features/friends/types.ts
@@ -1,0 +1,33 @@
+import type { CursorPage } from '@/shared/api/pagination';
+
+export type FriendRequestStatus = 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'CANCELLED';
+
+export interface FriendUser {
+  id: string;
+  display_name: string;
+  identify_tag: string;
+  avatar_url: string | null;
+}
+
+export interface Friend {
+  friendship_id: string;
+  user: FriendUser;
+  created_at: string;
+}
+
+export interface FriendRequest {
+  id: string;
+  sender: FriendUser;
+  receiver: FriendUser;
+  status: FriendRequestStatus;
+  resolved_at: string | null;
+  created_at: string;
+}
+
+export type FriendsPage = CursorPage<Friend>;
+export type FriendRequestsPage = CursorPage<FriendRequest>;
+
+export interface AcceptFriendRequestResult {
+  friendship: Friend;
+  friendRequestId: string;
+}

--- a/mobile/src/features/trips/__tests__/api.test.ts
+++ b/mobile/src/features/trips/__tests__/api.test.ts
@@ -5,11 +5,12 @@ jest.mock('@/shared/api/client', () => ({
 // eslint-disable-next-line import/first
 import { apiClient } from '@/shared/api/client';
 // eslint-disable-next-line import/first
+import { extractCursor } from '@/shared/api/pagination';
+// eslint-disable-next-line import/first
 import {
   cancelTrip,
   completeTrip,
   createTrip,
-  extractCursor,
   getTripDetail,
   leaveTrip,
   listTrips,

--- a/mobile/src/features/trips/api.ts
+++ b/mobile/src/features/trips/api.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '@/shared/api/client';
+import { extractCursor, type CursorPaginatedResponse } from '@/shared/api/pagination';
 import type {
   CreateTripInput,
   Trip,
@@ -9,23 +10,8 @@ import type {
   UpdateTripInput,
 } from './types';
 
-interface CursorPaginatedResponse {
-  next: string | null;
-  previous: string | null;
-  results: TripListItem[];
-}
-
-// DRF CursorPagination returns absolute URLs; the client only needs the cursor value.
-export function extractCursor(url: string | null): string | null {
-  if (!url) {
-    return null;
-  }
-  const match = /[?&]cursor=([^&]+)/.exec(url);
-  return match ? decodeURIComponent(match[1]) : null;
-}
-
 export async function listTrips(cursor?: string | null): Promise<TripListPage> {
-  const { data } = await apiClient.get<CursorPaginatedResponse>('/trips/', {
+  const { data } = await apiClient.get<CursorPaginatedResponse<TripListItem>>('/trips/', {
     params: cursor ? { cursor } : undefined,
   });
   return { items: data.results, nextCursor: extractCursor(data.next) };

--- a/mobile/src/shared/api/__tests__/pagination.test.ts
+++ b/mobile/src/shared/api/__tests__/pagination.test.ts
@@ -1,0 +1,34 @@
+import { extractCursor, toCursorPage } from '../pagination';
+
+describe('extractCursor', () => {
+  it('returns null when the pagination URL is absent or has no cursor', () => {
+    expect(extractCursor(null)).toBeNull();
+    expect(extractCursor('http://testserver/api/friends/')).toBeNull();
+    expect(extractCursor('http://testserver/api/friends/?cursor=')).toBeNull();
+  });
+
+  it('extracts and decodes the opaque cursor from an absolute DRF URL', () => {
+    expect(
+      extractCursor('http://testserver/api/friends/?cursor=abc%2B%2F%3D&page=2'),
+    ).toBe('abc+/=');
+  });
+
+  it('returns null instead of throwing for a malformed encoded cursor', () => {
+    expect(extractCursor('http://testserver/api/friends/?cursor=%E0%A4%A')).toBeNull();
+  });
+});
+
+describe('toCursorPage', () => {
+  it('maps a DRF cursor response to the mobile page shape', () => {
+    expect(
+      toCursorPage({
+        next: 'http://testserver/api/friends/?cursor=next%3D%3D',
+        previous: null,
+        results: [{ id: 'friend-1' }],
+      }),
+    ).toEqual({
+      items: [{ id: 'friend-1' }],
+      nextCursor: 'next==',
+    });
+  });
+});

--- a/mobile/src/shared/api/pagination.ts
+++ b/mobile/src/shared/api/pagination.ts
@@ -1,0 +1,34 @@
+export interface CursorPaginatedResponse<T> {
+  next: string | null;
+  previous: string | null;
+  results: T[];
+}
+
+export interface CursorPage<T> {
+  items: T[];
+  nextCursor: string | null;
+}
+
+export function extractCursor(url: string | null): string | null {
+  if (!url) {
+    return null;
+  }
+
+  const match = /[?&]cursor=([^&#]*)/.exec(url);
+  if (!match?.[1]) {
+    return null;
+  }
+
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return null;
+  }
+}
+
+export function toCursorPage<T>(response: CursorPaginatedResponse<T>): CursorPage<T> {
+  return {
+    items: response.results,
+    nextCursor: extractCursor(response.next),
+  };
+}


### PR DESCRIPTION
## Summary

- add the mobile friends list with cursor pagination, refresh, empty/error states, and friend removal
- add user search and outgoing request flows, including duplicate/concurrent-action guards
- add incoming/outgoing request management for accept, decline, and cancel actions
- wire Expo Router navigation, shared pagination handling, accessibility labels, and focused unit/component coverage

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test --runInBand` — 32 suites, 196 tests
- native iOS build on Simulator
- two-user iOS E2E across two simulators: send/cancel, send/decline, send/accept, session restore, and remove friendship from both sides

Closes #54