### PR TITLE
feat: add mobile notifications, invitations, and member management

### DIFF
--- a/backend/notifications/serializers.py
+++ b/backend/notifications/serializers.py
@@ -7,4 +7,8 @@ class NotificationSerializer(serializers.BaseSerializer):
     """Read-only serializer that delegates to the shared payload builder."""
 
     def to_representation(self, instance):
-        return build_notification_payload(instance)
+        invitation_statuses = self.context.get("invitation_statuses", {})
+        return build_notification_payload(
+            instance,
+            invitation_status=invitation_statuses.get(instance.id),
+        )

--- a/backend/notifications/services.py
+++ b/backend/notifications/services.py
@@ -1,8 +1,10 @@
 import logging
+import uuid
 
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 from django.db import transaction
+from django.db.models import Exists, OuterRef
 from django.utils import timezone
 
 from notifications.models import Notification, NotificationType
@@ -125,7 +127,128 @@ def _build_actor_payload(user):
     }
 
 
-def build_notification_payload(notification):
+def resolve_trip_invitation_statuses(
+    notifications,
+    *,
+    recipient_id,
+) -> dict[uuid.UUID, str]:
+    """Resolve output-only invitation statuses for a notification collection.
+
+    Notification records intentionally retain their original JSON payload. The
+    current invitation status is joined at read time so accepted, declined, or
+    cancelled invitations cannot become actionable again after a refresh.
+
+    The lookup is fail-closed: malformed legacy payloads and references that do
+    not belong to the notification recipient are omitted from the result.
+    """
+    from trips.models import (
+        InvitationStatus,
+        MemberStatus,
+        TripInvitation,
+        TripMember,
+        TripStatus,
+    )
+
+    parsed_by_notification_id: dict[uuid.UUID, tuple[uuid.UUID, uuid.UUID]] = {}
+    invitation_ids: set[uuid.UUID] = set()
+
+    for notification in notifications:
+        if notification.type != NotificationType.TRIP_INVITATION:
+            continue
+        if notification.recipient_id != recipient_id:
+            continue
+
+        try:
+            payload = validate_notification_payload(
+                NotificationType.TRIP_INVITATION,
+                notification.payload,
+            )
+            invitation_id = uuid.UUID(payload["invitation_id"])
+            trip_id = uuid.UUID(payload["trip_id"])
+        except (NotificationPayloadValidationError, TypeError, ValueError):
+            continue
+
+        parsed_by_notification_id[notification.id] = (invitation_id, trip_id)
+        invitation_ids.add(invitation_id)
+
+    if not invitation_ids:
+        return {}
+
+    active_membership = TripMember.objects.filter(
+        trip_id=OuterRef("trip_id"),
+        user_id=OuterRef("invitee_id"),
+        status=MemberStatus.ACTIVE,
+    )
+    invitations = {
+        row["id"]: row
+        for row in (
+            TripInvitation.objects.filter(
+                id__in=invitation_ids,
+                invitee_id=recipient_id,
+            )
+            .annotate(invitee_is_active=Exists(active_membership))
+            .values(
+                "id",
+                "trip_id",
+                "status",
+                "trip__status",
+                "invitee_is_active",
+            )
+        )
+    }
+
+    valid_statuses = set(InvitationStatus.values)
+    terminal_trip_statuses = {TripStatus.COMPLETED, TripStatus.CANCELLED}
+    resolved: dict[uuid.UUID, str] = {}
+
+    for notification_id, (invitation_id, payload_trip_id) in (
+        parsed_by_notification_id.items()
+    ):
+        invitation = invitations.get(invitation_id)
+        if invitation is None or invitation["trip_id"] != payload_trip_id:
+            continue
+
+        invitation_status = invitation["status"]
+        if invitation_status not in valid_statuses:
+            continue
+        if invitation_status == InvitationStatus.PENDING:
+            if invitation["trip__status"] in terminal_trip_statuses:
+                invitation_status = InvitationStatus.CANCELLED
+            elif invitation["invitee_is_active"]:
+                invitation_status = InvitationStatus.ACCEPTED
+
+        resolved[notification_id] = invitation_status
+
+    return resolved
+
+
+def _build_serialized_payload(notification, invitation_status: str | None) -> dict:
+    """Copy persisted JSON and add safe, server-derived output fields."""
+    payload = (
+        dict(notification.payload)
+        if isinstance(notification.payload, dict)
+        else {}
+    )
+
+    if notification.type != NotificationType.TRIP_INVITATION:
+        return payload
+
+    # Never trust a legacy/persisted value for this output-only field.
+    payload.pop("invitation_status", None)
+    if invitation_status is None:
+        # All malformed, missing, mismatched, and foreign references collapse
+        # to the same neutral representation.
+        return {}
+
+    payload["invitation_status"] = invitation_status
+    return payload
+
+
+def build_notification_payload(
+    notification,
+    *,
+    invitation_status: str | None = None,
+):
     """Single source of truth for notification serialization.
 
     Used by both the REST serializer and WebSocket message builder.
@@ -134,7 +257,7 @@ def build_notification_payload(notification):
         "id": str(notification.id),
         "notification_type": notification.type,
         "actor": _build_actor_payload(notification.actor),
-        "payload": notification.payload,
+        "payload": _build_serialized_payload(notification, invitation_status),
         "is_read": notification.read_at is not None,
         "read_at": (
             notification.read_at.isoformat() if notification.read_at else None
@@ -149,10 +272,17 @@ def build_ws_notification_message(notification):
     The outer ``type`` field is used by wsManager for routing.
     The inner ``notification`` dict carries the business payload.
     """
+    invitation_statuses = resolve_trip_invitation_statuses(
+        [notification],
+        recipient_id=notification.recipient_id,
+    )
     return {
         "type": "notification",
         "event": "created",
-        "notification": build_notification_payload(notification),
+        "notification": build_notification_payload(
+            notification,
+            invitation_status=invitation_statuses.get(notification.id),
+        ),
     }
 
 

--- a/backend/notifications/tests/test_services.py
+++ b/backend/notifications/tests/test_services.py
@@ -10,18 +10,43 @@ from notifications.models import Notification, NotificationType
 from notifications.services import (
     NotificationNotFoundError,
     NotificationPayloadValidationError,
+    build_notification_payload,
+    build_ws_notification_message,
     create_notification,
     mark_all_notifications_read,
     mark_notification_read,
+    resolve_trip_invitation_statuses,
     validate_notification_payload,
 )
 from test_helpers import create_verified_user
+from trips.models import InvitationStatus, Trip, TripInvitation
 
 TEST_CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels.layers.InMemoryChannelLayer",
     },
 }
+
+
+def _make_trip(inviter):
+    return Trip.objects.create(
+        created_by=inviter,
+        name="Da Nang",
+        destination="Da Nang",
+        start_date="2026-05-01",
+        end_date="2026-05-05",
+    )
+
+
+def _trip_invitation_payload(trip, invitation_id):
+    return {
+        "trip_id": str(trip.id),
+        "trip_name": trip.name,
+        "destination": trip.destination,
+        "start_date": str(trip.start_date),
+        "end_date": str(trip.end_date),
+        "invitation_id": str(invitation_id),
+    }
 
 
 # -------- create_notification --------
@@ -108,6 +133,23 @@ class NotificationPayloadValidationTests(APITestCase):
                 {"trip_id": "trip-1", "trip_name": 123},
             )
 
+    def test_validate_trip_payload_rejects_output_only_status(self):
+        payload = {
+            "trip_id": "trip-1",
+            "trip_name": "Da Nang",
+            "destination": "Da Nang",
+            "start_date": "2026-05-01",
+            "end_date": "2026-05-05",
+            "invitation_id": "invitation-1",
+            "invitation_status": InvitationStatus.PENDING,
+        }
+
+        with self.assertRaises(NotificationPayloadValidationError):
+            validate_notification_payload(
+                NotificationType.TRIP_INVITATION,
+                payload,
+            )
+
     def test_create_notification_does_not_persist_invalid_payload(self):
         recipient = create_verified_user()
 
@@ -138,6 +180,69 @@ class NotificationPayloadValidationTests(APITestCase):
         )
 
         self.assertEqual(result, payload)
+
+
+class TripInvitationPayloadBuilderTests(APITestCase):
+
+    def setUp(self):
+        self.recipient = create_verified_user(email="invitee@example.com")
+        self.inviter = create_verified_user(email="inviter@example.com")
+        self.trip = _make_trip(self.inviter)
+
+    def test_rest_and_websocket_use_same_server_derived_payload(self):
+        invitation = TripInvitation.objects.create(
+            trip=self.trip,
+            inviter=self.inviter,
+            invitee=self.recipient,
+            status=InvitationStatus.PENDING,
+        )
+        stored_payload = _trip_invitation_payload(self.trip, invitation.id)
+        notification = Notification.objects.create(
+            recipient=self.recipient,
+            actor=self.inviter,
+            type=NotificationType.TRIP_INVITATION,
+            payload=stored_payload,
+        )
+        TripInvitation.objects.filter(pk=invitation.id).update(
+            status=InvitationStatus.ACCEPTED
+        )
+        statuses = resolve_trip_invitation_statuses(
+            [notification],
+            recipient_id=self.recipient.id,
+        )
+
+        rest_payload = build_notification_payload(
+            notification,
+            invitation_status=statuses[notification.id],
+        )
+        websocket_payload = build_ws_notification_message(notification)[
+            "notification"
+        ]
+
+        self.assertEqual(websocket_payload, rest_payload)
+        self.assertEqual(
+            rest_payload["payload"]["invitation_status"],
+            InvitationStatus.ACCEPTED,
+        )
+        self.assertIsNot(rest_payload["payload"], notification.payload)
+        notification.refresh_from_db()
+        self.assertEqual(notification.payload, stored_payload)
+        self.assertNotIn("invitation_status", notification.payload)
+
+    def test_websocket_missing_invitation_is_neutral(self):
+        notification = Notification.objects.create(
+            recipient=self.recipient,
+            actor=self.inviter,
+            type=NotificationType.TRIP_INVITATION,
+            payload=_trip_invitation_payload(self.trip, self.trip.id),
+        )
+
+        websocket_payload = build_ws_notification_message(notification)
+
+        self.assertEqual(
+            websocket_payload["notification"]["payload"],
+            {},
+        )
 
 
 @override_settings(CHANNEL_LAYERS=TEST_CHANNEL_LAYERS)

--- a/backend/notifications/tests/test_views.py
+++ b/backend/notifications/tests/test_views.py
@@ -8,6 +8,15 @@ from rest_framework.test import APITestCase
 from accounts.tokens import AccessToken
 from notifications.models import Notification, NotificationType
 from test_helpers import create_verified_user
+from trips.models import (
+    InvitationStatus,
+    MemberStatus,
+    Trip,
+    TripInvitation,
+    TripMember,
+    TripRole,
+    TripStatus,
+)
 
 LIST_URL = "/api/notifications/"
 UNREAD_COUNT_URL = "/api/notifications/unread-count"
@@ -21,6 +30,50 @@ def _mark_read_url(notification_id):
 def _auth_header(user):
     token = AccessToken.for_user(user)
     return {"HTTP_AUTHORIZATION": f"Bearer {token}"}
+
+
+def _make_trip(captain, *, status=TripStatus.PLANNING, name="Test Trip"):
+    return Trip.objects.create(
+        created_by=captain,
+        name=name,
+        destination="Da Nang",
+        start_date="2026-05-01",
+        end_date="2026-05-05",
+        status=status,
+    )
+
+
+def _trip_invitation_payload(trip, invitation_id):
+    return {
+        "trip_id": str(trip.id),
+        "trip_name": trip.name,
+        "destination": trip.destination,
+        "start_date": str(trip.start_date),
+        "end_date": str(trip.end_date),
+        "invitation_id": str(invitation_id),
+    }
+
+
+def _make_invitation_notification(
+    *,
+    trip,
+    inviter,
+    invitee,
+    status=InvitationStatus.PENDING,
+):
+    invitation = TripInvitation.objects.create(
+        trip=trip,
+        inviter=inviter,
+        invitee=invitee,
+        status=status,
+    )
+    notification = Notification.objects.create(
+        recipient=invitee,
+        actor=inviter,
+        type=NotificationType.TRIP_INVITATION,
+        payload=_trip_invitation_payload(trip, invitation.id),
+    )
+    return invitation, notification
 
 
 class NotificationListTests(APITestCase):
@@ -56,6 +109,169 @@ class NotificationListTests(APITestCase):
     def test_list_requires_auth(self):
         response = self.client.get(LIST_URL)
         self.assertEqual(response.status_code, 401)
+
+
+class NotificationInvitationStatusTests(APITestCase):
+
+    def setUp(self):
+        self.recipient = create_verified_user(email="invitee@example.com")
+        self.inviter = create_verified_user(email="captain@example.com")
+
+    def _list_by_id(self):
+        response = self.client.get(
+            LIST_URL,
+            **_auth_header(self.recipient),
+        )
+        self.assertEqual(response.status_code, 200)
+        return {item["id"]: item for item in response.data["results"]}
+
+    def test_list_adds_current_status_without_mutating_stored_payload(self):
+        expected_by_notification_id = {}
+        notifications = []
+
+        for index, invitation_status in enumerate(InvitationStatus.values):
+            trip = _make_trip(
+                self.inviter,
+                name=f"Trip {index}",
+            )
+            _invitation, notification = _make_invitation_notification(
+                trip=trip,
+                inviter=self.inviter,
+                invitee=self.recipient,
+                status=invitation_status,
+            )
+            notifications.append(notification)
+            expected_by_notification_id[str(notification.id)] = invitation_status
+
+        results = self._list_by_id()
+
+        for notification_id, invitation_status in (
+            expected_by_notification_id.items()
+        ):
+            self.assertEqual(
+                results[notification_id]["payload"]["invitation_status"],
+                invitation_status,
+            )
+
+        for notification in notifications:
+            notification.refresh_from_db()
+            self.assertNotIn("invitation_status", notification.payload)
+
+    def test_pending_status_is_effectively_resolved_for_stale_invitations(self):
+        terminal_trip = _make_trip(
+            self.inviter,
+            status=TripStatus.COMPLETED,
+            name="Completed Trip",
+        )
+        _terminal_invitation, terminal_notification = (
+            _make_invitation_notification(
+                trip=terminal_trip,
+                inviter=self.inviter,
+                invitee=self.recipient,
+            )
+        )
+
+        joined_trip = _make_trip(self.inviter, name="Already Joined Trip")
+        _joined_invitation, joined_notification = _make_invitation_notification(
+            trip=joined_trip,
+            inviter=self.inviter,
+            invitee=self.recipient,
+        )
+        TripMember.objects.create(
+            trip=joined_trip,
+            user=self.recipient,
+            role=TripRole.MEMBER,
+            status=MemberStatus.ACTIVE,
+        )
+
+        results = self._list_by_id()
+
+        self.assertEqual(
+            results[str(terminal_notification.id)]["payload"][
+                "invitation_status"
+            ],
+            InvitationStatus.CANCELLED,
+        )
+        self.assertEqual(
+            results[str(joined_notification.id)]["payload"][
+                "invitation_status"
+            ],
+            InvitationStatus.ACCEPTED,
+        )
+
+    def test_invalid_or_foreign_references_share_neutral_payload(self):
+        trip = _make_trip(self.inviter)
+        own_invitation = TripInvitation.objects.create(
+            trip=trip,
+            inviter=self.inviter,
+            invitee=self.recipient,
+        )
+        other_invitee = create_verified_user(email="other-invitee@example.com")
+        foreign_invitation = TripInvitation.objects.create(
+            trip=trip,
+            inviter=self.inviter,
+            invitee=other_invitee,
+        )
+        TripInvitation.objects.filter(pk=own_invitation.id).update(
+            status="INVALID"
+        )
+
+        payloads = [
+            _trip_invitation_payload(trip, own_invitation.id),
+            _trip_invitation_payload(trip, uuid.uuid4()),
+            _trip_invitation_payload(trip, foreign_invitation.id),
+            {
+                **_trip_invitation_payload(trip, own_invitation.id),
+                "trip_id": str(uuid.uuid4()),
+            },
+            {
+                **_trip_invitation_payload(trip, own_invitation.id),
+                "invitation_id": "not-a-uuid",
+            },
+            {"invitation_id": str(own_invitation.id)},
+            ["legacy", "payload"],
+            {
+                **_trip_invitation_payload(trip, own_invitation.id),
+                "invitation_status": InvitationStatus.PENDING,
+            },
+        ]
+        notifications = [
+            Notification.objects.create(
+                recipient=self.recipient,
+                actor=self.inviter,
+                type=NotificationType.TRIP_INVITATION,
+                payload=payload,
+            )
+            for payload in payloads
+        ]
+
+        results = self._list_by_id()
+
+        for notification in notifications:
+            self.assertEqual(results[str(notification.id)]["payload"], {})
+
+    def test_twenty_item_page_resolves_statuses_in_one_extra_query(self):
+        for index in range(20):
+            trip = _make_trip(self.inviter, name=f"Query Trip {index}")
+            _make_invitation_notification(
+                trip=trip,
+                inviter=self.inviter,
+                invitee=self.recipient,
+            )
+
+        self.client.force_authenticate(user=self.recipient)
+        with self.assertNumQueries(2):
+            response = self.client.get(LIST_URL)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data["results"]), 20)
+        self.assertTrue(
+            all(
+                item["payload"]["invitation_status"]
+                == InvitationStatus.PENDING
+                for item in response.data["results"]
+            )
+        )
 
 
 class NotificationUnreadCountTests(APITestCase):

--- a/backend/notifications/views.py
+++ b/backend/notifications/views.py
@@ -9,6 +9,7 @@ from notifications.services import (
     NotificationNotFoundError,
     mark_all_notifications_read,
     mark_notification_read,
+    resolve_trip_invitation_statuses,
 )
 
 
@@ -34,7 +35,15 @@ class NotificationListAPIView(APIView):
 
         paginator = NotificationCursorPagination()
         page = paginator.paginate_queryset(queryset, request)
-        serializer = NotificationSerializer(page, many=True)
+        invitation_statuses = resolve_trip_invitation_statuses(
+            page,
+            recipient_id=request.user.id,
+        )
+        serializer = NotificationSerializer(
+            page,
+            many=True,
+            context={"invitation_statuses": invitation_statuses},
+        )
         return paginator.get_paginated_response(serializer.data)
 
 

--- a/backend/trips/services.py
+++ b/backend/trips/services.py
@@ -480,21 +480,30 @@ def send_trip_invitations(trip, captain, invitee_ids: list) -> list:
 def accept_invitation(invitation_id, actor) -> TripMember:
     """Accept a PENDING invitation. Creates ACTIVE TripMember for invitee."""
     with transaction.atomic():
+        invitation_reference = (
+            TripInvitation.objects.filter(pk=invitation_id, invitee=actor)
+            .values("trip_id")
+            .first()
+        )
+        if invitation_reference is None:
+            raise TripNotFoundError("Invitation not found.")
+
+        try:
+            trip = Trip.objects.select_for_update().get(
+                pk=invitation_reference["trip_id"]
+            )
+        except Trip.DoesNotExist:
+            raise TripNotFoundError("Trip not found.")
+
         try:
             invitation = (
                 TripInvitation.objects
-                .select_related("trip", "inviter")
+                .select_related("inviter")
                 .select_for_update()
-                .get(pk=invitation_id, invitee=actor)
+                .get(pk=invitation_id, invitee=actor, trip=trip)
             )
         except TripInvitation.DoesNotExist:
             raise TripNotFoundError("Invitation not found.")
-
-        trip = invitation.trip
-        try:
-            trip = Trip.objects.select_for_update().get(pk=trip.pk)
-        except Trip.DoesNotExist:
-            raise TripNotFoundError("Trip not found.")
 
         if invitation.status != InvitationStatus.PENDING:
             raise InvitationError("This invitation is no longer pending.")

--- a/backend/trips/tests/test_service_concurrency.py
+++ b/backend/trips/tests/test_service_concurrency.py
@@ -15,6 +15,8 @@ from trips.services import (
     InvitationError,
     TripTerminalError,
     accept_invitation,
+    cancel_trip,
+    complete_trip,
     send_trip_invitations,
     update_trip,
 )
@@ -112,7 +114,12 @@ class TripServiceConcurrencyTests(TransactionTestCase):
         self.assertIn("completed or cancelled", str(invite_outcome["error"]))
         self.assertFalse(TripInvitation.objects.filter(trip=trip).exists())
 
-    def test_accept_invitation_waits_for_terminal_trip_transition(self):
+    def _assert_accept_loses_to_terminal_transition(
+        self,
+        *,
+        transition,
+        terminal_status,
+    ):
         captain = create_completed_user("cap2@example.com", "captain2", "CAP002")
         invitee = create_completed_user("inv2@example.com", "invitee2", "INV002")
         trip = _make_trip(captain, status=TripStatus.ONGOING)
@@ -120,20 +127,24 @@ class TripServiceConcurrencyTests(TransactionTestCase):
 
         transition_started = threading.Event()
         allow_commit = threading.Event()
+        original_save = Trip.save
 
-        def close_trip_worker():
-            with transaction.atomic():
-                locked_trip = Trip.objects.select_for_update().get(pk=trip.pk)
-                locked_trip.status = TripStatus.COMPLETED
-                locked_trip.save(update_fields=["status"])
+        def blocking_terminal_save(instance, *args, **kwargs):
+            result = original_save(instance, *args, **kwargs)
+            if instance.pk == trip.pk and instance.status == terminal_status:
                 transition_started.set()
                 if not allow_commit.wait(timeout=5):
                     raise AssertionError("Timed out waiting to commit terminal trip transition.")
+            return result
 
-        close_thread, close_outcome = self._run_in_thread(close_trip_worker)
-        self.assertTrue(transition_started.wait(timeout=5))
+        with patch.object(Trip, "save", new=blocking_terminal_save), patch(
+            "trips.services.create_notification"
+        ):
+            close_thread, close_outcome = self._run_in_thread(
+                lambda: transition(trip.id, captain)
+            )
+            self.assertTrue(transition_started.wait(timeout=5))
 
-        with patch("trips.services.create_notification"):
             accept_thread, accept_outcome = self._run_in_thread(
                 lambda: accept_invitation(invitation_id=invitation.pk, actor=invitee)
             )
@@ -143,17 +154,28 @@ class TripServiceConcurrencyTests(TransactionTestCase):
 
             allow_commit.set()
             accept_thread.join(timeout=5)
-
-        close_thread.join(timeout=5)
+            close_thread.join(timeout=5)
 
         self.assertFalse(close_thread.is_alive())
         self.assertIsNone(close_outcome.get("error"))
         self.assertFalse(accept_thread.is_alive())
         self.assertIsInstance(accept_outcome.get("error"), InvitationError)
-        self.assertIn("no longer open to new members", str(accept_outcome["error"]))
+        self.assertIn("no longer pending", str(accept_outcome["error"]))
         self.assertFalse(TripMember.objects.filter(trip=trip, user=invitee, status=MemberStatus.ACTIVE).exists())
         invitation.refresh_from_db()
-        self.assertEqual(invitation.status, InvitationStatus.PENDING)
+        self.assertEqual(invitation.status, InvitationStatus.CANCELLED)
+
+    def test_accept_invitation_does_not_deadlock_with_complete_trip(self):
+        self._assert_accept_loses_to_terminal_transition(
+            transition=lambda trip_id, actor: complete_trip(trip_id, actor),
+            terminal_status=TripStatus.COMPLETED,
+        )
+
+    def test_accept_invitation_does_not_deadlock_with_cancel_trip(self):
+        self._assert_accept_loses_to_terminal_transition(
+            transition=lambda trip_id, actor: cancel_trip(trip_id, actor),
+            terminal_status=TripStatus.CANCELLED,
+        )
 
     def test_update_trip_waits_for_terminal_trip_transition(self):
         captain = create_completed_user("cap-edit@example.com", "captain_edit", "CAP004")

--- a/frontend/features/notifications/application/notifications-context.test.tsx
+++ b/frontend/features/notifications/application/notifications-context.test.tsx
@@ -1,10 +1,13 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
   Notification,
   NotificationListResponse,
+  TripInvitationStatus,
 } from "@/features/notifications/domain/types";
+import type { WsMessage } from "@/features/realtime/domain/types";
 
 const notificationsApiMock = vi.hoisted(() => ({
   bffNotificationsList: vi.fn(),
@@ -50,21 +53,30 @@ function makeListResponse(
   };
 }
 
-function NotificationsHarness() {
-  const {
-    unreadCount,
-    notifications,
-    fetchNotifications,
-    hasMore,
-    isLoading,
-    isListLoaded,
-    loadMore,
-    markAllRead,
-  } = useNotifications();
+function makeTripInvitationNotification(
+  id: string,
+  invitationStatus: TripInvitationStatus,
+): Notification {
+  return {
+    ...makeNotification(id),
+    notification_type: "TRIP_INVITATION",
+    payload: {
+      trip_id: "trip-1",
+      trip_name: "Da Nang Getaway",
+      destination: "Da Nang",
+      start_date: "2026-08-01",
+      end_date: "2026-08-05",
+      invitation_id: "invitation-1",
+      invitation_status: invitationStatus,
+    },
+  };
+}
+
+function NotificationRowsHarness() {
+  const { notifications } = useNotifications();
 
   return (
-    <div>
-      <div data-testid="unread-count">{String(unreadCount)}</div>
+    <>
       <div data-testid="notification-states">
         {notifications.map((notification) => (
           <span key={notification.id}>
@@ -72,6 +84,40 @@ function NotificationsHarness() {
           </span>
         ))}
       </div>
+      <div data-testid="invitation-statuses">
+        {notifications
+          .filter(
+            (notification) =>
+              notification.notification_type === "TRIP_INVITATION",
+          )
+          .map((notification) => (
+            <span key={notification.id}>
+              {notification.id}:
+              {String(notification.payload.invitation_status)}|
+            </span>
+          ))}
+      </div>
+    </>
+  );
+}
+
+function NotificationsHarness() {
+  const {
+    unreadCount,
+    fetchNotifications,
+    hasMore,
+    isLoading,
+    isListLoaded,
+    loadMore,
+    markAllRead,
+    confirmTripInvitationStatus,
+  } = useNotifications();
+  const [showRows, setShowRows] = useState(true);
+
+  return (
+    <div>
+      <div data-testid="unread-count">{String(unreadCount)}</div>
+      {showRows && <NotificationRowsHarness />}
       <div data-testid="has-more">{String(hasMore)}</div>
       <div data-testid="is-loading">{String(isLoading)}</div>
       <div data-testid="is-list-loaded">{String(isListLoaded)}</div>
@@ -83,6 +129,17 @@ function NotificationsHarness() {
       </button>
       <button type="button" onClick={() => void markAllRead()}>
         mark all
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          confirmTripInvitationStatus("n1", "ACCEPTED")
+        }
+      >
+        confirm accepted
+      </button>
+      <button type="button" onClick={() => setShowRows((current) => !current)}>
+        toggle rows
       </button>
     </div>
   );
@@ -107,6 +164,106 @@ afterEach(() => {
 });
 
 describe("NotificationsProvider", () => {
+  it("keeps a confirmed terminal invitation status through row remounts and stale fetches", async () => {
+    let notificationHandler: ((data: WsMessage) => void) | undefined;
+    wsManagerMock.on.mockImplementation(
+      (_event: string, handler: (data: WsMessage) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      },
+    );
+    notificationsApiMock.bffUnreadCount.mockResolvedValue({ unread_count: 1 });
+    notificationsApiMock.bffNotificationsList
+      .mockResolvedValueOnce(
+        makeListResponse([
+          makeTripInvitationNotification("n1", "PENDING"),
+        ], "cursor-2"),
+      )
+      .mockResolvedValueOnce(
+        makeListResponse([
+          makeTripInvitationNotification("n1", "PENDING"),
+        ]),
+      )
+      .mockRejectedValueOnce(new Error("reopen fetch failed"))
+      .mockResolvedValueOnce(
+        makeListResponse([
+          makeTripInvitationNotification("n1", "PENDING"),
+        ]),
+      );
+
+    renderNotifications();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("unread-count").textContent).toBe("1");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "fetch" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("invitation-statuses").textContent).toBe(
+        "n1:PENDING|",
+      );
+      expect(screen.getByTestId("has-more").textContent).toBe("true");
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "confirm accepted" }),
+    );
+
+    expect(screen.getByTestId("invitation-statuses").textContent).toBe(
+      "n1:ACCEPTED|",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "toggle rows" }));
+    expect(screen.queryByTestId("invitation-statuses")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "toggle rows" }));
+    expect(screen.getByTestId("invitation-statuses").textContent).toBe(
+      "n1:ACCEPTED|",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "load more" }));
+
+    await waitFor(() => {
+      expect(notificationsApiMock.bffNotificationsList).toHaveBeenCalledTimes(2);
+      expect(screen.getByTestId("is-loading").textContent).toBe("false");
+    });
+    expect(screen.getByTestId("invitation-statuses").textContent).toBe(
+      "n1:ACCEPTED|",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "fetch" }));
+
+    await waitFor(() => {
+      expect(notificationsApiMock.bffNotificationsList).toHaveBeenCalledTimes(3);
+      expect(screen.getByTestId("is-loading").textContent).toBe("false");
+    });
+    expect(screen.getByTestId("invitation-statuses").textContent).toBe(
+      "n1:ACCEPTED|",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "fetch" }));
+
+    await waitFor(() => {
+      expect(notificationsApiMock.bffNotificationsList).toHaveBeenCalledTimes(4);
+      expect(screen.getByTestId("is-loading").textContent).toBe("false");
+    });
+    expect(screen.getByTestId("invitation-statuses").textContent).toBe(
+      "n1:ACCEPTED|",
+    );
+
+    notificationHandler?.({
+      type: "notification",
+      event: "created",
+      notification: makeTripInvitationNotification("n1", "PENDING"),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("invitation-statuses").textContent).toBe(
+        "n1:ACCEPTED|",
+      );
+    });
+  });
+
   it("does not let snapshot reconcile get consumed by the count-only effect", async () => {
     notificationsApiMock.bffUnreadCount
       .mockResolvedValueOnce({ unread_count: 2 })
@@ -175,6 +332,7 @@ describe("NotificationsProvider", () => {
       expect(screen.getByTestId("notification-states").textContent).toBe(
         "n1:unread|",
       );
+      expect(screen.getByTestId("has-more").textContent).toBe("true");
     });
 
     fireEvent.click(screen.getByRole("button", { name: "load more" }));
@@ -233,6 +391,7 @@ describe("NotificationsProvider", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("notification-states").textContent).toBe("n1:unread|");
+      expect(screen.getByTestId("has-more").textContent).toBe("true");
     });
 
     fireEvent.click(screen.getByRole("button", { name: "load more" }));

--- a/frontend/features/notifications/application/notifications-context.tsx
+++ b/frontend/features/notifications/application/notifications-context.tsx
@@ -11,7 +11,10 @@ import {
   type ReactNode,
 } from "react";
 
-import type { Notification } from "@/features/notifications/domain/types";
+import type {
+  Notification,
+  TripInvitationStatus,
+} from "@/features/notifications/domain/types";
 import {
   bffMarkAllRead,
   bffMarkRead,
@@ -22,6 +25,11 @@ import { wsManager } from "@/features/realtime/infrastructure/ws-manager";
 import type { WsMessage } from "@/features/realtime/domain/types";
 
 // -------- State --------
+
+type TerminalTripInvitationStatus = Exclude<
+  TripInvitationStatus,
+  "PENDING"
+>;
 
 type NotificationsState = {
   unreadCount: number;
@@ -35,6 +43,12 @@ type NotificationsState = {
   /** IDs optimistically marked read by THIS tab — used to avoid double-decrement
    *  when the WS echo arrives back for our own mark-read action. */
   optimisticReadIds: string[];
+  /** Terminal invitation states observed or confirmed during this provider
+   *  lifetime. They prevent an older PENDING REST/WS snapshot from restoring
+   *  invitation actions after the server has accepted a mutation. */
+  confirmedInvitationStatuses: Partial<
+    Record<string, TerminalTripInvitationStatus>
+  >;
 };
 
 const initialState: NotificationsState = {
@@ -47,6 +61,7 @@ const initialState: NotificationsState = {
   isListLoaded: false,
   isLoading: false,
   optimisticReadIds: [],
+  confirmedInvitationStatuses: {},
 };
 
 // -------- Actions --------
@@ -63,7 +78,12 @@ type Action =
   | { type: "MARK_ALL_READ" }
   | { type: "MARK_READ_ROLLBACK"; notificationId: string }
   | { type: "MARK_ALL_READ_RECONCILE" }
-  | { type: "RECONCILE_APPLIED"; count: number; notifications: Notification[]; nextCursor: string | null };
+  | { type: "RECONCILE_APPLIED"; count: number; notifications: Notification[]; nextCursor: string | null }
+  | {
+      type: "CONFIRM_INVITATION_STATUS";
+      notificationId: string;
+      status: TerminalTripInvitationStatus;
+    };
 
 // -------- Helpers --------
 
@@ -98,6 +118,96 @@ function upsertMany(
   return result;
 }
 
+function getInvitationStatus(
+  notification: Notification,
+): TripInvitationStatus | null {
+  if (notification.notification_type !== "TRIP_INVITATION") return null;
+
+  const payload: unknown = notification.payload;
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    Array.isArray(payload)
+  ) {
+    return null;
+  }
+
+  const status = (payload as Record<string, unknown>).invitation_status;
+  return status === "PENDING" ||
+    status === "ACCEPTED" ||
+    status === "DECLINED" ||
+    status === "CANCELLED"
+    ? status
+    : null;
+}
+
+function getTerminalInvitationStatus(
+  notification: Notification,
+): TerminalTripInvitationStatus | null {
+  const status = getInvitationStatus(notification);
+  return status && status !== "PENDING" ? status : null;
+}
+
+function collectConfirmedInvitationStatuses(
+  current: NotificationsState["confirmedInvitationStatuses"],
+  notifications: Notification[],
+): NotificationsState["confirmedInvitationStatuses"] {
+  let result = current;
+
+  for (const notification of notifications) {
+    const status = getTerminalInvitationStatus(notification);
+    if (!status || result[notification.id]) continue;
+
+    if (result === current) result = { ...current };
+    result[notification.id] = status;
+  }
+
+  return result;
+}
+
+function applyConfirmedInvitationStatus(
+  notification: Notification,
+  confirmedStatuses: NotificationsState["confirmedInvitationStatuses"],
+): Notification {
+  if (notification.notification_type !== "TRIP_INVITATION") {
+    return notification;
+  }
+
+  const confirmedStatus = confirmedStatuses[notification.id];
+  const incomingStatus = getInvitationStatus(notification);
+
+  if (!confirmedStatus || !incomingStatus || incomingStatus === confirmedStatus) {
+    return notification;
+  }
+
+  return {
+    ...notification,
+    payload: {
+      ...notification.payload,
+      invitation_status: confirmedStatus,
+    },
+  };
+}
+
+function reconcileIncomingNotifications(
+  currentStatuses: NotificationsState["confirmedInvitationStatuses"],
+  notifications: Notification[],
+) {
+  const confirmedInvitationStatuses = collectConfirmedInvitationStatuses(
+    currentStatuses,
+    notifications,
+  );
+  return {
+    confirmedInvitationStatuses,
+    notifications: notifications.map((notification) =>
+      applyConfirmedInvitationStatus(
+        notification,
+        confirmedInvitationStatuses,
+      ),
+    ),
+  };
+}
+
 function mergePendingReconcile(
   current: NotificationsState["pendingReconcile"],
   requested: NotificationsState["pendingReconcile"],
@@ -124,33 +234,65 @@ function reducer(state: NotificationsState, action: Action): NotificationsState 
     case "SET_LOADING":
       return { ...state, isLoading: action.loading };
 
-    case "NOTIFICATIONS_LOADED":
+    case "NOTIFICATIONS_LOADED": {
+      const reconciled = reconcileIncomingNotifications(
+        state.confirmedInvitationStatuses,
+        action.notifications,
+      );
       return {
         ...state,
-        notifications: upsertMany(state.notifications, action.notifications),
+        notifications: upsertMany(
+          state.notifications,
+          reconciled.notifications,
+        ),
+        confirmedInvitationStatuses:
+          reconciled.confirmedInvitationStatuses,
         hasMore: action.nextCursor !== null,
         cursor: action.nextCursor,
         isListLoaded: true,
         isLoading: false,
       };
+    }
 
-    case "MORE_LOADED":
+    case "MORE_LOADED": {
+      const reconciled = reconcileIncomingNotifications(
+        state.confirmedInvitationStatuses,
+        action.notifications,
+      );
       return {
         ...state,
-        notifications: upsertMany(state.notifications, action.notifications),
+        notifications: upsertMany(
+          state.notifications,
+          reconciled.notifications,
+        ),
+        confirmedInvitationStatuses:
+          reconciled.confirmedInvitationStatuses,
         hasMore: action.nextCursor !== null,
         cursor: action.nextCursor,
         isLoading: false,
       };
+    }
 
     case "NOTIFICATION_RECEIVED": {
-      const exists = state.notifications.some((n) => n.id === action.notification.id);
-      const notifications = upsertNotification(state.notifications, action.notification);
+      const reconciled = reconcileIncomingNotifications(
+        state.confirmedInvitationStatuses,
+        [action.notification],
+      );
+      const incomingNotification = reconciled.notifications[0];
+      const exists = state.notifications.some(
+        (notification) => notification.id === incomingNotification.id,
+      );
+      const notifications = upsertNotification(
+        state.notifications,
+        incomingNotification,
+      );
 
       if (!state.unreadCountHydrated) {
         return {
           ...state,
           notifications,
+          confirmedInvitationStatuses:
+            reconciled.confirmedInvitationStatuses,
           pendingReconcile: mergePendingReconcile(
             state.pendingReconcile,
             "count_only",
@@ -161,6 +303,8 @@ function reducer(state: NotificationsState, action: Action): NotificationsState 
       return {
         ...state,
         notifications,
+        confirmedInvitationStatuses:
+          reconciled.confirmedInvitationStatuses,
         unreadCount: exists ? state.unreadCount : state.unreadCount + 1,
       };
     }
@@ -274,19 +418,47 @@ function reducer(state: NotificationsState, action: Action): NotificationsState 
         pendingReconcile: "snapshot_on_open",
       };
 
-    case "RECONCILE_APPLIED":
+    case "RECONCILE_APPLIED": {
+      const reconciled = reconcileIncomingNotifications(
+        state.confirmedInvitationStatuses,
+        action.notifications,
+      );
       return {
         ...state,
         unreadCount: action.count,
         unreadCountHydrated: true,
         pendingReconcile: "none",
-        notifications: action.notifications,
+        notifications: reconciled.notifications,
+        confirmedInvitationStatuses:
+          reconciled.confirmedInvitationStatuses,
         hasMore: action.nextCursor !== null,
         cursor: action.nextCursor,
         isListLoaded: true,
         isLoading: false,
         optimisticReadIds: [],
       };
+    }
+
+    case "CONFIRM_INVITATION_STATUS": {
+      const status =
+        state.confirmedInvitationStatuses[action.notificationId] ??
+        action.status;
+      const confirmedInvitationStatuses = {
+        ...state.confirmedInvitationStatuses,
+        [action.notificationId]: status,
+      };
+
+      return {
+        ...state,
+        confirmedInvitationStatuses,
+        notifications: state.notifications.map((notification) =>
+          applyConfirmedInvitationStatus(
+            notification,
+            confirmedInvitationStatuses,
+          ),
+        ),
+      };
+    }
   }
 }
 
@@ -302,6 +474,10 @@ type NotificationsContextValue = {
   loadMore: () => Promise<void>;
   markRead: (id: string) => Promise<void>;
   markAllRead: () => Promise<void>;
+  confirmTripInvitationStatus: (
+    notificationId: string,
+    status: TerminalTripInvitationStatus,
+  ) => void;
 };
 
 const NotificationsContext = createContext<NotificationsContextValue | null>(null);
@@ -470,6 +646,20 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
+  const confirmTripInvitationStatus = useCallback(
+    (
+      notificationId: string,
+      status: TerminalTripInvitationStatus,
+    ) => {
+      dispatch({
+        type: "CONFIRM_INVITATION_STATUS",
+        notificationId,
+        status,
+      });
+    },
+    [],
+  );
+
   const value = useMemo(
     () => ({
       unreadCount: state.unreadCount,
@@ -481,8 +671,9 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
       loadMore,
       markRead,
       markAllRead,
+      confirmTripInvitationStatus,
     }),
-    [state.unreadCount, state.notifications, state.isLoading, state.hasMore, state.isListLoaded, fetchNotifications, loadMore, markRead, markAllRead],
+    [state.unreadCount, state.notifications, state.isLoading, state.hasMore, state.isListLoaded, fetchNotifications, loadMore, markRead, markAllRead, confirmTripInvitationStatus],
   );
 
   return (

--- a/frontend/features/notifications/domain/payload-parsers.test.ts
+++ b/frontend/features/notifications/domain/payload-parsers.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import type { TripInvitationStatus } from "@/features/notifications/domain/types";
+import { parseTripInvitationPayload } from "@/features/notifications/domain/payload-parsers";
+
+const BASE_PAYLOAD = {
+  invitation_id: "invitation-1",
+  trip_id: "trip-1",
+  trip_name: "Da Nang Getaway",
+  destination: "Da Nang",
+  start_date: "2026-08-01",
+  end_date: "2026-08-05",
+};
+
+describe("parseTripInvitationPayload", () => {
+  it.each<TripInvitationStatus>([
+    "PENDING",
+    "ACCEPTED",
+    "DECLINED",
+    "CANCELLED",
+  ])("accepts the %s invitation status", (invitationStatus) => {
+    expect(
+      parseTripInvitationPayload({
+        ...BASE_PAYLOAD,
+        invitation_status: invitationStatus,
+      }),
+    ).toEqual({
+      ...BASE_PAYLOAD,
+      invitation_status: invitationStatus,
+    });
+  });
+
+  it.each([
+    ["missing", BASE_PAYLOAD],
+    ["null", { ...BASE_PAYLOAD, invitation_status: null }],
+    ["unknown", { ...BASE_PAYLOAD, invitation_status: "EXPIRED" }],
+    ["malformed payload", "not-an-object"],
+  ])("fails closed for a %s invitation status", (_case, payload) => {
+    expect(parseTripInvitationPayload(payload)).toBeNull();
+  });
+});

--- a/frontend/features/notifications/domain/payload-parsers.ts
+++ b/frontend/features/notifications/domain/payload-parsers.ts
@@ -1,7 +1,21 @@
 import type {
   TripInvitationPayload,
+  TripInvitationStatus,
   TripTimelineReminderPayload,
 } from "@/features/notifications/domain/types";
+
+const TRIP_INVITATION_STATUSES = new Set<string>([
+  "PENDING",
+  "ACCEPTED",
+  "DECLINED",
+  "CANCELLED",
+]);
+
+function isTripInvitationStatus(
+  value: unknown,
+): value is TripInvitationStatus {
+  return typeof value === "string" && TRIP_INVITATION_STATUSES.has(value);
+}
 
 export function parseTripInvitationPayload(
   raw: unknown
@@ -14,7 +28,8 @@ export function parseTripInvitationPayload(
     typeof p.trip_name !== "string" ||
     typeof p.destination !== "string" ||
     typeof p.start_date !== "string" ||
-    typeof p.end_date !== "string"
+    typeof p.end_date !== "string" ||
+    !isTripInvitationStatus(p.invitation_status)
   ) {
     return null;
   }
@@ -25,6 +40,7 @@ export function parseTripInvitationPayload(
     destination: p.destination,
     start_date: p.start_date,
     end_date: p.end_date,
+    invitation_status: p.invitation_status,
   };
 }
 

--- a/frontend/features/notifications/domain/types.ts
+++ b/frontend/features/notifications/domain/types.ts
@@ -4,6 +4,12 @@ export type NotificationActor = {
   identify_tag: string | null;
 };
 
+export type TripInvitationStatus =
+  | "PENDING"
+  | "ACCEPTED"
+  | "DECLINED"
+  | "CANCELLED";
+
 export type TripInvitationPayload = {
   trip_id: string;
   trip_name: string;
@@ -11,6 +17,7 @@ export type TripInvitationPayload = {
   start_date: string;
   end_date: string;
   invitation_id: string;
+  invitation_status: TripInvitationStatus;
 };
 
 export type TripCancelledPayload = {

--- a/frontend/features/notifications/presentation/notification-dropdown.test.tsx
+++ b/frontend/features/notifications/presentation/notification-dropdown.test.tsx
@@ -1,0 +1,149 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Notification } from "@/features/notifications/domain/types";
+
+const notificationsContextMock = vi.hoisted(() => ({
+  useNotifications: vi.fn(),
+}));
+
+const tripsApiMock = vi.hoisted(() => ({
+  bffAcceptInvitation: vi.fn(),
+  bffDeclineInvitation: vi.fn(),
+}));
+
+const routerMock = vi.hoisted(() => ({
+  refresh: vi.fn(),
+}));
+
+vi.mock(
+  "@/features/notifications/application/notifications-context",
+  () => notificationsContextMock,
+);
+vi.mock(
+  "@/features/trips/infrastructure/trips-api",
+  () => tripsApiMock,
+);
+vi.mock("next/navigation", () => ({
+  useRouter: () => routerMock,
+}));
+
+import { NotificationDropdown } from "@/features/notifications/presentation/notification-dropdown";
+
+function makeTripInvitationNotification(): Notification {
+  return {
+    id: "notification-1",
+    notification_type: "TRIP_INVITATION",
+    actor: {
+      id: "captain-1",
+      display_name: "Minh",
+      identify_tag: "minh#1234",
+    },
+    payload: {
+      trip_id: "trip-1",
+      trip_name: "Da Nang Getaway",
+      destination: "Da Nang",
+      start_date: "2026-08-01",
+      end_date: "2026-08-05",
+      invitation_id: "invitation-1",
+      invitation_status: "PENDING",
+    },
+    is_read: false,
+    read_at: null,
+    created_at: "2026-07-22T10:00:00.000Z",
+  };
+}
+
+function deferredMutation() {
+  let resolve: (() => void) | undefined;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return {
+    promise,
+    resolve: () => resolve?.(),
+  };
+}
+
+const markReadMock = vi.fn().mockResolvedValue(undefined);
+const confirmTripInvitationStatusMock = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  markReadMock.mockResolvedValue(undefined);
+  notificationsContextMock.useNotifications.mockReturnValue({
+    unreadCount: 1,
+    notifications: [makeTripInvitationNotification()],
+    isLoading: false,
+    hasMore: false,
+    isListLoaded: true,
+    fetchNotifications: vi.fn().mockResolvedValue(undefined),
+    loadMore: vi.fn().mockResolvedValue(undefined),
+    markRead: markReadMock,
+    markAllRead: vi.fn().mockResolvedValue(undefined),
+    confirmTripInvitationStatus: confirmTripInvitationStatusMock,
+  });
+});
+
+describe("NotificationDropdown", () => {
+  it("records an accepted status only after the invitation mutation succeeds", async () => {
+    const mutation = deferredMutation();
+    tripsApiMock.bffAcceptInvitation.mockReturnValue(mutation.promise);
+
+    render(<NotificationDropdown />);
+    fireEvent.click(screen.getByRole("button", { name: "Accept" }));
+
+    expect(confirmTripInvitationStatusMock).not.toHaveBeenCalled();
+    expect(markReadMock).not.toHaveBeenCalled();
+
+    mutation.resolve();
+
+    await waitFor(() => {
+      expect(confirmTripInvitationStatusMock).toHaveBeenCalledWith(
+        "notification-1",
+        "ACCEPTED",
+      );
+    });
+    expect(markReadMock).toHaveBeenCalledWith("notification-1");
+    expect(routerMock.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("records a declined status only after the invitation mutation succeeds", async () => {
+    const mutation = deferredMutation();
+    tripsApiMock.bffDeclineInvitation.mockReturnValue(mutation.promise);
+
+    render(<NotificationDropdown />);
+    fireEvent.click(screen.getByRole("button", { name: "Decline" }));
+
+    expect(confirmTripInvitationStatusMock).not.toHaveBeenCalled();
+    expect(markReadMock).not.toHaveBeenCalled();
+
+    mutation.resolve();
+
+    await waitFor(() => {
+      expect(confirmTripInvitationStatusMock).toHaveBeenCalledWith(
+        "notification-1",
+        "DECLINED",
+      );
+    });
+    expect(markReadMock).toHaveBeenCalledWith("notification-1");
+    expect(routerMock.refresh).not.toHaveBeenCalled();
+  });
+
+  it("does not record a terminal status when the invitation mutation fails", async () => {
+    tripsApiMock.bffAcceptInvitation.mockRejectedValue(
+      new Error("mutation failed"),
+    );
+
+    render(<NotificationDropdown />);
+    fireEvent.click(screen.getByRole("button", { name: "Accept" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Failed to accept invitation. Please try again."),
+      ).not.toBeNull();
+    });
+    expect(confirmTripInvitationStatusMock).not.toHaveBeenCalled();
+    expect(markReadMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/features/notifications/presentation/notification-dropdown.tsx
+++ b/frontend/features/notifications/presentation/notification-dropdown.tsx
@@ -17,18 +17,21 @@ export function NotificationDropdown() {
     loadMore,
     markRead,
     markAllRead,
+    confirmTripInvitationStatus,
   } = useNotifications();
   const router = useRouter();
 
   async function handleAcceptInvitation(invitationId: string, notificationId: string) {
     await bffAcceptInvitation(invitationId);
-    markRead(notificationId);
+    confirmTripInvitationStatus(notificationId, "ACCEPTED");
+    void markRead(notificationId);
     router.refresh();
   }
 
   async function handleDeclineInvitation(invitationId: string, notificationId: string) {
     await bffDeclineInvitation(invitationId);
-    markRead(notificationId);
+    confirmTripInvitationStatus(notificationId, "DECLINED");
+    void markRead(notificationId);
   }
 
   const canMarkAllRead =

--- a/frontend/features/notifications/presentation/notification-item.test.tsx
+++ b/frontend/features/notifications/presentation/notification-item.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Notification } from "@/features/notifications/domain/types";
@@ -34,6 +34,26 @@ function buildNotification(overrides: Partial<Notification> = {}): Notification 
   };
 }
 
+function buildTripInvitationNotification(invitationStatus: unknown): Notification {
+  return buildNotification({
+    notification_type: "TRIP_INVITATION",
+    actor: {
+      id: "captain-1",
+      display_name: "Minh",
+      identify_tag: "minh#1234",
+    },
+    payload: {
+      invitation_id: "invitation-1",
+      invitation_status: invitationStatus,
+      trip_id: "trip-1",
+      trip_name: "Da Nang Getaway",
+      destination: "Da Nang",
+      start_date: "2026-08-01",
+      end_date: "2026-08-05",
+    },
+  });
+}
+
 describe("NotificationItem", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -59,5 +79,72 @@ describe("NotificationItem", () => {
       "/trips/trip-1/timeline?activity=activity-1",
       { scroll: false },
     );
+  });
+
+  it("renders invitation actions only while the server status is pending", () => {
+    render(
+      <NotificationItem
+        notification={buildTripInvitationNotification("PENDING")}
+        onMarkRead={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Accept" })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Decline" })).not.toBeNull();
+  });
+
+  it.each([
+    ["ACCEPTED", "✓ You joined the trip"],
+    ["DECLINED", "Invitation declined"],
+    ["CANCELLED", "Invitation cancelled"],
+  ])("renders durable %s invitation state without actions", (status, label) => {
+    render(
+      <NotificationItem
+        notification={buildTripInvitationNotification(status)}
+        onMarkRead={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(label)).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Accept" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Decline" })).toBeNull();
+  });
+
+  it("renders a neutral non-actionable fallback for an unknown status", () => {
+    render(
+      <NotificationItem
+        notification={buildTripInvitationNotification("EXPIRED")}
+        onMarkRead={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Trip invitation (details unavailable)")).not.toBeNull();
+    expect(screen.queryByText("Da Nang Getaway")).toBeNull();
+    expect(screen.queryByText("invitation-1")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Accept" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Decline" })).toBeNull();
+  });
+
+  it("shows the accepted state immediately after a successful mutation", async () => {
+    const onAcceptInvitation = vi.fn().mockResolvedValue(undefined);
+    render(
+      <NotificationItem
+        notification={buildTripInvitationNotification("PENDING")}
+        onMarkRead={vi.fn()}
+        onAcceptInvitation={onAcceptInvitation}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Accept" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("✓ You joined the trip")).not.toBeNull();
+    });
+    expect(onAcceptInvitation).toHaveBeenCalledWith(
+      "invitation-1",
+      "notification-1",
+    );
+    expect(screen.queryByRole("button", { name: "Accept" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Decline" })).toBeNull();
   });
 });

--- a/frontend/features/notifications/presentation/trip-invitation-notification.tsx
+++ b/frontend/features/notifications/presentation/trip-invitation-notification.tsx
@@ -2,7 +2,10 @@
 
 import { useState } from "react";
 
-import type { Notification } from "@/features/notifications/domain/types";
+import type {
+  Notification,
+  TripInvitationStatus,
+} from "@/features/notifications/domain/types";
 import { parseTripInvitationPayload } from "@/features/notifications/domain/payload-parsers";
 import { Button } from "@/shared/ui/button";
 
@@ -12,9 +15,18 @@ type Props = {
   onDecline: (invitationId: string, notificationId: string) => Promise<void>;
 };
 
+const RESOLVED_STATUS_LABELS: Record<
+  Exclude<TripInvitationStatus, "PENDING">,
+  string
+> = {
+  ACCEPTED: "✓ You joined the trip",
+  DECLINED: "Invitation declined",
+  CANCELLED: "Invitation cancelled",
+};
+
 export function TripInvitationNotification({ notification, onAccept, onDecline }: Props) {
   const [loading, setLoading] = useState<"accept" | "decline" | null>(null);
-  const [responded, setResponded] = useState<"accepted" | "declined" | null>(null);
+  const [localStatus, setLocalStatus] = useState<"ACCEPTED" | "DECLINED" | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
   const payload = parseTripInvitationPayload(notification.payload);
@@ -29,13 +41,17 @@ export function TripInvitationNotification({ notification, onAccept, onDecline }
   }
 
   const invitationId = payload.invitation_id;
+  const status =
+    payload.invitation_status === "PENDING"
+      ? (localStatus ?? payload.invitation_status)
+      : payload.invitation_status;
 
   async function handleAccept() {
     setLoading("accept");
     setActionError(null);
     try {
       await onAccept(invitationId, notification.id);
-      setResponded("accepted");
+      setLocalStatus("ACCEPTED");
     } catch {
       setActionError("Failed to accept invitation. Please try again.");
     } finally {
@@ -48,7 +64,7 @@ export function TripInvitationNotification({ notification, onAccept, onDecline }
     setActionError(null);
     try {
       await onDecline(invitationId, notification.id);
-      setResponded("declined");
+      setLocalStatus("DECLINED");
     } catch {
       setActionError("Failed to decline invitation. Please try again.");
     } finally {
@@ -71,9 +87,9 @@ export function TripInvitationNotification({ notification, onAccept, onDecline }
             📍 {payload.destination} · {payload.start_date} → {payload.end_date}
           </p>
 
-          {responded ? (
+          {status !== "PENDING" ? (
             <p className="mt-2 text-xs text-muted-foreground">
-              {responded === "accepted" ? "✓ You joined the trip" : "Invitation declined"}
+              {RESOLVED_STATUS_LABELS[status]}
             </p>
           ) : (
             <>

--- a/mobile/src/app/(tabs)/_layout.tsx
+++ b/mobile/src/app/(tabs)/_layout.tsx
@@ -1,20 +1,14 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Redirect, Tabs } from 'expo-router';
 import { useSession } from '@/features/auth/session';
+import { NotificationsProvider, useNotifications } from '@/features/notifications/application/NotificationsProvider';
 import { colors } from '@/shared/theme/tokens';
 import { LoadingScreen } from '@/shared/ui/LoadingScreen';
 
-export default function TabsLayout() {
-  const { status, user } = useSession();
-  if (status === 'restoring') {
-    return <LoadingScreen />;
-  }
-  if (status === 'signedOut') {
-    return <Redirect href="/(auth)/login" />;
-  }
-  if (user?.requires_profile_setup) {
-    return <Redirect href="/(auth)/profile-setup" />;
-  }
+function TabsNavigator() {
+  const { unreadCount } = useNotifications();
+  const notificationsBadge =
+    unreadCount !== null && unreadCount > 0 ? (unreadCount > 99 ? '99+' : unreadCount) : undefined;
   return (
     <Tabs screenOptions={{ tabBarActiveTintColor: colors.primary, headerShown: true }}>
       <Tabs.Screen
@@ -37,6 +31,8 @@ export default function TabsLayout() {
         name="notifications"
         options={{
           title: 'Notifications',
+          headerShown: false,
+          tabBarBadge: notificationsBadge,
           tabBarIcon: ({ color, size }) => <Ionicons name="notifications-outline" color={color} size={size} />,
         }}
       />
@@ -48,5 +44,23 @@ export default function TabsLayout() {
         }}
       />
     </Tabs>
+  );
+}
+
+export default function TabsLayout() {
+  const { status, user } = useSession();
+  if (status === 'restoring') {
+    return <LoadingScreen />;
+  }
+  if (status === 'signedOut') {
+    return <Redirect href="/(auth)/login" />;
+  }
+  if (user?.requires_profile_setup) {
+    return <Redirect href="/(auth)/profile-setup" />;
+  }
+  return (
+    <NotificationsProvider ownerUserId={user?.id ?? null}>
+      <TabsNavigator />
+    </NotificationsProvider>
   );
 }

--- a/mobile/src/app/(tabs)/notifications.tsx
+++ b/mobile/src/app/(tabs)/notifications.tsx
@@ -1,15 +1,3 @@
-import { StyleSheet, Text } from 'react-native';
-import { colors, typography } from '@/shared/theme/tokens';
-import { Screen } from '@/shared/ui/Screen';
+import { NotificationsScreen } from '@/features/notifications/screens/NotificationsScreen';
 
-export default function NotificationsScreen() {
-  return (
-    <Screen>
-      <Text style={styles.placeholder}>Notifications will live here.</Text>
-    </Screen>
-  );
-}
-
-const styles = StyleSheet.create({
-  placeholder: { ...typography.body, color: colors.textMuted },
-});
+export default NotificationsScreen;

--- a/mobile/src/app/trips/[tripId]/invite.tsx
+++ b/mobile/src/app/trips/[tripId]/invite.tsx
@@ -1,0 +1,3 @@
+import { InviteMembersScreen } from '@/features/trips/screens/InviteMembersScreen';
+
+export default InviteMembersScreen;

--- a/mobile/src/app/trips/__tests__/_layout.test.tsx
+++ b/mobile/src/app/trips/__tests__/_layout.test.tsx
@@ -1,5 +1,6 @@
 const mockRouter = { canGoBack: jest.fn(), back: jest.fn(), replace: jest.fn() };
 const mockUseSession = jest.fn();
+const mockRegisterScreen = jest.fn();
 
 jest.mock('expo-router', () => {
   const React = jest.requireActual<typeof import('react')>('react');
@@ -14,8 +15,13 @@ jest.mock('expo-router', () => {
     options,
   }: {
     name: string;
-    options: { title: string; headerLeft?: () => import('react').ReactNode };
+    options: {
+      title: string;
+      presentation?: string;
+      headerLeft?: () => import('react').ReactNode;
+    };
   }) {
+    mockRegisterScreen(name, options);
     return React.createElement(View, { testID: `screen-${name}` }, options.headerLeft?.());
   };
 
@@ -45,6 +51,12 @@ describe('TripsLayout header actions', () => {
     await render(<TripsLayout />);
     expect(screen.getByTestId('screen-[tripId]/edit')).toBeTruthy();
     expect(screen.getByLabelText('Cancel trip editing')).toBeTruthy();
+    expect(screen.getByTestId('screen-[tripId]/invite')).toBeTruthy();
+    expect(screen.getByLabelText('Cancel member invitation')).toBeTruthy();
+    expect(mockRegisterScreen).toHaveBeenCalledWith(
+      '[tripId]/invite',
+      expect.objectContaining({ title: 'Invite Friends', presentation: 'formSheet' }),
+    );
   });
 
   it('returns to the previous route from the trip detail header when history exists', async () => {
@@ -58,6 +70,7 @@ describe('TripsLayout header actions', () => {
   it.each([
     ['Cancel trip creation'],
     ['Cancel trip editing'],
+    ['Cancel member invitation'],
   ])('returns to tabs from %s when there is no navigation history', async (label) => {
     mockRouter.canGoBack.mockReturnValue(false);
     await render(<TripsLayout />);

--- a/mobile/src/app/trips/_layout.tsx
+++ b/mobile/src/app/trips/_layout.tsx
@@ -92,6 +92,20 @@ export default function TripsLayout() {
           ),
         }}
       />
+      <Stack.Screen
+        name="[tripId]/invite"
+        options={{
+          title: 'Invite Friends',
+          presentation: 'formSheet',
+          headerLeft: () => (
+            <HeaderAction
+              label="Cancel"
+              accessibilityLabel="Cancel member invitation"
+              onPress={leaveTripsRoute}
+            />
+          ),
+        }}
+      />
     </Stack>
   );
 }

--- a/mobile/src/features/notifications/__tests__/NotificationRow.test.tsx
+++ b/mobile/src/features/notifications/__tests__/NotificationRow.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { NotificationRow } from '../components/NotificationRow';
+import type { NotificationItem } from '../types';
+
+const invitationPayload = {
+  trip_id: 'trip-1',
+  trip_name: 'Da Lat escape',
+  destination: 'Da Lat',
+  start_date: '2026-08-01',
+  end_date: '2026-08-03',
+  invitation_id: 'invitation-1',
+  invitation_status: 'PENDING',
+};
+
+const base: NotificationItem = {
+  id: 'notification-1',
+  notification_type: 'FRIEND_REQUEST',
+  actor: { id: 'user-2', display_name: 'Bob', identify_tag: 'bob#ABC123' },
+  payload: {},
+  is_read: false,
+  read_at: null,
+  created_at: '2026-07-22T01:00:00Z',
+};
+
+const defaultProps = {
+  readPending: false,
+  pendingInvitationAction: null,
+  error: null,
+  onOpen: jest.fn(),
+  onInvitationAction: jest.fn(),
+};
+
+describe('NotificationRow', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders a known simple notification and marks it through the row action', async () => {
+    const onOpen = jest.fn();
+    await render(<NotificationRow {...defaultProps} notification={base} onOpen={onOpen} />);
+
+    expect(screen.getByText('Bob sent you a friend request')).toBeTruthy();
+    await fireEvent.press(screen.getByRole('button', { name: 'Bob sent you a friend request' }));
+    expect(onOpen).toHaveBeenCalledWith('notification-1', null);
+  });
+
+  it('renders malformed and unknown payloads neutrally without exposing raw JSON', async () => {
+    await render(
+      <NotificationRow
+        {...defaultProps}
+        notification={{ ...base, notification_type: 'NEW_SECRET_TYPE', payload: { token: 'do-not-show' } }}
+      />,
+    );
+
+    expect(screen.getByText('You have a new notification')).toBeTruthy();
+    expect(screen.getByText('Details are unavailable.')).toBeTruthy();
+    expect(screen.queryByText(/do-not-show/)).toBeNull();
+    expect(screen.queryByText(/NEW_SECRET_TYPE/)).toBeNull();
+  });
+
+  it('shows both pending invitation actions and disables them through one shared pending state', async () => {
+    const onAction = jest.fn();
+    await render(
+      <NotificationRow
+        {...defaultProps}
+        notification={{ ...base, notification_type: 'TRIP_INVITATION', payload: invitationPayload }}
+        pendingInvitationAction="accept"
+        onInvitationAction={onAction}
+      />,
+    );
+
+    const accept = screen.getByRole('button', { name: 'Accept' });
+    const decline = screen.getByRole('button', { name: 'Decline' });
+    expect(accept.props.accessibilityState).toEqual(expect.objectContaining({ disabled: true, busy: true }));
+    expect(decline.props.accessibilityState).toEqual(expect.objectContaining({ disabled: true }));
+    await fireEvent.press(decline);
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it('dispatches invitation identity and only opens an accepted invitation trip', async () => {
+    const onAction = jest.fn();
+    const onOpen = jest.fn();
+    const { rerender } = await render(
+      <NotificationRow
+        {...defaultProps}
+        notification={{ ...base, notification_type: 'TRIP_INVITATION', payload: invitationPayload }}
+        onInvitationAction={onAction}
+        onOpen={onOpen}
+      />,
+    );
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Accept' }));
+    expect(onAction).toHaveBeenCalledWith('notification-1', 'invitation-1', 'trip-1', 'accept');
+    await fireEvent.press(screen.getByRole('button', { name: 'Trip invitation to Da Lat escape' }));
+    expect(onOpen).toHaveBeenCalledWith('notification-1', null);
+
+    await rerender(
+      <NotificationRow
+        {...defaultProps}
+        notification={{
+          ...base,
+          notification_type: 'TRIP_INVITATION',
+          payload: { ...invitationPayload, invitation_status: 'ACCEPTED' },
+        }}
+        onInvitationAction={onAction}
+        onOpen={onOpen}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'Accept' })).toBeNull();
+    expect(screen.getByText('You joined this trip.')).toBeTruthy();
+    await fireEvent.press(screen.getByRole('button', { name: 'Trip invitation to Da Lat escape' }));
+    expect(onOpen).toHaveBeenLastCalledWith('notification-1', 'trip-1');
+  });
+
+  it('keeps legacy invitation status non-actionable and displays normalized row errors', async () => {
+    await render(
+      <NotificationRow
+        {...defaultProps}
+        notification={{
+          ...base,
+          notification_type: 'TRIP_INVITATION',
+          payload: { ...invitationPayload, invitation_status: undefined },
+        }}
+        error={{ kind: 'message', message: 'This invitation is no longer pending.', status: 409 }}
+      />,
+    );
+
+    expect(screen.getByText('Invitation status is unavailable.')).toBeTruthy();
+    expect(screen.getByText('This invitation is no longer pending.')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Accept' })).toBeNull();
+  });
+});

--- a/mobile/src/features/notifications/__tests__/NotificationsProvider.test.tsx
+++ b/mobile/src/features/notifications/__tests__/NotificationsProvider.test.tsx
@@ -1,0 +1,489 @@
+jest.mock('../api', () => ({
+  acceptTripInvitation: jest.fn(),
+  declineTripInvitation: jest.fn(),
+  getUnreadCount: jest.fn(),
+  listNotifications: jest.fn(),
+  markAllNotificationsRead: jest.fn(),
+  markNotificationRead: jest.fn(),
+}));
+jest.mock('@/features/trips/tripEvents', () => ({ publishTripEvent: jest.fn() }));
+
+// eslint-disable-next-line import/first
+import { AxiosError, AxiosHeaders } from 'axios';
+// eslint-disable-next-line import/first
+import { type PropsWithChildren } from 'react';
+// eslint-disable-next-line import/first
+import { AppState, Pressable, Text, View } from 'react-native';
+// eslint-disable-next-line import/first
+import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { publishTripEvent } from '@/features/trips/tripEvents';
+// eslint-disable-next-line import/first
+import {
+  acceptTripInvitation,
+  declineTripInvitation,
+  getUnreadCount,
+  listNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+} from '../api';
+// eslint-disable-next-line import/first
+import { NotificationsProvider, useNotifications } from '../application/NotificationsProvider';
+// eslint-disable-next-line import/first
+import type { NotificationItem, NotificationPage } from '../types';
+
+const mockAccept = acceptTripInvitation as jest.MockedFunction<typeof acceptTripInvitation>;
+const mockDecline = declineTripInvitation as jest.MockedFunction<typeof declineTripInvitation>;
+const mockGetUnread = getUnreadCount as jest.MockedFunction<typeof getUnreadCount>;
+const mockList = listNotifications as jest.MockedFunction<typeof listNotifications>;
+const mockMarkAll = markAllNotificationsRead as jest.MockedFunction<typeof markAllNotificationsRead>;
+const mockMarkRead = markNotificationRead as jest.MockedFunction<typeof markNotificationRead>;
+const mockPublishTripEvent = publishTripEvent as jest.MockedFunction<typeof publishTripEvent>;
+
+const notification: NotificationItem = {
+  id: 'notification-1',
+  notification_type: 'FRIEND_REQUEST',
+  actor: { id: 'user-2', display_name: 'Bob', identify_tag: 'bob#ABC123' },
+  payload: {},
+  is_read: false,
+  read_at: null,
+  created_at: '2026-07-22T01:00:00Z',
+};
+
+const invitation: NotificationItem = {
+  ...notification,
+  id: 'notification-invite',
+  notification_type: 'TRIP_INVITATION',
+  payload: {
+    trip_id: 'trip-1',
+    trip_name: 'Da Lat escape',
+    destination: 'Da Lat',
+    start_date: '2026-08-01',
+    end_date: '2026-08-03',
+    invitation_id: 'invitation-1',
+    invitation_status: 'PENDING',
+  },
+};
+
+function page(items: NotificationItem[], nextCursor: string | null = null): NotificationPage {
+  return { items, nextCursor };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, {}, {
+    status,
+    statusText: '',
+    headers: {},
+    config,
+    data,
+  });
+}
+
+function wrapper({ children }: PropsWithChildren) {
+  return <NotificationsProvider ownerUserId="user-1">{children}</NotificationsProvider>;
+}
+
+function StateProbe({
+  onInvitationResponse,
+}: {
+  onInvitationResponse?: (response: Promise<boolean>) => void;
+}) {
+  const state = useNotifications();
+  return (
+    <View>
+      <Text testID="notification-state">{`${state.unreadCount ?? 'none'}:${state.items.length}`}</Text>
+      <Pressable accessibilityRole="button" accessibilityLabel="Load notifications" onPress={state.refreshForFocus} />
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Accept invitation"
+        onPress={() =>
+          onInvitationResponse?.(
+            state.respondToInvitation(
+              invitation.id,
+              'invitation-1',
+              'trip-1',
+              'accept',
+            ),
+          )
+        }
+      />
+    </View>
+  );
+}
+
+async function renderLoaded(items: NotificationItem[] = [notification], nextCursor: string | null = null) {
+  mockList.mockResolvedValueOnce(page(items, nextCursor));
+  const rendered = await renderHook(useNotifications, { wrapper });
+  await act(async () => rendered.result.current.refreshForFocus());
+  await waitFor(() => expect(rendered.result.current.status).toBe('ready'));
+  return rendered;
+}
+
+describe('NotificationsProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetUnread.mockResolvedValue(1);
+    mockMarkRead.mockResolvedValue(undefined);
+    mockMarkAll.mockResolvedValue(1);
+    mockAccept.mockResolvedValue(undefined);
+    mockDecline.mockResolvedValue(undefined);
+  });
+
+  it('loads cursor pages with de-duplication and retains the failed cursor for retry', async () => {
+    const second = { ...notification, id: 'notification-2' };
+    const rendered = await renderLoaded([notification], 'next-cursor');
+    mockList.mockResolvedValueOnce(page([notification, second], 'last-cursor'));
+
+    await act(async () => rendered.result.current.loadMore());
+    expect(mockList).toHaveBeenLastCalledWith('next-cursor');
+    expect(rendered.result.current.items.map((item) => item.id)).toEqual(['notification-1', 'notification-2']);
+
+    mockList.mockRejectedValueOnce(axiosErrorWith(503, { detail: 'Notifications are temporarily unavailable.' }));
+    await act(async () => rendered.result.current.loadMore());
+    expect(rendered.result.current.errorSource).toBe('loadMore');
+    expect(rendered.result.current.items).toHaveLength(2);
+
+    mockList.mockResolvedValueOnce(page([], null));
+    await act(async () => rendered.result.current.loadMore());
+    expect(mockList).toHaveBeenLastCalledWith('last-cursor');
+  });
+
+  it('keeps rendered notifications after a non-destructive refresh error', async () => {
+    const rendered = await renderLoaded();
+    mockList.mockRejectedValueOnce(axiosErrorWith(500, { detail: 'Try again later.' }));
+
+    await act(async () => rendered.result.current.refresh());
+
+    expect(rendered.result.current.status).toBe('ready');
+    expect(rendered.result.current.items).toEqual([notification]);
+    expect(rendered.result.current.errorSource).toBe('refresh');
+    expect(rendered.result.current.error?.message).toBe('Try again later.');
+  });
+
+  it('keeps a successful read over a list response that started before the mutation', async () => {
+    const rendered = await renderLoaded();
+    const staleRefresh = deferred<NotificationPage>();
+    mockList.mockReturnValueOnce(staleRefresh.promise);
+
+    let refreshPromise!: Promise<void>;
+    await act(() => {
+      refreshPromise = rendered.result.current.refreshForFocus();
+    });
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+    await act(async () => rendered.result.current.markRead(notification.id));
+    await act(async () => {
+      staleRefresh.resolve(page([notification]));
+      await refreshPromise;
+    });
+
+    await waitFor(() => expect(rendered.result.current.items[0]?.is_read).toBe(true));
+    expect(mockMarkRead).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores an older unread-count response after a read reconciliation has completed', async () => {
+    mockGetUnread.mockResolvedValue(5);
+    const rendered = await renderLoaded();
+    await waitFor(() => expect(rendered.result.current.unreadCount).toBe(5));
+    mockGetUnread.mockReset();
+    const staleCount = deferred<number>();
+    mockGetUnread.mockReturnValueOnce(staleCount.promise).mockResolvedValueOnce(4);
+    mockList.mockResolvedValueOnce(page([notification]));
+
+    let refreshPromise!: Promise<void>;
+    await act(() => {
+      refreshPromise = rendered.result.current.refreshForFocus();
+    });
+    await waitFor(() => expect(mockGetUnread).toHaveBeenCalledTimes(1));
+    await act(async () => rendered.result.current.markRead(notification.id));
+    await act(async () => {
+      staleCount.resolve(5);
+      await refreshPromise;
+    });
+
+    expect(rendered.result.current.unreadCount).toBe(4);
+  });
+
+  it('shares one synchronous invitation lock and publishes accepted-trip reconciliation', async () => {
+    const rendered = await renderLoaded([invitation]);
+    const pendingAccept = deferred<void>();
+    mockAccept.mockReturnValueOnce(pendingAccept.promise);
+    mockList.mockResolvedValueOnce(
+      page([{ ...invitation, is_read: true, payload: { ...(invitation.payload as object), invitation_status: 'ACCEPTED' } }]),
+    );
+
+    let first!: Promise<boolean>;
+    let duplicate!: Promise<boolean>;
+    await act(() => {
+      first = rendered.result.current.respondToInvitation(
+        invitation.id,
+        'invitation-1',
+        'trip-1',
+        'accept',
+      );
+      duplicate = rendered.result.current.respondToInvitation(
+        invitation.id,
+        'invitation-1',
+        'trip-1',
+        'decline',
+      );
+    });
+    await expect(duplicate).resolves.toBe(false);
+    expect(mockAccept).toHaveBeenCalledTimes(1);
+    expect(mockDecline).not.toHaveBeenCalled();
+
+    await act(async () => {
+      pendingAccept.resolve();
+      await first;
+    });
+
+    expect(mockPublishTripEvent).toHaveBeenCalledWith({ type: 'membershipAdded', tripId: 'trip-1' });
+    expect(mockMarkRead).toHaveBeenCalledWith(invitation.id);
+    expect(rendered.result.current.items[0]?.is_read).toBe(true);
+    expect(rendered.result.current.items[0]?.payload).toEqual(
+      expect.objectContaining({ invitation_status: 'ACCEPTED' }),
+    );
+  });
+
+  it('declines successfully, marks the notification read, and does not publish a trip event', async () => {
+    const rendered = await renderLoaded([invitation]);
+    mockList.mockResolvedValueOnce(
+      page([
+        {
+          ...invitation,
+          is_read: true,
+          payload: { ...(invitation.payload as object), invitation_status: 'DECLINED' },
+        },
+      ]),
+    );
+
+    let succeeded = false;
+    await act(async () => {
+      succeeded = await rendered.result.current.respondToInvitation(
+        invitation.id,
+        'invitation-1',
+        'trip-1',
+        'decline',
+      );
+    });
+
+    expect(succeeded).toBe(true);
+    expect(mockDecline).toHaveBeenCalledWith('invitation-1');
+    expect(mockAccept).not.toHaveBeenCalled();
+    expect(mockMarkRead).toHaveBeenCalledWith(invitation.id);
+    expect(mockPublishTripEvent).not.toHaveBeenCalled();
+    expect(rendered.result.current.items[0]?.is_read).toBe(true);
+    expect(rendered.result.current.items[0]?.payload).toEqual(
+      expect.objectContaining({ invitation_status: 'DECLINED' }),
+    );
+  });
+
+  it('fails a stale 409 invitation closed, displays the backend message, and refreshes server status', async () => {
+    const rendered = await renderLoaded([invitation]);
+    mockAccept.mockRejectedValueOnce(
+      axiosErrorWith(409, { detail: 'This invitation is no longer pending.', error_code: 'INVITATION_NOT_PENDING' }),
+    );
+    mockList.mockResolvedValueOnce(
+      page([{ ...invitation, payload: { ...(invitation.payload as object), invitation_status: 'CANCELLED' } }]),
+    );
+
+    await act(async () =>
+      rendered.result.current.respondToInvitation(invitation.id, 'invitation-1', 'trip-1', 'accept'),
+    );
+
+    expect(rendered.result.current.rowErrors.get(invitation.id)?.message).toBe(
+      'This invitation is no longer pending.',
+    );
+    expect(rendered.result.current.items[0]?.payload).toEqual(
+      expect.objectContaining({ invitation_status: 'CANCELLED' }),
+    );
+    expect(mockList).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails a stale 404 invitation closed before reconciling server status', async () => {
+    const rendered = await renderLoaded([invitation]);
+    const refreshedPage = deferred<NotificationPage>();
+    mockAccept.mockRejectedValueOnce(
+      axiosErrorWith(404, { detail: 'Invitation not found.', error_code: 'INVITATION_NOT_FOUND' }),
+    );
+    mockList.mockReturnValueOnce(refreshedPage.promise);
+
+    let response!: Promise<boolean>;
+    await act(() => {
+      response = rendered.result.current.respondToInvitation(
+        invitation.id,
+        'invitation-1',
+        'trip-1',
+        'accept',
+      );
+    });
+
+    await waitFor(() =>
+      expect(rendered.result.current.items[0]?.payload).toEqual(
+        expect.objectContaining({ invitation_status: null }),
+      ),
+    );
+    expect(rendered.result.current.rowErrors.get(invitation.id)?.message).toBe(
+      'Invitation not found.',
+    );
+    expect(mockList).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      refreshedPage.resolve(
+        page([
+          {
+            ...invitation,
+            payload: { ...(invitation.payload as object), invitation_status: 'CANCELLED' },
+          },
+        ]),
+      );
+      await response;
+    });
+    expect(rendered.result.current.items[0]?.payload).toEqual(
+      expect.objectContaining({ invitation_status: 'CANCELLED' }),
+    );
+    expect(mockPublishTripEvent).not.toHaveBeenCalled();
+    expect(mockMarkRead).not.toHaveBeenCalled();
+  });
+
+  it('keeps mark-all over an older list response and clamps the badge at zero', async () => {
+    mockGetUnread.mockResolvedValue(2);
+    const second = { ...notification, id: 'notification-2' };
+    const rendered = await renderLoaded([notification, second]);
+    const staleRefresh = deferred<NotificationPage>();
+    mockList.mockReturnValueOnce(staleRefresh.promise);
+    let refreshPromise!: Promise<void>;
+    await act(() => {
+      refreshPromise = rendered.result.current.refreshForFocus();
+    });
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+    mockGetUnread.mockResolvedValue(0);
+
+    await act(async () => rendered.result.current.markAllRead());
+    await act(async () => {
+      staleRefresh.resolve(page([notification, second]));
+      await refreshPromise;
+    });
+
+    expect(rendered.result.current.items.every((item) => item.is_read)).toBe(true);
+    expect(rendered.result.current.unreadCount).toBe(0);
+  });
+
+  it('reconciles both the badge and loaded list when the app returns to foreground', async () => {
+    let onChange: ((state: 'active' | 'background') => void) | undefined;
+    const remove = jest.fn();
+    const appStateSpy = jest.spyOn(AppState, 'addEventListener').mockImplementation((_, listener) => {
+      onChange = listener as (state: 'active' | 'background') => void;
+      return { remove };
+    });
+    const rendered = await renderLoaded();
+    mockList.mockClear();
+    mockGetUnread.mockClear();
+    mockList.mockResolvedValue(page([notification]));
+
+    await act(() => onChange?.('background'));
+    await act(() => onChange?.('active'));
+
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(1));
+    expect(mockGetUnread).toHaveBeenCalledTimes(1);
+    await rendered.unmount();
+    await waitFor(() => expect(remove).toHaveBeenCalled());
+    appStateSpy.mockRestore();
+  });
+
+  it('retries an initially failed requested list when the app returns to foreground', async () => {
+    let onChange: ((state: 'active' | 'background') => void) | undefined;
+    const remove = jest.fn();
+    const appStateSpy = jest.spyOn(AppState, 'addEventListener').mockImplementation((_, listener) => {
+      onChange = listener as (state: 'active' | 'background') => void;
+      return { remove };
+    });
+    mockList.mockRejectedValueOnce(
+      axiosErrorWith(503, { detail: 'Notifications are temporarily unavailable.' }),
+    );
+    const rendered = await renderHook(useNotifications, { wrapper });
+    await act(async () => rendered.result.current.refreshForFocus());
+    expect(rendered.result.current.status).toBe('error');
+    expect(rendered.result.current.errorSource).toBe('initial');
+
+    mockList.mockResolvedValueOnce(page([notification]));
+    await act(() => onChange?.('background'));
+    await act(() => onChange?.('active'));
+
+    await waitFor(() => expect(rendered.result.current.status).toBe('ready'));
+    expect(rendered.result.current.items).toEqual([notification]);
+    expect(mockList).toHaveBeenCalledTimes(2);
+    await rendered.unmount();
+    expect(remove).toHaveBeenCalled();
+    appStateSpy.mockRestore();
+  });
+
+  it('resets badge, list, locks, and errors when the authenticated owner changes', async () => {
+    mockGetUnread.mockReset();
+    mockGetUnread.mockResolvedValueOnce(3).mockResolvedValueOnce(3).mockResolvedValue(0);
+    mockList.mockResolvedValueOnce(page([notification])).mockResolvedValueOnce(page([]));
+    const rendered = await render(
+      <NotificationsProvider ownerUserId="user-1">
+        <StateProbe />
+      </NotificationsProvider>,
+    );
+    await fireEvent.press(screen.getByRole('button', { name: 'Load notifications' }));
+    await waitFor(() => expect(screen.getByTestId('notification-state').props.children).toBe('3:1'));
+
+    await rendered.rerender(
+      <NotificationsProvider ownerUserId="user-2">
+        <StateProbe />
+      </NotificationsProvider>,
+    );
+    expect(screen.getByTestId('notification-state').props.children).not.toBe('3:1');
+    await fireEvent.press(screen.getByRole('button', { name: 'Load notifications' }));
+    await waitFor(() => expect(screen.getByTestId('notification-state').props.children).toBe('0:0'));
+  });
+
+  it('does not finish an old owner invitation response under the new owner lifetime', async () => {
+    const pendingAccept = deferred<void>();
+    mockAccept.mockReturnValueOnce(pendingAccept.promise);
+    mockList.mockResolvedValueOnce(page([invitation]));
+    let oldOwnerResponse: Promise<boolean> | undefined;
+    const rendered = await render(
+      <NotificationsProvider ownerUserId="user-1">
+        <StateProbe onInvitationResponse={(response) => { oldOwnerResponse = response; }} />
+      </NotificationsProvider>,
+    );
+    await fireEvent.press(screen.getByRole('button', { name: 'Load notifications' }));
+    await waitFor(() => expect(screen.getByTestId('notification-state').props.children).toBe('1:1'));
+    await fireEvent.press(screen.getByRole('button', { name: 'Accept invitation' }));
+    await waitFor(() => expect(mockAccept).toHaveBeenCalledTimes(1));
+
+    await rendered.rerender(
+      <NotificationsProvider ownerUserId="user-2">
+        <StateProbe />
+      </NotificationsProvider>,
+    );
+    await waitFor(() => expect(mockGetUnread).toHaveBeenCalledTimes(3));
+    const listCallsBeforeResolution = mockList.mock.calls.length;
+    const countCallsBeforeResolution = mockGetUnread.mock.calls.length;
+
+    await act(async () => {
+      pendingAccept.resolve();
+      await oldOwnerResponse;
+    });
+
+    await expect(oldOwnerResponse).resolves.toBe(false);
+    expect(mockPublishTripEvent).not.toHaveBeenCalled();
+    expect(mockMarkRead).not.toHaveBeenCalled();
+    expect(mockList).toHaveBeenCalledTimes(listCallsBeforeResolution);
+    expect(mockGetUnread).toHaveBeenCalledTimes(countCallsBeforeResolution);
+    expect(screen.getByTestId('notification-state').props.children).toBe('1:0');
+  });
+});

--- a/mobile/src/features/notifications/__tests__/NotificationsScreen.test.tsx
+++ b/mobile/src/features/notifications/__tests__/NotificationsScreen.test.tsx
@@ -1,0 +1,178 @@
+const mockUseFocusEffect = jest.fn((effect: () => void) => effect());
+const mockRouter = { push: jest.fn() };
+const mockUseNotifications = jest.fn();
+const mockFlatListProps = jest.fn();
+
+jest.mock('react-native/Libraries/Lists/FlatList', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+
+  interface MockItem {
+    id: string;
+  }
+
+  interface MockFlatListProps {
+    data: MockItem[];
+    renderItem: (info: { item: MockItem }) => import('react').ReactNode;
+    onRefresh: () => void;
+    onEndReached: () => void;
+    refreshing: boolean;
+    ListEmptyComponent: import('react').ReactNode;
+    ListFooterComponent: import('react').ReactNode;
+  }
+
+  function MockFlatList(props: MockFlatListProps) {
+    mockFlatListProps(props);
+    return React.createElement(
+      View,
+      null,
+      props.data.length > 0
+        ? props.data.map((item) =>
+            React.createElement(React.Fragment, { key: item.id }, props.renderItem({ item })),
+          )
+        : props.ListEmptyComponent,
+      props.ListFooterComponent,
+    );
+  }
+
+  return { __esModule: true, default: MockFlatList };
+});
+
+jest.mock('expo-router', () => ({
+  useFocusEffect: (effect: () => void) => mockUseFocusEffect(effect),
+  useRouter: () => mockRouter,
+}));
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('../application/NotificationsProvider', () => ({
+  useNotifications: () => mockUseNotifications(),
+}));
+
+// eslint-disable-next-line import/first
+import { fireEvent, render, screen } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { NotificationsScreen } from '../screens/NotificationsScreen';
+// eslint-disable-next-line import/first
+import type { NotificationItem, NotificationsContextValue } from '../types';
+
+const notification: NotificationItem = {
+  id: 'notification-1',
+  notification_type: 'TRIP_CANCELLED',
+  actor: null,
+  payload: { trip_id: 'trip-1', trip_name: 'Da Lat escape' },
+  is_read: false,
+  read_at: null,
+  created_at: '2026-07-22T01:00:00Z',
+};
+
+function readyContext(overrides: Partial<NotificationsContextValue> = {}): NotificationsContextValue {
+  return {
+    items: [notification],
+    status: 'ready',
+    error: null,
+    errorSource: null,
+    refreshing: false,
+    loadingMore: false,
+    hasNextPage: false,
+    unreadCount: 1,
+    markingAllRead: false,
+    pendingReadIds: new Set(),
+    pendingInvitationActions: new Map(),
+    rowErrors: new Map(),
+    globalMutationError: null,
+    refreshForFocus: jest.fn().mockResolvedValue(undefined),
+    refresh: jest.fn().mockResolvedValue(undefined),
+    loadMore: jest.fn().mockResolvedValue(undefined),
+    markRead: jest.fn().mockResolvedValue(true),
+    markAllRead: jest.fn().mockResolvedValue(true),
+    respondToInvitation: jest.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+function latestListProps(): { onRefresh: () => void; onEndReached: () => void } {
+  const props = mockFlatListProps.mock.calls.at(-1)?.[0];
+  if (!props) {
+    throw new Error('Expected NotificationsScreen to render a FlatList.');
+  }
+  return props;
+}
+
+describe('NotificationsScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseNotifications.mockReturnValue(readyContext());
+  });
+
+  it('refreshes on focus, marks the row read, and navigates to a safe trip target', async () => {
+    const context = readyContext();
+    mockUseNotifications.mockReturnValue(context);
+    await render(<NotificationsScreen />);
+
+    expect(context.refreshForFocus).toHaveBeenCalledTimes(1);
+    await fireEvent.press(screen.getByRole('button', { name: 'Da Lat escape has been cancelled' }));
+    expect(context.markRead).toHaveBeenCalledWith('notification-1');
+    expect(mockRouter.push).toHaveBeenCalledWith('/trips/trip-1');
+  });
+
+  it('dispatches mark-all and disables it when authoritative unread count is zero', async () => {
+    const context = readyContext();
+    mockUseNotifications.mockReturnValue(context);
+    const { rerender } = await render(<NotificationsScreen />);
+    await fireEvent.press(screen.getByRole('button', { name: 'Mark all notifications as read' }));
+    expect(context.markAllRead).toHaveBeenCalledTimes(1);
+
+    mockUseNotifications.mockReturnValue(
+      readyContext({ unreadCount: 0, items: [{ ...notification, is_read: true }] }),
+    );
+    await rerender(<NotificationsScreen />);
+    expect(screen.getByRole('button', { name: 'Mark all notifications as read' }).props.accessibilityState).toEqual(
+      expect.objectContaining({ disabled: true }),
+    );
+  });
+
+  it('delegates pull-to-refresh and guarded cursor pagination', async () => {
+    const context = readyContext({ hasNextPage: true });
+    mockUseNotifications.mockReturnValue(context);
+    const rendered = await render(<NotificationsScreen />);
+    const list = latestListProps();
+
+    await list.onRefresh();
+    await list.onEndReached();
+    expect(context.refresh).toHaveBeenCalledTimes(1);
+    expect(context.loadMore).toHaveBeenCalledTimes(1);
+
+    mockUseNotifications.mockReturnValue(
+      readyContext({ hasNextPage: true, errorSource: 'loadMore', error: { kind: 'network', message: 'Offline' } }),
+    );
+    await rendered.rerender(<NotificationsScreen />);
+    await latestListProps().onEndReached();
+    expect(screen.getByRole('button', { name: 'Retry loading more notifications' })).toBeTruthy();
+  });
+
+  it('keeps the ready list visible during refresh errors and retries non-destructively', async () => {
+    const context = readyContext({
+      errorSource: 'refresh',
+      error: { kind: 'message', message: 'Refresh failed.' },
+    });
+    mockUseNotifications.mockReturnValue(context);
+    await render(<NotificationsScreen />);
+
+    expect(screen.getByText('Da Lat escape has been cancelled')).toBeTruthy();
+    expect(screen.getByText('Refresh failed.')).toBeTruthy();
+    await fireEvent.press(screen.getByRole('button', { name: 'Retry refreshing notifications' }));
+    expect(context.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders usable first-load error and empty states', async () => {
+    mockUseNotifications.mockReturnValue(
+      readyContext({ status: 'error', items: [], errorSource: 'initial', error: { kind: 'network', message: 'Offline' } }),
+    );
+    const { rerender } = await render(<NotificationsScreen />);
+    expect(screen.getByText('Could not load notifications')).toBeTruthy();
+    await fireEvent.press(screen.getByText('Try again'));
+
+    mockUseNotifications.mockReturnValue(readyContext({ items: [], unreadCount: 0 }));
+    await rerender(<NotificationsScreen />);
+    expect(screen.getByText('No notifications yet')).toBeTruthy();
+  });
+});

--- a/mobile/src/features/notifications/__tests__/TabsLayout.test.tsx
+++ b/mobile/src/features/notifications/__tests__/TabsLayout.test.tsx
@@ -1,0 +1,70 @@
+const mockUseSession = jest.fn();
+const mockUnreadCount = jest.fn();
+const mockTabsScreen = jest.fn();
+const mockProviderOwner = jest.fn();
+
+jest.mock('expo-router', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+
+  function MockTabs({ children }: { children: import('react').ReactNode }) {
+    return React.createElement(View, null, children);
+  }
+  MockTabs.Screen = function MockTabsScreen({ name, options }: { name: string; options: Record<string, unknown> }) {
+    mockTabsScreen(name, options);
+    return null;
+  };
+  return {
+    Redirect: ({ href }: { href: string }) => React.createElement(View, { testID: `redirect-${href}` }),
+    Tabs: MockTabs,
+  };
+});
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('@/features/auth/session', () => ({ useSession: () => mockUseSession() }));
+jest.mock('../application/NotificationsProvider', () => ({
+  NotificationsProvider: ({ children, ownerUserId }: { children: import('react').ReactNode; ownerUserId: string }) => {
+    mockProviderOwner(ownerUserId);
+    return children;
+  },
+  useNotifications: () => ({ unreadCount: mockUnreadCount() }),
+}));
+jest.mock('@/shared/ui/LoadingScreen', () => ({ LoadingScreen: () => null }));
+
+// eslint-disable-next-line import/first
+import { render } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import TabsLayout from '@/app/(tabs)/_layout';
+
+function notificationsOptions(): Record<string, unknown> {
+  const call = mockTabsScreen.mock.calls.find(([name]) => name === 'notifications');
+  if (!call) {
+    throw new Error('Expected the Notifications tab to be registered.');
+  }
+  return call[1] as Record<string, unknown>;
+}
+
+describe('TabsLayout notifications integration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSession.mockReturnValue({
+      status: 'signedIn',
+      user: { id: 'user-1', requires_profile_setup: false },
+    });
+  });
+
+  it('scopes the provider to the authenticated user and caps a large unread badge', async () => {
+    mockUnreadCount.mockReturnValue(120);
+    await render(<TabsLayout />);
+
+    expect(mockProviderOwner).toHaveBeenCalledWith('user-1');
+    expect(notificationsOptions()).toEqual(
+      expect.objectContaining({ headerShown: false, tabBarBadge: '99+' }),
+    );
+  });
+
+  it.each([0, null])('hides the badge for unread count %s', async (count) => {
+    mockUnreadCount.mockReturnValue(count);
+    await render(<TabsLayout />);
+    expect(notificationsOptions().tabBarBadge).toBeUndefined();
+  });
+});

--- a/mobile/src/features/notifications/__tests__/api.test.ts
+++ b/mobile/src/features/notifications/__tests__/api.test.ts
@@ -1,0 +1,86 @@
+jest.mock('@/shared/api/client', () => ({
+  apiClient: { get: jest.fn(), post: jest.fn() },
+}));
+
+// eslint-disable-next-line import/first
+import { apiClient } from '@/shared/api/client';
+// eslint-disable-next-line import/first
+import {
+  acceptTripInvitation,
+  declineTripInvitation,
+  getUnreadCount,
+  listNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+  normalizeNotification,
+} from '../api';
+
+const mockGet = apiClient.get as jest.MockedFunction<typeof apiClient.get>;
+const mockPost = apiClient.post as jest.MockedFunction<typeof apiClient.post>;
+
+const notification = {
+  id: 'notification-1',
+  notification_type: 'FRIEND_REQUEST',
+  actor: { id: 'user-2', display_name: 'Bob', identify_tag: 'bob#ABC123' },
+  payload: {},
+  is_read: false,
+  read_at: null,
+  created_at: '2026-07-22T01:00:00Z',
+};
+
+describe('notifications api', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('lists notifications, drops unusable records, and stores only the opaque cursor', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        next: 'http://testserver/api/notifications/?cursor=opaque%3D%3D',
+        previous: null,
+        results: [notification, { payload: { raw: 'missing id' } }],
+      },
+    } as never);
+
+    await expect(listNotifications()).resolves.toEqual({ items: [notification], nextCursor: 'opaque==' });
+    expect(mockGet).toHaveBeenCalledWith('/notifications/', { params: undefined });
+  });
+
+  it('passes only the opaque cursor on later pages', async () => {
+    mockGet.mockResolvedValue({ data: { next: null, previous: null, results: [] } } as never);
+    await listNotifications('cursor-token');
+    expect(mockGet).toHaveBeenCalledWith('/notifications/', { params: { cursor: 'cursor-token' } });
+  });
+
+  it('normalizes malformed optional actor and payload data without exposing assumptions', () => {
+    expect(normalizeNotification({ ...notification, actor: { display_name: 42 }, payload: 'legacy' })).toEqual({
+      ...notification,
+      actor: null,
+      payload: 'legacy',
+    });
+    expect(normalizeNotification({ payload: {} })).toBeNull();
+  });
+
+  it('loads a finite non-negative unread count and rejects malformed count data', async () => {
+    mockGet.mockResolvedValueOnce({ data: { unread_count: 7 } } as never);
+    await expect(getUnreadCount()).resolves.toBe(7);
+    expect(mockGet).toHaveBeenCalledWith('/notifications/unread-count');
+
+    mockGet.mockResolvedValueOnce({ data: { unread_count: -1 } } as never);
+    await expect(getUnreadCount()).rejects.toThrow('Invalid unread notification count response.');
+  });
+
+  it('uses the exact read and invitation mutation endpoints', async () => {
+    mockPost.mockResolvedValue({ data: {} } as never);
+
+    await markNotificationRead('notification-1');
+    await markAllNotificationsRead();
+    await acceptTripInvitation('invitation-1');
+    await declineTripInvitation('invitation-2');
+
+    expect(mockPost.mock.calls).toEqual([
+      ['/notifications/notification-1/read'],
+      ['/notifications/read-all'],
+      ['/invitations/invitation-1/accept'],
+      ['/invitations/invitation-2/decline'],
+    ]);
+  });
+});

--- a/mobile/src/features/notifications/__tests__/payloadParsers.test.ts
+++ b/mobile/src/features/notifications/__tests__/payloadParsers.test.ts
@@ -1,0 +1,77 @@
+import { getTripTarget, parseNotificationPayload, parseTripInvitationPayload } from '../payloadParsers';
+
+const tripInvitation = {
+  trip_id: 'trip-1',
+  trip_name: 'Da Lat escape',
+  destination: 'Da Lat',
+  start_date: '2026-08-01',
+  end_date: '2026-08-03',
+  invitation_id: 'invitation-1',
+  invitation_status: 'PENDING',
+};
+
+describe('notification payload parsers', () => {
+  it.each([
+    ['FRIEND_REQUEST', {}, 'friendRequest'],
+    ['FRIEND_ACCEPTED', {}, 'friendAccepted'],
+    ['TRIP_INVITATION', tripInvitation, 'tripInvitation'],
+    [
+      'TRIP_INVITATION_ACCEPTED',
+      { trip_id: 'trip-1', trip_name: 'Da Lat escape', accepted_by_name: 'Bob' },
+      'tripInvitationAccepted',
+    ],
+    [
+      'TRIP_INVITATION_DECLINED',
+      { trip_id: 'trip-1', trip_name: 'Da Lat escape', declined_by_name: 'Bob' },
+      'tripInvitationDeclined',
+    ],
+    ['TRIP_CANCELLED', { trip_id: 'trip-1', trip_name: 'Da Lat escape' }, 'tripCancelled'],
+    ['TRIP_MEMBER_REMOVED', { trip_id: 'trip-1', trip_name: 'Da Lat escape' }, 'tripMemberRemoved'],
+    [
+      'TRIP_TIMELINE_REMINDER',
+      {
+        trip_id: 'trip-1',
+        trip_name: 'Da Lat escape',
+        activity_id: 'activity-1',
+        activity_title: 'Cable car',
+        section_label: 'Day 1',
+        activity_date: '2026-08-01',
+        activity_time: '09:00',
+        location_label: 'Station',
+      },
+      'tripTimelineReminder',
+    ],
+  ])('parses %s without unsafe payload assertions', (type, payload, kind) => {
+    expect(parseNotificationPayload(type, payload).kind).toBe(kind);
+  });
+
+  it.each([
+    ['UNKNOWN_TYPE', { secret: 'must-not-render' }],
+    ['TRIP_INVITATION', { ...tripInvitation, invitation_id: 42 }],
+    ['TRIP_CANCELLED', []],
+    ['TRIP_MEMBER_REMOVED', 'raw payload'],
+    ['TRIP_TIMELINE_REMINDER', { trip_id: 'trip-1' }],
+    ['FRIEND_REQUEST', null],
+  ])('returns a neutral fallback for malformed or unknown %s payloads', (type, payload) => {
+    expect(parseNotificationPayload(type, payload)).toEqual({ kind: 'fallback' });
+  });
+
+  it('keeps legacy or unknown invitation status non-actionable while preserving safe details', () => {
+    expect(parseTripInvitationPayload({ ...tripInvitation, invitation_status: undefined })).toEqual({
+      ...tripInvitation,
+      invitation_status: null,
+    });
+    expect(parseTripInvitationPayload({ ...tripInvitation, invitation_status: 'EXPIRED' })?.invitation_status).toBeNull();
+  });
+
+  it('only exposes an accepted invitation as a directly accessible trip target', () => {
+    const pending = parseNotificationPayload('TRIP_INVITATION', tripInvitation);
+    const accepted = parseNotificationPayload('TRIP_INVITATION', {
+      ...tripInvitation,
+      invitation_status: 'ACCEPTED',
+    });
+
+    expect(getTripTarget(pending)).toBeNull();
+    expect(getTripTarget(accepted)).toBe('trip-1');
+  });
+});

--- a/mobile/src/features/notifications/api.ts
+++ b/mobile/src/features/notifications/api.ts
@@ -1,0 +1,73 @@
+import { apiClient } from '@/shared/api/client';
+import { extractCursor, type CursorPaginatedResponse } from '@/shared/api/pagination';
+import type { NotificationActor, NotificationItem, NotificationPage } from './types';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeActor(raw: unknown): NotificationActor | null {
+  if (!isRecord(raw) || typeof raw.id !== 'string' || typeof raw.display_name !== 'string') {
+    return null;
+  }
+  return {
+    id: raw.id,
+    display_name: raw.display_name,
+    identify_tag: typeof raw.identify_tag === 'string' ? raw.identify_tag : null,
+  };
+}
+
+export function normalizeNotification(raw: unknown): NotificationItem | null {
+  if (!isRecord(raw) || typeof raw.id !== 'string' || raw.id.length === 0) {
+    return null;
+  }
+  return {
+    id: raw.id,
+    notification_type: typeof raw.notification_type === 'string' ? raw.notification_type : 'UNKNOWN',
+    actor: normalizeActor(raw.actor),
+    payload: raw.payload,
+    is_read: typeof raw.is_read === 'boolean' ? raw.is_read : false,
+    read_at: typeof raw.read_at === 'string' ? raw.read_at : null,
+    created_at: typeof raw.created_at === 'string' ? raw.created_at : '',
+  };
+}
+
+export async function listNotifications(cursor?: string | null): Promise<NotificationPage> {
+  const { data } = await apiClient.get<CursorPaginatedResponse<unknown>>('/notifications/', {
+    params: cursor ? { cursor } : undefined,
+  });
+  const rawResults = Array.isArray(data.results) ? data.results : [];
+  const items = rawResults.flatMap((raw) => {
+    const notification = normalizeNotification(raw);
+    return notification ? [notification] : [];
+  });
+  return {
+    items,
+    nextCursor: extractCursor(typeof data.next === 'string' ? data.next : null),
+  };
+}
+
+export async function getUnreadCount(): Promise<number> {
+  const { data } = await apiClient.get<{ unread_count: unknown }>('/notifications/unread-count');
+  if (typeof data.unread_count !== 'number' || !Number.isFinite(data.unread_count) || data.unread_count < 0) {
+    throw new Error('Invalid unread notification count response.');
+  }
+  return Math.floor(data.unread_count);
+}
+
+export async function markNotificationRead(notificationId: string): Promise<void> {
+  await apiClient.post(`/notifications/${notificationId}/read`);
+}
+
+export async function markAllNotificationsRead(): Promise<number> {
+  const { data } = await apiClient.post<{ updated_count: number }>('/notifications/read-all');
+  return typeof data.updated_count === 'number' ? data.updated_count : 0;
+}
+
+export async function acceptTripInvitation(invitationId: string): Promise<void> {
+  await apiClient.post(`/invitations/${invitationId}/accept`);
+}
+
+export async function declineTripInvitation(invitationId: string): Promise<void> {
+  await apiClient.post(`/invitations/${invitationId}/decline`);
+}

--- a/mobile/src/features/notifications/application/NotificationsProvider.tsx
+++ b/mobile/src/features/notifications/application/NotificationsProvider.tsx
@@ -1,0 +1,730 @@
+import {
+  createContext,
+  type PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
+import { normalizeApiError, type ApiError } from '@/shared/api/errors';
+import { publishTripEvent } from '@/features/trips/tripEvents';
+import {
+  acceptTripInvitation,
+  declineTripInvitation,
+  getUnreadCount,
+  listNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+} from '../api';
+import type {
+  InvitationAction,
+  InvitationStatus,
+  NotificationErrorSource,
+  NotificationItem,
+  NotificationLoadMode,
+  NotificationOverride,
+  NotificationListStatus,
+  NotificationsContextValue,
+} from '../types';
+
+interface NotificationsProviderProps extends PropsWithChildren {
+  ownerUserId: string | null;
+}
+
+interface ReadAllOverride {
+  version: number;
+}
+
+interface OwnerGeneration {
+  ownerUserId: string;
+  generation: number;
+}
+
+const NotificationsContext = createContext<NotificationsContextValue | null>(null);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function applyOverride(item: NotificationItem, override: NotificationOverride | undefined): NotificationItem {
+  if (!override) {
+    return item;
+  }
+  let next = override.isRead === undefined ? item : { ...item, is_read: override.isRead };
+  if (override.invitationStatus !== undefined && item.notification_type === 'TRIP_INVITATION') {
+    const payload = isRecord(item.payload) ? item.payload : {};
+    next = {
+      ...next,
+      payload: { ...payload, invitation_status: override.invitationStatus },
+    };
+  }
+  return next;
+}
+
+function applyResponseOverrides(
+  items: NotificationItem[],
+  overrides: Map<string, NotificationOverride>,
+  readAllOverride: ReadAllOverride | null,
+  requestMutationVersion: number,
+): NotificationItem[] {
+  return items.map((item) => {
+    const override = overrides.get(item.id);
+    let next = applyOverride(
+      item,
+      override && override.version > requestMutationVersion ? override : undefined,
+    );
+    if (readAllOverride && readAllOverride.version > requestMutationVersion && !next.is_read) {
+      next = { ...next, is_read: true };
+    }
+    return next;
+  });
+}
+
+function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProviderProps) {
+  const [items, setItems] = useState<NotificationItem[]>([]);
+  const [status, setStatus] = useState<NotificationListStatus>('loading');
+  const [error, setError] = useState<ApiError | null>(null);
+  const [errorSource, setErrorSource] = useState<NotificationErrorSource>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasNextPage, setHasNextPage] = useState(false);
+  const [unreadCount, setUnreadCount] = useState<number | null>(null);
+  const [markingAllRead, setMarkingAllRead] = useState(false);
+  const [pendingReadIds, setPendingReadIds] = useState<ReadonlySet<string>>(new Set());
+  const [pendingInvitationActions, setPendingInvitationActions] = useState<ReadonlyMap<string, InvitationAction>>(
+    new Map(),
+  );
+  const [rowErrors, setRowErrors] = useState<ReadonlyMap<string, ApiError>>(new Map());
+  const [globalMutationError, setGlobalMutationError] = useState<ApiError | null>(null);
+
+  const itemsRef = useRef<NotificationItem[]>([]);
+  const nextCursorRef = useRef<string | null>(null);
+  const firstPageRequestRef = useRef(0);
+  const firstPageInFlightRef = useRef<number | null>(null);
+  const listGenerationRef = useRef(0);
+  const loadMoreInFlightRef = useRef(false);
+  const hasUsablePageRef = useRef(false);
+  const hasRequestedListRef = useRef(false);
+  const overridesRef = useRef(new Map<string, NotificationOverride>());
+  const readAllOverrideRef = useRef<ReadAllOverride | null>(null);
+  const mutationVersionRef = useRef(0);
+  const countRequestRef = useRef(0);
+  const readLocksRef = useRef(new Set<string>());
+  const markAllLockRef = useRef(false);
+  const invitationLocksRef = useRef(new Map<string, InvitationAction>());
+  const appStateRef = useRef<AppStateStatus>(AppState.currentState);
+
+  const providerActiveRef = useRef(true);
+  const activeOwnerUserIdRef = useRef(ownerUserId);
+  const ownerGenerationRef = useRef(1);
+
+  const captureOwnerGeneration = useCallback((): OwnerGeneration | null => {
+    if (
+      !ownerUserId ||
+      !providerActiveRef.current ||
+      activeOwnerUserIdRef.current !== ownerUserId
+    ) {
+      return null;
+    }
+    return { ownerUserId, generation: ownerGenerationRef.current };
+  }, [ownerUserId]);
+
+  const isOwnerGenerationCurrent = useCallback(
+    (ownerGeneration: OwnerGeneration | null): ownerGeneration is OwnerGeneration => {
+      return Boolean(
+        ownerGeneration &&
+          providerActiveRef.current &&
+          activeOwnerUserIdRef.current === ownerGeneration.ownerUserId &&
+          ownerGenerationRef.current === ownerGeneration.generation,
+      );
+    },
+    [],
+  );
+
+  useLayoutEffect(() => {
+    providerActiveRef.current = true;
+    activeOwnerUserIdRef.current = ownerUserId;
+    const readLocks = readLocksRef.current;
+    const invitationLocks = invitationLocksRef.current;
+    return () => {
+      providerActiveRef.current = false;
+      ownerGenerationRef.current += 1;
+      firstPageRequestRef.current += 1;
+      listGenerationRef.current += 1;
+      countRequestRef.current += 1;
+      firstPageInFlightRef.current = null;
+      loadMoreInFlightRef.current = false;
+      readLocks.clear();
+      markAllLockRef.current = false;
+      invitationLocks.clear();
+    };
+  }, [ownerUserId]);
+
+  const replaceItems = useCallback(
+    (next: NotificationItem[], ownerGeneration: OwnerGeneration) => {
+      if (!isOwnerGenerationCurrent(ownerGeneration)) {
+        return;
+      }
+      itemsRef.current = next;
+      setItems(next);
+    },
+    [isOwnerGenerationCurrent],
+  );
+
+  const updateItems = useCallback(
+    (
+      update: (current: NotificationItem[]) => NotificationItem[],
+      ownerGeneration: OwnerGeneration,
+    ) => {
+      if (!isOwnerGenerationCurrent(ownerGeneration)) {
+        return;
+      }
+      setItems((current) => {
+        const next = update(current);
+        itemsRef.current = next;
+        return next;
+      });
+    },
+    [isOwnerGenerationCurrent],
+  );
+
+  const clearRowError = useCallback(
+    (notificationId: string, ownerGeneration: OwnerGeneration) => {
+      if (!isOwnerGenerationCurrent(ownerGeneration)) {
+        return;
+      }
+      setRowErrors((current) => {
+        if (!current.has(notificationId)) {
+          return current;
+        }
+        const next = new Map(current);
+        next.delete(notificationId);
+        return next;
+      });
+    },
+    [isOwnerGenerationCurrent],
+  );
+
+  const setRowError = useCallback(
+    (notificationId: string, nextError: ApiError, ownerGeneration: OwnerGeneration) => {
+      if (!isOwnerGenerationCurrent(ownerGeneration)) {
+        return;
+      }
+      setRowErrors((current) => new Map(current).set(notificationId, nextError));
+    },
+    [isOwnerGenerationCurrent],
+  );
+
+  const applyLocalOverride = useCallback(
+    (
+      notificationId: string,
+      patch: Omit<NotificationOverride, 'version'>,
+      ownerGeneration: OwnerGeneration,
+    ) => {
+      if (!isOwnerGenerationCurrent(ownerGeneration)) {
+        return;
+      }
+      mutationVersionRef.current += 1;
+      const current = overridesRef.current.get(notificationId);
+      const override: NotificationOverride = {
+        ...current,
+        ...patch,
+        version: mutationVersionRef.current,
+      };
+      overridesRef.current.set(notificationId, override);
+      updateItems(
+        (visibleItems) =>
+          visibleItems.map((item) =>
+            item.id === notificationId ? applyOverride(item, override) : item,
+          ),
+        ownerGeneration,
+      );
+    },
+    [isOwnerGenerationCurrent, updateItems],
+  );
+
+  const reconcileUnreadCount = useCallback(
+    async (expectedOwnerGeneration?: OwnerGeneration) => {
+      const ownerGeneration = expectedOwnerGeneration ?? captureOwnerGeneration();
+      if (!isOwnerGenerationCurrent(ownerGeneration)) {
+        return;
+      }
+      const requestId = countRequestRef.current + 1;
+      countRequestRef.current = requestId;
+      const requestMutationVersion = mutationVersionRef.current;
+      try {
+        const count = await getUnreadCount();
+        if (
+          isOwnerGenerationCurrent(ownerGeneration) &&
+          requestId === countRequestRef.current &&
+          requestMutationVersion === mutationVersionRef.current
+        ) {
+          setUnreadCount(count);
+        }
+      } catch {
+        // Keep the last usable badge. Focus and foreground transitions retry.
+      }
+    },
+    [captureOwnerGeneration, isOwnerGenerationCurrent],
+  );
+
+  const loadFirstPage = useCallback(
+    async (mode: NotificationLoadMode, expectedOwnerGeneration?: OwnerGeneration) => {
+      const ownerGeneration = expectedOwnerGeneration ?? captureOwnerGeneration();
+      if (!isOwnerGenerationCurrent(ownerGeneration)) {
+        return;
+      }
+      hasRequestedListRef.current = true;
+      const requestId = firstPageRequestRef.current + 1;
+      firstPageRequestRef.current = requestId;
+      firstPageInFlightRef.current = requestId;
+      listGenerationRef.current += 1;
+      const requestMutationVersion = mutationVersionRef.current;
+      loadMoreInFlightRef.current = false;
+      setLoadingMore(false);
+      setError(null);
+      setErrorSource(null);
+      if (mode === 'initial') {
+        setStatus('loading');
+      } else if (mode === 'refresh') {
+        setRefreshing(true);
+      }
+
+      try {
+        const page = await listNotifications();
+        if (
+          !isOwnerGenerationCurrent(ownerGeneration) ||
+          requestId !== firstPageRequestRef.current
+        ) {
+          return;
+        }
+        nextCursorRef.current = page.nextCursor;
+        setHasNextPage(page.nextCursor !== null);
+        replaceItems(
+          applyResponseOverrides(
+            page.items,
+            overridesRef.current,
+            readAllOverrideRef.current,
+            requestMutationVersion,
+          ),
+          ownerGeneration,
+        );
+        hasUsablePageRef.current = true;
+        setStatus('ready');
+      } catch (caught) {
+        if (
+          !isOwnerGenerationCurrent(ownerGeneration) ||
+          requestId !== firstPageRequestRef.current
+        ) {
+          return;
+        }
+        setError(normalizeApiError(caught));
+        if (mode === 'initial' || !hasUsablePageRef.current) {
+          setErrorSource('initial');
+          setStatus('error');
+        } else {
+          setErrorSource('refresh');
+          setStatus('ready');
+        }
+      } finally {
+        if (requestId === firstPageRequestRef.current) {
+          firstPageInFlightRef.current = null;
+          if (isOwnerGenerationCurrent(ownerGeneration)) {
+            setRefreshing(false);
+          }
+        }
+      }
+    },
+    [captureOwnerGeneration, isOwnerGenerationCurrent, replaceItems],
+  );
+
+  const loadMore = useCallback(async () => {
+    const ownerGeneration = captureOwnerGeneration();
+    const cursor = nextCursorRef.current;
+    if (
+      !isOwnerGenerationCurrent(ownerGeneration) ||
+      firstPageInFlightRef.current !== null ||
+      loadMoreInFlightRef.current ||
+      !cursor
+    ) {
+      return;
+    }
+    const generation = listGenerationRef.current;
+    const requestMutationVersion = mutationVersionRef.current;
+    loadMoreInFlightRef.current = true;
+    setLoadingMore(true);
+    setError(null);
+    setErrorSource(null);
+    try {
+      const page = await listNotifications(cursor);
+      if (
+        !isOwnerGenerationCurrent(ownerGeneration) ||
+        generation !== listGenerationRef.current
+      ) {
+        return;
+      }
+      nextCursorRef.current = page.nextCursor;
+      setHasNextPage(page.nextCursor !== null);
+      updateItems(
+        (current) => {
+          const seen = new Set(current.map((item) => item.id));
+          const additions = applyResponseOverrides(
+            page.items,
+            overridesRef.current,
+            readAllOverrideRef.current,
+            requestMutationVersion,
+          ).filter((item) => !seen.has(item.id));
+          return [...current, ...additions];
+        },
+        ownerGeneration,
+      );
+    } catch (caught) {
+      if (
+        !isOwnerGenerationCurrent(ownerGeneration) ||
+        generation !== listGenerationRef.current
+      ) {
+        return;
+      }
+      setError(normalizeApiError(caught));
+      setErrorSource('loadMore');
+    } finally {
+      if (generation === listGenerationRef.current) {
+        loadMoreInFlightRef.current = false;
+        if (isOwnerGenerationCurrent(ownerGeneration)) {
+          setLoadingMore(false);
+        }
+      }
+    }
+  }, [captureOwnerGeneration, isOwnerGenerationCurrent, updateItems]);
+
+  const refreshForFocus = useCallback(async () => {
+    const ownerGeneration = captureOwnerGeneration();
+    if (!isOwnerGenerationCurrent(ownerGeneration)) {
+      return;
+    }
+    await Promise.all([
+      loadFirstPage(hasUsablePageRef.current ? 'silent' : 'initial', ownerGeneration),
+      reconcileUnreadCount(ownerGeneration),
+    ]);
+  }, [captureOwnerGeneration, isOwnerGenerationCurrent, loadFirstPage, reconcileUnreadCount]);
+
+  const refresh = useCallback(async () => {
+    const ownerGeneration = captureOwnerGeneration();
+    if (!isOwnerGenerationCurrent(ownerGeneration)) {
+      return;
+    }
+    setGlobalMutationError(null);
+    await Promise.all([
+      loadFirstPage('refresh', ownerGeneration),
+      reconcileUnreadCount(ownerGeneration),
+    ]);
+  }, [captureOwnerGeneration, isOwnerGenerationCurrent, loadFirstPage, reconcileUnreadCount]);
+
+  const markRead = useCallback(
+    async (notificationId: string): Promise<boolean> => {
+      const ownerGeneration = captureOwnerGeneration();
+      if (
+        !isOwnerGenerationCurrent(ownerGeneration) ||
+        readLocksRef.current.has(notificationId)
+      ) {
+        return false;
+      }
+      const notification = itemsRef.current.find((item) => item.id === notificationId);
+      if (notification?.is_read) {
+        return true;
+      }
+      readLocksRef.current.add(notificationId);
+      setPendingReadIds(new Set(readLocksRef.current));
+      clearRowError(notificationId, ownerGeneration);
+      try {
+        await markNotificationRead(notificationId);
+        if (!isOwnerGenerationCurrent(ownerGeneration)) {
+          return false;
+        }
+        applyLocalOverride(notificationId, { isRead: true }, ownerGeneration);
+        if (notification && !notification.is_read) {
+          setUnreadCount((current) => (current === null ? null : Math.max(0, current - 1)));
+        }
+        await reconcileUnreadCount(ownerGeneration);
+        return isOwnerGenerationCurrent(ownerGeneration);
+      } catch (caught) {
+        if (!isOwnerGenerationCurrent(ownerGeneration)) {
+          return false;
+        }
+        setRowError(notificationId, normalizeApiError(caught), ownerGeneration);
+        return false;
+      } finally {
+        readLocksRef.current.delete(notificationId);
+        if (isOwnerGenerationCurrent(ownerGeneration)) {
+          setPendingReadIds(new Set(readLocksRef.current));
+        }
+      }
+    },
+    [
+      applyLocalOverride,
+      captureOwnerGeneration,
+      clearRowError,
+      isOwnerGenerationCurrent,
+      reconcileUnreadCount,
+      setRowError,
+    ],
+  );
+
+  const markAllRead = useCallback(async (): Promise<boolean> => {
+    const ownerGeneration = captureOwnerGeneration();
+    if (!isOwnerGenerationCurrent(ownerGeneration) || markAllLockRef.current) {
+      return false;
+    }
+    markAllLockRef.current = true;
+    setMarkingAllRead(true);
+    setGlobalMutationError(null);
+    try {
+      await markAllNotificationsRead();
+      if (!isOwnerGenerationCurrent(ownerGeneration)) {
+        return false;
+      }
+      mutationVersionRef.current += 1;
+      readAllOverrideRef.current = { version: mutationVersionRef.current };
+      updateItems(
+        (current) => current.map((item) => (item.is_read ? item : { ...item, is_read: true })),
+        ownerGeneration,
+      );
+      setUnreadCount(0);
+      await reconcileUnreadCount(ownerGeneration);
+      return isOwnerGenerationCurrent(ownerGeneration);
+    } catch (caught) {
+      if (!isOwnerGenerationCurrent(ownerGeneration)) {
+        return false;
+      }
+      setGlobalMutationError(normalizeApiError(caught));
+      return false;
+    } finally {
+      markAllLockRef.current = false;
+      if (isOwnerGenerationCurrent(ownerGeneration)) {
+        setMarkingAllRead(false);
+      }
+    }
+  }, [captureOwnerGeneration, isOwnerGenerationCurrent, reconcileUnreadCount, updateItems]);
+
+  const respondToInvitation = useCallback(
+    async (
+      notificationId: string,
+      invitationId: string,
+      tripId: string,
+      action: InvitationAction,
+    ): Promise<boolean> => {
+      const ownerGeneration = captureOwnerGeneration();
+      if (
+        !isOwnerGenerationCurrent(ownerGeneration) ||
+        invitationLocksRef.current.has(notificationId)
+      ) {
+        return false;
+      }
+      invitationLocksRef.current.set(notificationId, action);
+      setPendingInvitationActions(new Map(invitationLocksRef.current));
+      clearRowError(notificationId, ownerGeneration);
+      try {
+        if (action === 'accept') {
+          await acceptTripInvitation(invitationId);
+        } else {
+          await declineTripInvitation(invitationId);
+        }
+
+        if (!isOwnerGenerationCurrent(ownerGeneration)) {
+          return false;
+        }
+
+        const nextStatus: InvitationStatus = action === 'accept' ? 'ACCEPTED' : 'DECLINED';
+        applyLocalOverride(notificationId, { invitationStatus: nextStatus }, ownerGeneration);
+        if (action === 'accept') {
+          publishTripEvent({ type: 'membershipAdded', tripId });
+        }
+
+        if (!isOwnerGenerationCurrent(ownerGeneration)) {
+          return false;
+        }
+
+        try {
+          await markNotificationRead(notificationId);
+          if (!isOwnerGenerationCurrent(ownerGeneration)) {
+            return false;
+          }
+          const notification = itemsRef.current.find((item) => item.id === notificationId);
+          applyLocalOverride(notificationId, { isRead: true }, ownerGeneration);
+          if (notification && !notification.is_read) {
+            setUnreadCount((current) => (current === null ? null : Math.max(0, current - 1)));
+          }
+        } catch (caught) {
+          if (!isOwnerGenerationCurrent(ownerGeneration)) {
+            return false;
+          }
+          setRowError(notificationId, normalizeApiError(caught), ownerGeneration);
+        }
+
+        if (!isOwnerGenerationCurrent(ownerGeneration)) {
+          return false;
+        }
+        await Promise.all([
+          loadFirstPage('silent', ownerGeneration),
+          reconcileUnreadCount(ownerGeneration),
+        ]);
+        return isOwnerGenerationCurrent(ownerGeneration);
+      } catch (caught) {
+        if (!isOwnerGenerationCurrent(ownerGeneration)) {
+          return false;
+        }
+        const nextError = normalizeApiError(caught);
+        setRowError(notificationId, nextError, ownerGeneration);
+        if (nextError.status === 404 || nextError.status === 409) {
+          applyLocalOverride(notificationId, { invitationStatus: null }, ownerGeneration);
+          await Promise.all([
+            loadFirstPage('silent', ownerGeneration),
+            reconcileUnreadCount(ownerGeneration),
+          ]);
+        }
+        return false;
+      } finally {
+        invitationLocksRef.current.delete(notificationId);
+        if (isOwnerGenerationCurrent(ownerGeneration)) {
+          setPendingInvitationActions(new Map(invitationLocksRef.current));
+        }
+      }
+    },
+    [
+      applyLocalOverride,
+      captureOwnerGeneration,
+      clearRowError,
+      isOwnerGenerationCurrent,
+      loadFirstPage,
+      reconcileUnreadCount,
+      setRowError,
+    ],
+  );
+
+  useEffect(() => {
+    const ownerGeneration = captureOwnerGeneration();
+    if (!isOwnerGenerationCurrent(ownerGeneration)) {
+      return;
+    }
+    let cancelled = false;
+    const requestId = countRequestRef.current + 1;
+    countRequestRef.current = requestId;
+    const requestMutationVersion = mutationVersionRef.current;
+
+    async function hydrateUnreadCount() {
+      try {
+        const count = await getUnreadCount();
+        if (
+          !cancelled &&
+          isOwnerGenerationCurrent(ownerGeneration) &&
+          requestId === countRequestRef.current &&
+          requestMutationVersion === mutationVersionRef.current
+        ) {
+          setUnreadCount(count);
+        }
+      } catch {
+        // Focus and foreground transitions provide the next retry.
+      }
+    }
+
+    void hydrateUnreadCount();
+    return () => {
+      cancelled = true;
+    };
+  }, [captureOwnerGeneration, isOwnerGenerationCurrent]);
+
+  useEffect(() => {
+    const ownerGeneration = captureOwnerGeneration();
+    if (!isOwnerGenerationCurrent(ownerGeneration)) {
+      return;
+    }
+    appStateRef.current = AppState.currentState;
+    const subscription = AppState.addEventListener('change', (nextState) => {
+      const becameActive = appStateRef.current !== 'active' && nextState === 'active';
+      appStateRef.current = nextState;
+      if (!becameActive || !isOwnerGenerationCurrent(ownerGeneration)) {
+        return;
+      }
+      void reconcileUnreadCount(ownerGeneration);
+      if (hasRequestedListRef.current) {
+        void loadFirstPage(
+          hasUsablePageRef.current ? 'silent' : 'initial',
+          ownerGeneration,
+        );
+      }
+    });
+    return () => subscription?.remove();
+  }, [
+    captureOwnerGeneration,
+    isOwnerGenerationCurrent,
+    loadFirstPage,
+    reconcileUnreadCount,
+  ]);
+
+  const value = useMemo<NotificationsContextValue>(
+    () => ({
+      items,
+      status,
+      error,
+      errorSource,
+      refreshing,
+      loadingMore,
+      hasNextPage,
+      unreadCount,
+      markingAllRead,
+      pendingReadIds,
+      pendingInvitationActions,
+      rowErrors,
+      globalMutationError,
+      refreshForFocus,
+      refresh,
+      loadMore,
+      markRead,
+      markAllRead,
+      respondToInvitation,
+    }),
+    [
+      error,
+      errorSource,
+      globalMutationError,
+      hasNextPage,
+      items,
+      loadMore,
+      loadingMore,
+      markAllRead,
+      markRead,
+      markingAllRead,
+      pendingInvitationActions,
+      pendingReadIds,
+      refresh,
+      refreshForFocus,
+      refreshing,
+      respondToInvitation,
+      rowErrors,
+      status,
+      unreadCount,
+    ],
+  );
+
+  return <NotificationsContext.Provider value={value}>{children}</NotificationsContext.Provider>;
+}
+
+export function NotificationsProvider({ children, ownerUserId }: NotificationsProviderProps) {
+  return (
+    <OwnedNotificationsProvider key={ownerUserId ?? 'signed-out'} ownerUserId={ownerUserId}>
+      {children}
+    </OwnedNotificationsProvider>
+  );
+}
+
+export function useNotifications(): NotificationsContextValue {
+  const context = useContext(NotificationsContext);
+  if (!context) {
+    throw new Error('useNotifications must be used within NotificationsProvider');
+  }
+  return context;
+}

--- a/mobile/src/features/notifications/components/NotificationRow.tsx
+++ b/mobile/src/features/notifications/components/NotificationRow.tsx
@@ -1,0 +1,152 @@
+import { memo, useCallback, useMemo } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import type { ApiError } from '@/shared/api/errors';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { getTripTarget, parseNotificationPayload } from '../payloadParsers';
+import type { InvitationAction, NotificationItem, ParsedNotificationPayload } from '../types';
+import { TripInvitationNotificationRow } from './TripInvitationNotificationRow';
+
+const dateTimeFormatter = new Intl.DateTimeFormat('en', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+function formatTimestamp(value: string): string {
+  if (!value) {
+    return '';
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? '' : dateTimeFormatter.format(date);
+}
+
+function presentationText(parsed: ParsedNotificationPayload, actorName: string): { title: string; body: string | null } {
+  switch (parsed.kind) {
+    case 'friendRequest':
+      return { title: `${actorName} sent you a friend request`, body: null };
+    case 'friendAccepted':
+      return { title: `${actorName} accepted your friend request`, body: null };
+    case 'tripInvitationAccepted':
+      return {
+        title: `${parsed.response.responder_name ?? actorName} joined your trip`,
+        body: parsed.response.trip_name,
+      };
+    case 'tripInvitationDeclined':
+      return {
+        title: `${parsed.response.responder_name ?? actorName} declined your trip invitation`,
+        body: parsed.response.trip_name,
+      };
+    case 'tripCancelled':
+      return { title: `${parsed.trip.trip_name} has been cancelled`, body: null };
+    case 'tripMemberRemoved':
+      return { title: `You were removed from ${parsed.trip.trip_name}`, body: null };
+    case 'tripTimelineReminder':
+      return {
+        title: `Upcoming: ${parsed.reminder.activity_title}`,
+        body: `${parsed.reminder.trip_name} · ${parsed.reminder.section_label} · ${parsed.reminder.activity_time}`,
+      };
+    default:
+      return { title: 'You have a new notification', body: 'Details are unavailable.' };
+  }
+}
+
+interface NotificationRowProps {
+  notification: NotificationItem;
+  readPending: boolean;
+  pendingInvitationAction: InvitationAction | null;
+  error: ApiError | null;
+  onOpen: (notificationId: string, tripId: string | null) => void;
+  onInvitationAction: (
+    notificationId: string,
+    invitationId: string,
+    tripId: string,
+    action: InvitationAction,
+  ) => void;
+}
+
+export const NotificationRow = memo(function NotificationRow({
+  notification,
+  readPending,
+  pendingInvitationAction,
+  error,
+  onOpen,
+  onInvitationAction,
+}: NotificationRowProps) {
+  const parsed = useMemo(
+    () => parseNotificationPayload(notification.notification_type, notification.payload),
+    [notification.notification_type, notification.payload],
+  );
+  const actorName = notification.actor?.display_name.trim() || 'Someone';
+  const timestamp = formatTimestamp(notification.created_at);
+  const tripTarget = getTripTarget(parsed);
+  const open = useCallback(
+    () => onOpen(notification.id, tripTarget),
+    [notification.id, onOpen, tripTarget],
+  );
+
+  if (parsed.kind === 'tripInvitation') {
+    return (
+      <TripInvitationNotificationRow
+        notificationId={notification.id}
+        actorName={actorName}
+        invitation={parsed.invitation}
+        isRead={notification.is_read}
+        createdAtLabel={timestamp}
+        readPending={readPending}
+        pendingAction={pendingInvitationAction}
+        error={error}
+        onOpen={onOpen}
+        onAction={onInvitationAction}
+      />
+    );
+  }
+
+  const presentation = presentationText(parsed, actorName);
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={presentation.title}
+      accessibilityState={{ busy: readPending }}
+      disabled={readPending}
+      onPress={open}
+      style={({ pressed }) => [
+        styles.card,
+        notification.is_read ? styles.readCard : styles.unreadCard,
+        pressed && !readPending ? styles.pressed : null,
+      ]}
+    >
+      <View style={styles.titleRow}>
+        {!notification.is_read ? <View accessibilityLabel="Unread" style={styles.unreadDot} /> : null}
+        <Text style={styles.title}>{presentation.title}</Text>
+        {readPending ? <ActivityIndicator size="small" color={colors.primary} /> : null}
+      </View>
+      {presentation.body ? <Text style={styles.body}>{presentation.body}</Text> : null}
+      {timestamp ? <Text style={styles.timestamp}>{timestamp}</Text> : null}
+      {error ? (
+        <Text accessibilityRole="alert" style={styles.errorText}>
+          {error.message}
+        </Text>
+      ) : null}
+    </Pressable>
+  );
+});
+
+const styles = StyleSheet.create({
+  card: {
+    gap: spacing.xs,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderRadius: radii.lg,
+    borderCurve: 'continuous',
+    backgroundColor: colors.background,
+  },
+  unreadCard: { borderColor: colors.primary },
+  readCard: { borderColor: colors.border },
+  pressed: { opacity: 0.6 },
+  titleRow: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
+  unreadDot: { width: 8, height: 8, borderRadius: radii.full, backgroundColor: colors.primary },
+  title: { ...typography.body, color: colors.text, flex: 1 },
+  body: { ...typography.caption, color: colors.textMuted },
+  timestamp: { ...typography.caption, color: colors.textMuted, marginTop: spacing.xs },
+  errorText: { ...typography.caption, color: colors.danger, marginTop: spacing.xs },
+});

--- a/mobile/src/features/notifications/components/TripInvitationNotificationRow.tsx
+++ b/mobile/src/features/notifications/components/TripInvitationNotificationRow.tsx
@@ -1,0 +1,186 @@
+import { memo, useCallback } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import type { ApiError } from '@/shared/api/errors';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import type { InvitationAction, TripInvitationPayload } from '../types';
+
+interface TripInvitationNotificationRowProps {
+  notificationId: string;
+  actorName: string;
+  invitation: TripInvitationPayload;
+  isRead: boolean;
+  createdAtLabel: string;
+  readPending: boolean;
+  pendingAction: InvitationAction | null;
+  error: ApiError | null;
+  onOpen: (notificationId: string, tripId: string | null) => void;
+  onAction: (
+    notificationId: string,
+    invitationId: string,
+    tripId: string,
+    action: InvitationAction,
+  ) => void;
+}
+
+interface ActionButtonProps {
+  action: InvitationAction;
+  pendingAction: InvitationAction | null;
+  onPress: (action: InvitationAction) => void;
+}
+
+const InvitationActionButton = memo(function InvitationActionButton({
+  action,
+  pendingAction,
+  onPress,
+}: ActionButtonProps) {
+  const primary = action === 'accept';
+  const title = primary ? 'Accept' : 'Decline';
+  const loading = pendingAction === action;
+  const disabled = pendingAction !== null;
+  const press = useCallback(() => onPress(action), [action, onPress]);
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={title}
+      accessibilityState={{ disabled, busy: loading }}
+      disabled={disabled}
+      onPress={press}
+      style={({ pressed }) => [
+        styles.actionButton,
+        primary ? styles.primaryAction : styles.secondaryAction,
+        pressed && !disabled ? styles.pressed : null,
+        disabled && !loading ? styles.disabled : null,
+      ]}
+    >
+      {loading ? (
+        <ActivityIndicator color={primary ? colors.background : colors.primary} />
+      ) : (
+        <Text style={[styles.actionText, primary ? styles.primaryActionText : styles.secondaryActionText]}>
+          {title}
+        </Text>
+      )}
+    </Pressable>
+  );
+});
+
+export const TripInvitationNotificationRow = memo(function TripInvitationNotificationRow({
+  notificationId,
+  actorName,
+  invitation,
+  isRead,
+  createdAtLabel,
+  readPending,
+  pendingAction,
+  error,
+  onOpen,
+  onAction,
+}: TripInvitationNotificationRowProps) {
+  const actionable = invitation.invitation_status === 'PENDING';
+  const tripTarget = invitation.invitation_status === 'ACCEPTED' ? invitation.trip_id : null;
+  const open = useCallback(
+    () => onOpen(notificationId, tripTarget),
+    [notificationId, onOpen, tripTarget],
+  );
+  const respond = useCallback(
+    (action: InvitationAction) =>
+      onAction(notificationId, invitation.invitation_id, invitation.trip_id, action),
+    [invitation.invitation_id, invitation.trip_id, notificationId, onAction],
+  );
+
+  const resolutionLabel =
+    invitation.invitation_status === 'ACCEPTED'
+      ? 'You joined this trip.'
+      : invitation.invitation_status === 'DECLINED'
+        ? 'Invitation declined.'
+        : invitation.invitation_status === 'CANCELLED'
+          ? 'This invitation is no longer available.'
+          : invitation.invitation_status === null
+            ? 'Invitation status is unavailable.'
+            : null;
+
+  return (
+    <View style={[styles.card, isRead ? styles.readCard : styles.unreadCard]}>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`Trip invitation to ${invitation.trip_name}`}
+        accessibilityState={{ busy: readPending }}
+        disabled={readPending}
+        onPress={open}
+        style={({ pressed }) => [styles.content, pressed && !readPending ? styles.pressed : null]}
+      >
+        <View style={styles.titleRow}>
+          {!isRead ? <View accessibilityLabel="Unread" style={styles.unreadDot} /> : null}
+          <Text style={styles.title}>
+            <Text style={styles.actor}>{actorName}</Text> invited you to a trip
+          </Text>
+          {readPending ? <ActivityIndicator size="small" color={colors.primary} /> : null}
+        </View>
+        <Text style={styles.tripName}>{invitation.trip_name}</Text>
+        <Text style={styles.meta}>{invitation.destination}</Text>
+        <Text style={styles.meta}>
+          {invitation.start_date} – {invitation.end_date}
+        </Text>
+        {createdAtLabel ? <Text style={styles.timestamp}>{createdAtLabel}</Text> : null}
+      </Pressable>
+
+      {actionable ? (
+        <View style={styles.actions}>
+          <InvitationActionButton action="accept" pendingAction={pendingAction} onPress={respond} />
+          <InvitationActionButton action="decline" pendingAction={pendingAction} onPress={respond} />
+        </View>
+      ) : resolutionLabel ? (
+        <Text style={invitation.invitation_status === 'ACCEPTED' ? styles.acceptedText : styles.resolutionText}>
+          {resolutionLabel}
+        </Text>
+      ) : null}
+
+      {error ? (
+        <Text accessibilityRole="alert" style={styles.errorText}>
+          {error.message}
+        </Text>
+      ) : null}
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  card: {
+    gap: spacing.sm,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderRadius: radii.lg,
+    borderCurve: 'continuous',
+    backgroundColor: colors.background,
+  },
+  unreadCard: { borderColor: colors.primary },
+  readCard: { borderColor: colors.border },
+  content: { gap: spacing.xs },
+  pressed: { opacity: 0.6 },
+  titleRow: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
+  unreadDot: { width: 8, height: 8, borderRadius: radii.full, backgroundColor: colors.primary },
+  title: { ...typography.body, color: colors.text, flex: 1 },
+  actor: { fontWeight: '600' },
+  tripName: { ...typography.heading, color: colors.primary },
+  meta: { ...typography.caption, color: colors.textMuted },
+  timestamp: { ...typography.caption, color: colors.textMuted, marginTop: spacing.xs },
+  actions: { flexDirection: 'row', gap: spacing.sm },
+  actionButton: {
+    minHeight: 44,
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.md,
+    borderWidth: 1,
+    borderRadius: radii.md,
+    borderCurve: 'continuous',
+  },
+  primaryAction: { borderColor: colors.primary, backgroundColor: colors.primary },
+  secondaryAction: { borderColor: colors.border, backgroundColor: colors.background },
+  disabled: { opacity: 0.45 },
+  actionText: { ...typography.label },
+  primaryActionText: { color: colors.background },
+  secondaryActionText: { color: colors.text },
+  acceptedText: { ...typography.caption, color: colors.success, fontWeight: '600' },
+  resolutionText: { ...typography.caption, color: colors.textMuted },
+  errorText: { ...typography.caption, color: colors.danger },
+});

--- a/mobile/src/features/notifications/payloadParsers.ts
+++ b/mobile/src/features/notifications/payloadParsers.ts
@@ -1,0 +1,142 @@
+import type {
+  InvitationStatus,
+  ParsedNotificationPayload,
+  TripInvitationPayload,
+  TripPayload,
+  TripResponsePayload,
+  TripTimelineReminderPayload,
+} from './types';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function isInvitationStatus(value: unknown): value is InvitationStatus {
+  return value === 'PENDING' || value === 'ACCEPTED' || value === 'DECLINED' || value === 'CANCELLED';
+}
+
+export function parseTripInvitationPayload(raw: unknown): TripInvitationPayload | null {
+  if (!isRecord(raw)) {
+    return null;
+  }
+  const tripId = readString(raw, 'trip_id');
+  const tripName = readString(raw, 'trip_name');
+  const destination = readString(raw, 'destination');
+  const startDate = readString(raw, 'start_date');
+  const endDate = readString(raw, 'end_date');
+  const invitationId = readString(raw, 'invitation_id');
+  if (!tripId || !tripName || !destination || !startDate || !endDate || !invitationId) {
+    return null;
+  }
+  return {
+    trip_id: tripId,
+    trip_name: tripName,
+    destination,
+    start_date: startDate,
+    end_date: endDate,
+    invitation_id: invitationId,
+    invitation_status: isInvitationStatus(raw.invitation_status) ? raw.invitation_status : null,
+  };
+}
+
+function parseTripPayload(raw: unknown): TripPayload | null {
+  if (!isRecord(raw)) {
+    return null;
+  }
+  const tripId = readString(raw, 'trip_id');
+  const tripName = readString(raw, 'trip_name');
+  return tripId && tripName ? { trip_id: tripId, trip_name: tripName } : null;
+}
+
+function parseTripResponsePayload(raw: unknown, nameKey: string): TripResponsePayload | null {
+  const trip = parseTripPayload(raw);
+  if (!trip || !isRecord(raw)) {
+    return null;
+  }
+  return {
+    ...trip,
+    responder_name: readString(raw, nameKey),
+  };
+}
+
+function parseTimelineReminderPayload(raw: unknown): TripTimelineReminderPayload | null {
+  const trip = parseTripPayload(raw);
+  if (!trip || !isRecord(raw)) {
+    return null;
+  }
+  const activityId = readString(raw, 'activity_id');
+  const activityTitle = readString(raw, 'activity_title');
+  const sectionLabel = readString(raw, 'section_label');
+  const activityDate = readString(raw, 'activity_date');
+  const activityTime = readString(raw, 'activity_time');
+  const locationLabel = readString(raw, 'location_label');
+  if (!activityId || !activityTitle || !sectionLabel || !activityDate || !activityTime || !locationLabel) {
+    return null;
+  }
+  return {
+    ...trip,
+    activity_id: activityId,
+    activity_title: activityTitle,
+    section_label: sectionLabel,
+    activity_date: activityDate,
+    activity_time: activityTime,
+    location_label: locationLabel,
+  };
+}
+
+export function parseNotificationPayload(notificationType: string, raw: unknown): ParsedNotificationPayload {
+  switch (notificationType) {
+    case 'FRIEND_REQUEST':
+      return isRecord(raw) ? { kind: 'friendRequest' } : { kind: 'fallback' };
+    case 'FRIEND_ACCEPTED':
+      return isRecord(raw) ? { kind: 'friendAccepted' } : { kind: 'fallback' };
+    case 'TRIP_INVITATION': {
+      const invitation = parseTripInvitationPayload(raw);
+      return invitation ? { kind: 'tripInvitation', invitation } : { kind: 'fallback' };
+    }
+    case 'TRIP_INVITATION_ACCEPTED': {
+      const response = parseTripResponsePayload(raw, 'accepted_by_name');
+      return response ? { kind: 'tripInvitationAccepted', response } : { kind: 'fallback' };
+    }
+    case 'TRIP_INVITATION_DECLINED': {
+      const response = parseTripResponsePayload(raw, 'declined_by_name');
+      return response ? { kind: 'tripInvitationDeclined', response } : { kind: 'fallback' };
+    }
+    case 'TRIP_CANCELLED': {
+      const trip = parseTripPayload(raw);
+      return trip ? { kind: 'tripCancelled', trip } : { kind: 'fallback' };
+    }
+    case 'TRIP_MEMBER_REMOVED': {
+      const trip = parseTripPayload(raw);
+      return trip ? { kind: 'tripMemberRemoved', trip } : { kind: 'fallback' };
+    }
+    case 'TRIP_TIMELINE_REMINDER': {
+      const reminder = parseTimelineReminderPayload(raw);
+      return reminder ? { kind: 'tripTimelineReminder', reminder } : { kind: 'fallback' };
+    }
+    default:
+      return { kind: 'fallback' };
+  }
+}
+
+export function getTripTarget(parsed: ParsedNotificationPayload): string | null {
+  switch (parsed.kind) {
+    case 'tripInvitation':
+      return parsed.invitation.invitation_status === 'ACCEPTED' ? parsed.invitation.trip_id : null;
+    case 'tripInvitationAccepted':
+    case 'tripInvitationDeclined':
+      return parsed.response.trip_id;
+    case 'tripCancelled':
+    case 'tripMemberRemoved':
+      return parsed.trip.trip_id;
+    case 'tripTimelineReminder':
+      return parsed.reminder.trip_id;
+    default:
+      return null;
+  }
+}

--- a/mobile/src/features/notifications/screens/NotificationsScreen.tsx
+++ b/mobile/src/features/notifications/screens/NotificationsScreen.tsx
@@ -1,0 +1,260 @@
+import { Ionicons } from '@expo/vector-icons';
+import { useFocusEffect, useRouter } from 'expo-router';
+import { useCallback, useMemo } from 'react';
+import { ActivityIndicator, FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { Button } from '@/shared/ui/Button';
+import { LoadingScreen } from '@/shared/ui/LoadingScreen';
+import { useNotifications } from '../application/NotificationsProvider';
+import { NotificationRow } from '../components/NotificationRow';
+import type { InvitationAction, NotificationItem } from '../types';
+
+const notificationKey = (item: NotificationItem) => item.id;
+
+export function NotificationsScreen() {
+  const router = useRouter();
+  const {
+    items,
+    status,
+    error,
+    errorSource,
+    refreshing,
+    loadingMore,
+    hasNextPage,
+    unreadCount,
+    markingAllRead,
+    pendingReadIds,
+    pendingInvitationActions,
+    rowErrors,
+    globalMutationError,
+    refreshForFocus,
+    refresh,
+    loadMore,
+    markRead,
+    markAllRead,
+    respondToInvitation,
+  } = useNotifications();
+
+  useFocusEffect(
+    useCallback(() => {
+      void refreshForFocus();
+    }, [refreshForFocus]),
+  );
+
+  const hasUnread = useMemo(
+    () => (unreadCount ?? 0) > 0 || items.some((item) => !item.is_read),
+    [items, unreadCount],
+  );
+
+  const openNotification = useCallback(
+    (notificationId: string, tripId: string | null) => {
+      void markRead(notificationId);
+      if (tripId) {
+        router.push(`/trips/${tripId}`);
+      }
+    },
+    [markRead, router],
+  );
+
+  const handleInvitationAction = useCallback(
+    (notificationId: string, invitationId: string, tripId: string, action: InvitationAction) => {
+      void respondToInvitation(notificationId, invitationId, tripId, action);
+    },
+    [respondToInvitation],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: NotificationItem }) => (
+      <NotificationRow
+        notification={item}
+        readPending={pendingReadIds.has(item.id)}
+        pendingInvitationAction={pendingInvitationActions.get(item.id) ?? null}
+        error={rowErrors.get(item.id) ?? null}
+        onOpen={openNotification}
+        onInvitationAction={handleInvitationAction}
+      />
+    ),
+    [
+      handleInvitationAction,
+      openNotification,
+      pendingInvitationActions,
+      pendingReadIds,
+      rowErrors,
+    ],
+  );
+
+  const autoLoadMore = useCallback(() => {
+    if (hasNextPage && errorSource !== 'loadMore') {
+      void loadMore();
+    }
+  }, [errorSource, hasNextPage, loadMore]);
+
+  const header = (
+    <View style={styles.header}>
+      <Text accessibilityRole="header" style={styles.title}>
+        Notifications
+      </Text>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Mark all notifications as read"
+        accessibilityState={{ disabled: !hasUnread || markingAllRead, busy: markingAllRead }}
+        disabled={!hasUnread || markingAllRead}
+        onPress={() => void markAllRead()}
+        style={({ pressed }) => [
+          styles.markAllButton,
+          pressed && !markingAllRead ? styles.pressed : null,
+          !hasUnread && !markingAllRead ? styles.disabledButton : null,
+        ]}
+      >
+        {markingAllRead ? (
+          <ActivityIndicator size="small" color={colors.primary} />
+        ) : (
+          <Text style={[styles.markAllText, !hasUnread ? styles.disabledText : null]}>Mark all read</Text>
+        )}
+      </Pressable>
+    </View>
+  );
+
+  if (status === 'loading') {
+    return (
+      <SafeAreaView style={styles.safe}>
+        {header}
+        <LoadingScreen />
+      </SafeAreaView>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <SafeAreaView style={styles.safe}>
+        {header}
+        <View style={styles.centered}>
+          <Ionicons name="cloud-offline-outline" size={44} color={colors.textMuted} />
+          <Text style={styles.stateTitle}>Could not load notifications</Text>
+          <Text style={styles.stateBody}>{error?.message}</Text>
+          <Button title="Try again" onPress={() => void refreshForFocus()} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const inlineError = globalMutationError ?? (errorSource === 'refresh' ? error : null);
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+      {header}
+      {inlineError ? (
+        <View accessibilityRole="alert" style={styles.inlineError}>
+          <Ionicons name="alert-circle-outline" size={20} color={colors.danger} />
+          <Text style={styles.inlineErrorText}>{inlineError.message}</Text>
+          {!globalMutationError ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Retry refreshing notifications"
+              onPress={() => void refresh()}
+              style={({ pressed }) => [styles.retryButton, pressed ? styles.pressed : null]}
+            >
+              <Text style={styles.retryText}>Retry</Text>
+            </Pressable>
+          ) : null}
+        </View>
+      ) : null}
+      <FlatList
+        style={styles.list}
+        data={items}
+        keyExtractor={notificationKey}
+        renderItem={renderItem}
+        contentContainerStyle={items.length === 0 ? styles.emptyContainer : styles.listContent}
+        onRefresh={() => void refresh()}
+        refreshing={refreshing}
+        onEndReached={autoLoadMore}
+        onEndReachedThreshold={0.4}
+        ListEmptyComponent={
+          <View style={styles.emptyState}>
+            <Ionicons name="notifications-off-outline" size={44} color={colors.textMuted} />
+            <Text style={styles.stateTitle}>No notifications yet</Text>
+            <Text style={styles.stateBody}>Trip updates and friend activity will appear here.</Text>
+          </View>
+        }
+        ListFooterComponent={
+          errorSource === 'loadMore' && error ? (
+            <View accessibilityRole="alert" style={styles.footerError}>
+              <Text style={styles.footerErrorText}>{error.message}</Text>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Retry loading more notifications"
+                onPress={() => void loadMore()}
+                style={({ pressed }) => [styles.retryButton, pressed ? styles.pressed : null]}
+              >
+                <Text style={styles.retryText}>Try again</Text>
+              </Pressable>
+            </View>
+          ) : loadingMore ? (
+            <ActivityIndicator style={styles.footerSpinner} color={colors.primary} />
+          ) : null
+        }
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.background },
+  header: {
+    minHeight: 66,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  title: { ...typography.largeTitle, color: colors.text, flexShrink: 1 },
+  markAllButton: {
+    minHeight: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.sm,
+    borderRadius: radii.md,
+    borderCurve: 'continuous',
+    backgroundColor: colors.primarySoft,
+  },
+  disabledButton: { backgroundColor: colors.surface },
+  markAllText: { ...typography.label, color: colors.primary },
+  disabledText: { color: colors.textMuted },
+  pressed: { opacity: 0.55 },
+  list: { flex: 1 },
+  listContent: { paddingHorizontal: spacing.md, paddingBottom: spacing.xl, gap: spacing.sm },
+  emptyContainer: { flexGrow: 1, justifyContent: 'center', padding: spacing.lg },
+  emptyState: { alignItems: 'center', gap: spacing.md },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.md,
+    padding: spacing.lg,
+  },
+  stateTitle: { ...typography.heading, color: colors.text },
+  stateBody: { ...typography.body, color: colors.textMuted, textAlign: 'center' },
+  inlineError: {
+    minHeight: 48,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    marginHorizontal: spacing.md,
+    marginBottom: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.dangerBorder,
+    borderRadius: radii.md,
+    borderCurve: 'continuous',
+    backgroundColor: colors.dangerSoft,
+  },
+  inlineErrorText: { ...typography.caption, color: colors.danger, flex: 1 },
+  retryButton: { minHeight: 44, justifyContent: 'center', paddingHorizontal: spacing.xs },
+  retryText: { ...typography.label, color: colors.danger },
+  footerSpinner: { marginVertical: spacing.md },
+  footerError: { alignItems: 'center', gap: spacing.xs, paddingVertical: spacing.md },
+  footerErrorText: { ...typography.caption, color: colors.danger, textAlign: 'center' },
+});

--- a/mobile/src/features/notifications/types.ts
+++ b/mobile/src/features/notifications/types.ts
@@ -1,0 +1,115 @@
+import type { ApiError } from '@/shared/api/errors';
+
+export const NOTIFICATION_TYPES = [
+  'FRIEND_REQUEST',
+  'FRIEND_ACCEPTED',
+  'TRIP_INVITATION',
+  'TRIP_INVITATION_ACCEPTED',
+  'TRIP_INVITATION_DECLINED',
+  'TRIP_CANCELLED',
+  'TRIP_MEMBER_REMOVED',
+  'TRIP_TIMELINE_REMINDER',
+] as const;
+
+export type NotificationType = (typeof NOTIFICATION_TYPES)[number];
+export type InvitationStatus = 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'CANCELLED';
+
+export interface NotificationActor {
+  id: string;
+  display_name: string;
+  identify_tag: string | null;
+}
+
+export interface NotificationItem {
+  id: string;
+  notification_type: string;
+  actor: NotificationActor | null;
+  payload: unknown;
+  is_read: boolean;
+  read_at: string | null;
+  created_at: string;
+}
+
+export interface NotificationPage {
+  items: NotificationItem[];
+  nextCursor: string | null;
+}
+
+export type NotificationListStatus = 'loading' | 'ready' | 'error';
+export type NotificationLoadMode = 'initial' | 'refresh' | 'silent';
+export type NotificationErrorSource = 'initial' | 'refresh' | 'loadMore' | null;
+export type InvitationAction = 'accept' | 'decline';
+
+export interface TripInvitationPayload {
+  trip_id: string;
+  trip_name: string;
+  destination: string;
+  start_date: string;
+  end_date: string;
+  invitation_id: string;
+  invitation_status: InvitationStatus | null;
+}
+
+export interface TripResponsePayload {
+  trip_id: string;
+  trip_name: string;
+  responder_name: string | null;
+}
+
+export interface TripPayload {
+  trip_id: string;
+  trip_name: string;
+}
+
+export interface TripTimelineReminderPayload extends TripPayload {
+  activity_id: string;
+  activity_title: string;
+  section_label: string;
+  activity_date: string;
+  activity_time: string;
+  location_label: string;
+}
+
+export type ParsedNotificationPayload =
+  | { kind: 'friendRequest' }
+  | { kind: 'friendAccepted' }
+  | { kind: 'tripInvitation'; invitation: TripInvitationPayload }
+  | { kind: 'tripInvitationAccepted'; response: TripResponsePayload }
+  | { kind: 'tripInvitationDeclined'; response: TripResponsePayload }
+  | { kind: 'tripCancelled'; trip: TripPayload }
+  | { kind: 'tripMemberRemoved'; trip: TripPayload }
+  | { kind: 'tripTimelineReminder'; reminder: TripTimelineReminderPayload }
+  | { kind: 'fallback' };
+
+export interface NotificationOverride {
+  version: number;
+  isRead?: boolean;
+  invitationStatus?: InvitationStatus | null;
+}
+
+export interface NotificationsContextValue {
+  items: NotificationItem[];
+  status: NotificationListStatus;
+  error: ApiError | null;
+  errorSource: NotificationErrorSource;
+  refreshing: boolean;
+  loadingMore: boolean;
+  hasNextPage: boolean;
+  unreadCount: number | null;
+  markingAllRead: boolean;
+  pendingReadIds: ReadonlySet<string>;
+  pendingInvitationActions: ReadonlyMap<string, InvitationAction>;
+  rowErrors: ReadonlyMap<string, ApiError>;
+  globalMutationError: ApiError | null;
+  refreshForFocus: () => Promise<void>;
+  refresh: () => Promise<void>;
+  loadMore: () => Promise<void>;
+  markRead: (notificationId: string) => Promise<boolean>;
+  markAllRead: () => Promise<boolean>;
+  respondToInvitation: (
+    notificationId: string,
+    invitationId: string,
+    tripId: string,
+    action: InvitationAction,
+  ) => Promise<boolean>;
+}

--- a/mobile/src/features/trips/__tests__/InviteMembersScreen.test.tsx
+++ b/mobile/src/features/trips/__tests__/InviteMembersScreen.test.tsx
@@ -1,0 +1,198 @@
+const mockParams = { tripId: 'trip-1' };
+const mockRouter = {
+  canGoBack: jest.fn(),
+  back: jest.fn(),
+  replace: jest.fn(),
+};
+const mockUseTripDetail = jest.fn();
+const mockUseInviteMembers = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: () => mockParams,
+  useRouter: () => mockRouter,
+}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('@/shared/ui/LoadingScreen', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const { Text } = jest.requireActual<typeof import('react-native')>('react-native');
+  return { LoadingScreen: () => React.createElement(Text, null, 'Loading') };
+});
+jest.mock('../hooks/useTripDetail', () => ({
+  useTripDetail: (...args: unknown[]) => mockUseTripDetail(...args),
+}));
+jest.mock('../hooks/useInviteMembers', () => ({
+  useInviteMembers: (...args: unknown[]) => mockUseInviteMembers(...args),
+}));
+
+// eslint-disable-next-line import/first
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { InviteMembersScreen } from '../screens/InviteMembersScreen';
+// eslint-disable-next-line import/first
+import type { TripDetailResponse } from '../types';
+
+const detail: TripDetailResponse = {
+  trip: {
+    id: 'trip-1',
+    name: 'Da Lat escape',
+    destination: 'Da Lat, Vietnam',
+    destination_provider: '',
+    destination_provider_id: '',
+    destination_lat: null,
+    destination_lng: null,
+    destination_country_code: 'VN',
+    cover_image_url: '',
+    start_date: '2026-08-01',
+    end_date: '2026-08-03',
+    description: '',
+    status: 'PLANNING',
+    currency_code: 'VND',
+    timezone: 'Asia/Ho_Chi_Minh',
+    budget_estimate: null,
+    cancelled_at: null,
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  my_membership: {
+    role: 'CAPTAIN',
+    status: 'ACTIVE',
+    joined_at: '2026-01-01T00:00:00Z',
+  },
+  members: [],
+};
+
+function readyDetail(nextDetail: TripDetailResponse = detail) {
+  return {
+    detail: nextDetail,
+    status: 'ready' as const,
+    error: null,
+    refreshing: false,
+    refresh: jest.fn(),
+  };
+}
+
+function readyInvite(overrides: Record<string, unknown> = {}) {
+  return {
+    items: [
+      {
+        id: 'user-1',
+        display_name: 'Lan Nguyen',
+        identify_tag: 'lan#1234',
+      },
+    ],
+    status: 'ready' as const,
+    loadError: null,
+    selectedIds: new Set<string>(),
+    selectionError: null,
+    submitError: null,
+    submitting: false,
+    load: jest.fn(),
+    toggleSelection: jest.fn(),
+    submit: jest.fn().mockResolvedValue(false),
+    ...overrides,
+  };
+}
+
+describe('InviteMembersScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseTripDetail.mockReturnValue(readyDetail());
+    mockUseInviteMembers.mockReturnValue(readyInvite());
+    mockRouter.canGoBack.mockReturnValue(true);
+  });
+
+  it('renders eligible friends as a native multi-select list', async () => {
+    const invite = readyInvite();
+    mockUseInviteMembers.mockReturnValue(invite);
+    await render(<InviteMembersScreen />);
+
+    expect(await screen.findByText('Choose friends')).toBeTruthy();
+    const friend = screen.getByRole('checkbox', { name: 'Invite Lan Nguyen' });
+    expect(friend.props.accessibilityState).toEqual({ checked: false, disabled: false });
+    await fireEvent.press(friend);
+    expect(invite.toggleSelection).toHaveBeenCalledWith('user-1');
+    expect(screen.getByRole('button', { name: 'Send invitations' }).props.accessibilityState).toEqual({
+      disabled: true,
+      busy: false,
+    });
+  });
+
+  it('closes after a successful send and falls back to the trip route without history', async () => {
+    const submit = jest.fn().mockResolvedValue(true);
+    mockUseInviteMembers.mockReturnValue(
+      readyInvite({ selectedIds: new Set(['user-1']), submit }),
+    );
+    const { rerender } = await render(<InviteMembersScreen />);
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Send invitations (1)' }));
+    await waitFor(() => expect(mockRouter.back).toHaveBeenCalledTimes(1));
+
+    jest.clearAllMocks();
+    mockUseTripDetail.mockReturnValue(readyDetail());
+    mockUseInviteMembers.mockReturnValue(
+      readyInvite({ selectedIds: new Set(['user-1']), submit }),
+    );
+    mockRouter.canGoBack.mockReturnValue(false);
+    await rerender(<InviteMembersScreen />);
+    await fireEvent.press(screen.getByRole('button', { name: 'Send invitations (1)' }));
+    await waitFor(() => expect(mockRouter.replace).toHaveBeenCalledWith('/trips/trip-1'));
+  });
+
+  it.each([
+    ['MEMBER', 'PLANNING'],
+    ['CAPTAIN', 'COMPLETED'],
+    ['CAPTAIN', 'CANCELLED'],
+  ] as const)('guards direct links for a %s on a %s trip', async (role, status) => {
+    mockUseTripDetail.mockReturnValue(
+      readyDetail({
+        ...detail,
+        trip: { ...detail.trip, status },
+        my_membership: { ...detail.my_membership, role },
+      }),
+    );
+    await render(<InviteMembersScreen />);
+
+    expect(await screen.findByText('Invitations unavailable')).toBeTruthy();
+    expect(mockUseInviteMembers).toHaveBeenCalledWith('trip-1', false);
+    expect(screen.queryByText('Lan Nguyen')).toBeNull();
+  });
+
+  it('shows retry and empty states without submitting', async () => {
+    const load = jest.fn();
+    mockUseInviteMembers.mockReturnValue(
+      readyInvite({
+        items: [],
+        status: 'error',
+        loadError: { kind: 'network', message: 'Cannot reach the server.' },
+        load,
+      }),
+    );
+    const { rerender } = await render(<InviteMembersScreen />);
+    expect(await screen.findByText('Could not load eligible friends')).toBeTruthy();
+    await fireEvent.press(screen.getByRole('button', { name: 'Try again' }));
+    expect(load).toHaveBeenCalledWith('initial');
+
+    mockUseInviteMembers.mockReturnValue(readyInvite({ items: [] }));
+    await rerender(<InviteMembersScreen />);
+    expect(await screen.findByText('No eligible friends')).toBeTruthy();
+    expect(screen.getByText('Select at least one friend to continue.')).toBeTruthy();
+  });
+
+  it('renders normalized selection, field, and business errors', async () => {
+    mockUseInviteMembers.mockReturnValue(
+      readyInvite({
+        selectedIds: new Set(['user-1']),
+        selectionError: 'You can select up to 20 friends.',
+        submitError: {
+          kind: 'field',
+          message: 'Please fix the highlighted fields.',
+          fieldErrors: { invitee_ids: 'One or more users cannot be invited.' },
+        },
+      }),
+    );
+    await render(<InviteMembersScreen />);
+
+    expect(await screen.findByText('You can select up to 20 friends.')).toBeTruthy();
+    expect(screen.getByText('One or more users cannot be invited.')).toBeTruthy();
+  });
+});

--- a/mobile/src/features/trips/__tests__/MemberRow.test.tsx
+++ b/mobile/src/features/trips/__tests__/MemberRow.test.tsx
@@ -1,0 +1,47 @@
+jest.mock('expo-image', () => ({ Image: () => null }));
+
+// eslint-disable-next-line import/first
+import { fireEvent, render, screen } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { MemberRow } from '../components/MemberRow';
+// eslint-disable-next-line import/first
+import type { TripMember } from '../types';
+
+const member: TripMember = {
+  membership_id: 'membership-2',
+  user: {
+    id: 'user-2',
+    display_name: 'Lan Nguyen',
+    identify_tag: 'lan#1234',
+    avatar_url: null,
+  },
+  role: 'MEMBER',
+  joined_at: '2026-01-02T00:00:00Z',
+};
+
+describe('MemberRow', () => {
+  it('only offers removal when captain controls explicitly enable it', async () => {
+    const onRemoveRequest = jest.fn();
+    const { rerender } = await render(
+      <MemberRow member={member} onRemoveRequest={onRemoveRequest} />,
+    );
+    expect(screen.queryByRole('button', { name: 'Remove Lan Nguyen from trip' })).toBeNull();
+
+    await rerender(
+      <MemberRow member={member} showRemove onRemoveRequest={onRemoveRequest} />,
+    );
+    await fireEvent.press(screen.getByRole('button', { name: 'Remove Lan Nguyen from trip' }));
+    expect(onRemoveRequest).toHaveBeenCalledWith('user-2', 'Lan Nguyen');
+  });
+
+  it('locks the remove control while its mutation is running', async () => {
+    const onRemoveRequest = jest.fn();
+    await render(
+      <MemberRow member={member} showRemove removing onRemoveRequest={onRemoveRequest} />,
+    );
+    const button = screen.getByRole('button', { name: 'Remove Lan Nguyen from trip' });
+    expect(button.props.accessibilityState).toEqual({ disabled: true, busy: true });
+    await fireEvent.press(button);
+    expect(onRemoveRequest).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/features/trips/__tests__/TripDetailScreen.test.tsx
+++ b/mobile/src/features/trips/__tests__/TripDetailScreen.test.tsx
@@ -1,8 +1,15 @@
 import { Alert } from 'react-native';
 
 const mockParams = { tripId: 'trip-123' };
-const mockRouter = { push: jest.fn(), dismissTo: jest.fn() };
+const mockRouter = {
+  push: jest.fn(),
+  dismissTo: jest.fn(),
+  canGoBack: jest.fn(),
+  back: jest.fn(),
+  replace: jest.fn(),
+};
 const mockUseTripDetail = jest.fn();
+const mockUsePendingInvitations = jest.fn();
 const mockPublishTripEvent = jest.fn();
 
 interface MockStackScreenProps {
@@ -20,12 +27,16 @@ jest.mock('expo-router', () => ({
 jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
 jest.mock('expo-image', () => ({ Image: () => null }));
 jest.mock('../hooks/useTripDetail', () => ({ useTripDetail: (...args: unknown[]) => mockUseTripDetail(...args) }));
+jest.mock('../hooks/usePendingInvitations', () => ({
+  usePendingInvitations: (...args: unknown[]) => mockUsePendingInvitations(...args),
+}));
 jest.mock('../tripEvents', () => ({ publishTripEvent: (...args: unknown[]) => mockPublishTripEvent(...args) }));
 jest.mock('../api', () => ({
   startTrip: jest.fn(),
   completeTrip: jest.fn(),
   cancelTrip: jest.fn(),
   leaveTrip: jest.fn(),
+  removeTripMember: jest.fn(),
 }));
 
 // eslint-disable-next-line import/first
@@ -33,7 +44,7 @@ import { AxiosError, AxiosHeaders } from 'axios';
 // eslint-disable-next-line import/first
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 // eslint-disable-next-line import/first
-import { cancelTrip, completeTrip, leaveTrip, startTrip } from '../api';
+import { cancelTrip, completeTrip, leaveTrip, removeTripMember, startTrip } from '../api';
 // eslint-disable-next-line import/first
 import { TripDetailScreen } from '../screens/TripDetailScreen';
 // eslint-disable-next-line import/first
@@ -45,6 +56,7 @@ const mockStartTrip = startTrip as jest.MockedFunction<typeof startTrip>;
 const mockCompleteTrip = completeTrip as jest.MockedFunction<typeof completeTrip>;
 const mockCancelTrip = cancelTrip as jest.MockedFunction<typeof cancelTrip>;
 const mockLeaveTrip = leaveTrip as jest.MockedFunction<typeof leaveTrip>;
+const mockRemoveTripMember = removeTripMember as jest.MockedFunction<typeof removeTripMember>;
 const notFoundError: ApiError = { kind: 'message', message: 'Trip not found.', errorCode: 'TRIP_NOT_FOUND', status: 404 };
 
 function axiosErrorWith(status: number, data: unknown): AxiosError {
@@ -90,6 +102,18 @@ const tripDetail: TripDetailResponse = {
   ],
 };
 
+const member = {
+  membership_id: 'membership-2',
+  user: {
+    id: 'user-2',
+    display_name: 'Lan Nguyen',
+    identify_tag: 'lan#1234',
+    avatar_url: null,
+  },
+  role: 'MEMBER' as const,
+  joined_at: '2026-01-02T00:00:00Z',
+};
+
 function readyHook(detail: TripDetailResponse = tripDetail) {
   return {
     detail,
@@ -98,6 +122,16 @@ function readyHook(detail: TripDetailResponse = tripDetail) {
     refreshing: false,
     refresh: jest.fn().mockResolvedValue(undefined),
     applyStatus: jest.fn(),
+  };
+}
+
+function readyPendingHook() {
+  return {
+    items: [],
+    status: 'ready' as const,
+    error: null,
+    refreshing: false,
+    load: jest.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -114,6 +148,7 @@ describe('TripDetailScreen', () => {
     jest.clearAllMocks();
     mockParams.tripId = 'trip-123';
     mockUseTripDetail.mockReturnValue(readyHook());
+    mockUsePendingInvitations.mockReturnValue(readyPendingHook());
   });
 
   afterEach(() => jest.restoreAllMocks());
@@ -128,9 +163,12 @@ describe('TripDetailScreen', () => {
     expect(screen.getByText('Members (1)')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Start trip' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Cancel trip' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Invite friends' })).toBeTruthy();
 
     await fireEvent.press(screen.getByRole('button', { name: 'Edit trip' }));
     expect(mockRouter.push).toHaveBeenCalledWith('/trips/trip-123/edit');
+    await fireEvent.press(screen.getByRole('button', { name: 'Invite friends' }));
+    expect(mockRouter.push).toHaveBeenCalledWith('/trips/trip-123/invite');
   });
 
   it('shows only leave for an active member and no actions for a terminal trip', async () => {
@@ -146,6 +184,7 @@ describe('TripDetailScreen', () => {
     );
     await rerender(<TripDetailScreen />);
     expect(screen.queryByLabelText('Trip actions')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Invite friends' })).toBeNull();
   });
 
   it('applies a successful start immediately, publishes it, and silently refreshes', async () => {
@@ -214,6 +253,127 @@ describe('TripDetailScreen', () => {
 
     await fireEvent.press(screen.getByRole('button', { name: 'Start trip' }));
     expect(await screen.findByText('This trip cannot be started from its current status.')).toBeTruthy();
+  });
+
+  it('keeps a pending-invitation failure isolated from the rest of trip detail', async () => {
+    const pending = {
+      ...readyPendingHook(),
+      status: 'error' as const,
+      error: { kind: 'message', message: 'Invitations are temporarily unavailable.' },
+    };
+    mockUsePendingInvitations.mockReturnValue(pending);
+    await render(<TripDetailScreen />);
+
+    expect(await screen.findByText('Overview')).toBeTruthy();
+    expect(screen.getByText('Invitations are temporarily unavailable.')).toBeTruthy();
+    await fireEvent.press(screen.getByRole('button', { name: 'Retry pending invitations' }));
+    expect(pending.load).toHaveBeenCalledWith('initial');
+  });
+
+  it('shows a retry when an empty pending list fails to refresh', async () => {
+    const pending = {
+      ...readyPendingHook(),
+      error: { kind: 'message', message: 'Could not refresh invitations.' },
+    };
+    mockUsePendingInvitations.mockReturnValue(pending);
+    await render(<TripDetailScreen />);
+
+    expect(await screen.findByText('No pending invitations.')).toBeTruthy();
+    expect(screen.getByText('Could not refresh invitations.')).toBeTruthy();
+    await fireEvent.press(screen.getByRole('button', { name: 'Retry pending invitations' }));
+    expect(pending.load).toHaveBeenCalledWith('silent');
+  });
+
+  it('shows pending invitee identity, status, and creation time for captains', async () => {
+    mockUsePendingInvitations.mockReturnValue({
+      ...readyPendingHook(),
+      items: [
+        {
+          id: 'invitation-1',
+          invitee: { id: 'user-2', display_name: 'Lan Nguyen', identify_tag: 'lan#1234' },
+          status: 'PENDING',
+          created_at: '2026-07-22T08:00:00Z',
+        },
+      ],
+    });
+    await render(<TripDetailScreen />);
+
+    expect(await screen.findByText('Lan Nguyen')).toBeTruthy();
+    expect(screen.getByText('lan#1234')).toBeTruthy();
+    expect(screen.getByText('Pending')).toBeTruthy();
+    expect(screen.getByText(/^Invited /)).toBeTruthy();
+  });
+
+  it('confirms member removal once, publishes the local event, and refreshes detail', async () => {
+    const hook = readyHook({ ...tripDetail, members: [...tripDetail.members, member] });
+    mockUseTripDetail.mockReturnValue(hook);
+    mockRemoveTripMember.mockResolvedValue(undefined);
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+    await render(<TripDetailScreen />);
+
+    const removeButton = screen.getByRole('button', { name: 'Remove Lan Nguyen from trip' });
+    await fireEvent.press(removeButton);
+    await fireEvent.press(removeButton);
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('button', { name: 'Remove Quang Minh from trip' })).toBeNull();
+
+    await confirmAlertAction('Remove member');
+
+    await waitFor(() => expect(mockRemoveTripMember).toHaveBeenCalledWith('trip-123', 'user-2'));
+    expect(mockPublishTripEvent).toHaveBeenCalledWith({
+      type: 'memberRemoved',
+      tripId: 'trip-123',
+      userId: 'user-2',
+    });
+    expect(hook.refresh).toHaveBeenCalledWith('silent');
+  });
+
+  it('shows the normalized member-removal error without publishing a local removal', async () => {
+    mockUseTripDetail.mockReturnValue(
+      readyHook({ ...tripDetail, members: [...tripDetail.members, member] }),
+    );
+    mockRemoveTripMember.mockRejectedValue(
+      axiosErrorWith(409, {
+        detail: 'This trip is in a terminal state.',
+        error_code: 'TRIP_TERMINAL',
+      }),
+    );
+    jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+    await render(<TripDetailScreen />);
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Remove Lan Nguyen from trip' }),
+    );
+    await confirmAlertAction('Remove member');
+
+    expect(await screen.findByText('This trip is in a terminal state.')).toBeTruthy();
+    expect(mockPublishTripEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'memberRemoved' }),
+    );
+  });
+
+  it('hides captain-only member controls from members and terminal trips', async () => {
+    const detailWithMember = { ...tripDetail, members: [...tripDetail.members, member] };
+    mockUseTripDetail.mockReturnValue(
+      readyHook({
+        ...detailWithMember,
+        my_membership: { ...detailWithMember.my_membership, role: 'MEMBER' },
+      }),
+    );
+    const { rerender } = await render(<TripDetailScreen />);
+    expect(screen.queryByRole('button', { name: 'Invite friends' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Remove Lan Nguyen from trip' })).toBeNull();
+    expect(screen.queryByText('Pending invitations')).toBeNull();
+
+    mockUseTripDetail.mockReturnValue(
+      readyHook({
+        ...detailWithMember,
+        trip: { ...detailWithMember.trip, status: 'CANCELLED' },
+      }),
+    );
+    await rerender(<TripDetailScreen />);
+    expect(screen.queryByRole('button', { name: 'Invite friends' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Remove Lan Nguyen from trip' })).toBeNull();
   });
 
   it('shows one friendly not-found state for a 404 response', async () => {

--- a/mobile/src/features/trips/__tests__/api.test.ts
+++ b/mobile/src/features/trips/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 jest.mock('@/shared/api/client', () => ({
-  apiClient: { get: jest.fn(), patch: jest.fn(), post: jest.fn() },
+  apiClient: { delete: jest.fn(), get: jest.fn(), patch: jest.fn(), post: jest.fn() },
 }));
 
 // eslint-disable-next-line import/first
@@ -13,12 +13,17 @@ import {
   createTrip,
   getTripDetail,
   leaveTrip,
+  listInvitableFriends,
+  listPendingInvitations,
   listTrips,
+  removeTripMember,
+  sendTripInvitations,
   startTrip,
   updateTrip,
 } from '../api';
 
 const mockGet = apiClient.get as jest.MockedFunction<typeof apiClient.get>;
+const mockDelete = apiClient.delete as jest.MockedFunction<typeof apiClient.delete>;
 const mockPatch = apiClient.patch as jest.MockedFunction<typeof apiClient.patch>;
 const mockPost = apiClient.post as jest.MockedFunction<typeof apiClient.post>;
 
@@ -113,5 +118,43 @@ describe('trips api', () => {
     await expect(leaveTrip('t1')).resolves.toBeUndefined();
 
     expect(mockPost).toHaveBeenCalledWith('/trips/t1/leave');
+  });
+
+  it('lists invitable friends and pending invitations from trip-scoped endpoints', async () => {
+    const friend = { id: 'user-1', display_name: 'Lan', identify_tag: 'lan#1234' };
+    const invitation = {
+      id: 'invitation-1',
+      invitee: friend,
+      status: 'PENDING',
+      created_at: '2026-07-22T08:00:00Z',
+    };
+    mockGet
+      .mockResolvedValueOnce({ data: { users: [friend] } } as never)
+      .mockResolvedValueOnce({ data: { invitations: [invitation] } } as never);
+
+    await expect(listInvitableFriends('t1')).resolves.toEqual([friend]);
+    await expect(listPendingInvitations('t1')).resolves.toEqual([invitation]);
+
+    expect(mockGet).toHaveBeenNthCalledWith(1, '/trips/t1/invitations/invitable-friends');
+    expect(mockGet).toHaveBeenNthCalledWith(2, '/trips/t1/invitations');
+  });
+
+  it('sends unique invitee ids and unwraps created invitations', async () => {
+    const invitations = [{ id: 'invitation-1' }];
+    mockPost.mockResolvedValue({ data: { invitations } } as never);
+
+    await expect(sendTripInvitations('t1', ['user-1', 'user-2'])).resolves.toEqual(invitations);
+
+    expect(mockPost).toHaveBeenCalledWith('/trips/t1/invitations', {
+      invitee_ids: ['user-1', 'user-2'],
+    });
+  });
+
+  it('removes a trip member through the member endpoint', async () => {
+    mockDelete.mockResolvedValue({ data: {} } as never);
+
+    await expect(removeTripMember('t1', 'user-2')).resolves.toBeUndefined();
+
+    expect(mockDelete).toHaveBeenCalledWith('/trips/t1/members/user-2');
   });
 });

--- a/mobile/src/features/trips/__tests__/useInviteMembers.test.tsx
+++ b/mobile/src/features/trips/__tests__/useInviteMembers.test.tsx
@@ -1,0 +1,285 @@
+const mockUseFocusEffect = jest.fn();
+const mockUseAppForegroundEffect = jest.fn();
+const mockPublishTripEvent = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useFocusEffect: (effect: () => (() => void) | void) => mockUseFocusEffect(effect),
+}));
+
+jest.mock('@/shared/hooks/useAppForegroundEffect', () => ({
+  useAppForegroundEffect: (listener: () => void) => mockUseAppForegroundEffect(listener),
+}));
+
+jest.mock('../api', () => ({
+  listInvitableFriends: jest.fn(),
+  sendTripInvitations: jest.fn(),
+}));
+
+jest.mock('../tripEvents', () => ({
+  publishTripEvent: (...args: unknown[]) => mockPublishTripEvent(...args),
+}));
+
+// eslint-disable-next-line import/first
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { AxiosError, AxiosHeaders } from 'axios';
+// eslint-disable-next-line import/first
+import { listInvitableFriends, sendTripInvitations } from '../api';
+// eslint-disable-next-line import/first
+import { MAX_INVITEES_PER_REQUEST, useInviteMembers } from '../hooks/useInviteMembers';
+// eslint-disable-next-line import/first
+import type { InvitableFriend, TripInvitation } from '../types';
+
+const mockListInvitableFriends = listInvitableFriends as jest.MockedFunction<
+  typeof listInvitableFriends
+>;
+const mockSendTripInvitations = sendTripInvitations as jest.MockedFunction<
+  typeof sendTripInvitations
+>;
+
+const friend: InvitableFriend = {
+  id: 'user-1',
+  display_name: 'Lan Nguyen',
+  identify_tag: 'lan#1234',
+};
+
+const invitation: TripInvitation = {
+  id: 'invitation-1',
+  invitee: friend,
+  status: 'PENDING',
+  created_at: '2026-07-22T08:00:00Z',
+};
+
+function latestFocusCallback(): () => (() => void) | void {
+  const callback = mockUseFocusEffect.mock.calls.at(-1)?.[0] as
+    | (() => (() => void) | void)
+    | undefined;
+  if (!callback) {
+    throw new Error('Expected useFocusEffect to register a callback.');
+  }
+  return callback;
+}
+
+function latestForegroundCallback(): () => void {
+  const callback = mockUseAppForegroundEffect.mock.calls.at(-1)?.[0] as (() => void) | undefined;
+  if (!callback) {
+    throw new Error('Expected useAppForegroundEffect to register a callback.');
+  }
+  return callback;
+}
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, {}, {
+    status,
+    statusText: '',
+    headers: {},
+    config,
+    data,
+  });
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+describe('useInviteMembers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads eligible friends on focus only when the route guard enables it', async () => {
+    mockListInvitableFriends.mockResolvedValue([friend]);
+    const disabled = await renderHook(() => useInviteMembers('trip-1', false));
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    expect(mockListInvitableFriends).not.toHaveBeenCalled();
+    await disabled.unmount();
+
+    const { result } = await renderHook(() => useInviteMembers('trip-1', true));
+    await act(async () => {
+      latestFocusCallback()();
+    });
+
+    await waitFor(() => expect(result.current.items).toEqual([friend]));
+    expect(mockListInvitableFriends).toHaveBeenCalledWith('trip-1');
+    expect(result.current.status).toBe('ready');
+  });
+
+  it('keeps selection unique and enforces the backend maximum of 20', async () => {
+    const friends = Array.from({ length: MAX_INVITEES_PER_REQUEST + 1 }, (_, index) => ({
+      ...friend,
+      id: `user-${index + 1}`,
+      identify_tag: `user#${index + 1}`,
+    }));
+    mockListInvitableFriends.mockResolvedValue(friends);
+    const { result } = await renderHook(() => useInviteMembers('trip-1', true));
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.items).toHaveLength(friends.length));
+
+    await act(async () => {
+      for (const item of friends.slice(0, MAX_INVITEES_PER_REQUEST)) {
+        result.current.toggleSelection(item.id);
+      }
+      result.current.toggleSelection(friends[0].id);
+      result.current.toggleSelection(friends[0].id);
+      result.current.toggleSelection(friends[MAX_INVITEES_PER_REQUEST].id);
+    });
+
+    expect(result.current.selectedIds.size).toBe(MAX_INVITEES_PER_REQUEST);
+    expect(result.current.selectionError).toBe('You can select up to 20 friends.');
+  });
+
+  it('handles an empty selection without calling the API', async () => {
+    mockListInvitableFriends.mockResolvedValue([]);
+    const { result } = await renderHook(() => useInviteMembers('trip-1', true));
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    let succeeded = true;
+    await act(async () => {
+      succeeded = await result.current.submit();
+    });
+
+    expect(succeeded).toBe(false);
+    expect(mockSendTripInvitations).not.toHaveBeenCalled();
+    expect(result.current.selectionError).toBe('Select at least one friend.');
+  });
+
+  it('blocks duplicate submits, publishes created invitations, and clears selection', async () => {
+    const pending = deferred<TripInvitation[]>();
+    mockListInvitableFriends.mockResolvedValue([friend]);
+    mockSendTripInvitations.mockReturnValue(pending.promise);
+    const { result } = await renderHook(() => useInviteMembers('trip-1', true));
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    await act(async () => {
+      result.current.toggleSelection(friend.id);
+    });
+
+    let firstSubmit: Promise<boolean> = Promise.resolve(false);
+    let secondResult = true;
+    await act(async () => {
+      firstSubmit = result.current.submit();
+      secondResult = await result.current.submit();
+    });
+    expect(secondResult).toBe(false);
+    expect(mockSendTripInvitations).toHaveBeenCalledTimes(1);
+    expect(mockSendTripInvitations).toHaveBeenCalledWith('trip-1', ['user-1']);
+
+    await act(async () => {
+      pending.resolve([invitation]);
+      await firstSubmit;
+    });
+
+    expect(mockPublishTripEvent).toHaveBeenCalledWith({
+      type: 'invitationsSent',
+      tripId: 'trip-1',
+      invitations: [invitation],
+    });
+    expect(result.current.selectedIds.size).toBe(0);
+    expect(result.current.submitting).toBe(false);
+  });
+
+  it('normalizes backend field and business errors without clearing selection', async () => {
+    mockListInvitableFriends.mockResolvedValue([friend]);
+    mockSendTripInvitations.mockRejectedValue(
+      axiosErrorWith(400, { invitee_ids: ['Choose no more than 20 users.'] }),
+    );
+    const { result } = await renderHook(() => useInviteMembers('trip-1', true));
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    await act(async () => {
+      result.current.toggleSelection(friend.id);
+      await result.current.submit();
+    });
+
+    expect(result.current.submitError).toMatchObject({
+      kind: 'field',
+      fieldErrors: { invitee_ids: 'Choose no more than 20 users.' },
+    });
+    expect(result.current.selectedIds.has(friend.id)).toBe(true);
+  });
+
+  it('does not let an eligible-friends response started before send restore invitees', async () => {
+    const staleFriends = deferred<InvitableFriend[]>();
+    mockListInvitableFriends
+      .mockResolvedValueOnce([friend])
+      .mockReturnValueOnce(staleFriends.promise);
+    mockSendTripInvitations.mockResolvedValue([invitation]);
+    const { result } = await renderHook(() => useInviteMembers('trip-1', true));
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.items).toEqual([friend]));
+
+    await act(async () => {
+      void result.current.load('silent');
+      result.current.toggleSelection(friend.id);
+      await result.current.submit();
+    });
+    expect(result.current.items).toEqual([]);
+
+    await act(async () => {
+      staleFriends.resolve([friend]);
+    });
+    expect(result.current.items).toEqual([]);
+  });
+
+  it('removes invisible selections when foreground refresh changes eligibility', async () => {
+    mockListInvitableFriends
+      .mockResolvedValueOnce([friend])
+      .mockResolvedValueOnce([]);
+    const { result } = await renderHook(() => useInviteMembers('trip-1', true));
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.items).toEqual([friend]));
+    await act(async () => {
+      result.current.toggleSelection(friend.id);
+      latestForegroundCallback()();
+    });
+
+    await waitFor(() => expect(result.current.items).toEqual([]));
+    expect(result.current.selectedIds.size).toBe(0);
+    expect(result.current.selectionError).toBeNull();
+    await act(async () => {
+      await result.current.submit();
+    });
+    expect(mockSendTripInvitations).not.toHaveBeenCalled();
+  });
+
+  it('keeps eligible friends and selections when foreground refresh fails', async () => {
+    mockListInvitableFriends
+      .mockResolvedValueOnce([friend])
+      .mockRejectedValueOnce(new Error('offline'));
+    const { result } = await renderHook(() => useInviteMembers('trip-1', true));
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.items).toEqual([friend]));
+    await act(async () => {
+      result.current.toggleSelection(friend.id);
+      latestForegroundCallback()();
+    });
+
+    await waitFor(() => expect(result.current.loadError).not.toBeNull());
+    expect(result.current.items).toEqual([friend]);
+    expect(result.current.selectedIds.has(friend.id)).toBe(true);
+    expect(result.current.status).toBe('ready');
+  });
+});

--- a/mobile/src/features/trips/__tests__/usePendingInvitations.test.tsx
+++ b/mobile/src/features/trips/__tests__/usePendingInvitations.test.tsx
@@ -1,0 +1,204 @@
+const mockUseFocusEffect = jest.fn();
+const mockUseAppForegroundEffect = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useFocusEffect: (effect: () => (() => void) | void) => mockUseFocusEffect(effect),
+}));
+
+jest.mock('@/shared/hooks/useAppForegroundEffect', () => ({
+  useAppForegroundEffect: (listener: () => void) => mockUseAppForegroundEffect(listener),
+}));
+
+jest.mock('../api', () => ({
+  listPendingInvitations: jest.fn(),
+}));
+
+// eslint-disable-next-line import/first
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { listPendingInvitations } from '../api';
+// eslint-disable-next-line import/first
+import { usePendingInvitations } from '../hooks/usePendingInvitations';
+// eslint-disable-next-line import/first
+import { publishTripEvent } from '../tripEvents';
+// eslint-disable-next-line import/first
+import type { TripInvitation } from '../types';
+
+const mockListPendingInvitations = listPendingInvitations as jest.MockedFunction<
+  typeof listPendingInvitations
+>;
+
+const invitation: TripInvitation = {
+  id: 'invitation-1',
+  invitee: {
+    id: 'user-1',
+    display_name: 'Lan Nguyen',
+    identify_tag: 'lan#1234',
+  },
+  status: 'PENDING',
+  created_at: '2026-07-22T08:00:00Z',
+};
+
+function latestFocusCallback(): () => (() => void) | void {
+  const callback = mockUseFocusEffect.mock.calls.at(-1)?.[0] as
+    | (() => (() => void) | void)
+    | undefined;
+  if (!callback) {
+    throw new Error('Expected useFocusEffect to register a callback.');
+  }
+  return callback;
+}
+
+function latestForegroundCallback(): () => void {
+  const callback = mockUseAppForegroundEffect.mock.calls.at(-1)?.[0] as (() => void) | undefined;
+  if (!callback) {
+    throw new Error('Expected useAppForegroundEffect to register a callback.');
+  }
+  return callback;
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+describe('usePendingInvitations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads independently on focus only for a captain', async () => {
+    mockListPendingInvitations.mockResolvedValue([invitation]);
+    const disabled = await renderHook(() => usePendingInvitations('trip-1', false));
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    expect(mockListPendingInvitations).not.toHaveBeenCalled();
+    await disabled.unmount();
+
+    const { result } = await renderHook(() => usePendingInvitations('trip-1', true));
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.items).toEqual([invitation]));
+    expect(result.current.status).toBe('ready');
+  });
+
+  it('exposes an isolated first-load error without affecting trip detail state', async () => {
+    mockListPendingInvitations.mockRejectedValue(new Error('offline'));
+    const { result } = await renderHook(() => usePendingInvitations('trip-1', true));
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+
+    await waitFor(() => expect(result.current.status).toBe('error'));
+    expect(result.current.error?.message).toBe('Something went wrong. Please try again.');
+    expect(result.current.items).toEqual([]);
+  });
+
+  it('keeps rendered invitations when a foreground refresh fails', async () => {
+    mockListPendingInvitations
+      .mockResolvedValueOnce([invitation])
+      .mockRejectedValueOnce(new Error('offline'));
+    const { result } = await renderHook(() => usePendingInvitations('trip-1', true));
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.items).toEqual([invitation]));
+
+    await act(async () => {
+      latestForegroundCallback()();
+    });
+
+    expect(result.current.status).toBe('ready');
+    expect(result.current.items).toEqual([invitation]);
+    expect(result.current.error).not.toBeNull();
+  });
+
+  it('reconciles pending invitations when the app returns to foreground', async () => {
+    const newerInvitation = {
+      ...invitation,
+      id: 'invitation-2',
+      invitee: { ...invitation.invitee, id: 'user-2', display_name: 'Mai' },
+    };
+    mockListPendingInvitations
+      .mockResolvedValueOnce([invitation])
+      .mockResolvedValueOnce([newerInvitation]);
+    const { result } = await renderHook(() => usePendingInvitations('trip-1', true));
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.items).toEqual([invitation]));
+
+    await act(async () => {
+      latestForegroundCallback()();
+    });
+
+    await waitFor(() => expect(result.current.items).toEqual([newerInvitation]));
+    expect(mockListPendingInvitations).toHaveBeenCalledTimes(2);
+  });
+
+  it('upserts sent invitations and rejects an older pending response', async () => {
+    const staleResponse = deferred<TripInvitation[]>();
+    const newerInvitation: TripInvitation = {
+      ...invitation,
+      id: 'invitation-2',
+      invitee: { ...invitation.invitee, id: 'user-2', display_name: 'Mai' },
+      created_at: '2026-07-22T09:00:00Z',
+    };
+    mockListPendingInvitations.mockReturnValue(staleResponse.promise);
+    const { result } = await renderHook(() => usePendingInvitations('trip-1', true));
+    await act(async () => {
+      latestFocusCallback()();
+      publishTripEvent({
+        type: 'invitationsSent',
+        tripId: 'trip-1',
+        invitations: [newerInvitation],
+      });
+    });
+    expect(result.current.items).toEqual([newerInvitation]);
+
+    await act(async () => {
+      staleResponse.resolve([invitation]);
+    });
+
+    expect(result.current.items).toEqual([newerInvitation]);
+    expect(result.current.status).toBe('ready');
+  });
+
+  it('does not merge invitations retained from a previous trip into the next trip', async () => {
+    const nextTripInvitation: TripInvitation = {
+      ...invitation,
+      id: 'invitation-2',
+      invitee: { ...invitation.invitee, id: 'user-2', display_name: 'Mai' },
+    };
+    mockListPendingInvitations.mockResolvedValue([invitation]);
+    const { result, rerender } = await renderHook<
+      ReturnType<typeof usePendingInvitations>,
+      { currentTripId: string }
+    >(
+      ({ currentTripId }) => usePendingInvitations(currentTripId, true),
+      { initialProps: { currentTripId: 'trip-1' } },
+    );
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.items).toEqual([invitation]));
+
+    await rerender({ currentTripId: 'trip-2' });
+    await act(async () => {
+      publishTripEvent({
+        type: 'invitationsSent',
+        tripId: 'trip-2',
+        invitations: [nextTripInvitation],
+      });
+    });
+
+    expect(result.current.items).toEqual([nextTripInvitation]);
+  });
+});

--- a/mobile/src/features/trips/__tests__/useTripDetail.test.tsx
+++ b/mobile/src/features/trips/__tests__/useTripDetail.test.tsx
@@ -1,7 +1,12 @@
 const mockUseFocusEffect = jest.fn();
+const mockUseAppForegroundEffect = jest.fn();
 
 jest.mock('expo-router', () => ({
   useFocusEffect: (effect: () => (() => void) | void) => mockUseFocusEffect(effect),
+}));
+
+jest.mock('@/shared/hooks/useAppForegroundEffect', () => ({
+  useAppForegroundEffect: (listener: () => void) => mockUseAppForegroundEffect(listener),
 }));
 
 jest.mock('../api', () => ({
@@ -48,6 +53,18 @@ const tripDetail = {
   members: [],
 };
 
+const member = {
+  membership_id: 'membership-2',
+  user: {
+    id: 'user-2',
+    display_name: 'Lan Nguyen',
+    identify_tag: 'lan#1234',
+    avatar_url: null,
+  },
+  role: 'MEMBER' as const,
+  joined_at: '2026-01-02T00:00:00Z',
+};
+
 function axiosErrorWith(status: number, data: unknown): AxiosError {
   const config = { headers: new AxiosHeaders() };
   return new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, {}, {
@@ -71,6 +88,14 @@ function latestFocusCallback(): () => (() => void) | void {
   const callback = mockUseFocusEffect.mock.calls.at(-1)?.[0] as (() => (() => void) | void) | undefined;
   if (!callback) {
     throw new Error('Expected useFocusEffect to register a callback.');
+  }
+  return callback;
+}
+
+function latestForegroundCallback(): () => void {
+  const callback = mockUseAppForegroundEffect.mock.calls.at(-1)?.[0] as (() => void) | undefined;
+  if (!callback) {
+    throw new Error('Expected useAppForegroundEffect to register a callback.');
   }
   return callback;
 }
@@ -99,7 +124,7 @@ describe('useTripDetail', () => {
     unmount();
   });
 
-  it('retains rendered detail after a non-404 silent refresh failure', async () => {
+  it('retains rendered detail after a non-404 foreground refresh failure', async () => {
     mockGetTripDetail
       .mockResolvedValueOnce(tripDetail)
       .mockRejectedValueOnce(axiosErrorWith(500, { detail: 'Service unavailable.' }));
@@ -110,12 +135,32 @@ describe('useTripDetail', () => {
     });
     await waitFor(() => expect(result.current.detail).toEqual(tripDetail));
     await act(async () => {
-      latestFocusCallback()();
+      latestForegroundCallback()();
     });
 
     await waitFor(() => expect(result.current.error?.message).toBe('Service unavailable.'));
     expect(result.current.detail).toEqual(tripDetail);
     expect(result.current.status).toBe('ready');
+    unmount();
+  });
+
+  it('reconciles member data when the app returns to foreground', async () => {
+    const detailWithMember = { ...tripDetail, members: [member] };
+    mockGetTripDetail
+      .mockResolvedValueOnce(tripDetail)
+      .mockResolvedValueOnce(detailWithMember);
+    const { result, unmount } = await renderHook(() => useTripDetail('trip-1'));
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.detail).toEqual(tripDetail));
+
+    await act(async () => {
+      latestForegroundCallback()();
+    });
+
+    await waitFor(() => expect(result.current.detail?.members).toEqual([member]));
+    expect(mockGetTripDetail).toHaveBeenCalledTimes(2);
     unmount();
   });
 
@@ -180,6 +225,33 @@ describe('useTripDetail', () => {
     });
 
     expect(result.current.detail?.trip).toMatchObject({ name: 'Updated Da Lat', status: 'ONGOING' });
+    unmount();
+  });
+
+  it('removes a member locally and prevents an older detail response from restoring them', async () => {
+    const detailWithMember = { ...tripDetail, members: [member] };
+    const staleRefresh = deferred<typeof detailWithMember>();
+    mockGetTripDetail
+      .mockResolvedValueOnce(detailWithMember)
+      .mockReturnValueOnce(staleRefresh.promise);
+    const { result, unmount } = await renderHook(() => useTripDetail('trip-1'));
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.detail?.members).toEqual([member]));
+    await act(async () => {
+      void result.current.refresh('silent');
+      publishTripEvent({ type: 'memberRemoved', tripId: 'trip-1', userId: 'user-2' });
+    });
+
+    expect(result.current.detail?.members).toEqual([]);
+    await act(async () => {
+      staleRefresh.resolve(detailWithMember);
+    });
+
+    expect(result.current.detail?.members).toEqual([]);
+    expect(result.current.refreshing).toBe(false);
     unmount();
   });
 });

--- a/mobile/src/features/trips/__tests__/useTripsList.test.tsx
+++ b/mobile/src/features/trips/__tests__/useTripsList.test.tsx
@@ -1,3 +1,9 @@
+const mockUseAppForegroundEffect = jest.fn();
+
+jest.mock('@/shared/hooks/useAppForegroundEffect', () => ({
+  useAppForegroundEffect: (listener: () => void) => mockUseAppForegroundEffect(listener),
+}));
+
 jest.mock('../api', () => ({
   listTrips: jest.fn(),
 }));
@@ -12,6 +18,14 @@ import { useTripsList } from '../hooks/useTripsList';
 import { publishTripEvent } from '../tripEvents';
 
 const mockListTrips = listTrips as jest.MockedFunction<typeof listTrips>;
+
+function latestForegroundCallback(): () => void {
+  const callback = mockUseAppForegroundEffect.mock.calls.at(-1)?.[0] as (() => void) | undefined;
+  if (!callback) {
+    throw new Error('Expected useAppForegroundEffect to register a callback.');
+  }
+  return callback;
+}
 
 const tripA = {
   id: 'trip-a',
@@ -101,7 +115,7 @@ describe('useTripsList', () => {
     expect(mockListTrips).toHaveBeenCalledTimes(2);
   });
 
-  it('preserves the rendered list when a silent focus refresh fails', async () => {
+  it('preserves the rendered list when a foreground refresh fails', async () => {
     mockListTrips
       .mockResolvedValueOnce({ items: [tripA], nextCursor: 'cursor-1' })
       .mockRejectedValueOnce(new Error('offline'));
@@ -112,12 +126,26 @@ describe('useTripsList', () => {
       await result.current.loadFirstPage('initial');
     });
     await act(async () => {
-      await result.current.loadFirstPage('silent');
+      latestForegroundCallback()();
     });
 
     expect(result.current.items).toEqual([tripA]);
     expect(result.current.status).toBe('ready');
     expect(result.current.error).toBeNull();
+  });
+
+  it('reconciles the first page when the app returns to foreground', async () => {
+    mockListTrips
+      .mockResolvedValueOnce({ items: [tripA], nextCursor: null })
+      .mockResolvedValueOnce({ items: [tripB], nextCursor: null });
+    const { result } = await renderHook(() => useTripsList());
+    await act(async () => {
+      await result.current.loadFirstPage('initial');
+      latestForegroundCallback()();
+    });
+
+    await waitFor(() => expect(result.current.items).toEqual([tripB]));
+    expect(mockListTrips).toHaveBeenCalledTimes(2);
   });
 
   it('finishes a failed pull-to-refresh while retaining the ready list and exposing the error', async () => {
@@ -276,6 +304,56 @@ describe('useTripsList', () => {
     });
 
     expect(result.current.items).toEqual([serverTrip]);
+    unmount();
+  });
+
+  it('reconciles an accepted membership with a new first page and ignores the older response', async () => {
+    const staleRefresh = deferred<{ items: typeof tripA[]; nextCursor: null }>();
+    mockListTrips
+      .mockResolvedValueOnce({ items: [tripA], nextCursor: null })
+      .mockReturnValueOnce(staleRefresh.promise)
+      .mockResolvedValueOnce({ items: [tripA, tripB], nextCursor: null });
+    const { result, unmount } = await renderHook(() => useTripsList());
+    await act(async () => {
+      await result.current.loadFirstPage('initial');
+    });
+    await act(async () => {
+      void result.current.loadFirstPage('silent');
+      publishTripEvent({ type: 'membershipAdded', tripId: 'trip-b' });
+    });
+
+    await waitFor(() => expect(result.current.items).toEqual([tripA, tripB]));
+    expect(mockListTrips).toHaveBeenCalledTimes(3);
+    await act(async () => {
+      staleRefresh.resolve({ items: [tripA], nextCursor: null });
+    });
+
+    expect(result.current.items).toEqual([tripA, tripB]);
+    unmount();
+  });
+
+  it('refreshes list metadata after member removal and ignores invitation-only events', async () => {
+    const updatedTrip = { ...tripA, member_count: 1 };
+    mockListTrips
+      .mockResolvedValueOnce({ items: [{ ...tripA, member_count: 2 }], nextCursor: null })
+      .mockResolvedValueOnce({ items: [updatedTrip], nextCursor: null });
+    const { result, unmount } = await renderHook(() => useTripsList());
+    await act(async () => {
+      await result.current.loadFirstPage('initial');
+      publishTripEvent({
+        type: 'invitationsSent',
+        tripId: 'trip-a',
+        invitations: [],
+      });
+    });
+    expect(mockListTrips).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      publishTripEvent({ type: 'memberRemoved', tripId: 'trip-a', userId: 'user-2' });
+    });
+
+    await waitFor(() => expect(result.current.items).toEqual([updatedTrip]));
+    expect(mockListTrips).toHaveBeenCalledTimes(2);
     unmount();
   });
 });

--- a/mobile/src/features/trips/api.ts
+++ b/mobile/src/features/trips/api.ts
@@ -2,8 +2,10 @@ import { apiClient } from '@/shared/api/client';
 import { extractCursor, type CursorPaginatedResponse } from '@/shared/api/pagination';
 import type {
   CreateTripInput,
+  InvitableFriend,
   Trip,
   TripDetailResponse,
+  TripInvitation,
   TripListItem,
   TripListPage,
   TripStatus,
@@ -55,4 +57,33 @@ export function cancelTrip(tripId: string): Promise<TripStatus> {
 
 export async function leaveTrip(tripId: string): Promise<void> {
   await apiClient.post(`/trips/${tripId}/leave`);
+}
+
+export async function listInvitableFriends(tripId: string): Promise<InvitableFriend[]> {
+  const { data } = await apiClient.get<{ users: InvitableFriend[] }>(
+    `/trips/${tripId}/invitations/invitable-friends`,
+  );
+  return data.users;
+}
+
+export async function listPendingInvitations(tripId: string): Promise<TripInvitation[]> {
+  const { data } = await apiClient.get<{ invitations: TripInvitation[] }>(
+    `/trips/${tripId}/invitations`,
+  );
+  return data.invitations;
+}
+
+export async function sendTripInvitations(
+  tripId: string,
+  inviteeIds: string[],
+): Promise<TripInvitation[]> {
+  const { data } = await apiClient.post<{ invitations: TripInvitation[] }>(
+    `/trips/${tripId}/invitations`,
+    { invitee_ids: inviteeIds },
+  );
+  return data.invitations;
+}
+
+export async function removeTripMember(tripId: string, userId: string): Promise<void> {
+  await apiClient.delete(`/trips/${tripId}/members/${userId}`);
 }

--- a/mobile/src/features/trips/components/InvitableFriendRow.tsx
+++ b/mobile/src/features/trips/components/InvitableFriendRow.tsx
@@ -1,0 +1,95 @@
+import { Ionicons } from '@expo/vector-icons';
+import { memo, useCallback } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import type { InvitableFriend } from '../types';
+
+interface InvitableFriendRowProps {
+  friend: InvitableFriend;
+  selected: boolean;
+  disabled: boolean;
+  onToggle: (friendId: string) => void;
+}
+
+export const InvitableFriendRow = memo(function InvitableFriendRow({
+  friend,
+  selected,
+  disabled,
+  onToggle,
+}: InvitableFriendRowProps) {
+  const toggle = useCallback(() => {
+    onToggle(friend.id);
+  }, [friend.id, onToggle]);
+  const initial = friend.display_name.trim().charAt(0).toUpperCase() || '?';
+
+  return (
+    <Pressable
+      accessibilityRole="checkbox"
+      accessibilityLabel={`Invite ${friend.display_name}`}
+      accessibilityState={{ checked: selected, disabled }}
+      disabled={disabled}
+      onPress={toggle}
+      style={({ pressed }) => [
+        styles.row,
+        selected ? styles.selectedRow : null,
+        pressed && !disabled ? styles.pressed : null,
+        disabled ? styles.disabled : null,
+      ]}
+    >
+      <View style={styles.avatar}>
+        <Text style={styles.avatarText}>{initial}</Text>
+      </View>
+      <View style={styles.identity}>
+        <Text style={styles.name} numberOfLines={1}>
+          {friend.display_name}
+        </Text>
+        <Text style={styles.tag} numberOfLines={1}>
+          {friend.identify_tag}
+        </Text>
+      </View>
+      <View style={[styles.check, selected ? styles.selectedCheck : null]}>
+        {selected ? <Ionicons name="checkmark" size={18} color={colors.background} /> : null}
+      </View>
+    </Pressable>
+  );
+});
+
+const styles = StyleSheet.create({
+  row: {
+    minHeight: 72,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.lg,
+    backgroundColor: colors.background,
+  },
+  selectedRow: { borderColor: colors.primary, backgroundColor: colors.primarySoft },
+  pressed: { opacity: 0.72 },
+  disabled: { opacity: 0.55 },
+  avatar: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.full,
+    backgroundColor: colors.surface,
+  },
+  avatarText: { ...typography.label, color: colors.textMuted },
+  identity: { flex: 1, minWidth: 0, gap: spacing.xs },
+  name: { ...typography.body, color: colors.text, fontWeight: '600' },
+  tag: { ...typography.caption, color: colors.textMuted },
+  check: {
+    width: 28,
+    height: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.full,
+    backgroundColor: colors.background,
+  },
+  selectedCheck: { borderColor: colors.primary, backgroundColor: colors.primary },
+});

--- a/mobile/src/features/trips/components/MemberRow.tsx
+++ b/mobile/src/features/trips/components/MemberRow.tsx
@@ -1,16 +1,38 @@
 import { Image } from 'expo-image';
-import { StyleSheet, Text, View } from 'react-native';
+import { memo, useCallback } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 import { resolveMediaUrl } from '@/shared/api/base-url';
-import { colors, spacing, typography } from '@/shared/theme/tokens';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
 import type { TripMember } from '../types';
 
 const AVATAR_SIZE = 40;
 
-export function MemberRow({ member, showDivider = false }: { member: TripMember; showDivider?: boolean }) {
+interface MemberRowProps {
+  member: TripMember;
+  showDivider?: boolean;
+  showRemove?: boolean;
+  removeDisabled?: boolean;
+  removing?: boolean;
+  onRemoveRequest?: (userId: string, displayName: string) => void;
+}
+
+export const MemberRow = memo(function MemberRow({
+  member,
+  showDivider = false,
+  showRemove = false,
+  removeDisabled = false,
+  removing = false,
+  onRemoveRequest,
+}: MemberRowProps) {
   const avatarUrl = resolveMediaUrl(member.user.avatar_url);
   const initial = member.user.display_name.trim().charAt(0).toUpperCase() || '?';
+  const requestRemoval = useCallback(() => {
+    onRemoveRequest?.(member.user.id, member.user.display_name);
+  }, [member.user.display_name, member.user.id, onRemoveRequest]);
+  const removeBlocked = removeDisabled || removing;
+
   return (
-    <View style={[styles.row, showDivider && styles.divider]}>
+    <View style={[styles.row, showDivider ? styles.divider : null]}>
       {avatarUrl ? (
         <Image source={{ uri: avatarUrl }} style={styles.avatar} contentFit="cover" />
       ) : (
@@ -27,9 +49,30 @@ export function MemberRow({ member, showDivider = false }: { member: TripMember;
         </Text>
       </View>
       <Text style={styles.role}>{member.role === 'CAPTAIN' ? 'Captain' : 'Member'}</Text>
+      {showRemove ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={`Remove ${member.user.display_name} from trip`}
+          accessibilityState={{ disabled: removeBlocked, busy: removing }}
+          disabled={removeBlocked}
+          hitSlop={spacing.xs}
+          onPress={requestRemoval}
+          style={({ pressed }) => [
+            styles.removeButton,
+            pressed && !removeBlocked ? styles.removePressed : null,
+            removeBlocked ? styles.removeDisabled : null,
+          ]}
+        >
+          {removing ? (
+            <ActivityIndicator size="small" color={colors.danger} />
+          ) : (
+            <Text style={styles.removeText}>Remove</Text>
+          )}
+        </Pressable>
+      ) : null}
     </View>
   );
-}
+});
 
 const styles = StyleSheet.create({
   row: {
@@ -51,4 +94,14 @@ const styles = StyleSheet.create({
   name: { ...typography.body, color: colors.text },
   tag: { ...typography.caption, color: colors.textMuted },
   role: { ...typography.label, color: colors.textMuted, flexShrink: 0 },
+  removeButton: {
+    minHeight: 44,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.sm,
+    borderRadius: radii.md,
+    backgroundColor: colors.dangerSoft,
+  },
+  removePressed: { opacity: 0.55 },
+  removeDisabled: { opacity: 0.5 },
+  removeText: { ...typography.label, color: colors.danger },
 });

--- a/mobile/src/features/trips/components/PendingInvitationRow.tsx
+++ b/mobile/src/features/trips/components/PendingInvitationRow.tsx
@@ -1,0 +1,52 @@
+import { memo } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { colors, spacing, typography } from '@/shared/theme/tokens';
+import type { TripInvitation } from '../types';
+
+const invitationDateFormatter = new Intl.DateTimeFormat('en-US', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+function formatCreatedAt(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : invitationDateFormatter.format(date);
+}
+
+export const PendingInvitationRow = memo(function PendingInvitationRow({
+  invitation,
+  showDivider = false,
+}: {
+  invitation: TripInvitation;
+  showDivider?: boolean;
+}) {
+  return (
+    <View style={[styles.row, showDivider ? styles.divider : null]}>
+      <View style={styles.identity}>
+        <Text style={styles.name} numberOfLines={1}>
+          {invitation.invitee.display_name}
+        </Text>
+        <Text style={styles.meta} numberOfLines={1}>
+          {invitation.invitee.identify_tag}
+        </Text>
+        <Text style={styles.meta}>Invited {formatCreatedAt(invitation.created_at)}</Text>
+      </View>
+      <Text style={styles.status}>Pending</Text>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  row: {
+    minHeight: 72,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  divider: { borderBottomWidth: 1, borderBottomColor: colors.border },
+  identity: { flex: 1, minWidth: 0, gap: spacing.xs },
+  name: { ...typography.body, color: colors.text, fontWeight: '600' },
+  meta: { ...typography.caption, color: colors.textMuted },
+  status: { ...typography.label, color: colors.primary },
+});

--- a/mobile/src/features/trips/hooks/useInviteMembers.ts
+++ b/mobile/src/features/trips/hooks/useInviteMembers.ts
@@ -1,0 +1,171 @@
+import { useFocusEffect } from 'expo-router';
+import { useCallback, useRef, useState } from 'react';
+import { type ApiError, normalizeApiError } from '@/shared/api/errors';
+import { useAppForegroundEffect } from '@/shared/hooks/useAppForegroundEffect';
+import { listInvitableFriends, sendTripInvitations } from '../api';
+import { publishTripEvent } from '../tripEvents';
+import type { InvitableFriend } from '../types';
+
+export const MAX_INVITEES_PER_REQUEST = 20;
+
+export type InviteMembersLoadStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+const EMPTY_SELECTED_IDS: ReadonlySet<string> = new Set();
+
+export function useInviteMembers(tripId: string | undefined, enabled: boolean) {
+  const [items, setItems] = useState<InvitableFriend[]>([]);
+  const [status, setStatus] = useState<InviteMembersLoadStatus>('idle');
+  const [loadError, setLoadError] = useState<ApiError | null>(null);
+  const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(new Set());
+  const [selectionError, setSelectionError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<ApiError | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [stateTripId, setStateTripId] = useState<string | undefined>(undefined);
+  const selectedIdsRef = useRef<ReadonlySet<string>>(new Set());
+  const requestIdRef = useRef(0);
+  const loadedTripIdRef = useRef<string | null>(null);
+  const submitLockRef = useRef(false);
+
+  const commitSelection = useCallback((nextSelection: ReadonlySet<string>) => {
+    selectedIdsRef.current = nextSelection;
+    setSelectedIds(nextSelection);
+  }, []);
+
+  const load = useCallback(
+    async (mode: 'initial' | 'silent' = 'silent') => {
+      if (!enabled || !tripId) {
+        return;
+      }
+
+      const requestId = requestIdRef.current + 1;
+      requestIdRef.current = requestId;
+      const hasCurrentData = loadedTripIdRef.current === tripId;
+      setLoadError(null);
+      if (mode === 'initial' || !hasCurrentData) {
+        setStateTripId(tripId);
+        setItems([]);
+        commitSelection(new Set());
+        setSelectionError(null);
+        setSubmitError(null);
+        setStatus('loading');
+      }
+
+      try {
+        const friends = await listInvitableFriends(tripId);
+        if (requestId !== requestIdRef.current) {
+          return;
+        }
+        loadedTripIdRef.current = tripId;
+        setItems(friends);
+        const eligibleIds = new Set(friends.map((friend) => friend.id));
+        commitSelection(
+          new Set(Array.from(selectedIdsRef.current).filter((friendId) => eligibleIds.has(friendId))),
+        );
+        setSelectionError(null);
+        setStatus('ready');
+      } catch (caught) {
+        if (requestId !== requestIdRef.current) {
+          return;
+        }
+        setLoadError(normalizeApiError(caught));
+        setStatus(hasCurrentData ? 'ready' : 'error');
+      }
+    },
+    [commitSelection, enabled, tripId],
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!enabled || !tripId) {
+        return undefined;
+      }
+      void load(loadedTripIdRef.current === tripId ? 'silent' : 'initial');
+      return () => {
+        requestIdRef.current += 1;
+      };
+    }, [enabled, load, tripId]),
+  );
+
+  const reconcileOnForeground = useCallback(() => {
+    if (enabled && tripId) {
+      void load(loadedTripIdRef.current === tripId ? 'silent' : 'initial');
+    }
+  }, [enabled, load, tripId]);
+
+  useAppForegroundEffect(reconcileOnForeground);
+
+  const toggleSelection = useCallback(
+    (friendId: string) => {
+      if (submitLockRef.current) {
+        return;
+      }
+      const current = selectedIdsRef.current;
+      const next = new Set(current);
+      if (next.has(friendId)) {
+        next.delete(friendId);
+        commitSelection(next);
+        setSelectionError(null);
+        return;
+      }
+      if (next.size >= MAX_INVITEES_PER_REQUEST) {
+        setSelectionError(`You can select up to ${MAX_INVITEES_PER_REQUEST} friends.`);
+        return;
+      }
+      next.add(friendId);
+      commitSelection(next);
+      setSelectionError(null);
+      setSubmitError(null);
+    },
+    [commitSelection],
+  );
+
+  const submit = useCallback(async (): Promise<boolean> => {
+    const inviteeIds = Array.from(selectedIdsRef.current);
+    if (inviteeIds.length === 0) {
+      setSelectionError('Select at least one friend.');
+      return false;
+    }
+    if (inviteeIds.length > MAX_INVITEES_PER_REQUEST || !tripId || !enabled) {
+      setSelectionError(`You can select up to ${MAX_INVITEES_PER_REQUEST} friends.`);
+      return false;
+    }
+    if (submitLockRef.current) {
+      return false;
+    }
+
+    submitLockRef.current = true;
+    setSubmitting(true);
+    setSelectionError(null);
+    setSubmitError(null);
+    try {
+      const invitations = await sendTripInvitations(tripId, inviteeIds);
+      requestIdRef.current += 1;
+      const submittedIds = new Set(inviteeIds);
+      setItems((current) => current.filter((friend) => !submittedIds.has(friend.id)));
+      commitSelection(new Set());
+      publishTripEvent({ type: 'invitationsSent', tripId, invitations });
+      return true;
+    } catch (caught) {
+      setSubmitError(normalizeApiError(caught));
+      return false;
+    } finally {
+      submitLockRef.current = false;
+      setSubmitting(false);
+    }
+  }, [commitSelection, enabled, tripId]);
+
+  const stateMatchesTrip = enabled && Boolean(tripId) && stateTripId === tripId;
+
+  return {
+    items: stateMatchesTrip ? items : [],
+    status: stateMatchesTrip ? status : enabled && tripId ? 'loading' : 'idle',
+    loadError: stateMatchesTrip ? loadError : null,
+    selectedIds: stateMatchesTrip ? selectedIds : EMPTY_SELECTED_IDS,
+    selectionError: stateMatchesTrip ? selectionError : null,
+    submitError: stateMatchesTrip ? submitError : null,
+    submitting: stateMatchesTrip ? submitting : false,
+    load,
+    toggleSelection,
+    submit,
+  };
+}

--- a/mobile/src/features/trips/hooks/usePendingInvitations.ts
+++ b/mobile/src/features/trips/hooks/usePendingInvitations.ts
@@ -1,0 +1,124 @@
+import { useFocusEffect } from 'expo-router';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { type ApiError, normalizeApiError } from '@/shared/api/errors';
+import { useAppForegroundEffect } from '@/shared/hooks/useAppForegroundEffect';
+import { listPendingInvitations } from '../api';
+import { subscribeToTripEvents } from '../tripEvents';
+import type { TripInvitation } from '../types';
+
+export type PendingInvitationsStatus = 'idle' | 'loading' | 'ready' | 'error';
+export type PendingInvitationsLoadMode = 'initial' | 'refresh' | 'silent';
+
+function mergeInvitations(
+  current: TripInvitation[],
+  incoming: TripInvitation[],
+): TripInvitation[] {
+  const byId = new Map(current.map((invitation) => [invitation.id, invitation]));
+  for (const invitation of incoming) {
+    byId.set(invitation.id, invitation);
+  }
+  return Array.from(byId.values()).sort((left, right) =>
+    right.created_at.localeCompare(left.created_at),
+  );
+}
+
+export function usePendingInvitations(tripId: string | undefined, enabled: boolean) {
+  const [items, setItems] = useState<TripInvitation[]>([]);
+  const [status, setStatus] = useState<PendingInvitationsStatus>('idle');
+  const [error, setError] = useState<ApiError | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [stateTripId, setStateTripId] = useState<string | undefined>(undefined);
+  const requestIdRef = useRef(0);
+  const loadedTripIdRef = useRef<string | null>(null);
+
+  const load = useCallback(
+    async (mode: PendingInvitationsLoadMode = 'silent') => {
+      if (!enabled || !tripId) {
+        return;
+      }
+
+      const requestId = requestIdRef.current + 1;
+      requestIdRef.current = requestId;
+      const hasCurrentData = loadedTripIdRef.current === tripId;
+      setError(null);
+      if (mode === 'initial' || !hasCurrentData) {
+        setStateTripId(tripId);
+        setItems([]);
+        setStatus('loading');
+      } else if (mode === 'refresh') {
+        setRefreshing(true);
+      }
+
+      try {
+        const invitations = await listPendingInvitations(tripId);
+        if (requestId !== requestIdRef.current) {
+          return;
+        }
+        loadedTripIdRef.current = tripId;
+        setItems(invitations);
+        setStatus('ready');
+      } catch (caught) {
+        if (requestId !== requestIdRef.current) {
+          return;
+        }
+        setError(normalizeApiError(caught));
+        setStatus(hasCurrentData ? 'ready' : 'error');
+      } finally {
+        if (requestId === requestIdRef.current) {
+          setRefreshing(false);
+        }
+      }
+    },
+    [enabled, tripId],
+  );
+
+  useEffect(
+    () =>
+      subscribeToTripEvents((event) => {
+        if (event.type !== 'invitationsSent' || event.tripId !== tripId) {
+          return;
+        }
+        requestIdRef.current += 1;
+        const canMergeCurrent = loadedTripIdRef.current === event.tripId;
+        loadedTripIdRef.current = event.tripId;
+        setStateTripId(event.tripId);
+        setItems((current) =>
+          mergeInvitations(canMergeCurrent ? current : [], event.invitations),
+        );
+        setError(null);
+        setRefreshing(false);
+        setStatus('ready');
+      }),
+    [tripId],
+  );
+
+  const reconcileOnForeground = useCallback(() => {
+    if (enabled && tripId) {
+      void load(loadedTripIdRef.current === tripId ? 'silent' : 'initial');
+    }
+  }, [enabled, load, tripId]);
+
+  useAppForegroundEffect(reconcileOnForeground);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!enabled || !tripId) {
+        return undefined;
+      }
+      void load(loadedTripIdRef.current === tripId ? 'silent' : 'initial');
+      return () => {
+        requestIdRef.current += 1;
+      };
+    }, [enabled, load, tripId]),
+  );
+
+  const stateMatchesTrip = enabled && Boolean(tripId) && stateTripId === tripId;
+
+  return {
+    items: stateMatchesTrip ? items : [],
+    status: stateMatchesTrip ? status : enabled && tripId ? 'loading' : 'idle',
+    error: stateMatchesTrip ? error : null,
+    refreshing: stateMatchesTrip ? refreshing : false,
+    load,
+  };
+}

--- a/mobile/src/features/trips/hooks/useTripDetail.ts
+++ b/mobile/src/features/trips/hooks/useTripDetail.ts
@@ -1,6 +1,7 @@
 import { useFocusEffect } from 'expo-router';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { type ApiError, normalizeApiError } from '@/shared/api/errors';
+import { useAppForegroundEffect } from '@/shared/hooks/useAppForegroundEffect';
 import { getTripDetail } from '../api';
 import { subscribeToTripEvents } from '../tripEvents';
 import type { Trip, TripDetailResponse, TripStatus } from '../types';
@@ -108,6 +109,22 @@ export function useTripDetail(tripId: string | undefined) {
     [applyTrip],
   );
 
+  const applyMemberRemoved = useCallback(
+    (userId: string) => {
+      const current = detailRef.current;
+      if (!current || current.trip.id !== tripId) {
+        return;
+      }
+      requestIdRef.current += 1;
+      commitDetail({
+        ...current,
+        members: current.members.filter((member) => member.user.id !== userId),
+      });
+      setRefreshing(false);
+    },
+    [commitDetail, tripId],
+  );
+
   useEffect(
     () =>
       subscribeToTripEvents((event) => {
@@ -115,10 +132,18 @@ export function useTripDetail(tripId: string | undefined) {
           applyTrip(event.trip);
         } else if (event.type === 'statusChanged' && event.tripId === tripId) {
           applyStatus(event.status);
+        } else if (event.type === 'memberRemoved' && event.tripId === tripId) {
+          applyMemberRemoved(event.userId);
         }
       }),
-    [applyStatus, applyTrip, tripId],
+    [applyMemberRemoved, applyStatus, applyTrip, tripId],
   );
+
+  const reconcileOnForeground = useCallback(() => {
+    void refresh(detailRef.current?.trip.id === tripId ? 'silent' : 'initial');
+  }, [refresh, tripId]);
+
+  useAppForegroundEffect(reconcileOnForeground);
 
   useFocusEffect(
     useCallback(() => {

--- a/mobile/src/features/trips/hooks/useTripsList.ts
+++ b/mobile/src/features/trips/hooks/useTripsList.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { type ApiError, normalizeApiError } from '@/shared/api/errors';
+import { useAppForegroundEffect } from '@/shared/hooks/useAppForegroundEffect';
 import { listTrips } from '../api';
 import { subscribeToTripEvents, type TripEvent } from '../tripEvents';
 import type { Trip, TripListItem, TripStatus } from '../types';
@@ -53,7 +54,13 @@ function applyOverrides(
   });
 }
 
-function overrideFromEvent(event: TripEvent, version: number, current?: TripListOverride): [string, TripListOverride] {
+type TripListOverrideEvent = Extract<TripEvent, { type: 'updated' | 'statusChanged' | 'removed' }>;
+
+function overrideFromEvent(
+  event: TripListOverrideEvent,
+  version: number,
+  current?: TripListOverride,
+): [string, TripListOverride] {
   if (event.type === 'updated') {
     return [event.trip.id, { ...current, version, trip: event.trip, status: event.trip.status, removed: false }];
   }
@@ -76,30 +83,7 @@ export function useTripsList() {
   const loadMoreInFlightRef = useRef(false);
   const overridesRef = useRef(new Map<string, TripListOverride>());
   const eventVersionRef = useRef(0);
-
-  useEffect(
-    () =>
-      subscribeToTripEvents((event) => {
-        const eventTripId = event.type === 'updated' ? event.trip.id : event.tripId;
-        eventVersionRef.current += 1;
-        const [tripId, override] = overrideFromEvent(
-          event,
-          eventVersionRef.current,
-          overridesRef.current.get(eventTripId),
-        );
-        overridesRef.current.set(tripId, override);
-        setItems((current) =>
-          current.flatMap((item) => {
-            if (item.id !== tripId) {
-              return [item];
-            }
-            const next = applyOverride(item, override);
-            return next ? [next] : [];
-          }),
-        );
-      }),
-    [],
-  );
+  const hasLoadedFirstPageRef = useRef(false);
 
   const loadFirstPage = useCallback(async (mode: 'initial' | 'refresh' | 'silent') => {
     const requestId = firstPageRequestRef.current + 1;
@@ -122,6 +106,7 @@ export function useTripsList() {
       }
       nextCursorRef.current = page.nextCursor;
       setItems(applyOverrides(page.items, overridesRef.current, requestEventVersion));
+      hasLoadedFirstPageRef.current = true;
       setError(null);
       setStatus('ready');
     } catch (err) {
@@ -143,6 +128,48 @@ export function useTripsList() {
       }
     }
   }, []);
+
+  const reconcileOnForeground = useCallback(() => {
+    void loadFirstPage(hasLoadedFirstPageRef.current ? 'silent' : 'initial');
+  }, [loadFirstPage]);
+
+  useAppForegroundEffect(reconcileOnForeground);
+
+  useEffect(
+    () =>
+      subscribeToTripEvents((event) => {
+        if (event.type === 'membershipAdded') {
+          void loadFirstPage('silent');
+          return;
+        }
+        if (event.type === 'memberRemoved') {
+          void loadFirstPage('silent');
+          return;
+        }
+        if (event.type === 'invitationsSent') {
+          return;
+        }
+
+        const eventTripId = event.type === 'updated' ? event.trip.id : event.tripId;
+        eventVersionRef.current += 1;
+        const [tripId, override] = overrideFromEvent(
+          event,
+          eventVersionRef.current,
+          overridesRef.current.get(eventTripId),
+        );
+        overridesRef.current.set(tripId, override);
+        setItems((current) =>
+          current.flatMap((item) => {
+            if (item.id !== tripId) {
+              return [item];
+            }
+            const next = applyOverride(item, override);
+            return next ? [next] : [];
+          }),
+        );
+      }),
+    [loadFirstPage],
+  );
 
   const loadMore = useCallback(async () => {
     const cursor = nextCursorRef.current;

--- a/mobile/src/features/trips/screens/InviteMembersScreen.tsx
+++ b/mobile/src/features/trips/screens/InviteMembersScreen.tsx
@@ -1,0 +1,219 @@
+import { Ionicons } from '@expo/vector-icons';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useCallback } from 'react';
+import { FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors, spacing, typography } from '@/shared/theme/tokens';
+import { Button } from '@/shared/ui/Button';
+import { FormError } from '@/shared/ui/FormError';
+import { LoadingScreen } from '@/shared/ui/LoadingScreen';
+import { InvitableFriendRow } from '../components/InvitableFriendRow';
+import { useInviteMembers } from '../hooks/useInviteMembers';
+import { useTripDetail } from '../hooks/useTripDetail';
+import type { InvitableFriend } from '../types';
+
+export function InviteMembersScreen() {
+  const { tripId } = useLocalSearchParams<{ tripId: string }>();
+  const router = useRouter();
+  const tripDetail = useTripDetail(tripId);
+  const canInvite = Boolean(
+    tripDetail.detail?.my_membership.role === 'CAPTAIN' &&
+      tripDetail.detail.my_membership.status === 'ACTIVE' &&
+      (tripDetail.detail.trip.status === 'PLANNING' || tripDetail.detail.trip.status === 'ONGOING'),
+  );
+  const invite = useInviteMembers(tripId, canInvite);
+
+  const close = useCallback(() => {
+    if (router.canGoBack()) {
+      router.back();
+      return;
+    }
+    router.replace(`/trips/${tripId}`);
+  }, [router, tripId]);
+
+  const submitInvitations = invite.submit;
+  const send = useCallback(async () => {
+    if (await submitInvitations()) {
+      close();
+    }
+  }, [close, submitInvitations]);
+
+  const renderFriend = useCallback(
+    ({ item }: { item: InvitableFriend }) => (
+      <InvitableFriendRow
+        friend={item}
+        selected={invite.selectedIds.has(item.id)}
+        disabled={invite.submitting}
+        onToggle={invite.toggleSelection}
+      />
+    ),
+    [invite.selectedIds, invite.submitting, invite.toggleSelection],
+  );
+
+  if (tripDetail.status === 'loading') {
+    return <LoadingScreen />;
+  }
+
+  if (tripDetail.status === 'error' || !tripDetail.detail) {
+    const notFound = tripDetail.error?.status === 404;
+    return (
+      <SafeAreaView style={styles.safe} edges={['left', 'right', 'bottom']}>
+        <View style={styles.centered}>
+          <Ionicons
+            name={notFound ? 'help-circle-outline' : 'cloud-offline-outline'}
+            size={44}
+            color={colors.textMuted}
+          />
+          <Text style={styles.stateTitle}>{notFound ? 'Trip not found' : 'Could not load trip'}</Text>
+          <Text style={styles.stateBody}>
+            {notFound
+              ? 'This trip does not exist or you are not a member of it.'
+              : tripDetail.error?.message}
+          </Text>
+          {notFound ? null : (
+            <Button title="Try again" onPress={() => void tripDetail.refresh('initial')} />
+          )}
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (!canInvite) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['left', 'right', 'bottom']}>
+        <View style={styles.centered}>
+          <Ionicons name="lock-closed-outline" size={44} color={colors.textMuted} />
+          <Text style={styles.stateTitle}>Invitations unavailable</Text>
+          <Text style={styles.stateBody}>
+            Only the captain can invite friends while this trip is active.
+          </Text>
+          <Button title="Back to trip" variant="secondary" onPress={close} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (invite.status === 'loading' || invite.status === 'idle') {
+    return <LoadingScreen />;
+  }
+
+  if (invite.status === 'error') {
+    return (
+      <SafeAreaView style={styles.safe} edges={['left', 'right', 'bottom']}>
+        <View style={styles.centered}>
+          <Ionicons name="cloud-offline-outline" size={44} color={colors.textMuted} />
+          <Text style={styles.stateTitle}>Could not load eligible friends</Text>
+          <Text style={styles.stateBody}>{invite.loadError?.message}</Text>
+          <Button title="Try again" onPress={() => void invite.load('initial')} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const selectedCount = invite.selectedIds.size;
+  const fieldError = invite.submitError?.fieldErrors?.invitee_ids;
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['left', 'right', 'bottom']}>
+      <FlatList
+        data={invite.items}
+        keyExtractor={(friend) => friend.id}
+        renderItem={renderFriend}
+        extraData={invite.selectedIds}
+        contentInsetAdjustmentBehavior="automatic"
+        contentContainerStyle={invite.items.length === 0 ? styles.emptyContent : styles.listContent}
+        ListHeaderComponent={
+          <View style={styles.header}>
+            <Text accessibilityRole="header" style={styles.title}>
+              Choose friends
+            </Text>
+            <Text style={styles.stateBody}>
+              Select up to 20 eligible friends. Active members and pending invitees are already excluded.
+            </Text>
+            <Text style={styles.selectionCount}>{selectedCount} selected</Text>
+            {invite.loadError ? (
+              <View accessibilityRole="alert" style={styles.inlineError}>
+                <Text style={styles.inlineErrorText}>{invite.loadError.message}</Text>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Retry eligible friends"
+                  onPress={() => void invite.load('silent')}
+                  style={({ pressed }) => [styles.inlineRetry, pressed ? styles.pressed : null]}
+                >
+                  <Text style={styles.inlineRetryText}>Retry</Text>
+                </Pressable>
+              </View>
+            ) : null}
+          </View>
+        }
+        ListEmptyComponent={
+          <View style={styles.emptyState}>
+            <Ionicons name="people-outline" size={44} color={colors.textMuted} />
+            <Text style={styles.stateTitle}>No eligible friends</Text>
+            <Text style={styles.stateBody}>
+              Everyone eligible is already a member or has a pending invitation.
+            </Text>
+          </View>
+        }
+      />
+      <View style={styles.footer}>
+        {invite.selectionError ? <Text style={styles.errorText}>{invite.selectionError}</Text> : null}
+        {fieldError ? <Text style={styles.errorText}>{fieldError}</Text> : null}
+        <FormError error={invite.submitError} />
+        {selectedCount === 0 && !invite.selectionError ? (
+          <Text style={styles.hint}>Select at least one friend to continue.</Text>
+        ) : null}
+        <Button
+          title={selectedCount > 0 ? `Send invitations (${selectedCount})` : 'Send invitations'}
+          onPress={() => void send()}
+          loading={invite.submitting}
+          disabled={selectedCount === 0}
+        />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.background },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.md,
+    padding: spacing.lg,
+  },
+  stateTitle: { ...typography.heading, color: colors.text, textAlign: 'center' },
+  stateBody: { ...typography.body, color: colors.textMuted, textAlign: 'center' },
+  listContent: { padding: spacing.md, paddingBottom: spacing.xl, gap: spacing.sm },
+  emptyContent: { flexGrow: 1, padding: spacing.md },
+  header: { gap: spacing.sm, paddingBottom: spacing.sm },
+  title: { ...typography.heading, color: colors.text },
+  selectionCount: { ...typography.label, color: colors.primary },
+  inlineError: {
+    minHeight: 48,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.dangerBorder,
+    backgroundColor: colors.dangerSoft,
+  },
+  inlineErrorText: { ...typography.caption, color: colors.danger, flex: 1 },
+  inlineRetry: { minHeight: 44, justifyContent: 'center', paddingHorizontal: spacing.xs },
+  inlineRetryText: { ...typography.label, color: colors.danger },
+  pressed: { opacity: 0.55 },
+  emptyState: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: spacing.md },
+  footer: {
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.sm,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    backgroundColor: colors.background,
+  },
+  errorText: { ...typography.caption, color: colors.danger },
+  hint: { ...typography.caption, color: colors.textMuted, textAlign: 'center' },
+});

--- a/mobile/src/features/trips/screens/TripDetailScreen.tsx
+++ b/mobile/src/features/trips/screens/TripDetailScreen.tsx
@@ -2,18 +2,20 @@ import { Ionicons } from '@expo/vector-icons';
 import { Image } from 'expo-image';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import { type ComponentProps, useCallback, useRef, useState } from 'react';
-import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { ActivityIndicator, Alert, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { resolveMediaUrl } from '@/shared/api/base-url';
 import { type ApiError, normalizeApiError } from '@/shared/api/errors';
 import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
 import { Button } from '@/shared/ui/Button';
 import { LoadingScreen } from '@/shared/ui/LoadingScreen';
-import { cancelTrip, completeTrip, leaveTrip, startTrip } from '../api';
+import { cancelTrip, completeTrip, leaveTrip, removeTripMember, startTrip } from '../api';
 import { MemberRow } from '../components/MemberRow';
+import { PendingInvitationRow } from '../components/PendingInvitationRow';
 import { StatusBadge } from '../components/StatusBadge';
 import { TripActions, type TripDisplayAction } from '../components/TripActions';
 import { formatDateRange } from '../dates';
+import { usePendingInvitations } from '../hooks/usePendingInvitations';
 import { useTripDetail } from '../hooks/useTripDetail';
 import { publishTripEvent } from '../tripEvents';
 
@@ -48,8 +50,13 @@ export function TripDetailScreen() {
   const { tripId } = useLocalSearchParams<{ tripId: string }>();
   const router = useRouter();
   const { detail, status, error, refreshing, refresh, applyStatus } = useTripDetail(tripId);
+  const captainControlsEnabled = Boolean(
+    detail?.my_membership.role === 'CAPTAIN' && detail.my_membership.status === 'ACTIVE',
+  );
+  const pendingInvitations = usePendingInvitations(tripId, captainControlsEnabled);
   const [mutationError, setMutationError] = useState<ApiError | null>(null);
   const [mutatingAction, setMutatingAction] = useState<TripDisplayAction | null>(null);
+  const [removingMemberId, setRemovingMemberId] = useState<string | null>(null);
   const mutationLockRef = useRef(false);
 
   const handleAction = useCallback(
@@ -92,6 +99,69 @@ export function TripDetailScreen() {
     [applyStatus, refresh, router, tripId],
   );
 
+  const removeMember = useCallback(
+    async (userId: string) => {
+      if (!tripId) {
+        mutationLockRef.current = false;
+        return;
+      }
+      setMutationError(null);
+      setRemovingMemberId(userId);
+      try {
+        await removeTripMember(tripId, userId);
+        publishTripEvent({ type: 'memberRemoved', tripId, userId });
+        void refresh('silent');
+      } catch (caught) {
+        setMutationError(normalizeApiError(caught));
+      } finally {
+        mutationLockRef.current = false;
+        setRemovingMemberId(null);
+      }
+    },
+    [refresh, tripId],
+  );
+
+  const confirmMemberRemoval = useCallback(
+    (userId: string, displayName: string) => {
+      if (!tripId || mutationLockRef.current) {
+        return;
+      }
+      mutationLockRef.current = true;
+      let confirmed = false;
+      const releaseLock = () => {
+        mutationLockRef.current = false;
+      };
+      Alert.alert(
+        'Remove trip member?',
+        `Remove ${displayName} from this trip? They will lose access immediately.`,
+        [
+          { text: 'Keep member', style: 'cancel', onPress: releaseLock },
+          {
+            text: 'Remove member',
+            style: 'destructive',
+            onPress: () => {
+              confirmed = true;
+              void removeMember(userId);
+            },
+          },
+        ],
+        {
+          cancelable: true,
+          onDismiss: () => {
+            if (!confirmed) {
+              releaseLock();
+            }
+          },
+        },
+      );
+    },
+    [removeMember, tripId],
+  );
+
+  const openInvite = useCallback(() => {
+    router.push(`/trips/${tripId}/invite`);
+  }, [router, tripId]);
+
   if (status === 'loading') {
     return <LoadingScreen />;
   }
@@ -116,6 +186,10 @@ export function TripDetailScreen() {
   const { trip, members, my_membership: membership } = detail;
   const coverUrl = resolveMediaUrl(trip.cover_image_url || null);
   const inlineError = mutationError ?? error;
+  const isNonTerminal = trip.status === 'PLANNING' || trip.status === 'ONGOING';
+  const canInvite = captainControlsEnabled && isNonTerminal;
+  const canRemoveMembers = captainControlsEnabled && isNonTerminal;
+  const mutationInFlight = mutatingAction !== null || removingMemberId !== null;
 
   return (
     <SafeAreaView style={styles.safe} edges={['left', 'right', 'bottom']}>
@@ -171,7 +245,7 @@ export function TripDetailScreen() {
         <TripActions
           trip={trip}
           membership={membership}
-          isMutating={mutatingAction !== null}
+          isMutating={mutationInFlight}
           onAction={handleAction}
         />
         {mutatingAction ? (
@@ -191,15 +265,93 @@ export function TripDetailScreen() {
           </View>
         ) : null}
         <View style={styles.section}>
-          <Text accessibilityRole="header" style={styles.sectionTitle}>
-            Members ({members.length})
-          </Text>
+          <View style={styles.sectionHeader}>
+            <Text accessibilityRole="header" style={styles.sectionTitle}>
+              Members ({members.length})
+            </Text>
+          </View>
           <View style={[styles.card, styles.membersCard]}>
             {members.map((member, index) => (
-              <MemberRow key={member.membership_id} member={member} showDivider={index < members.length - 1} />
+              <MemberRow
+                key={member.membership_id}
+                member={member}
+                showDivider={index < members.length - 1}
+                showRemove={canRemoveMembers && member.role !== 'CAPTAIN'}
+                removeDisabled={mutationInFlight}
+                removing={removingMemberId === member.user.id}
+                onRemoveRequest={confirmMemberRemoval}
+              />
             ))}
           </View>
         </View>
+        {captainControlsEnabled ? (
+          <View style={styles.section}>
+            <View style={styles.sectionHeader}>
+              <Text accessibilityRole="header" style={styles.sectionTitle}>
+                Pending invitations
+              </Text>
+              {canInvite ? (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Invite friends"
+                  disabled={mutationInFlight}
+                  onPress={openInvite}
+                  style={({ pressed }) => [
+                    styles.inviteButton,
+                    pressed && !mutationInFlight ? styles.inviteButtonPressed : null,
+                    mutationInFlight ? styles.inviteButtonDisabled : null,
+                  ]}
+                >
+                  <Ionicons name="person-add-outline" size={18} color={colors.primary} />
+                  <Text style={styles.inviteButtonText}>Invite</Text>
+                </Pressable>
+              ) : null}
+            </View>
+            <View style={[styles.card, styles.pendingCard]}>
+              {pendingInvitations.status === 'loading' || pendingInvitations.status === 'idle' ? (
+                <View accessibilityLabel="Loading pending invitations" style={styles.pendingState}>
+                  <ActivityIndicator size="small" color={colors.primary} />
+                  <Text style={styles.pendingStateText}>Loading invitations…</Text>
+                </View>
+              ) : pendingInvitations.status === 'error' ? (
+                <View accessibilityRole="alert" style={styles.pendingState}>
+                  <Text style={styles.pendingErrorText}>{pendingInvitations.error?.message}</Text>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Retry pending invitations"
+                    onPress={() => void pendingInvitations.load('initial')}
+                    style={({ pressed }) => [styles.pendingRetry, pressed ? styles.retryButtonPressed : null]}
+                  >
+                    <Text style={styles.retryText}>Try again</Text>
+                  </Pressable>
+                </View>
+              ) : pendingInvitations.items.length === 0 ? (
+                <Text style={styles.pendingEmpty}>No pending invitations.</Text>
+              ) : (
+                pendingInvitations.items.map((invitation, index) => (
+                  <PendingInvitationRow
+                    key={invitation.id}
+                    invitation={invitation}
+                    showDivider={index < pendingInvitations.items.length - 1}
+                  />
+                ))
+              )}
+              {pendingInvitations.status === 'ready' && pendingInvitations.error ? (
+                <View accessibilityRole="alert" style={styles.pendingInlineError}>
+                  <Text style={styles.pendingErrorText}>{pendingInvitations.error.message}</Text>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Retry pending invitations"
+                    onPress={() => void pendingInvitations.load('silent')}
+                    style={({ pressed }) => [styles.pendingRetry, pressed ? styles.retryButtonPressed : null]}
+                  >
+                    <Text style={styles.retryText}>Retry</Text>
+                  </Pressable>
+                </View>
+              ) : null}
+            </View>
+          </View>
+        ) : null}
       </ScrollView>
     </SafeAreaView>
   );
@@ -262,4 +414,36 @@ const styles = StyleSheet.create({
   retryText: { ...typography.label, color: colors.danger },
   refreshingRow: { minHeight: 32, flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
   refreshingText: { ...typography.caption, color: colors.textMuted },
+  inviteButton: {
+    minHeight: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    borderRadius: radii.md,
+    backgroundColor: colors.primarySoft,
+  },
+  inviteButtonPressed: { opacity: 0.55 },
+  inviteButtonDisabled: { opacity: 0.5 },
+  inviteButtonText: { ...typography.label, color: colors.primary },
+  pendingCard: { paddingVertical: 0 },
+  pendingState: {
+    minHeight: 72,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.sm,
+    paddingVertical: spacing.md,
+  },
+  pendingStateText: { ...typography.caption, color: colors.textMuted },
+  pendingErrorText: { ...typography.caption, color: colors.danger, textAlign: 'center' },
+  pendingRetry: { minHeight: 44, justifyContent: 'center', paddingHorizontal: spacing.sm },
+  pendingEmpty: { ...typography.body, color: colors.textMuted, paddingVertical: spacing.md },
+  pendingInlineError: {
+    minHeight: 56,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    borderTopWidth: 1,
+    borderTopColor: colors.dangerBorder,
+  },
 });

--- a/mobile/src/features/trips/tripEvents.ts
+++ b/mobile/src/features/trips/tripEvents.ts
@@ -1,9 +1,12 @@
-import type { Trip, TripStatus } from './types';
+import type { Trip, TripInvitation, TripStatus } from './types';
 
 export type TripEvent =
   | { type: 'updated'; trip: Trip }
   | { type: 'statusChanged'; tripId: string; status: TripStatus }
-  | { type: 'removed'; tripId: string };
+  | { type: 'removed'; tripId: string }
+  | { type: 'memberRemoved'; tripId: string; userId: string }
+  | { type: 'invitationsSent'; tripId: string; invitations: TripInvitation[] }
+  | { type: 'membershipAdded'; tripId: string };
 
 type TripEventListener = (event: TripEvent) => void;
 

--- a/mobile/src/features/trips/types.ts
+++ b/mobile/src/features/trips/types.ts
@@ -1,6 +1,7 @@
 export type TripStatus = 'PLANNING' | 'ONGOING' | 'COMPLETED' | 'CANCELLED';
 export type TripRole = 'CAPTAIN' | 'MEMBER';
 export type MemberStatus = 'ACTIVE' | 'LEFT' | 'REMOVED';
+export type InvitationStatus = 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'CANCELLED';
 
 export interface TripListItem {
   id: string;
@@ -61,6 +62,19 @@ export interface TripDetailResponse {
   trip: Trip;
   my_membership: MyMembership;
   members: TripMember[];
+}
+
+export interface InvitableFriend {
+  id: string;
+  display_name: string;
+  identify_tag: string;
+}
+
+export interface TripInvitation {
+  id: string;
+  invitee: InvitableFriend;
+  status: InvitationStatus;
+  created_at: string;
 }
 
 export interface TripListPage {

--- a/mobile/src/shared/hooks/__tests__/useAppForegroundEffect.test.tsx
+++ b/mobile/src/shared/hooks/__tests__/useAppForegroundEffect.test.tsx
@@ -1,0 +1,39 @@
+import { AppState, type AppStateStatus } from 'react-native';
+import { act, renderHook } from '@testing-library/react-native';
+import { useAppForegroundEffect } from '../useAppForegroundEffect';
+
+describe('useAppForegroundEffect', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('shares one AppState listener, fires only on foreground transitions, and removes it when idle', async () => {
+    let appStateListener: ((state: AppStateStatus) => void) | undefined;
+    const remove = jest.fn();
+    const addEventListener = jest
+      .spyOn(AppState, 'addEventListener')
+      .mockImplementation((_, listener) => {
+        appStateListener = listener;
+        return { remove };
+      });
+    const firstListener = jest.fn();
+    const secondListener = jest.fn();
+
+    const first = await renderHook(() => useAppForegroundEffect(firstListener));
+    const second = await renderHook(() => useAppForegroundEffect(secondListener));
+
+    expect(addEventListener).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      appStateListener?.('background');
+      appStateListener?.('active');
+      appStateListener?.('active');
+    });
+    expect(firstListener).toHaveBeenCalledTimes(1);
+    expect(secondListener).toHaveBeenCalledTimes(1);
+
+    await first.unmount();
+    expect(remove).not.toHaveBeenCalled();
+    await second.unmount();
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/src/shared/hooks/useAppForegroundEffect.ts
+++ b/mobile/src/shared/hooks/useAppForegroundEffect.ts
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
+
+type ForegroundListener = () => void;
+
+const listeners = new Set<ForegroundListener>();
+let appStateSubscription: ReturnType<typeof AppState.addEventListener> | null = null;
+let previousAppState: AppStateStatus = AppState.currentState;
+
+function stopListeningWhenIdle(): void {
+  if (listeners.size > 0 || !appStateSubscription) {
+    return;
+  }
+  appStateSubscription.remove();
+  appStateSubscription = null;
+  previousAppState = AppState.currentState;
+}
+
+function subscribeToAppForeground(listener: ForegroundListener): () => void {
+  listeners.add(listener);
+  if (!appStateSubscription) {
+    previousAppState = AppState.currentState;
+    appStateSubscription = AppState.addEventListener('change', (nextAppState) => {
+      const returnedToForeground = previousAppState !== 'active' && nextAppState === 'active';
+      previousAppState = nextAppState;
+      if (returnedToForeground) {
+        for (const currentListener of Array.from(listeners)) {
+          currentListener();
+        }
+      }
+    });
+  }
+
+  return () => {
+    listeners.delete(listener);
+    stopListeningWhenIdle();
+  };
+}
+
+export function useAppForegroundEffect(listener: ForegroundListener): void {
+  useEffect(() => subscribeToAppForeground(listener), [listener]);
+}


### PR DESCRIPTION
Closes #56

## Summary

- add the mobile notifications inbox with cursor pagination, unread reconciliation, foreground refresh, and safe fallbacks for all supported notification types
- add durable trip invitation acceptance and decline states across backend REST/WebSocket contracts, web, and mobile
- add captain invitation, pending invitation, and member removal flows on mobile
- harden account-switch, stale-response, foreground, and concurrent trip mutation behavior

## Validation

- Backend: `python manage.py test notifications trips` — 244 tests passed
- Frontend: `pnpm test` — 574 tests passed; lint and production build passed
- Mobile: `pnpm test --runInBand` — 282 tests passed; lint and typecheck passed
- iPhone 17 Pro Max Simulator E2E:
  - invite → accept → relaunch → remove
  - decline → relaunch
  - foreground notification reconciliation
  - all 8 notification types plus malformed/unknown fallback
  - mark-all-read and cursor pagination beyond 20 records
- Runtime and backend logs contained no redbox, unhandled exception, or 5xx response
