### PR TITLE
feat(mobile): add trip timeline planning

### DIFF
--- a/mobile/src/app/trips/[tripId]/timeline/activity-form.tsx
+++ b/mobile/src/app/trips/[tripId]/timeline/activity-form.tsx
@@ -1,0 +1,3 @@
+import { ActivityFormScreen } from '@/features/timeline/screens/ActivityFormScreen';
+
+export default ActivityFormScreen;

--- a/mobile/src/app/trips/[tripId]/timeline/custom-types.tsx
+++ b/mobile/src/app/trips/[tripId]/timeline/custom-types.tsx
@@ -1,0 +1,3 @@
+import { CustomTypeManagerScreen } from '@/features/timeline/screens/CustomTypeManagerScreen';
+
+export default CustomTypeManagerScreen;

--- a/mobile/src/app/trips/[tripId]/timeline/index.tsx
+++ b/mobile/src/app/trips/[tripId]/timeline/index.tsx
@@ -1,0 +1,3 @@
+import { TimelineScreen } from '@/features/timeline/screens/TimelineScreen';
+
+export default TimelineScreen;

--- a/mobile/src/app/trips/[tripId]/timeline/section-form.tsx
+++ b/mobile/src/app/trips/[tripId]/timeline/section-form.tsx
@@ -1,0 +1,3 @@
+import { SectionFormScreen } from '@/features/timeline/screens/SectionFormScreen';
+
+export default SectionFormScreen;

--- a/mobile/src/app/trips/__tests__/_layout.test.tsx
+++ b/mobile/src/app/trips/__tests__/_layout.test.tsx
@@ -59,6 +59,30 @@ describe('TripsLayout header actions', () => {
     );
   });
 
+  it('registers Timeline as a push route and its management routes as form sheets', async () => {
+    await render(<TripsLayout />);
+
+    expect(mockRegisterScreen).toHaveBeenCalledWith(
+      '[tripId]/timeline/index',
+      expect.objectContaining({ title: 'Timeline' }),
+    );
+    expect(mockRegisterScreen).toHaveBeenCalledWith(
+      '[tripId]/timeline/section-form',
+      expect.objectContaining({ title: 'Timeline Day', presentation: 'formSheet' }),
+    );
+    expect(mockRegisterScreen).toHaveBeenCalledWith(
+      '[tripId]/timeline/activity-form',
+      expect.objectContaining({ title: 'Activity', presentation: 'formSheet' }),
+    );
+    expect(mockRegisterScreen).toHaveBeenCalledWith(
+      '[tripId]/timeline/custom-types',
+      expect.objectContaining({ title: 'Custom Types', presentation: 'formSheet' }),
+    );
+    expect(screen.getByLabelText('Cancel timeline day form')).toBeTruthy();
+    expect(screen.getByLabelText('Cancel timeline activity form')).toBeTruthy();
+    expect(screen.getByLabelText('Close custom types')).toBeTruthy();
+  });
+
   it('returns to the previous route from the trip detail header when history exists', async () => {
     mockRouter.canGoBack.mockReturnValue(true);
     await render(<TripsLayout />);
@@ -71,6 +95,9 @@ describe('TripsLayout header actions', () => {
     ['Cancel trip creation'],
     ['Cancel trip editing'],
     ['Cancel member invitation'],
+    ['Cancel timeline day form'],
+    ['Cancel timeline activity form'],
+    ['Close custom types'],
   ])('returns to tabs from %s when there is no navigation history', async (label) => {
     mockRouter.canGoBack.mockReturnValue(false);
     await render(<TripsLayout />);

--- a/mobile/src/app/trips/_layout.tsx
+++ b/mobile/src/app/trips/_layout.tsx
@@ -79,6 +79,54 @@ export default function TripsLayout() {
         }}
       />
       <Stack.Screen
+        name="[tripId]/timeline/index"
+        options={{
+          title: 'Timeline',
+        }}
+      />
+      <Stack.Screen
+        name="[tripId]/timeline/section-form"
+        options={{
+          title: 'Timeline Day',
+          presentation: 'formSheet',
+          headerLeft: () => (
+            <HeaderAction
+              label="Cancel"
+              accessibilityLabel="Cancel timeline day form"
+              onPress={leaveTripsRoute}
+            />
+          ),
+        }}
+      />
+      <Stack.Screen
+        name="[tripId]/timeline/activity-form"
+        options={{
+          title: 'Activity',
+          presentation: 'formSheet',
+          headerLeft: () => (
+            <HeaderAction
+              label="Cancel"
+              accessibilityLabel="Cancel timeline activity form"
+              onPress={leaveTripsRoute}
+            />
+          ),
+        }}
+      />
+      <Stack.Screen
+        name="[tripId]/timeline/custom-types"
+        options={{
+          title: 'Custom Types',
+          presentation: 'formSheet',
+          headerLeft: () => (
+            <HeaderAction
+              label="Close"
+              accessibilityLabel="Close custom types"
+              onPress={leaveTripsRoute}
+            />
+          ),
+        }}
+      />
+      <Stack.Screen
         name="[tripId]/edit"
         options={{
           title: 'Edit Trip',

--- a/mobile/src/features/notifications/__tests__/payloadParsers.test.ts
+++ b/mobile/src/features/notifications/__tests__/payloadParsers.test.ts
@@ -74,4 +74,23 @@ describe('notification payload parsers', () => {
     expect(getTripTarget(pending)).toBeNull();
     expect(getTripTarget(accepted)).toBe('trip-1');
   });
+
+  it.each([
+    ['an empty location', { location_label: '' }],
+    ['an omitted location', {}],
+  ])('keeps a timeline reminder with %s actionable', (_label, locationFields) => {
+    const parsed = parseNotificationPayload('TRIP_TIMELINE_REMINDER', {
+      trip_id: 'trip-1',
+      trip_name: 'Da Lat escape',
+      activity_id: 'activity-1',
+      activity_title: 'Cable car',
+      section_label: 'Day 1',
+      activity_date: '2026-08-01',
+      activity_time: '09:00',
+      ...locationFields,
+    });
+
+    expect(parsed.kind).toBe('tripTimelineReminder');
+    expect(getTripTarget(parsed)).toBe('trip-1');
+  });
 });

--- a/mobile/src/features/notifications/payloadParsers.ts
+++ b/mobile/src/features/notifications/payloadParsers.ts
@@ -16,6 +16,14 @@ function readString(record: Record<string, unknown>, key: string): string | null
   return typeof value === 'string' && value.length > 0 ? value : null;
 }
 
+function readOptionalString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  if (value === undefined) {
+    return '';
+  }
+  return typeof value === 'string' ? value : null;
+}
+
 function isInvitationStatus(value: unknown): value is InvitationStatus {
   return value === 'PENDING' || value === 'ACCEPTED' || value === 'DECLINED' || value === 'CANCELLED';
 }
@@ -74,8 +82,8 @@ function parseTimelineReminderPayload(raw: unknown): TripTimelineReminderPayload
   const sectionLabel = readString(raw, 'section_label');
   const activityDate = readString(raw, 'activity_date');
   const activityTime = readString(raw, 'activity_time');
-  const locationLabel = readString(raw, 'location_label');
-  if (!activityId || !activityTitle || !sectionLabel || !activityDate || !activityTime || !locationLabel) {
+  const locationLabel = readOptionalString(raw, 'location_label');
+  if (!activityId || !activityTitle || !sectionLabel || !activityDate || !activityTime || locationLabel === null) {
     return null;
   }
   return {

--- a/mobile/src/features/timeline/__tests__/ActivityForm.test.tsx
+++ b/mobile/src/features/timeline/__tests__/ActivityForm.test.tsx
@@ -1,0 +1,379 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import type { ComponentProps } from 'react';
+import { Pressable, Text } from 'react-native';
+import type { TripMember } from '@/features/trips/types';
+import { ActivityForm } from '../components/ActivityForm';
+import {
+  ACTIVITY_FIELD_LIMITS,
+  createActivityDraft,
+  type ActivityFormDraft,
+} from '../formModel';
+import type {
+  TimelineActivity,
+  TimelineCustomTypeMeta,
+  TimelineSystemTypeMeta,
+} from '../types';
+
+const systemTypes: TimelineSystemTypeMeta[] = [
+  {
+    code: 'FOOD',
+    label: 'Food',
+    color_token: 'amber',
+    icon_key: 'restaurant',
+  },
+  {
+    code: 'OTHER',
+    label: 'Other',
+    color_token: 'slate',
+    icon_key: 'tag',
+  },
+];
+
+const customTypes: TimelineCustomTypeMeta[] = [
+  {
+    id: 'custom-active',
+    name: 'Coffee stop',
+    normalized_name: 'coffee-stop',
+    color_token: 'amber',
+    icon_key: 'cafe',
+    is_active: true,
+  },
+];
+
+const members: TripMember[] = [
+  {
+    membership_id: 'membership-1',
+    user: {
+      id: 'member-1',
+      display_name: 'Minh',
+      identify_tag: 'minh',
+      avatar_url: null,
+    },
+    role: 'CAPTAIN',
+    joined_at: '2026-01-01T00:00:00Z',
+  },
+];
+
+function validDraft(
+  overrides: Partial<ActivityFormDraft> = {},
+): ActivityFormDraft {
+  return {
+    ...createActivityDraft(),
+    title: 'Breakfast',
+    start_time: '08:30',
+    system_type: 'FOOD',
+    ...overrides,
+  };
+}
+
+function buildActivity(
+  overrides: Partial<TimelineActivity> = {},
+): TimelineActivity {
+  return {
+    id: 'activity-1',
+    title: 'Breakfast',
+    time_mode: 'AT_TIME',
+    start_time: '08:30:00',
+    end_time: null,
+    status: 'UPCOMING',
+    position: 0,
+    activity_type: {
+      kind: 'SYSTEM',
+      code: 'FOOD',
+      label: 'Food',
+      color_token: 'amber',
+      icon_key: 'restaurant',
+    },
+    assignee_scope: 'NONE',
+    assignee: null,
+    location: {
+      location_mode: 'MANUAL',
+      location_label: '',
+      location_note: '',
+      place: null,
+      open_url: null,
+    },
+    note: '',
+    meeting_point: '',
+    contact_name: '',
+    contact_phone: '',
+    booking_reference: '',
+    external_link: '',
+    reminder_offsets_minutes: [],
+    capabilities: {
+      can_edit: true,
+      can_delete: true,
+      can_update_status: true,
+    },
+    ...overrides,
+  };
+}
+
+function renderForm(
+  overrides: Partial<ComponentProps<typeof ActivityForm>> = {},
+) {
+  const props: ComponentProps<typeof ActivityForm> = {
+    mode: 'create',
+    draft: validDraft(),
+    systemTypes,
+    customTypes,
+    members,
+    canManageCustomTypes: true,
+    canSubmit: true,
+    submitting: false,
+    refreshing: false,
+    localFieldErrors: {},
+    submitError: null,
+    backgroundError: null,
+    onDraftChange: jest.fn(),
+    onSubmit: jest.fn(),
+    onRefresh: jest.fn(),
+    onRetryBackground: jest.fn(),
+    onManageCustomTypes: jest.fn(),
+    ...overrides,
+  };
+  return { props, view: render(<ActivityForm {...props} />) };
+}
+
+describe('ActivityForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders all draft fields, virtualized choices, caps, and server reminder boundary', async () => {
+    await renderForm().view;
+
+    expect(screen.getByTestId('custom-type-list')).toBeTruthy();
+    expect(screen.getByTestId('assignee-member-list')).toBeTruthy();
+    expect(screen.getByLabelText('Activity title').props.maxLength).toBe(
+      ACTIVITY_FIELD_LIMITS.title,
+    );
+    expect(screen.getByLabelText('Location label').props.maxLength).toBe(
+      ACTIVITY_FIELD_LIMITS.location_label,
+    );
+    expect(screen.getByLabelText('Meeting point')).toBeTruthy();
+    expect(screen.getByLabelText('Contact name')).toBeTruthy();
+    expect(screen.getByLabelText('Contact phone')).toBeTruthy();
+    expect(screen.getByLabelText('Booking reference')).toBeTruthy();
+    expect(screen.getByLabelText('External link')).toBeTruthy();
+    expect(screen.getByLabelText('Reminder 30 min before')).toBeTruthy();
+    expect(
+      screen.getByText(/does not schedule device notifications/i),
+    ).toBeTruthy();
+  });
+
+  it('applies time-mode invariants before reporting the changed fields', async () => {
+    const onDraftChange = jest.fn();
+    await renderForm({
+      draft: validDraft({
+        time_mode: 'TIME_RANGE',
+        start_time: '08:30',
+        end_time: '09:30',
+        reminder_offsets_minutes: [30],
+      }),
+      onDraftChange,
+    }).view;
+
+    await fireEvent.press(screen.getByLabelText('Schedule All day'));
+
+    expect(onDraftChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        time_mode: 'ALL_DAY',
+        start_time: '',
+        end_time: '',
+        reminder_offsets_minutes: [],
+      }),
+      [
+        'time_mode',
+        'start_time',
+        'end_time',
+        'reminder_offsets_minutes',
+      ],
+    );
+  });
+
+  it('keeps only the inactive custom type selected by the edited activity', async () => {
+    const inactiveCurrent: TimelineCustomTypeMeta = {
+      id: 'inactive-current',
+      name: 'Legacy stop',
+      normalized_name: 'legacy-stop',
+      color_token: 'slate',
+      icon_key: 'tag',
+      is_active: false,
+    };
+    const inactiveOther: TimelineCustomTypeMeta = {
+      ...inactiveCurrent,
+      id: 'inactive-other',
+      name: 'Unused legacy',
+      normalized_name: 'unused-legacy',
+    };
+    const initialActivity = buildActivity({
+      activity_type: {
+        kind: 'CUSTOM',
+        id: inactiveCurrent.id,
+        label: inactiveCurrent.name,
+        color_token: inactiveCurrent.color_token,
+        icon_key: inactiveCurrent.icon_key,
+      },
+    });
+    await renderForm({
+      mode: 'edit',
+      draft: validDraft({
+        system_type: null,
+        custom_type_id: inactiveCurrent.id,
+      }),
+      customTypes: [...customTypes, inactiveCurrent, inactiveOther],
+      initialActivity,
+    }).view;
+
+    expect(screen.getByText('Legacy stop · inactive')).toBeTruthy();
+    expect(screen.queryByText('Unused legacy · inactive')).toBeNull();
+  });
+
+  it('uses horizontal active-member choices to build USER assignee state', async () => {
+    const onDraftChange = jest.fn();
+    await renderForm({ onDraftChange }).view;
+
+    await fireEvent.press(screen.getByLabelText('Assign to Minh'));
+
+    expect(onDraftChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assignee_scope: 'USER',
+        assignee_user_id: 'member-1',
+      }),
+      ['assignee_scope', 'assignee_user_id'],
+    );
+  });
+
+  it('clears structured place only through an explicit manual switch', async () => {
+    const onDraftChange = jest.fn();
+    await renderForm({
+      draft: validDraft({
+        location_mode: 'STRUCTURED',
+        location_label: 'Verified cafe',
+        place: {
+          provider: 'here',
+          provider_id: 'canonical-id',
+          title: 'Verified cafe',
+          address: 'Da Nang',
+          lat: 16,
+          lng: 108,
+        },
+      }),
+      onDraftChange,
+    }).view;
+
+    await fireEvent.press(screen.getByLabelText('Use manual location'));
+
+    expect(onDraftChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location_mode: 'MANUAL',
+        place: null,
+      }),
+      ['location_mode', 'place'],
+    );
+  });
+
+  it('exposes a canonical structured-location integration seam', async () => {
+    const onDraftChange = jest.fn();
+    await renderForm({
+      onDraftChange,
+      renderStructuredLocationEditor: ({ onChange }) => (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Choose verified place"
+          onPress={() =>
+            onChange({
+              location_label: 'Canonical title',
+              place: {
+                provider: 'here',
+                provider_id: 'canonical-lookup-id',
+                title: 'Canonical title',
+                address: 'Canonical address',
+                lat: 16,
+                lng: 108,
+              },
+            })
+          }
+        >
+          <Text>Choose verified place</Text>
+        </Pressable>
+      ),
+    }).view;
+
+    await fireEvent.press(screen.getByLabelText('Choose verified place'));
+
+    expect(onDraftChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location_mode: 'STRUCTURED',
+        location_label: 'Canonical title',
+        place: expect.objectContaining({
+          provider_id: 'canonical-lookup-id',
+        }),
+      }),
+      ['location_mode', 'location_label', 'place'],
+    );
+  });
+
+  it('renders location_label and every nested place error inline', async () => {
+    await renderForm({
+      draft: validDraft({
+        location_mode: 'STRUCTURED',
+        location_label: 'Verified cafe',
+        place: {
+          provider: 'here',
+          provider_id: 'canonical-id',
+          title: 'Verified cafe',
+          address: '',
+          lat: null,
+          lng: null,
+        },
+      }),
+      submitError: {
+        kind: 'field',
+        message: 'Please fix the highlighted fields.',
+        fieldErrors: {
+          location_label: 'Location label is invalid.',
+          'place.provider_id': 'Provider id is invalid.',
+          'place.title': 'Place title is invalid.',
+          'place.extra': 'Unknown nested place issue.',
+        },
+      },
+    }).view;
+
+    expect(screen.getByText('Location label is invalid.')).toBeTruthy();
+    expect(screen.getByText('Provider id is invalid.')).toBeTruthy();
+    expect(screen.getByText('Place title is invalid.')).toBeTruthy();
+    expect(screen.getByText('Unknown nested place issue.')).toBeTruthy();
+  });
+
+  it('toggles only supported reminder presets through the pure form model', async () => {
+    const onDraftChange = jest.fn();
+    await renderForm({ onDraftChange }).view;
+
+    await fireEvent.press(screen.getByLabelText('Reminder 30 min before'));
+
+    expect(onDraftChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reminder_offsets_minutes: [30],
+      }),
+      ['reminder_offsets_minutes'],
+    );
+  });
+
+  it('disables editing and submit controls after authority is lost', async () => {
+    await renderForm({
+      canSubmit: false,
+      authorityMessage: 'You no longer have permission.',
+    }).view;
+
+    expect(screen.getByLabelText('Activity title').props.editable).toBe(false);
+    expect(
+      screen.getByLabelText('System type Food').props.accessibilityState,
+    ).toMatchObject({ disabled: true });
+    expect(
+      screen.getByLabelText('Create activity').props.accessibilityState,
+    ).toMatchObject({ disabled: true });
+    expect(screen.getByText('You no longer have permission.')).toBeTruthy();
+  });
+});

--- a/mobile/src/features/timeline/__tests__/ActivityForm.test.tsx
+++ b/mobile/src/features/timeline/__tests__/ActivityForm.test.tsx
@@ -315,6 +315,47 @@ describe('ActivityForm', () => {
     );
   });
 
+  it('commits a settled lookup fallback as manual text without retaining a place', async () => {
+    const onDraftChange = jest.fn();
+    await renderForm({
+      draft: validDraft({
+        location_mode: 'STRUCTURED',
+        location_label: 'Old verified place',
+        place: {
+          provider: 'here',
+          provider_id: 'canonical-id',
+          title: 'Old verified place',
+          address: 'Da Nang',
+          lat: 16,
+          lng: 108,
+        },
+      }),
+      onDraftChange,
+      renderStructuredLocationEditor: ({ onUseManual }) => (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Use failed lookup fallback"
+          onPress={() => onUseManual('Unverified suggestion')}
+        >
+          <Text>Use failed lookup fallback</Text>
+        </Pressable>
+      ),
+    }).view;
+
+    await fireEvent.press(
+      screen.getByLabelText('Use failed lookup fallback'),
+    );
+
+    expect(onDraftChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location_mode: 'MANUAL',
+        location_label: 'Unverified suggestion',
+        place: null,
+      }),
+      ['location_mode', 'location_label', 'place'],
+    );
+  });
+
   it('renders location_label and every nested place error inline', async () => {
     await renderForm({
       draft: validDraft({

--- a/mobile/src/features/timeline/__tests__/ActivityFormScreen.test.tsx
+++ b/mobile/src/features/timeline/__tests__/ActivityFormScreen.test.tsx
@@ -1,6 +1,7 @@
 import type { ComponentProps, ReactNode } from 'react';
 import { View } from 'react-native';
 import type { ActivityForm } from '../components/ActivityForm';
+import type { PlacePicker } from '../components/PlacePicker';
 
 let mockParams: Record<string, string | string[] | undefined> = {};
 const mockRouter = {
@@ -18,6 +19,7 @@ const mockPublishTimelineEvent = jest.fn();
 const mockSubscribeToTimelineEvents = jest.fn();
 const mockSubscribeToTripEvents = jest.fn();
 let mockActivityFormProps: unknown;
+let mockPlacePickerProps: unknown;
 let mockTimelineListener:
   | ((event: { type: 'timelineChanged'; tripId: string }) =>
       void | Promise<void>)
@@ -53,6 +55,11 @@ function mockRenderActivityForm(props: unknown) {
   return <View testID="mock-activity-form" />;
 }
 
+function mockRenderPlacePicker(props: unknown) {
+  mockPlacePickerProps = props;
+  return <View testID="mock-place-picker" />;
+}
+
 jest.mock('expo-router', () => ({
   Stack: { Screen: mockRenderStackScreen },
   useFocusEffect: (effect: () => (() => void) | void) =>
@@ -74,6 +81,9 @@ jest.mock('@/features/trips/hooks/useTripDetail', () => ({
 }));
 jest.mock('../components/ActivityForm', () => ({
   ActivityForm: mockRenderActivityForm,
+}));
+jest.mock('../components/PlacePicker', () => ({
+  PlacePicker: mockRenderPlacePicker,
 }));
 jest.mock('../api', () => ({
   createActivity: jest.fn(),
@@ -324,6 +334,13 @@ function currentFormProps(): ComponentProps<typeof ActivityForm> {
   return mockActivityFormProps as ComponentProps<typeof ActivityForm>;
 }
 
+function currentPlacePickerProps(): ComponentProps<typeof PlacePicker> {
+  if (!mockPlacePickerProps) {
+    throw new Error('Expected PlacePicker to be rendered.');
+  }
+  return mockPlacePickerProps as ComponentProps<typeof PlacePicker>;
+}
+
 function latestFocusCallback(): () => (() => void) | void {
   const callback = mockUseFocusEffect.mock.calls.at(-1)?.[0] as
     | (() => (() => void) | void)
@@ -365,6 +382,7 @@ describe('ActivityFormScreen', () => {
       activityId: ACTIVITY_ID,
     };
     mockActivityFormProps = undefined;
+    mockPlacePickerProps = undefined;
     mockTimelineListener = undefined;
     mockTripListener = undefined;
     mockLatestStackOptions = undefined;
@@ -427,6 +445,64 @@ describe('ActivityFormScreen', () => {
     expect(mockUseTripDetail).not.toHaveBeenCalled();
     expect(mockCreateActivity).not.toHaveBeenCalled();
     expect(mockPatchActivity).not.toHaveBeenCalled();
+  });
+
+  it('bridges canonical and failed lookups into the ActivityForm draft contract', async () => {
+    await render(<ActivityFormScreen />);
+    const editor = currentFormProps().renderStructuredLocationEditor;
+    const onChange = jest.fn();
+    const onUseManual = jest.fn();
+
+    await render(
+      <View>
+        {editor?.({
+          value: null,
+          locationLabel: 'Existing manual label',
+          disabled: false,
+          fieldErrors: {
+            'place.provider_id': 'Provider id is invalid.',
+          },
+          onChange,
+          onUseManual,
+        })}
+      </View>,
+    );
+
+    const picker = currentPlacePickerProps();
+    expect(picker.value).toEqual({
+      location_label: 'Existing manual label',
+      place: null,
+    });
+    expect(picker.error).toBe('Provider id is invalid.');
+
+    picker.onSelectLocation({
+      location_mode: 'STRUCTURED',
+      location_label: 'Canonical place',
+      place: {
+        provider: 'here',
+        provider_id: 'canonical-id',
+        title: 'Canonical place',
+        address: 'Da Nang',
+        lat: 16,
+        lng: 108,
+      },
+    });
+    expect(onChange).toHaveBeenCalledWith({
+      location_label: 'Canonical place',
+      place: expect.objectContaining({ provider_id: 'canonical-id' }),
+    });
+
+    picker.onLookupFailure({
+      location_mode: 'MANUAL',
+      location_label: 'Unverified suggestion',
+      place: null,
+      error: {
+        kind: 'network',
+        message: 'Cannot reach the server.',
+      },
+      guidance: 'Enter the location manually.',
+    });
+    expect(onUseManual).toHaveBeenCalledWith('Unverified suggestion');
   });
 
   it.each(['timeline-first', 'trip-first'] as const)(

--- a/mobile/src/features/timeline/__tests__/ActivityFormScreen.test.tsx
+++ b/mobile/src/features/timeline/__tests__/ActivityFormScreen.test.tsx
@@ -134,6 +134,7 @@ const TRIP_ID = '123e4567-e89b-12d3-a456-426614174000';
 const SECTION_ID = '2c1dfd8d-9c7f-43c7-9b99-71f6d1edda55';
 const ACTIVITY_ID = 'a11957b3-3329-4fcf-9c7b-673a51c1d8a7';
 const OTHER_ACTIVITY_ID = '7191f7c4-16f0-4fc5-996f-3264a46e7761';
+const CUSTOM_TYPE_ID = '4f44f738-0f5c-4608-a0b8-fd4ca3ecacde';
 
 function activity(
   overrides: Partial<TimelineActivity> = {},
@@ -581,6 +582,64 @@ describe('ActivityFormScreen', () => {
     expect(currentFormProps().canSubmit).toBe(true);
   });
 
+  it('blocks a stale custom type selection locally after the type is deactivated', async () => {
+    mockParams = {
+      tripId: TRIP_ID,
+      mode: 'create',
+      sectionId: SECTION_ID,
+    };
+    const activeCustomType = {
+      id: CUSTOM_TYPE_ID,
+      name: 'Coffee stop',
+      normalized_name: 'coffee-stop',
+      color_token: 'amber',
+      icon_key: 'cafe',
+      is_active: true,
+    };
+    mockUseTimeline.mockReturnValue(
+      readyTimelineHook(
+        timeline({
+          custom_types: [activeCustomType],
+        }),
+      ),
+    );
+    const view = await render(<ActivityFormScreen />);
+    await changeDraft(
+      (draft) => ({
+        ...draft,
+        title: 'Draft with stale type',
+        start_time: '09:00',
+        system_type: null,
+        custom_type_id: CUSTOM_TYPE_ID,
+      }),
+      ['title', 'start_time', 'system_type', 'custom_type_id'],
+    );
+
+    mockUseTimeline.mockReturnValue(
+      readyTimelineHook(
+        timeline({
+          custom_types: [
+            {
+              ...activeCustomType,
+              is_active: false,
+            },
+          ],
+        }),
+      ),
+    );
+    await view.rerender(<ActivityFormScreen />);
+
+    expect(currentFormProps().draft.custom_type_id).toBe(CUSTOM_TYPE_ID);
+    await act(async () => {
+      currentFormProps().onSubmit();
+    });
+
+    expect(mockCreateActivity).not.toHaveBeenCalled();
+    expect(currentFormProps().localFieldErrors.activity_type).toBe(
+      'The selected custom type is no longer available. Choose another activity type.',
+    );
+  });
+
   it('creates with a full payload, locks duplicate submit and Cancel, then reconciles once before dismissing', async () => {
     const pending = deferred<TimelineActivity>();
     mockCreateActivity.mockReturnValue(pending.promise);
@@ -734,6 +793,111 @@ describe('ActivityFormScreen', () => {
     expect(mockRefreshTrip).toHaveBeenCalledTimes(1);
     expect(mockRefreshTimeline).toHaveBeenCalledWith('silent');
     expect(mockRefreshTrip).toHaveBeenCalledWith('silent');
+    expect(mockPublishTimelineEvent).not.toHaveBeenCalled();
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+  });
+
+  it('clears stale pending UI on refocus when the mutation settled while inactive', async () => {
+    const pending = deferred<TimelineActivity>();
+    mockCreateActivity.mockReturnValue(pending.promise);
+    mockParams = {
+      tripId: TRIP_ID,
+      mode: 'create',
+      sectionId: SECTION_ID,
+    };
+    await render(<ActivityFormScreen />);
+    const blur = await focusScreen();
+    await changeDraft(
+      (draft) => ({
+        ...draft,
+        title: 'Settles while inactive',
+        start_time: '10:30',
+      }),
+      ['title', 'start_time'],
+    );
+    await act(async () => {
+      currentFormProps().onSubmit();
+    });
+    await waitFor(() =>
+      expect(mockCreateActivity).toHaveBeenCalledTimes(1),
+    );
+
+    await act(async () => {
+      blur?.();
+      pending.reject(
+        axiosErrorWith(409, {
+          detail: 'This inactive failure must remain invisible.',
+        }),
+      );
+    });
+
+    expect(currentFormProps().submitting).toBe(true);
+    await focusScreen();
+    await waitFor(() =>
+      expect(currentFormProps().submitting).toBe(false),
+    );
+    expect(mockLatestStackOptions?.gestureEnabled).toBe(true);
+    expect(
+      screen.getByLabelText('Cancel timeline activity form').props
+        .accessibilityState,
+    ).toMatchObject({ disabled: false });
+    expect(currentFormProps().submitError).toBeNull();
+    expect(mockPublishTimelineEvent).not.toHaveBeenCalled();
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+  });
+
+  it('clears stale pending UI when the old mutation settles after refocus', async () => {
+    const pending = deferred<TimelineActivity>();
+    mockCreateActivity.mockReturnValue(pending.promise);
+    mockParams = {
+      tripId: TRIP_ID,
+      mode: 'create',
+      sectionId: SECTION_ID,
+    };
+    await render(<ActivityFormScreen />);
+    const blur = await focusScreen();
+    await changeDraft(
+      (draft) => ({
+        ...draft,
+        title: 'Settles after refocus',
+        start_time: '10:45',
+      }),
+      ['title', 'start_time'],
+    );
+    await act(async () => {
+      currentFormProps().onSubmit();
+    });
+    await waitFor(() =>
+      expect(mockCreateActivity).toHaveBeenCalledTimes(1),
+    );
+
+    await act(async () => {
+      blur?.();
+    });
+    await focusScreen();
+    expect(currentFormProps().submitting).toBe(true);
+    mockRefreshTimeline.mockClear();
+    mockRefreshTrip.mockClear();
+
+    await act(async () => {
+      pending.reject(
+        axiosErrorWith(409, {
+          detail: 'This stale generation must remain invisible.',
+        }),
+      );
+    });
+
+    await waitFor(() =>
+      expect(currentFormProps().submitting).toBe(false),
+    );
+    expect(mockLatestStackOptions?.gestureEnabled).toBe(true);
+    expect(
+      screen.getByLabelText('Cancel timeline activity form').props
+        .accessibilityState,
+    ).toMatchObject({ disabled: false });
+    expect(currentFormProps().submitError).toBeNull();
+    expect(mockRefreshTimeline).not.toHaveBeenCalled();
+    expect(mockRefreshTrip).not.toHaveBeenCalled();
     expect(mockPublishTimelineEvent).not.toHaveBeenCalled();
     expect(mockRouter.dismissTo).not.toHaveBeenCalled();
   });

--- a/mobile/src/features/timeline/__tests__/ActivityFormScreen.test.tsx
+++ b/mobile/src/features/timeline/__tests__/ActivityFormScreen.test.tsx
@@ -1,0 +1,807 @@
+import type { ComponentProps, ReactNode } from 'react';
+import { View } from 'react-native';
+import type { ActivityForm } from '../components/ActivityForm';
+
+let mockParams: Record<string, string | string[] | undefined> = {};
+const mockRouter = {
+  dismissTo: jest.fn(),
+  push: jest.fn(),
+};
+const mockUseFocusEffect = jest.fn();
+const mockUseAppForegroundEffect = jest.fn();
+const mockUseTimeline = jest.fn();
+const mockUseTripDetail = jest.fn();
+const mockRefreshTimeline = jest.fn();
+const mockRefreshTrip = jest.fn();
+const mockInvalidateTimeline = jest.fn();
+const mockPublishTimelineEvent = jest.fn();
+const mockSubscribeToTimelineEvents = jest.fn();
+const mockSubscribeToTripEvents = jest.fn();
+let mockActivityFormProps: unknown;
+let mockTimelineListener:
+  | ((event: { type: 'timelineChanged'; tripId: string }) =>
+      void | Promise<void>)
+  | undefined;
+let mockTripListener:
+  | ((event: {
+      type: 'statusChanged';
+      tripId: string;
+      status: 'PLANNING' | 'ONGOING' | 'COMPLETED' | 'CANCELLED';
+    }) => void)
+  | undefined;
+let mockLatestStackOptions:
+  | {
+      gestureEnabled?: boolean;
+      headerLeft?: () => ReactNode;
+    }
+  | undefined;
+
+function mockRenderStackScreen({
+  options,
+}: {
+  options: {
+    gestureEnabled?: boolean;
+    headerLeft?: () => ReactNode;
+  };
+}) {
+  mockLatestStackOptions = options;
+  return <View>{options.headerLeft?.()}</View>;
+}
+
+function mockRenderActivityForm(props: unknown) {
+  mockActivityFormProps = props;
+  return <View testID="mock-activity-form" />;
+}
+
+jest.mock('expo-router', () => ({
+  Stack: { Screen: mockRenderStackScreen },
+  useFocusEffect: (effect: () => (() => void) | void) =>
+    mockUseFocusEffect(effect),
+  useLocalSearchParams: () => mockParams,
+  useRouter: () => mockRouter,
+}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('@/shared/hooks/useAppForegroundEffect', () => ({
+  useAppForegroundEffect: (listener: () => void) =>
+    mockUseAppForegroundEffect(listener),
+}));
+jest.mock('../hooks/useTimeline', () => ({
+  useTimeline: (...args: unknown[]) => mockUseTimeline(...args),
+}));
+jest.mock('@/features/trips/hooks/useTripDetail', () => ({
+  useTripDetail: (...args: unknown[]) => mockUseTripDetail(...args),
+}));
+jest.mock('../components/ActivityForm', () => ({
+  ActivityForm: mockRenderActivityForm,
+}));
+jest.mock('../api', () => ({
+  createActivity: jest.fn(),
+  patchActivity: jest.fn(),
+}));
+jest.mock('../timelineEvents', () => ({
+  publishTimelineEvent: (...args: unknown[]) =>
+    mockPublishTimelineEvent(...args),
+  subscribeToTimelineEvents: (...args: unknown[]) =>
+    mockSubscribeToTimelineEvents(...args),
+}));
+jest.mock('@/features/trips/tripEvents', () => ({
+  subscribeToTripEvents: (...args: unknown[]) =>
+    mockSubscribeToTripEvents(...args),
+}));
+
+// eslint-disable-next-line import/first
+import { AxiosError, AxiosHeaders } from 'axios';
+// eslint-disable-next-line import/first
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { createActivity, patchActivity } from '../api';
+// eslint-disable-next-line import/first
+import { ActivityFormScreen } from '../screens/ActivityFormScreen';
+// eslint-disable-next-line import/first
+import type { TripDetailResponse } from '@/features/trips/types';
+// eslint-disable-next-line import/first
+import type {
+  TimelineActivity,
+  TimelineResponse,
+  TimelineSection,
+} from '../types';
+
+const mockCreateActivity = createActivity as jest.MockedFunction<
+  typeof createActivity
+>;
+const mockPatchActivity = patchActivity as jest.MockedFunction<
+  typeof patchActivity
+>;
+
+const TRIP_ID = '123e4567-e89b-12d3-a456-426614174000';
+const SECTION_ID = '2c1dfd8d-9c7f-43c7-9b99-71f6d1edda55';
+const ACTIVITY_ID = 'a11957b3-3329-4fcf-9c7b-673a51c1d8a7';
+const OTHER_ACTIVITY_ID = '7191f7c4-16f0-4fc5-996f-3264a46e7761';
+
+function activity(
+  overrides: Partial<TimelineActivity> = {},
+): TimelineActivity {
+  return {
+    id: ACTIVITY_ID,
+    title: 'Breakfast',
+    time_mode: 'AT_TIME',
+    start_time: '08:00:00',
+    end_time: null,
+    status: 'UPCOMING',
+    position: 0,
+    activity_type: {
+      kind: 'SYSTEM',
+      code: 'OTHER',
+      label: 'Other',
+      color_token: 'slate',
+      icon_key: 'tag',
+    },
+    assignee_scope: 'NONE',
+    assignee: null,
+    location: {
+      location_mode: 'MANUAL',
+      location_label: '',
+      location_note: '',
+      place: null,
+      open_url: null,
+    },
+    note: '',
+    meeting_point: '',
+    contact_name: '',
+    contact_phone: '',
+    booking_reference: '',
+    external_link: '',
+    reminder_offsets_minutes: [],
+    capabilities: {
+      can_edit: true,
+      can_delete: true,
+      can_update_status: true,
+    },
+    ...overrides,
+  };
+}
+
+function section(
+  activities: TimelineActivity[] = [activity()],
+): TimelineSection {
+  return {
+    id: SECTION_ID,
+    section_date: '2026-08-01',
+    label: 'Arrival',
+    is_label_custom: true,
+    is_in_trip_range: true,
+    position: 0,
+    activities,
+  };
+}
+
+function timeline(
+  overrides: Partial<TimelineResponse> = {},
+): TimelineResponse {
+  return {
+    trip_timezone: 'Asia/Ho_Chi_Minh',
+    permissions: {
+      can_edit_timeline: true,
+      can_manage_custom_types: true,
+      can_create_sections: true,
+    },
+    system_types: [
+      {
+        code: 'OTHER',
+        label: 'Other',
+        color_token: 'slate',
+        icon_key: 'tag',
+      },
+    ],
+    custom_types: [],
+    sections: [section()],
+    ...overrides,
+  };
+}
+
+function tripDetail(
+  overrides: {
+    tripStatus?: TripDetailResponse['trip']['status'];
+    membershipStatus?: TripDetailResponse['my_membership']['status'];
+  } = {},
+): TripDetailResponse {
+  return {
+    trip: {
+      id: TRIP_ID,
+      name: 'Da Nang weekend',
+      destination: 'Da Nang, Vietnam',
+      destination_provider: '',
+      destination_provider_id: '',
+      destination_lat: null,
+      destination_lng: null,
+      destination_country_code: 'VN',
+      cover_image_url: '',
+      start_date: '2026-08-01',
+      end_date: '2026-08-03',
+      description: '',
+      status: overrides.tripStatus ?? 'PLANNING',
+      currency_code: 'VND',
+      timezone: 'Asia/Ho_Chi_Minh',
+      budget_estimate: null,
+      cancelled_at: null,
+      created_at: '2026-01-01T00:00:00Z',
+    },
+    my_membership: {
+      role: 'CAPTAIN',
+      status: overrides.membershipStatus ?? 'ACTIVE',
+      joined_at: '2026-01-01T00:00:00Z',
+    },
+    members: [
+      {
+        membership_id: 'membership-1',
+        user: {
+          id: 'member-1',
+          display_name: 'Minh',
+          identify_tag: 'minh',
+          avatar_url: null,
+        },
+        role: 'CAPTAIN',
+        joined_at: '2026-01-01T00:00:00Z',
+      },
+    ],
+  };
+}
+
+function readyTimelineHook(nextTimeline = timeline()) {
+  return {
+    timeline: nextTimeline,
+    status: 'ready' as const,
+    error: null,
+    refreshing: false,
+    refresh: mockRefreshTimeline,
+    invalidate: mockInvalidateTimeline,
+  };
+}
+
+function loadingTimelineHook() {
+  return {
+    timeline: null,
+    status: 'loading' as const,
+    error: null,
+    refreshing: false,
+    refresh: mockRefreshTimeline,
+    invalidate: mockInvalidateTimeline,
+  };
+}
+
+function readyTripHook(nextDetail = tripDetail()) {
+  return {
+    detail: nextDetail,
+    status: 'ready' as const,
+    error: null,
+    refreshing: false,
+    refresh: mockRefreshTrip,
+  };
+}
+
+function loadingTripHook() {
+  return {
+    detail: null,
+    status: 'loading' as const,
+    error: null,
+    refreshing: false,
+    refresh: mockRefreshTrip,
+  };
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, {}, {
+    status,
+    statusText: '',
+    headers: {},
+    config,
+    data,
+  });
+}
+
+function currentFormProps(): ComponentProps<typeof ActivityForm> {
+  if (!mockActivityFormProps) {
+    throw new Error('Expected ActivityForm to be rendered.');
+  }
+  return mockActivityFormProps as ComponentProps<typeof ActivityForm>;
+}
+
+function latestFocusCallback(): () => (() => void) | void {
+  const callback = mockUseFocusEffect.mock.calls.at(-1)?.[0] as
+    | (() => (() => void) | void)
+    | undefined;
+  if (!callback) {
+    throw new Error('Expected useFocusEffect to register a callback.');
+  }
+  return callback;
+}
+
+async function focusScreen(): Promise<(() => void) | undefined> {
+  let cleanup: (() => void) | undefined;
+  await act(async () => {
+    cleanup = latestFocusCallback()() || undefined;
+  });
+  return cleanup;
+}
+
+async function changeDraft(
+  mutate: (
+    draft: ComponentProps<typeof ActivityForm>['draft'],
+  ) => ComponentProps<typeof ActivityForm>['draft'],
+  fields: Parameters<
+    ComponentProps<typeof ActivityForm>['onDraftChange']
+  >[1],
+): Promise<void> {
+  const props = currentFormProps();
+  await act(async () => {
+    props.onDraftChange(mutate(props.draft), fields);
+  });
+}
+
+describe('ActivityFormScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockParams = {
+      tripId: TRIP_ID,
+      mode: 'edit',
+      activityId: ACTIVITY_ID,
+    };
+    mockActivityFormProps = undefined;
+    mockTimelineListener = undefined;
+    mockTripListener = undefined;
+    mockLatestStackOptions = undefined;
+    mockRefreshTimeline.mockResolvedValue(undefined);
+    mockRefreshTrip.mockResolvedValue(undefined);
+    mockUseTimeline.mockReturnValue(readyTimelineHook());
+    mockUseTripDetail.mockReturnValue(readyTripHook());
+    mockCreateActivity.mockResolvedValue(activity());
+    mockPatchActivity.mockResolvedValue(activity());
+    mockSubscribeToTimelineEvents.mockImplementation(
+      (
+        _tripId: string,
+        listener: (
+          event: { type: 'timelineChanged'; tripId: string },
+        ) => void | Promise<void>,
+      ) => {
+        mockTimelineListener = listener;
+        return () => {
+          if (mockTimelineListener === listener) {
+            mockTimelineListener = undefined;
+          }
+        };
+      },
+    );
+    mockPublishTimelineEvent.mockImplementation(
+      async (event: { type: 'timelineChanged'; tripId: string }) => {
+        await mockTimelineListener?.(event);
+      },
+    );
+    mockSubscribeToTripEvents.mockImplementation(
+      (
+        listener: (event: {
+          type: 'statusChanged';
+          tripId: string;
+          status: 'PLANNING' | 'ONGOING' | 'COMPLETED' | 'CANCELLED';
+        }) => void,
+      ) => {
+        mockTripListener = listener;
+        return () => {
+          if (mockTripListener === listener) {
+            mockTripListener = undefined;
+          }
+        };
+      },
+    );
+  });
+
+  it('rejects invalid route intent before mounting either data hook', async () => {
+    mockParams = {
+      tripId: TRIP_ID,
+      mode: 'edit',
+      sectionId: SECTION_ID,
+      activityId: ACTIVITY_ID,
+    };
+
+    await render(<ActivityFormScreen />);
+
+    expect(screen.getByText('Form unavailable')).toBeTruthy();
+    expect(mockUseTimeline).not.toHaveBeenCalled();
+    expect(mockUseTripDetail).not.toHaveBeenCalled();
+    expect(mockCreateActivity).not.toHaveBeenCalled();
+    expect(mockPatchActivity).not.toHaveBeenCalled();
+  });
+
+  it.each(['timeline-first', 'trip-first'] as const)(
+    'waits for both authoritative sources before hydrating (%s)',
+    async (order) => {
+      if (order === 'timeline-first') {
+        mockUseTimeline.mockReturnValue(readyTimelineHook());
+        mockUseTripDetail.mockReturnValue(loadingTripHook());
+      } else {
+        mockUseTimeline.mockReturnValue(loadingTimelineHook());
+        mockUseTripDetail.mockReturnValue(readyTripHook());
+      }
+      const view = await render(<ActivityFormScreen />);
+
+      expect(screen.queryByTestId('mock-activity-form')).toBeNull();
+      expect(mockActivityFormProps).toBeUndefined();
+
+      mockUseTimeline.mockReturnValue(readyTimelineHook());
+      mockUseTripDetail.mockReturnValue(readyTripHook());
+      await view.rerender(<ActivityFormScreen />);
+
+      expect(screen.getByTestId('mock-activity-form')).toBeTruthy();
+      expect(currentFormProps().draft.title).toBe('Breakfast');
+      expect(mockUseTimeline).toHaveBeenCalledWith(TRIP_ID, {
+        autoReconcile: false,
+      });
+      expect(mockUseTripDetail).toHaveBeenCalledWith(TRIP_ID, {
+        autoReconcile: false,
+      });
+    },
+  );
+
+  it('hydrates once, preserves edits across authority refresh, and rehydrates for a new route identity', async () => {
+    const view = await render(<ActivityFormScreen />);
+    await changeDraft(
+      (draft) => ({ ...draft, title: 'My immutable draft' }),
+      ['title'],
+    );
+
+    mockUseTimeline.mockReturnValue(
+      readyTimelineHook(
+        timeline({
+          sections: [
+            section([
+              activity({ title: 'Server refresh title' }),
+              activity({
+                id: OTHER_ACTIVITY_ID,
+                title: 'Dinner',
+                position: 1,
+              }),
+            ]),
+          ],
+        }),
+      ),
+    );
+    mockUseTripDetail.mockReturnValue(
+      readyTripHook(tripDetail({ membershipStatus: 'REMOVED' })),
+    );
+    await view.rerender(<ActivityFormScreen />);
+
+    expect(currentFormProps().draft.title).toBe('My immutable draft');
+    expect(currentFormProps().canSubmit).toBe(false);
+    expect(currentFormProps().authorityMessage).toBe(
+      'You are no longer an active member of this trip.',
+    );
+
+    mockParams = {
+      tripId: TRIP_ID,
+      mode: 'edit',
+      activityId: OTHER_ACTIVITY_ID,
+    };
+    mockUseTripDetail.mockReturnValue(readyTripHook());
+    await view.rerender(<ActivityFormScreen />);
+
+    expect(currentFormProps().draft.title).toBe('Dinner');
+    expect(currentFormProps().canSubmit).toBe(true);
+  });
+
+  it('creates with a full payload, locks duplicate submit and Cancel, then reconciles once before dismissing', async () => {
+    const pending = deferred<TimelineActivity>();
+    mockCreateActivity.mockReturnValue(pending.promise);
+    mockParams = {
+      tripId: TRIP_ID,
+      mode: 'create',
+      sectionId: SECTION_ID,
+    };
+    await render(<ActivityFormScreen />);
+    await focusScreen();
+    mockRefreshTimeline.mockClear();
+    mockRefreshTrip.mockClear();
+
+    await changeDraft(
+      (draft) => ({
+        ...draft,
+        title: '  Coffee stop  ',
+        start_time: '09:15',
+      }),
+      ['title', 'start_time'],
+    );
+    const props = currentFormProps();
+    await act(async () => {
+      props.onSubmit();
+      props.onSubmit();
+    });
+
+    await waitFor(() =>
+      expect(mockCreateActivity).toHaveBeenCalledTimes(1),
+    );
+    expect(mockCreateActivity).toHaveBeenCalledWith(
+      TRIP_ID,
+      SECTION_ID,
+      {
+        title: 'Coffee stop',
+        time_mode: 'AT_TIME',
+        start_time: '09:15',
+        end_time: null,
+        system_type: 'OTHER',
+        custom_type_id: null,
+        assignee_scope: 'NONE',
+        assignee_user_id: null,
+        location_mode: 'MANUAL',
+        location_label: '',
+        location_note: '',
+        place: null,
+        note: '',
+        meeting_point: '',
+        contact_name: '',
+        contact_phone: '',
+        booking_reference: '',
+        external_link: '',
+        reminder_offsets_minutes: [],
+      },
+    );
+    expect(mockInvalidateTimeline).toHaveBeenCalledTimes(1);
+    expect(mockLatestStackOptions?.gestureEnabled).toBe(false);
+    expect(currentFormProps().submitting).toBe(true);
+    expect(
+      screen.getByLabelText('Cancel timeline activity form').props
+        .accessibilityState,
+    ).toMatchObject({ disabled: true });
+    await fireEvent.press(
+      screen.getByLabelText('Cancel timeline activity form'),
+    );
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+
+    await act(async () => {
+      pending.resolve(activity({ title: 'Coffee stop' }));
+    });
+
+    await waitFor(() =>
+      expect(mockRouter.dismissTo).toHaveBeenCalledWith(
+        `/trips/${TRIP_ID}/timeline`,
+      ),
+    );
+    expect(mockPublishTimelineEvent).toHaveBeenCalledTimes(1);
+    expect(mockRefreshTimeline).toHaveBeenCalledTimes(1);
+    expect(mockRefreshTrip).toHaveBeenCalledTimes(1);
+    expect(mockRefreshTimeline).toHaveBeenCalledWith('silent');
+    expect(mockRefreshTrip).toHaveBeenCalledWith('silent');
+    expect(mockInvalidateTimeline.mock.invocationCallOrder[0]).toBeLessThan(
+      mockCreateActivity.mock.invocationCallOrder[0]!,
+    );
+    expect(mockCreateActivity.mock.invocationCallOrder[0]).toBeLessThan(
+      mockPublishTimelineEvent.mock.invocationCallOrder[0]!,
+    );
+    expect(mockRefreshTimeline.mock.invocationCallOrder[0]).toBeLessThan(
+      mockRouter.dismissTo.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it('sends only dirty changed fields in edit PATCH', async () => {
+    await render(<ActivityFormScreen />);
+    await focusScreen();
+    mockRefreshTimeline.mockClear();
+    mockRefreshTrip.mockClear();
+    await changeDraft(
+      (draft) => ({ ...draft, title: '  Updated breakfast  ' }),
+      ['title'],
+    );
+
+    await act(async () => {
+      currentFormProps().onSubmit();
+    });
+
+    await waitFor(() =>
+      expect(mockPatchActivity).toHaveBeenCalledWith(
+        TRIP_ID,
+        ACTIVITY_ID,
+        { title: 'Updated breakfast' },
+      ),
+    );
+    expect(mockCreateActivity).not.toHaveBeenCalled();
+  });
+
+  it('refreshes both sources after an active 409 without publishing or navigating', async () => {
+    mockParams = {
+      tripId: TRIP_ID,
+      mode: 'create',
+      sectionId: SECTION_ID,
+    };
+    mockCreateActivity.mockRejectedValueOnce(
+      axiosErrorWith(409, {
+        detail: 'The timeline changed before this save.',
+      }),
+    );
+    await render(<ActivityFormScreen />);
+    await focusScreen();
+    mockRefreshTimeline.mockClear();
+    mockRefreshTrip.mockClear();
+    await changeDraft(
+      (draft) => ({
+        ...draft,
+        title: 'Conflict',
+        start_time: '10:00',
+      }),
+      ['title', 'start_time'],
+    );
+
+    await act(async () => {
+      currentFormProps().onSubmit();
+    });
+
+    await waitFor(() =>
+      expect(currentFormProps().submitError?.message).toBe(
+        'The timeline changed before this save.',
+      ),
+    );
+    expect(mockRefreshTimeline).toHaveBeenCalledTimes(1);
+    expect(mockRefreshTrip).toHaveBeenCalledTimes(1);
+    expect(mockRefreshTimeline).toHaveBeenCalledWith('silent');
+    expect(mockRefreshTrip).toHaveBeenCalledWith('silent');
+    expect(mockPublishTimelineEvent).not.toHaveBeenCalled();
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+  });
+
+  it('ignores a late failure after unmount without event, refresh, or navigation effects', async () => {
+    const pending = deferred<TimelineActivity>();
+    mockCreateActivity.mockReturnValue(pending.promise);
+    mockParams = {
+      tripId: TRIP_ID,
+      mode: 'create',
+      sectionId: SECTION_ID,
+    };
+    const view = await render(<ActivityFormScreen />);
+    const blur = await focusScreen();
+    mockRefreshTimeline.mockClear();
+    mockRefreshTrip.mockClear();
+    await changeDraft(
+      (draft) => ({
+        ...draft,
+        title: 'Late failure',
+        start_time: '11:00',
+      }),
+      ['title', 'start_time'],
+    );
+    await act(async () => {
+      currentFormProps().onSubmit();
+    });
+    await waitFor(() =>
+      expect(mockCreateActivity).toHaveBeenCalledTimes(1),
+    );
+
+    await act(async () => {
+      blur?.();
+    });
+    await view.unmount();
+    await act(async () => {
+      pending.reject(
+        axiosErrorWith(409, {
+          detail: 'This unmounted error must remain invisible.',
+        }),
+      );
+    });
+
+    expect(mockRefreshTimeline).not.toHaveBeenCalled();
+    expect(mockRefreshTrip).not.toHaveBeenCalled();
+    expect(mockPublishTimelineEvent).not.toHaveBeenCalled();
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+  });
+
+  it('publishes one late success after unmount without refresh or navigation', async () => {
+    const pending = deferred<TimelineActivity>();
+    mockCreateActivity.mockReturnValue(pending.promise);
+    mockParams = {
+      tripId: TRIP_ID,
+      mode: 'create',
+      sectionId: SECTION_ID,
+    };
+    const view = await render(<ActivityFormScreen />);
+    const blur = await focusScreen();
+    mockRefreshTimeline.mockClear();
+    mockRefreshTrip.mockClear();
+    await changeDraft(
+      (draft) => ({
+        ...draft,
+        title: 'Late success',
+        start_time: '12:00',
+      }),
+      ['title', 'start_time'],
+    );
+    await act(async () => {
+      currentFormProps().onSubmit();
+    });
+    await waitFor(() =>
+      expect(mockCreateActivity).toHaveBeenCalledTimes(1),
+    );
+
+    await act(async () => {
+      blur?.();
+    });
+    await view.unmount();
+    await act(async () => {
+      pending.resolve(activity({ title: 'Late success' }));
+    });
+
+    await waitFor(() =>
+      expect(mockPublishTimelineEvent).toHaveBeenCalledTimes(1),
+    );
+    expect(mockRefreshTimeline).not.toHaveBeenCalled();
+    expect(mockRefreshTrip).not.toHaveBeenCalled();
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+  });
+
+  it('reconciles both sources for focus, foreground, timeline, and matching trip events only', async () => {
+    await render(<ActivityFormScreen />);
+    await focusScreen();
+
+    expect(mockRefreshTimeline).toHaveBeenCalledWith('initial');
+    expect(mockRefreshTrip).toHaveBeenCalledWith('initial');
+    mockRefreshTimeline.mockClear();
+    mockRefreshTrip.mockClear();
+
+    await act(async () => {
+      await mockTimelineListener?.({
+        type: 'timelineChanged',
+        tripId: TRIP_ID,
+      });
+    });
+    expect(mockRefreshTimeline).toHaveBeenCalledWith('silent');
+    expect(mockRefreshTrip).toHaveBeenCalledWith('silent');
+    mockRefreshTimeline.mockClear();
+    mockRefreshTrip.mockClear();
+
+    await act(async () => {
+      mockTripListener?.({
+        type: 'statusChanged',
+        tripId: 'another-trip',
+        status: 'COMPLETED',
+      });
+    });
+    expect(mockRefreshTimeline).not.toHaveBeenCalled();
+    expect(mockRefreshTrip).not.toHaveBeenCalled();
+
+    await act(async () => {
+      mockTripListener?.({
+        type: 'statusChanged',
+        tripId: TRIP_ID,
+        status: 'COMPLETED',
+      });
+    });
+    expect(mockRefreshTimeline).toHaveBeenCalledWith('silent');
+    expect(mockRefreshTrip).toHaveBeenCalledWith('silent');
+    mockRefreshTimeline.mockClear();
+    mockRefreshTrip.mockClear();
+
+    const foreground = mockUseAppForegroundEffect.mock.calls.at(-1)?.[0] as
+      | (() => void)
+      | undefined;
+    if (!foreground) {
+      throw new Error('Expected foreground callback registration.');
+    }
+    await act(async () => {
+      foreground();
+    });
+    expect(mockRefreshTimeline).toHaveBeenCalledWith('silent');
+    expect(mockRefreshTrip).toHaveBeenCalledWith('silent');
+  });
+});

--- a/mobile/src/features/timeline/__tests__/ActivityFormScreen.test.tsx
+++ b/mobile/src/features/timeline/__tests__/ActivityFormScreen.test.tsx
@@ -448,6 +448,24 @@ describe('ActivityFormScreen', () => {
     expect(mockPatchActivity).not.toHaveBeenCalled();
   });
 
+  it('canonicalizes uppercase UUID route keys before hydration and lookup', async () => {
+    mockParams = {
+      tripId: TRIP_ID.toUpperCase(),
+      mode: 'edit',
+      activityId: ACTIVITY_ID.toUpperCase(),
+    };
+
+    await render(<ActivityFormScreen />);
+
+    expect(mockUseTimeline).toHaveBeenCalledWith(TRIP_ID, {
+      autoReconcile: false,
+    });
+    expect(mockUseTripDetail).toHaveBeenCalledWith(TRIP_ID, {
+      autoReconcile: false,
+    });
+    expect(currentFormProps().draft.title).toBe('Breakfast');
+  });
+
   it('bridges canonical and failed lookups into the ActivityForm draft contract', async () => {
     await render(<ActivityFormScreen />);
     const editor = currentFormProps().renderStructuredLocationEditor;
@@ -535,6 +553,40 @@ describe('ActivityFormScreen', () => {
       });
     },
   );
+
+  it('prioritizes an authoritative Trip Detail 404 over a Timeline background error', async () => {
+    mockUseTimeline.mockReturnValue({
+      ...readyTimelineHook(),
+      error: {
+        kind: 'message',
+        message: 'Timeline is temporarily unavailable.',
+        status: 500,
+      },
+    });
+    mockUseTripDetail.mockReturnValue({
+      ...loadingTripHook(),
+      status: 'error',
+      error: {
+        kind: 'message',
+        message: 'Trip not found.',
+        errorCode: 'TRIP_NOT_FOUND',
+        status: 404,
+      },
+    });
+
+    await render(<ActivityFormScreen />);
+
+    expect(screen.getByText('Activity form unavailable')).toBeTruthy();
+    expect(
+      screen.getByText(
+        'This trip or activity no longer exists, or you no longer have access.',
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText('Timeline is temporarily unavailable.'),
+    ).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Try again' })).toBeNull();
+  });
 
   it('hydrates once, preserves edits across authority refresh, and rehydrates for a new route identity', async () => {
     const view = await render(<ActivityFormScreen />);
@@ -640,7 +692,7 @@ describe('ActivityFormScreen', () => {
     );
   });
 
-  it('creates with a full payload, locks duplicate submit and Cancel, then reconciles once before dismissing', async () => {
+  it('creates with a full payload, locks duplicate submit and Cancel, then dismisses without self-reconciliation', async () => {
     const pending = deferred<TimelineActivity>();
     mockCreateActivity.mockReturnValue(pending.promise);
     mockParams = {
@@ -717,17 +769,15 @@ describe('ActivityFormScreen', () => {
       ),
     );
     expect(mockPublishTimelineEvent).toHaveBeenCalledTimes(1);
-    expect(mockRefreshTimeline).toHaveBeenCalledTimes(1);
-    expect(mockRefreshTrip).toHaveBeenCalledTimes(1);
-    expect(mockRefreshTimeline).toHaveBeenCalledWith('silent');
-    expect(mockRefreshTrip).toHaveBeenCalledWith('silent');
+    expect(mockRefreshTimeline).not.toHaveBeenCalled();
+    expect(mockRefreshTrip).not.toHaveBeenCalled();
     expect(mockInvalidateTimeline.mock.invocationCallOrder[0]).toBeLessThan(
       mockCreateActivity.mock.invocationCallOrder[0]!,
     );
     expect(mockCreateActivity.mock.invocationCallOrder[0]).toBeLessThan(
       mockPublishTimelineEvent.mock.invocationCallOrder[0]!,
     );
-    expect(mockRefreshTimeline.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(mockPublishTimelineEvent.mock.invocationCallOrder[0]).toBeLessThan(
       mockRouter.dismissTo.mock.invocationCallOrder[0]!,
     );
   });
@@ -988,6 +1038,108 @@ describe('ActivityFormScreen', () => {
     expect(mockRefreshTimeline).not.toHaveBeenCalled();
     expect(mockRefreshTrip).not.toHaveBeenCalled();
     expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+  });
+
+  it('keeps a blurred committed create terminal and dismisses on refocus without replay', async () => {
+    const pending = deferred<TimelineActivity>();
+    mockCreateActivity.mockReturnValue(pending.promise);
+    mockParams = {
+      tripId: TRIP_ID,
+      mode: 'create',
+      sectionId: SECTION_ID,
+    };
+    await render(<ActivityFormScreen />);
+    const blur = await focusScreen();
+    mockRefreshTimeline.mockClear();
+    mockRefreshTrip.mockClear();
+    await changeDraft(
+      (draft) => ({
+        ...draft,
+        title: 'Committed while blurred',
+        start_time: '12:30',
+      }),
+      ['title', 'start_time'],
+    );
+    await act(async () => {
+      currentFormProps().onSubmit();
+    });
+    await waitFor(() =>
+      expect(mockCreateActivity).toHaveBeenCalledTimes(1),
+    );
+
+    await act(async () => {
+      blur?.();
+      pending.resolve(activity({ title: 'Committed while blurred' }));
+    });
+    await waitFor(() =>
+      expect(mockPublishTimelineEvent).toHaveBeenCalledTimes(1),
+    );
+
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+    expect(currentFormProps().submitting).toBe(true);
+    expect(mockLatestStackOptions?.gestureEnabled).toBe(false);
+    expect(mockRefreshTimeline).not.toHaveBeenCalled();
+    expect(mockRefreshTrip).not.toHaveBeenCalled();
+    await act(async () => {
+      currentFormProps().onSubmit();
+    });
+    expect(mockCreateActivity).toHaveBeenCalledTimes(1);
+
+    await focusScreen();
+    await waitFor(() =>
+      expect(mockRouter.dismissTo).toHaveBeenCalledWith(
+        `/trips/${TRIP_ID}/timeline`,
+      ),
+    );
+    await act(async () => {
+      currentFormProps().onSubmit();
+    });
+    expect(mockCreateActivity).toHaveBeenCalledTimes(1);
+    expect(mockRefreshTimeline).not.toHaveBeenCalled();
+    expect(mockRefreshTrip).not.toHaveBeenCalled();
+  });
+
+  it('dismisses a refocused form when its older generation commits successfully', async () => {
+    const pending = deferred<TimelineActivity>();
+    mockCreateActivity.mockReturnValue(pending.promise);
+    mockParams = {
+      tripId: TRIP_ID,
+      mode: 'create',
+      sectionId: SECTION_ID,
+    };
+    await render(<ActivityFormScreen />);
+    const blur = await focusScreen();
+    await changeDraft(
+      (draft) => ({
+        ...draft,
+        title: 'Commits after refocus',
+        start_time: '12:45',
+      }),
+      ['title', 'start_time'],
+    );
+    await act(async () => {
+      currentFormProps().onSubmit();
+    });
+    await waitFor(() =>
+      expect(mockCreateActivity).toHaveBeenCalledTimes(1),
+    );
+
+    await act(async () => {
+      blur?.();
+    });
+    await focusScreen();
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+
+    await act(async () => {
+      pending.resolve(activity({ title: 'Commits after refocus' }));
+    });
+    await waitFor(() =>
+      expect(mockRouter.dismissTo).toHaveBeenCalledWith(
+        `/trips/${TRIP_ID}/timeline`,
+      ),
+    );
+    expect(mockCreateActivity).toHaveBeenCalledTimes(1);
+    expect(mockPublishTimelineEvent).toHaveBeenCalledTimes(1);
   });
 
   it('reconciles both sources for focus, foreground, timeline, and matching trip events only', async () => {

--- a/mobile/src/features/timeline/__tests__/ActivityStatusControls.test.tsx
+++ b/mobile/src/features/timeline/__tests__/ActivityStatusControls.test.tsx
@@ -265,6 +265,45 @@ describe('ActivityStatusControls', () => {
     );
   });
 
+  it('keeps a rejection visible when reconciliation changes status and revokes capability', async () => {
+    const pending = deferred<void>();
+    const onChangeStatus = jest.fn(() => pending.promise);
+    const rendered = await render(
+      <ActivityStatusControls
+        activity={buildActivity('UPCOMING')}
+        onChangeStatus={onChangeStatus}
+      />,
+    );
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Start activity' }),
+    );
+    await rendered.rerender(
+      <ActivityStatusControls
+        activity={buildActivity('IN_PROGRESS', {
+          canUpdateStatus: false,
+        })}
+        onChangeStatus={onChangeStatus}
+      />,
+    );
+    await act(async () => {
+      pending.reject(
+        axiosErrorWith(409, {
+          detail: 'This status transition is no longer allowed.',
+          error_code: 'INVALID_STATUS_TRANSITION',
+        }),
+      );
+    });
+
+    expect(
+      await screen.findByText(
+        'This status transition is no longer allowed.',
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.getByLabelText('Activity status controls')).toBeTruthy();
+  });
+
   it('renders an externally supplied error without replacing its ownership', async () => {
     const externalError: ApiError = {
       kind: 'message',

--- a/mobile/src/features/timeline/__tests__/ActivityStatusControls.test.tsx
+++ b/mobile/src/features/timeline/__tests__/ActivityStatusControls.test.tsx
@@ -1,0 +1,313 @@
+import { AxiosError, AxiosHeaders } from 'axios';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
+import {
+  ActivityStatusControls,
+  getActivityStatusActions,
+} from '../components/ActivityStatusControls';
+import type {
+  TimelineActivity,
+  TimelineActivityStatus,
+} from '../types';
+import type { ApiError } from '@/shared/api/errors';
+
+function buildActivity(
+  status: TimelineActivityStatus,
+  {
+    canEdit = false,
+    canUpdateStatus = true,
+  }: { canEdit?: boolean; canUpdateStatus?: boolean } = {},
+): TimelineActivity {
+  return {
+    id: 'activity-1',
+    title: 'Airport transfer',
+    time_mode: 'AT_TIME',
+    start_time: '09:00:00',
+    end_time: null,
+    status,
+    position: 0,
+    activity_type: null,
+    assignee_scope: 'USER',
+    assignee: null,
+    location: {
+      location_mode: 'MANUAL',
+      location_label: '',
+      location_note: '',
+      place: null,
+      open_url: null,
+    },
+    note: '',
+    meeting_point: '',
+    contact_name: '',
+    contact_phone: '',
+    booking_reference: '',
+    external_link: '',
+    reminder_offsets_minutes: [],
+    capabilities: {
+      can_edit: canEdit,
+      can_delete: false,
+      can_update_status: canUpdateStatus,
+    },
+  };
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, {}, {
+    status,
+    statusText: '',
+    headers: {},
+    config,
+    data,
+  });
+}
+
+describe('getActivityStatusActions', () => {
+  it.each([
+    ['UPCOMING', ['IN_PROGRESS']],
+    ['IN_PROGRESS', ['UPCOMING', 'DONE']],
+    ['DONE', []],
+    ['CANCELLED', []],
+  ] as const)(
+    'returns the base %s transition matrix without captain edit capability',
+    (status, expected) => {
+      expect(
+        getActivityStatusActions(buildActivity(status)).map(
+          (action) => action.status,
+        ),
+      ).toEqual(expected);
+    },
+  );
+
+  it.each([
+    ['UPCOMING', ['IN_PROGRESS', 'DONE', 'CANCELLED']],
+    ['IN_PROGRESS', ['UPCOMING', 'DONE', 'CANCELLED']],
+    ['DONE', ['IN_PROGRESS', 'UPCOMING', 'CANCELLED']],
+    ['CANCELLED', ['UPCOMING']],
+  ] as const)(
+    'merges captain extras for %s in stable order without duplicates',
+    (status, expected) => {
+      const actions = getActivityStatusActions(
+        buildActivity(status, { canEdit: true }),
+      );
+      expect(actions.map((action) => action.status)).toEqual(expected);
+      expect(new Set(actions.map((action) => action.status)).size).toBe(
+        actions.length,
+      );
+    },
+  );
+
+  it('returns no actions when per-activity status capability denies updates', () => {
+    expect(
+      getActivityStatusActions(
+        buildActivity('UPCOMING', {
+          canEdit: true,
+          canUpdateStatus: false,
+        }),
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe('ActivityStatusControls', () => {
+  it('renders null unless the activity can update status', async () => {
+    await render(
+      <ActivityStatusControls
+        activity={buildActivity('UPCOMING', {
+          canEdit: true,
+          canUpdateStatus: false,
+        })}
+        onChangeStatus={jest.fn()}
+      />,
+    );
+
+    expect(screen.queryByLabelText('Activity status controls')).toBeNull();
+  });
+
+  it('renders clear accessible labels in the matrix order', async () => {
+    await render(
+      <ActivityStatusControls
+        activity={buildActivity('UPCOMING', { canEdit: true })}
+        onChangeStatus={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen
+        .getAllByRole('button')
+        .map((button) => button.props.accessibilityLabel),
+    ).toEqual(['Start activity', 'Mark done', 'Cancel activity']);
+  });
+
+  it('honors an external mutation lock without calling the handler', async () => {
+    const onChangeStatus = jest.fn().mockResolvedValue(undefined);
+    await render(
+      <ActivityStatusControls
+        activity={buildActivity('UPCOMING', { canEdit: true })}
+        disabled
+        onChangeStatus={onChangeStatus}
+      />,
+    );
+
+    const start = screen.getByRole('button', { name: 'Start activity' });
+    expect(start.props.accessibilityState).toMatchObject({ disabled: true });
+    await fireEvent.press(start);
+    expect(onChangeStatus).not.toHaveBeenCalled();
+  });
+
+  it('locks rapid presses across different transitions until the request settles', async () => {
+    const pending = deferred<void>();
+    const onChangeStatus = jest.fn(() => pending.promise);
+    await render(
+      <ActivityStatusControls
+        activity={buildActivity('UPCOMING', { canEdit: true })}
+        onChangeStatus={onChangeStatus}
+      />,
+    );
+
+    const [startPressable, , cancelPressable] =
+      screen.getAllByTestId('button-pressable');
+    await act(async () => {
+      startPressable.props.onClick({});
+      cancelPressable.props.onClick({});
+    });
+
+    expect(onChangeStatus).toHaveBeenCalledTimes(1);
+    expect(onChangeStatus).toHaveBeenCalledWith('IN_PROGRESS');
+    expect(
+      screen.getByRole('button', { name: 'Start activity' }).props
+        .accessibilityState,
+    ).toMatchObject({ busy: true, disabled: true });
+    expect(
+      screen.getByRole('button', { name: 'Cancel activity' }).props
+        .accessibilityState,
+    ).toMatchObject({ disabled: true });
+
+    await act(async () => {
+      pending.resolve();
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Cancel activity' }).props
+          .accessibilityState,
+      ).toMatchObject({ disabled: false }),
+    );
+  });
+
+  it('unlocks after success without displaying an error', async () => {
+    const onChangeStatus = jest.fn().mockResolvedValue(undefined);
+    await render(
+      <ActivityStatusControls
+        activity={buildActivity('IN_PROGRESS')}
+        onChangeStatus={onChangeStatus}
+      />,
+    );
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Mark done' }),
+    );
+    await waitFor(() =>
+      expect(onChangeStatus).toHaveBeenCalledWith('DONE'),
+    );
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(
+      screen.getByRole('button', { name: 'Reset to upcoming' }).props
+        .accessibilityState,
+    ).toMatchObject({ disabled: false, busy: false });
+  });
+
+  it('normalizes a rejection verbatim and notifies the reconciliation owner', async () => {
+    const onSettledFailure = jest.fn();
+    const onChangeStatus = jest.fn().mockRejectedValue(
+      axiosErrorWith(409, {
+        detail: 'This status transition is no longer allowed.',
+        error_code: 'INVALID_STATUS_TRANSITION',
+      }),
+    );
+    await render(
+      <ActivityStatusControls
+        activity={buildActivity('UPCOMING')}
+        onChangeStatus={onChangeStatus}
+        onSettledFailure={onSettledFailure}
+      />,
+    );
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Start activity' }),
+    );
+
+    expect(
+      await screen.findByText(
+        'This status transition is no longer allowed.',
+      ),
+    ).toBeTruthy();
+    expect(onSettledFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'This status transition is no longer allowed.',
+        errorCode: 'INVALID_STATUS_TRANSITION',
+        status: 409,
+      }),
+    );
+  });
+
+  it('renders an externally supplied error without replacing its ownership', async () => {
+    const externalError: ApiError = {
+      kind: 'message',
+      message: 'Permission changed. Refresh the timeline.',
+      status: 403,
+    };
+    await render(
+      <ActivityStatusControls
+        activity={buildActivity('UPCOMING')}
+        error={externalError}
+        onChangeStatus={jest.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    expect(
+      screen.getByText('Permission changed. Refresh the timeline.'),
+    ).toBeTruthy();
+  });
+
+  it('does not update local state when a rejection settles after unmount', async () => {
+    const pending = deferred<void>();
+    const onSettledFailure = jest.fn();
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const rendered = await render(
+      <ActivityStatusControls
+        activity={buildActivity('UPCOMING')}
+        onChangeStatus={() => pending.promise}
+        onSettledFailure={onSettledFailure}
+      />,
+    );
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Start activity' }),
+    );
+    await rendered.unmount();
+    await act(async () => {
+      pending.reject(new Error('Late failure.'));
+    });
+
+    expect(onSettledFailure).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});

--- a/mobile/src/features/timeline/__tests__/CustomTypeManagerScreen.test.tsx
+++ b/mobile/src/features/timeline/__tests__/CustomTypeManagerScreen.test.tsx
@@ -1,0 +1,619 @@
+import type { ReactNode } from 'react';
+import { Alert, View } from 'react-native';
+
+let mockParams: Record<string, string | string[] | undefined> = {};
+const mockRouter = { dismissTo: jest.fn() };
+const mockUseFocusEffect = jest.fn();
+const mockUseAppForegroundEffect = jest.fn();
+const mockUseTimeline = jest.fn();
+const mockRefresh = jest.fn();
+const mockInvalidate = jest.fn();
+const mockPublishTimelineEvent = jest.fn();
+const mockSubscribeToTimelineEvents = jest.fn();
+let mockTimelineListener:
+  | ((event: { type: 'timelineChanged'; tripId: string }) =>
+      void | Promise<void>)
+  | undefined;
+let mockLatestStackOptions:
+  | {
+      gestureEnabled?: boolean;
+      headerLeft?: () => ReactNode;
+    }
+  | undefined;
+
+function mockRenderStackScreen({
+  options,
+}: {
+  options: {
+    gestureEnabled?: boolean;
+    headerLeft?: () => ReactNode;
+  };
+}) {
+  mockLatestStackOptions = options;
+  return <View>{options.headerLeft?.()}</View>;
+}
+
+jest.mock('expo-router', () => ({
+  Stack: { Screen: mockRenderStackScreen },
+  useFocusEffect: (effect: () => (() => void) | void) =>
+    mockUseFocusEffect(effect),
+  useLocalSearchParams: () => mockParams,
+  useRouter: () => mockRouter,
+}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('@/shared/hooks/useAppForegroundEffect', () => ({
+  useAppForegroundEffect: (listener: () => void) =>
+    mockUseAppForegroundEffect(listener),
+}));
+jest.mock('../hooks/useTimeline', () => ({
+  useTimeline: (...args: unknown[]) => mockUseTimeline(...args),
+}));
+jest.mock('../api', () => ({
+  createCustomType: jest.fn(),
+  patchCustomType: jest.fn(),
+  deleteCustomType: jest.fn(),
+}));
+jest.mock('../timelineEvents', () => ({
+  publishTimelineEvent: (...args: unknown[]) =>
+    mockPublishTimelineEvent(...args),
+  subscribeToTimelineEvents: (...args: unknown[]) =>
+    mockSubscribeToTimelineEvents(...args),
+}));
+
+// eslint-disable-next-line import/first
+import { AxiosError, AxiosHeaders } from 'axios';
+// eslint-disable-next-line import/first
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import {
+  createCustomType,
+  deleteCustomType,
+  patchCustomType,
+} from '../api';
+// eslint-disable-next-line import/first
+import { CustomTypeManagerScreen } from '../screens/CustomTypeManagerScreen';
+// eslint-disable-next-line import/first
+import type {
+  TimelineCustomTypeMeta,
+  TimelineResponse,
+} from '../types';
+
+const mockCreateCustomType = createCustomType as jest.MockedFunction<
+  typeof createCustomType
+>;
+const mockPatchCustomType = patchCustomType as jest.MockedFunction<
+  typeof patchCustomType
+>;
+const mockDeleteCustomType = deleteCustomType as jest.MockedFunction<
+  typeof deleteCustomType
+>;
+const mockAlert = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+
+const TRIP_ID = '123e4567-e89b-12d3-a456-426614174000';
+const ACTIVE_TYPE_ID = 'ec5945d1-0025-4c4b-af6c-21e49cfce949';
+const INACTIVE_TYPE_ID = 'c2efc0e2-33ca-4a60-9690-88fbd438476f';
+const UNKNOWN_TYPE_ID = '345232e3-eed9-4919-aec3-4988531ab625';
+
+const activeType: TimelineCustomTypeMeta = {
+  id: ACTIVE_TYPE_ID,
+  name: 'Coffee',
+  normalized_name: 'coffee',
+  color_token: 'amber',
+  icon_key: 'utensils',
+  is_active: true,
+};
+
+const inactiveType: TimelineCustomTypeMeta = {
+  id: INACTIVE_TYPE_ID,
+  name: 'Relax',
+  normalized_name: 'relax',
+  color_token: 'teal',
+  icon_key: 'smile',
+  is_active: false,
+};
+
+const unknownType: TimelineCustomTypeMeta = {
+  id: UNKNOWN_TYPE_ID,
+  name: 'Legacy',
+  normalized_name: 'legacy',
+  color_token: 'brand-gold',
+  icon_key: 'rocket',
+  is_active: true,
+};
+
+function timeline(
+  canManageCustomTypes = true,
+): TimelineResponse {
+  return {
+    trip_timezone: 'Asia/Ho_Chi_Minh',
+    permissions: {
+      can_edit_timeline: canManageCustomTypes,
+      can_manage_custom_types: canManageCustomTypes,
+      can_create_sections: canManageCustomTypes,
+    },
+    system_types: [],
+    custom_types: [activeType, inactiveType, unknownType],
+    sections: [],
+  };
+}
+
+function readyHook(nextTimeline = timeline()) {
+  return {
+    timeline: nextTimeline,
+    status: 'ready' as const,
+    error: null,
+    refreshing: false,
+    refresh: mockRefresh,
+    invalidate: mockInvalidate,
+  };
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, {}, {
+    status,
+    statusText: '',
+    headers: {},
+    config,
+    data,
+  });
+}
+
+function latestFocusCallback(): () => (() => void) | void {
+  const callback = mockUseFocusEffect.mock.calls.at(-1)?.[0] as
+    | (() => (() => void) | void)
+    | undefined;
+  if (!callback) {
+    throw new Error('Expected useFocusEffect to register a callback.');
+  }
+  return callback;
+}
+
+async function focusScreen(): Promise<(() => void) | undefined> {
+  let cleanup: (() => void) | undefined;
+  await act(async () => {
+    cleanup = latestFocusCallback()() || undefined;
+  });
+  return cleanup;
+}
+
+function destructiveAlertAction() {
+  const buttons = mockAlert.mock.calls.at(-1)?.[2];
+  const action = buttons?.find((button) => button.style === 'destructive');
+  if (!action?.onPress) {
+    throw new Error('Expected a destructive alert action.');
+  }
+  return action.onPress;
+}
+
+describe('CustomTypeManagerScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockParams = { tripId: TRIP_ID };
+    mockTimelineListener = undefined;
+    mockLatestStackOptions = undefined;
+    mockRefresh.mockResolvedValue(undefined);
+    mockUseTimeline.mockReturnValue(readyHook());
+    mockCreateCustomType.mockResolvedValue({
+      ...activeType,
+      id: 'cb938507-5c32-460f-9707-651756b3e96f',
+    });
+    mockPatchCustomType.mockResolvedValue(activeType);
+    mockDeleteCustomType.mockResolvedValue(undefined);
+    mockSubscribeToTimelineEvents.mockImplementation(
+      (
+        _tripId: string,
+        listener: (
+          event: { type: 'timelineChanged'; tripId: string },
+        ) => void | Promise<void>,
+      ) => {
+        mockTimelineListener = listener;
+        return jest.fn();
+      },
+    );
+    mockPublishTimelineEvent.mockImplementation(
+      async (event: { type: 'timelineChanged'; tripId: string }) => {
+        await mockTimelineListener?.(event);
+      },
+    );
+  });
+
+  it('rejects malformed trip routes before loading or mutating', async () => {
+    mockParams = { tripId: [TRIP_ID] };
+
+    await render(<CustomTypeManagerScreen />);
+
+    expect(screen.getByText('Custom types unavailable')).toBeTruthy();
+    expect(mockUseTimeline).not.toHaveBeenCalled();
+    expect(mockCreateCustomType).not.toHaveBeenCalled();
+    expect(mockPatchCustomType).not.toHaveBeenCalled();
+    expect(mockDeleteCustomType).not.toHaveBeenCalled();
+  });
+
+  it('gates direct links with aggregate custom-type authority', async () => {
+    mockUseTimeline.mockReturnValue(readyHook(timeline(false)));
+
+    await render(<CustomTypeManagerScreen />);
+
+    expect(
+      screen.getByText(
+        'You do not have permission to manage custom activity types.',
+      ),
+    ).toBeTruthy();
+    expect(mockUseTimeline).toHaveBeenCalledWith(TRIP_ID, {
+      autoReconcile: false,
+    });
+    expect(
+      screen.queryByTestId('custom-type-manager-list'),
+    ).toBeNull();
+  });
+
+  it('keeps active, inactive, and unknown-token types visible and manageable', async () => {
+    await render(<CustomTypeManagerScreen />);
+
+    expect(screen.getByText('Coffee')).toBeTruthy();
+    expect(screen.getByText('Relax')).toBeTruthy();
+    expect(screen.getByText('Legacy')).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: 'Activate Relax' }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: 'Edit Legacy' }),
+    ).toBeTruthy();
+  });
+
+  it('creates from finite picker values with a global ref lock and one event-owned reconcile', async () => {
+    const pending = deferred<TimelineCustomTypeMeta>();
+    mockCreateCustomType.mockReturnValue(pending.promise);
+    await render(<CustomTypeManagerScreen />);
+    await focusScreen();
+    mockRefresh.mockClear();
+
+    await fireEvent.changeText(
+      screen.getByLabelText('New custom type name'),
+      '  Dinner stop  ',
+    );
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: 'New custom type color Rose',
+      }),
+    );
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: 'New custom type icon Sightseeing',
+      }),
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Add custom type' }),
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Add custom type' }),
+    );
+
+    await waitFor(() =>
+      expect(mockCreateCustomType).toHaveBeenCalledTimes(1),
+    );
+    expect(mockCreateCustomType).toHaveBeenCalledWith(TRIP_ID, {
+      name: 'Dinner stop',
+      color_token: 'rose',
+      icon_key: 'camera',
+    });
+    expect(mockLatestStackOptions?.gestureEnabled).toBe(false);
+    expect(
+      screen.getByRole('button', { name: 'Close custom types' }).props
+        .accessibilityState,
+    ).toMatchObject({ disabled: true });
+
+    await act(async () => {
+      pending.resolve({
+        ...activeType,
+        id: 'cb938507-5c32-460f-9707-651756b3e96f',
+        name: 'Dinner stop',
+        normalized_name: 'dinner-stop',
+        color_token: 'rose',
+        icon_key: 'camera',
+      });
+    });
+
+    expect(await screen.findByText('Custom type created.')).toBeTruthy();
+    expect(
+      screen.getByLabelText('New custom type name').props.value,
+    ).toBe('');
+    expect(mockInvalidate).toHaveBeenCalledTimes(1);
+    expect(mockPublishTimelineEvent).toHaveBeenCalledTimes(1);
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+    expect(mockRefresh).toHaveBeenCalledWith('silent');
+    expect(mockInvalidate.mock.invocationCallOrder[0]).toBeLessThan(
+      mockCreateCustomType.mock.invocationCallOrder[0]!,
+    );
+    expect(mockCreateCustomType.mock.invocationCallOrder[0]).toBeLessThan(
+      mockPublishTimelineEvent.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it('renames with a minimal PATCH while preserving unknown raw tokens', async () => {
+    await render(<CustomTypeManagerScreen />);
+    await focusScreen();
+    mockRefresh.mockClear();
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Edit Legacy' }),
+    );
+
+    expect(
+      screen.getByText(/Current unsupported color token: brand-gold/),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/Current unsupported icon key: rocket/),
+    ).toBeTruthy();
+    await fireEvent.changeText(
+      screen.getByLabelText('Name for Legacy'),
+      '  Legacy renamed  ',
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Save type' }),
+    );
+
+    await waitFor(() =>
+      expect(mockPatchCustomType).toHaveBeenCalledWith(
+        TRIP_ID,
+        UNKNOWN_TYPE_ID,
+        { name: 'Legacy renamed' },
+      ),
+    );
+    expect(await screen.findByText('Custom type updated.')).toBeTruthy();
+    expect(
+      screen.queryByLabelText('Name for Legacy'),
+    ).toBeNull();
+  });
+
+  it('patches unknown color and icon only after explicit supported replacements', async () => {
+    await render(<CustomTypeManagerScreen />);
+    await focusScreen();
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Edit Legacy' }),
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Legacy color Violet' }),
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Legacy icon Transport' }),
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Save type' }),
+    );
+
+    await waitFor(() =>
+      expect(mockPatchCustomType).toHaveBeenCalledWith(
+        TRIP_ID,
+        UNKNOWN_TYPE_ID,
+        {
+          color_token: 'violet',
+          icon_key: 'bus',
+        },
+      ),
+    );
+  });
+
+  it.each([
+    ['Deactivate Coffee', ACTIVE_TYPE_ID, false, 'Custom type deactivated.'],
+    ['Activate Relax', INACTIVE_TYPE_ID, true, 'Custom type activated.'],
+  ])(
+    'handles %s with a minimal active-state PATCH',
+    async (actionLabel, typeId, isActive, message) => {
+      await render(<CustomTypeManagerScreen />);
+      await focusScreen();
+      mockRefresh.mockClear();
+
+      await fireEvent.press(
+        screen.getByRole('button', { name: actionLabel }),
+      );
+
+      await waitFor(() =>
+        expect(mockPatchCustomType).toHaveBeenCalledWith(
+          TRIP_ID,
+          typeId,
+          { is_active: isActive },
+        ),
+      );
+      expect(await screen.findByText(message)).toBeTruthy();
+      expect(mockPublishTimelineEvent).toHaveBeenCalledTimes(1);
+      expect(mockRefresh).toHaveBeenCalledWith('silent');
+    },
+  );
+
+  it('confirms and deletes exactly once before publishing and reconciling', async () => {
+    await render(<CustomTypeManagerScreen />);
+    await focusScreen();
+    mockRefresh.mockClear();
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Delete Coffee' }),
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Delete Coffee' }),
+    );
+    expect(mockAlert).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      destructiveAlertAction()();
+    });
+
+    await waitFor(() =>
+      expect(mockDeleteCustomType).toHaveBeenCalledWith(
+        TRIP_ID,
+        ACTIVE_TYPE_ID,
+      ),
+    );
+    expect(await screen.findByText('Custom type deleted.')).toBeTruthy();
+    expect(mockPublishTimelineEvent).toHaveBeenCalledTimes(1);
+    expect(mockRefresh).toHaveBeenCalledWith('silent');
+  });
+
+  it('shows duplicate and in-use 409 details verbatim and reconciles', async () => {
+    mockCreateCustomType.mockRejectedValueOnce(
+      axiosErrorWith(409, {
+        detail:
+          'A custom type with this name already exists for this trip.',
+        error_code: 'CUSTOM_TYPE_DUPLICATE',
+      }),
+    );
+    mockDeleteCustomType.mockRejectedValueOnce(
+      axiosErrorWith(409, {
+        detail: 'Custom type is still used by timeline activities.',
+        error_code: 'CUSTOM_TYPE_IN_USE',
+      }),
+    );
+    await render(<CustomTypeManagerScreen />);
+    await focusScreen();
+    mockRefresh.mockClear();
+
+    await fireEvent.changeText(
+      screen.getByLabelText('New custom type name'),
+      'Coffee',
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Add custom type' }),
+    );
+    expect(
+      await screen.findByText(
+        'A custom type with this name already exists for this trip.',
+      ),
+    ).toBeTruthy();
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Delete Coffee' }),
+    );
+    await act(async () => {
+      destructiveAlertAction()();
+    });
+    expect(
+      await screen.findByText(
+        'Custom type is still used by timeline activities.',
+      ),
+    ).toBeTruthy();
+    expect(mockRefresh).toHaveBeenCalledTimes(2);
+    expect(mockRefresh).toHaveBeenNthCalledWith(1, 'silent');
+    expect(mockRefresh).toHaveBeenNthCalledWith(2, 'silent');
+    expect(mockPublishTimelineEvent).not.toHaveBeenCalled();
+  });
+
+  it.each([403, 404, 409])(
+    'silently reconciles an authoritative %s toggle failure',
+    async (status) => {
+      const detail = `Authority changed (${status}).`;
+      mockPatchCustomType.mockRejectedValueOnce(
+        axiosErrorWith(status, { detail }),
+      );
+      await render(<CustomTypeManagerScreen />);
+      await focusScreen();
+      mockRefresh.mockClear();
+
+      await fireEvent.press(
+        screen.getByRole('button', { name: 'Deactivate Coffee' }),
+      );
+
+      expect(await screen.findByText(detail)).toBeTruthy();
+      expect(mockRefresh).toHaveBeenCalledTimes(1);
+      expect(mockRefresh).toHaveBeenCalledWith('silent');
+      expect(mockPublishTimelineEvent).not.toHaveBeenCalled();
+    },
+  );
+
+  it('renders normalized backend field errors verbatim', async () => {
+    mockCreateCustomType.mockRejectedValueOnce(
+      axiosErrorWith(400, {
+        name: ['Use a different custom type name.'],
+      }),
+    );
+    await render(<CustomTypeManagerScreen />);
+    await focusScreen();
+    await fireEvent.changeText(
+      screen.getByLabelText('New custom type name'),
+      'Server check',
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Add custom type' }),
+    );
+
+    expect(
+      await screen.findByText('Use a different custom type name.'),
+    ).toBeTruthy();
+  });
+
+  it('ignores late inactive failure state, navigation, event, and reconcile effects', async () => {
+    const pending = deferred<TimelineCustomTypeMeta>();
+    mockCreateCustomType.mockReturnValue(pending.promise);
+    await render(<CustomTypeManagerScreen />);
+    const blur = await focusScreen();
+    mockRefresh.mockClear();
+    await fireEvent.changeText(
+      screen.getByLabelText('New custom type name'),
+      'Late failure',
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Add custom type' }),
+    );
+
+    await act(async () => {
+      blur?.();
+      pending.reject(
+        axiosErrorWith(409, {
+          detail: 'This late failure must remain invisible.',
+        }),
+      );
+    });
+
+    expect(
+      screen.queryByText('This late failure must remain invisible.'),
+    ).toBeNull();
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(mockPublishTimelineEvent).not.toHaveBeenCalled();
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+  });
+
+  it('publishes one late confirmed success without inactive UI, reconcile, or navigation', async () => {
+    const pending = deferred<TimelineCustomTypeMeta>();
+    mockCreateCustomType.mockReturnValue(pending.promise);
+    await render(<CustomTypeManagerScreen />);
+    const blur = await focusScreen();
+    mockRefresh.mockClear();
+    await fireEvent.changeText(
+      screen.getByLabelText('New custom type name'),
+      'Late success',
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Add custom type' }),
+    );
+
+    await act(async () => {
+      blur?.();
+      pending.resolve({
+        ...activeType,
+        id: '3549643d-88a9-486c-b855-92363429112f',
+      });
+    });
+
+    await waitFor(() =>
+      expect(mockPublishTimelineEvent).toHaveBeenCalledTimes(1),
+    );
+    expect(screen.queryByText('Custom type created.')).toBeNull();
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/features/timeline/__tests__/CustomTypeManagerScreen.test.tsx
+++ b/mobile/src/features/timeline/__tests__/CustomTypeManagerScreen.test.tsx
@@ -207,8 +207,17 @@ function destructiveAlertAction() {
   return action.onPress;
 }
 
+async function renderManager() {
+  const view = await render(<CustomTypeManagerScreen />);
+  await act(async () => {
+    jest.runOnlyPendingTimers();
+  });
+  return view;
+}
+
 describe('CustomTypeManagerScreen', () => {
   beforeEach(() => {
+    jest.useFakeTimers();
     jest.clearAllMocks();
     mockRouter.canGoBack.mockReturnValue(true);
     mockParams = { tripId: TRIP_ID };
@@ -240,10 +249,17 @@ describe('CustomTypeManagerScreen', () => {
     );
   });
 
+  afterEach(async () => {
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
   it('rejects malformed trip routes before loading or mutating', async () => {
     mockParams = { tripId: [TRIP_ID] };
 
-    await render(<CustomTypeManagerScreen />);
+    await renderManager();
 
     expect(screen.getByText('Custom types unavailable')).toBeTruthy();
     expect(mockUseTimeline).not.toHaveBeenCalled();
@@ -255,7 +271,7 @@ describe('CustomTypeManagerScreen', () => {
   it('gates direct links with aggregate custom-type authority', async () => {
     mockUseTimeline.mockReturnValue(readyHook(timeline(false)));
 
-    await render(<CustomTypeManagerScreen />);
+    await renderManager();
 
     expect(
       screen.getByText(
@@ -271,7 +287,7 @@ describe('CustomTypeManagerScreen', () => {
   });
 
   it('closes back to the calling activity form when navigation history exists', async () => {
-    await render(<CustomTypeManagerScreen />);
+    await renderManager();
 
     await fireEvent.press(
       screen.getByRole('button', { name: 'Close custom types' }),
@@ -283,7 +299,7 @@ describe('CustomTypeManagerScreen', () => {
 
   it('falls back to the Timeline route when opened without navigation history', async () => {
     mockRouter.canGoBack.mockReturnValue(false);
-    await render(<CustomTypeManagerScreen />);
+    await renderManager();
 
     await fireEvent.press(
       screen.getByRole('button', { name: 'Close custom types' }),
@@ -296,7 +312,7 @@ describe('CustomTypeManagerScreen', () => {
   });
 
   it('keeps active, inactive, and unknown-token types visible and manageable', async () => {
-    await render(<CustomTypeManagerScreen />);
+    await renderManager();
 
     expect(screen.getByText('Coffee')).toBeTruthy();
     expect(screen.getByText('Relax')).toBeTruthy();
@@ -312,7 +328,7 @@ describe('CustomTypeManagerScreen', () => {
   it('creates from finite picker values with a global ref lock and one event-owned reconcile', async () => {
     const pending = deferred<TimelineCustomTypeMeta>();
     mockCreateCustomType.mockReturnValue(pending.promise);
-    await render(<CustomTypeManagerScreen />);
+    await renderManager();
     await focusScreen();
     mockRefresh.mockClear();
 
@@ -379,7 +395,7 @@ describe('CustomTypeManagerScreen', () => {
   });
 
   it('renames with a minimal PATCH while preserving unknown raw tokens', async () => {
-    await render(<CustomTypeManagerScreen />);
+    await renderManager();
     await focusScreen();
     mockRefresh.mockClear();
     await fireEvent.press(
@@ -414,7 +430,7 @@ describe('CustomTypeManagerScreen', () => {
   });
 
   it('patches unknown color and icon only after explicit supported replacements', async () => {
-    await render(<CustomTypeManagerScreen />);
+    await renderManager();
     await focusScreen();
     await fireEvent.press(
       screen.getByRole('button', { name: 'Edit Legacy' }),
@@ -447,7 +463,7 @@ describe('CustomTypeManagerScreen', () => {
   ])(
     'handles %s with a minimal active-state PATCH',
     async (actionLabel, typeId, isActive, message) => {
-      await render(<CustomTypeManagerScreen />);
+      await renderManager();
       await focusScreen();
       mockRefresh.mockClear();
 
@@ -469,7 +485,7 @@ describe('CustomTypeManagerScreen', () => {
   );
 
   it('confirms and deletes exactly once before publishing and reconciling', async () => {
-    await render(<CustomTypeManagerScreen />);
+    await renderManager();
     await focusScreen();
     mockRefresh.mockClear();
 
@@ -509,7 +525,7 @@ describe('CustomTypeManagerScreen', () => {
         error_code: 'CUSTOM_TYPE_IN_USE',
       }),
     );
-    await render(<CustomTypeManagerScreen />);
+    await renderManager();
     await focusScreen();
     mockRefresh.mockClear();
 
@@ -550,7 +566,7 @@ describe('CustomTypeManagerScreen', () => {
       mockPatchCustomType.mockRejectedValueOnce(
         axiosErrorWith(status, { detail }),
       );
-      await render(<CustomTypeManagerScreen />);
+      await renderManager();
       await focusScreen();
       mockRefresh.mockClear();
 
@@ -571,7 +587,7 @@ describe('CustomTypeManagerScreen', () => {
         name: ['Use a different custom type name.'],
       }),
     );
-    await render(<CustomTypeManagerScreen />);
+    await renderManager();
     await focusScreen();
     await fireEvent.changeText(
       screen.getByLabelText('New custom type name'),
@@ -589,7 +605,7 @@ describe('CustomTypeManagerScreen', () => {
   it('ignores late inactive failure state, navigation, event, and reconcile effects', async () => {
     const pending = deferred<TimelineCustomTypeMeta>();
     mockCreateCustomType.mockReturnValue(pending.promise);
-    await render(<CustomTypeManagerScreen />);
+    await renderManager();
     const blur = await focusScreen();
     mockRefresh.mockClear();
     await fireEvent.changeText(
@@ -615,12 +631,78 @@ describe('CustomTypeManagerScreen', () => {
     expect(mockRefresh).not.toHaveBeenCalled();
     expect(mockPublishTimelineEvent).not.toHaveBeenCalled();
     expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole('button', { name: 'Close custom types' }).props
+        .accessibilityState,
+    ).toMatchObject({ disabled: true });
+
+    await focusScreen();
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Close custom types' }).props
+          .accessibilityState,
+      ).toMatchObject({ disabled: false }),
+    );
+    expect(mockLatestStackOptions?.gestureEnabled).toBe(true);
+    expect(
+      screen.queryByText('This late failure must remain invisible.'),
+    ).toBeNull();
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+  });
+
+  it('recovers pending UI when an old mutation settles after refocus', async () => {
+    const pending = deferred<TimelineCustomTypeMeta>();
+    mockCreateCustomType.mockReturnValue(pending.promise);
+    await renderManager();
+    const blur = await focusScreen();
+    await fireEvent.changeText(
+      screen.getByLabelText('New custom type name'),
+      'Refocused failure',
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Add custom type' }),
+    );
+    await waitFor(() =>
+      expect(mockCreateCustomType).toHaveBeenCalledTimes(1),
+    );
+
+    await act(async () => {
+      blur?.();
+    });
+    await focusScreen();
+    expect(
+      screen.getByRole('button', { name: 'Close custom types' }).props
+        .accessibilityState,
+    ).toMatchObject({ disabled: true });
+    mockRefresh.mockClear();
+
+    await act(async () => {
+      pending.reject(
+        axiosErrorWith(409, {
+          detail: 'This stale generation must remain invisible.',
+        }),
+      );
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Close custom types' }).props
+          .accessibilityState,
+      ).toMatchObject({ disabled: false }),
+    );
+    expect(mockLatestStackOptions?.gestureEnabled).toBe(true);
+    expect(
+      screen.queryByText('This stale generation must remain invisible.'),
+    ).toBeNull();
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(mockPublishTimelineEvent).not.toHaveBeenCalled();
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
   });
 
   it('publishes one late confirmed success without inactive UI, reconcile, or navigation', async () => {
     const pending = deferred<TimelineCustomTypeMeta>();
     mockCreateCustomType.mockReturnValue(pending.promise);
-    await render(<CustomTypeManagerScreen />);
+    await renderManager();
     const blur = await focusScreen();
     mockRefresh.mockClear();
     await fireEvent.changeText(

--- a/mobile/src/features/timeline/__tests__/CustomTypeManagerScreen.test.tsx
+++ b/mobile/src/features/timeline/__tests__/CustomTypeManagerScreen.test.tsx
@@ -725,6 +725,9 @@ describe('CustomTypeManagerScreen', () => {
       expect(mockPublishTimelineEvent).toHaveBeenCalledTimes(1),
     );
     expect(screen.queryByText('Custom type created.')).toBeNull();
+    expect(
+      screen.getByLabelText('New custom type name').props.value,
+    ).toBe('');
     expect(mockRefresh).not.toHaveBeenCalled();
     expect(mockRouter.dismissTo).not.toHaveBeenCalled();
   });

--- a/mobile/src/features/timeline/__tests__/CustomTypeManagerScreen.test.tsx
+++ b/mobile/src/features/timeline/__tests__/CustomTypeManagerScreen.test.tsx
@@ -2,7 +2,11 @@ import type { ReactNode } from 'react';
 import { Alert, View } from 'react-native';
 
 let mockParams: Record<string, string | string[] | undefined> = {};
-const mockRouter = { dismissTo: jest.fn() };
+const mockRouter = {
+  back: jest.fn(),
+  canGoBack: jest.fn(),
+  dismissTo: jest.fn(),
+};
 const mockUseFocusEffect = jest.fn();
 const mockUseAppForegroundEffect = jest.fn();
 const mockUseTimeline = jest.fn();
@@ -206,6 +210,7 @@ function destructiveAlertAction() {
 describe('CustomTypeManagerScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRouter.canGoBack.mockReturnValue(true);
     mockParams = { tripId: TRIP_ID };
     mockTimelineListener = undefined;
     mockLatestStackOptions = undefined;
@@ -263,6 +268,31 @@ describe('CustomTypeManagerScreen', () => {
     expect(
       screen.queryByTestId('custom-type-manager-list'),
     ).toBeNull();
+  });
+
+  it('closes back to the calling activity form when navigation history exists', async () => {
+    await render(<CustomTypeManagerScreen />);
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Close custom types' }),
+    );
+
+    expect(mockRouter.back).toHaveBeenCalledTimes(1);
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the Timeline route when opened without navigation history', async () => {
+    mockRouter.canGoBack.mockReturnValue(false);
+    await render(<CustomTypeManagerScreen />);
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Close custom types' }),
+    );
+
+    expect(mockRouter.back).not.toHaveBeenCalled();
+    expect(mockRouter.dismissTo).toHaveBeenCalledWith(
+      `/trips/${TRIP_ID}/timeline`,
+    );
   });
 
   it('keeps active, inactive, and unknown-token types visible and manageable', async () => {

--- a/mobile/src/features/timeline/__tests__/PlacePicker.test.tsx
+++ b/mobile/src/features/timeline/__tests__/PlacePicker.test.tsx
@@ -1,0 +1,323 @@
+jest.mock('../api', () => ({
+  lookupLocation: jest.fn(),
+  suggestLocations: jest.fn(),
+}));
+
+// eslint-disable-next-line import/first
+import { AxiosError, AxiosHeaders } from 'axios';
+// eslint-disable-next-line import/first
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+} from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { lookupLocation, suggestLocations } from '../api';
+// eslint-disable-next-line import/first
+import { PlacePicker, type PlacePickerProps } from '../components/PlacePicker';
+// eslint-disable-next-line import/first
+import {
+  LOCATION_SEARCH_DEBOUNCE_MS,
+  MANUAL_LOCATION_GUIDANCE,
+  PLACE_SEARCH_UNAVAILABLE_MESSAGE,
+} from '../hooks/useLocationSearch';
+// eslint-disable-next-line import/first
+import type {
+  LocationSuggestion,
+  ResolvedLocationLookup,
+} from '../types';
+
+const mockSuggestLocations = suggestLocations as jest.MockedFunction<
+  typeof suggestLocations
+>;
+const mockLookupLocation = lookupLocation as jest.MockedFunction<
+  typeof lookupLocation
+>;
+
+const suggestion: LocationSuggestion = {
+  provider: 'here',
+  provider_id: 'unverified-suggestion-id',
+  title: 'Da Nang International Airport',
+  subtitle: 'Da Nang, Vietnam',
+};
+
+const lookup: ResolvedLocationLookup = {
+  destination: 'Duy Tan, Hoa Thuan Tay, Da Nang, Vietnam',
+  destination_provider: 'here',
+  destination_provider_id: 'canonical-here-id',
+  destination_lat: 16.0439,
+  destination_lng: 108.199,
+  destination_country_code: 'VN',
+};
+
+const selectedPlace: PlacePickerProps['value'] = {
+  location_label: 'Existing Station',
+  place: {
+    provider: 'here',
+    provider_id: 'existing-canonical-id',
+    title: 'Existing Station',
+    address: 'Existing address',
+    lat: 16,
+    lng: 108,
+  },
+};
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, {}, {
+    status,
+    statusText: '',
+    headers: {},
+    config,
+    data,
+  });
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+function pickerCallbacks() {
+  return {
+    onSelectLocation: jest.fn(),
+    onUseManualEntry: jest.fn(),
+    onLookupFailure: jest.fn(),
+  };
+}
+
+async function enterSearch(query: string) {
+  await fireEvent.changeText(screen.getByLabelText('Search places'), query);
+}
+
+async function advanceDebounce() {
+  await act(async () => {
+    jest.advanceTimersByTime(LOCATION_SEARCH_DEBOUNCE_MS);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('PlacePicker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it.each([
+    [
+      'network',
+      () => new AxiosError('Network unavailable'),
+      'Cannot reach the server. Check your connection.',
+    ],
+    [
+      'disabled 503',
+      () =>
+        axiosErrorWith(503, {
+          detail: 'Location search is disabled.',
+          error_code: 'LOCATION_SEARCH_DISABLED',
+        }),
+      PLACE_SEARCH_UNAVAILABLE_MESSAGE,
+    ],
+    [
+      '429',
+      () => axiosErrorWith(429, { detail: 'Request was throttled.' }),
+      'Too many attempts. Please wait a moment and try again.',
+    ],
+  ])(
+    'keeps an existing structured selection after a %s suggest failure',
+    async (_caseName, createError, expectedMessage) => {
+      mockSuggestLocations.mockRejectedValue(createError());
+      const callbacks = pickerCallbacks();
+      const rendered = await render(
+        <PlacePicker
+          value={selectedPlace}
+          {...callbacks}
+        />,
+      );
+
+      await enterSearch('Da Nang');
+      await advanceDebounce();
+
+      expect(screen.getByText('Existing Station')).toBeTruthy();
+      expect(screen.getByText('Existing address')).toBeTruthy();
+      expect(screen.getByText(expectedMessage)).toBeTruthy();
+      expect(screen.getByLabelText('Search places').props.value).toBe(
+        'Da Nang',
+      );
+      expect(callbacks.onSelectLocation).not.toHaveBeenCalled();
+      expect(callbacks.onUseManualEntry).not.toHaveBeenCalled();
+      expect(callbacks.onLookupFailure).not.toHaveBeenCalled();
+      rendered.unmount();
+    },
+  );
+
+  it('offers an explicit manual fallback when search is disabled', async () => {
+    mockSuggestLocations.mockRejectedValue(
+      axiosErrorWith(503, {
+        detail: 'Location search is disabled.',
+        error_code: 'LOCATION_SEARCH_NOT_CONFIGURED',
+      }),
+    );
+    const callbacks = pickerCallbacks();
+    const rendered = await render(
+      <PlacePicker value={selectedPlace} {...callbacks} />,
+    );
+
+    await enterSearch('Hotel lobby');
+    await advanceDebounce();
+    expect(screen.getByText(PLACE_SEARCH_UNAVAILABLE_MESSAGE)).toBeTruthy();
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Enter location manually' }),
+    );
+
+    expect(callbacks.onUseManualEntry).toHaveBeenCalledWith({
+      location_mode: 'MANUAL',
+      location_label: 'Hotel lobby',
+      place: null,
+    });
+    expect(callbacks.onSelectLocation).not.toHaveBeenCalled();
+    rendered.unmount();
+  });
+
+  it('emits only the canonical structured selection after lookup succeeds', async () => {
+    mockSuggestLocations.mockResolvedValue([suggestion]);
+    mockLookupLocation.mockResolvedValue(lookup);
+    const callbacks = pickerCallbacks();
+    const rendered = await render(
+      <PlacePicker value={selectedPlace} {...callbacks} />,
+    );
+
+    await enterSearch('Da Nang');
+    await advanceDebounce();
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: `Select ${suggestion.title}`,
+      }),
+    );
+    await flushPromises();
+
+    expect(callbacks.onSelectLocation).toHaveBeenCalledWith({
+      location_mode: 'STRUCTURED',
+      location_label: suggestion.title,
+      place: {
+        provider: 'here',
+        provider_id: lookup.destination_provider_id,
+        title: suggestion.title,
+        address: lookup.destination,
+        lat: lookup.destination_lat,
+        lng: lookup.destination_lng,
+      },
+    });
+    expect(callbacks.onLookupFailure).not.toHaveBeenCalled();
+    expect(callbacks.onUseManualEntry).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Search places').props.value).toBe('');
+    rendered.unmount();
+  });
+
+  it('emits a manual commit contract and guidance after settled lookup failure', async () => {
+    mockSuggestLocations.mockResolvedValue([suggestion]);
+    mockLookupLocation.mockRejectedValue(
+      axiosErrorWith(502, {
+        detail: 'Could not verify this place.',
+        error_code: 'LOCATION_LOOKUP_FAILED',
+      }),
+    );
+    const callbacks = pickerCallbacks();
+    const rendered = await render(
+      <PlacePicker value={selectedPlace} {...callbacks} />,
+    );
+
+    await enterSearch('Da Nang');
+    await advanceDebounce();
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: `Select ${suggestion.title}`,
+      }),
+    );
+    await flushPromises();
+
+    expect(callbacks.onLookupFailure).toHaveBeenCalledWith({
+      location_mode: 'MANUAL',
+      location_label: suggestion.title,
+      place: null,
+      guidance: MANUAL_LOCATION_GUIDANCE,
+      error: {
+        kind: 'message',
+        message: 'Could not verify this place.',
+        status: 502,
+        errorCode: 'LOCATION_LOOKUP_FAILED',
+      },
+    });
+    expect(callbacks.onSelectLocation).not.toHaveBeenCalled();
+    expect(callbacks.onUseManualEntry).not.toHaveBeenCalled();
+    expect(screen.getByText(MANUAL_LOCATION_GUIDANCE)).toBeTruthy();
+    expect(screen.queryByText(suggestion.provider_id)).toBeNull();
+    rendered.unmount();
+  });
+
+  it('does not emit any commit callback for an aborted stale lookup', async () => {
+    const pendingLookup = deferred<ResolvedLocationLookup>();
+    mockSuggestLocations.mockResolvedValue([suggestion]);
+    mockLookupLocation.mockReturnValue(pendingLookup.promise);
+    const callbacks = pickerCallbacks();
+    const rendered = await render(
+      <PlacePicker value={selectedPlace} {...callbacks} />,
+    );
+
+    await enterSearch('Da Nang');
+    await advanceDebounce();
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: `Select ${suggestion.title}`,
+      }),
+    );
+    const lookupSignal = mockLookupLocation.mock.calls[0]?.[1];
+
+    await enterSearch('Another place');
+    expect(lookupSignal?.aborted).toBe(true);
+    await act(async () => {
+      pendingLookup.resolve(lookup);
+      await Promise.resolve();
+    });
+
+    expect(callbacks.onSelectLocation).not.toHaveBeenCalled();
+    expect(callbacks.onLookupFailure).not.toHaveBeenCalled();
+    expect(callbacks.onUseManualEntry).not.toHaveBeenCalled();
+    rendered.unmount();
+  });
+
+  it('uses the existing label when manual entry is chosen without a query', async () => {
+    const callbacks = pickerCallbacks();
+    const rendered = await render(
+      <PlacePicker value={selectedPlace} {...callbacks} />,
+    );
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Enter location manually' }),
+    );
+
+    expect(callbacks.onUseManualEntry).toHaveBeenCalledWith({
+      location_mode: 'MANUAL',
+      location_label: selectedPlace?.location_label,
+      place: null,
+    });
+    rendered.unmount();
+  });
+});

--- a/mobile/src/features/timeline/__tests__/RouteScreens.test.tsx
+++ b/mobile/src/features/timeline/__tests__/RouteScreens.test.tsx
@@ -1,9 +1,16 @@
 let mockParams: Record<string, string | string[] | undefined> = {};
-const mockRouter = { push: jest.fn() };
+const mockRouter = {
+  dismissTo: jest.fn(),
+  push: jest.fn(),
+};
 const mockUseTimeline = jest.fn();
+const mockUseTripDetail = jest.fn();
+const mockUseFocusEffect = jest.fn();
 
 jest.mock('expo-router', () => ({
   Stack: { Screen: () => null },
+  useFocusEffect: (effect: () => (() => void) | void) =>
+    mockUseFocusEffect(effect),
   useLocalSearchParams: () => mockParams,
   useRouter: () => mockRouter,
 }));
@@ -11,6 +18,9 @@ jest.mock('expo-router', () => ({
 jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
 jest.mock('../hooks/useTimeline', () => ({
   useTimeline: (...args: unknown[]) => mockUseTimeline(...args),
+}));
+jest.mock('@/features/trips/hooks/useTripDetail', () => ({
+  useTripDetail: (...args: unknown[]) => mockUseTripDetail(...args),
 }));
 
 // eslint-disable-next-line import/first
@@ -32,6 +42,24 @@ describe('Timeline route screens', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockParams = {};
+    mockUseTripDetail.mockReturnValue({
+      detail: {
+        trip: {
+          id: TRIP_ID,
+          status: 'PLANNING',
+        },
+        my_membership: {
+          role: 'CAPTAIN',
+          status: 'ACTIVE',
+          joined_at: '2026-01-01T00:00:00Z',
+        },
+        members: [],
+      },
+      status: 'ready',
+      error: null,
+      refreshing: false,
+      refresh: jest.fn(),
+    });
     mockUseTimeline.mockReturnValue({
       timeline: {
         trip_timezone: 'UTC',
@@ -57,15 +85,7 @@ describe('Timeline route screens', () => {
     await render(<SectionFormScreen />);
 
     expect(screen.getByText('Form unavailable')).toBeTruthy();
-    expect(screen.queryByTestId('section-form-edit-route-ready')).toBeNull();
-  });
-
-  it('mounts the section form shell only for a valid explicit intent', async () => {
-    mockParams = { tripId: TRIP_ID, mode: 'create' };
-    await render(<SectionFormScreen />);
-
-    expect(screen.getByTestId('section-form-create-route-ready')).toBeTruthy();
-    expect(screen.queryByText('Form unavailable')).toBeNull();
+    expect(mockUseTimeline).not.toHaveBeenCalled();
   });
 
   it('renders a neutral state for a contradictory activity form intent', async () => {
@@ -83,9 +103,82 @@ describe('Timeline route screens', () => {
 
   it('mounts the activity form shell only for a valid explicit intent', async () => {
     mockParams = { tripId: TRIP_ID, mode: 'edit', activityId: ACTIVITY_ID };
+    mockUseTimeline.mockReturnValue({
+      timeline: {
+        trip_timezone: 'UTC',
+        permissions: {
+          can_edit_timeline: true,
+          can_manage_custom_types: true,
+          can_create_sections: true,
+        },
+        system_types: [
+          {
+            code: 'OTHER',
+            label: 'Other',
+            color_token: 'slate',
+            icon_key: 'tag',
+          },
+        ],
+        custom_types: [],
+        sections: [
+          {
+            id: SECTION_ID,
+            section_date: '2026-06-01',
+            label: 'Day 1',
+            is_label_custom: false,
+            is_in_trip_range: true,
+            position: 0,
+            activities: [
+              {
+                id: ACTIVITY_ID,
+                title: 'Breakfast',
+                time_mode: 'AT_TIME',
+                start_time: '08:00:00',
+                end_time: null,
+                status: 'UPCOMING',
+                position: 0,
+                activity_type: {
+                  kind: 'SYSTEM',
+                  code: 'OTHER',
+                  label: 'Other',
+                  color_token: 'slate',
+                  icon_key: 'tag',
+                },
+                assignee_scope: 'NONE',
+                assignee: null,
+                location: {
+                  location_mode: 'MANUAL',
+                  location_label: '',
+                  location_note: '',
+                  place: null,
+                  open_url: null,
+                },
+                note: '',
+                meeting_point: '',
+                contact_name: '',
+                contact_phone: '',
+                booking_reference: '',
+                external_link: '',
+                reminder_offsets_minutes: [],
+                capabilities: {
+                  can_edit: true,
+                  can_delete: true,
+                  can_update_status: true,
+                },
+              },
+            ],
+          },
+        ],
+      },
+      status: 'ready',
+      error: null,
+      refreshing: false,
+      refresh: jest.fn(),
+      invalidate: jest.fn(),
+    });
     await render(<ActivityFormScreen />);
 
-    expect(screen.getByTestId('activity-form-edit-route-ready')).toBeTruthy();
+    expect(screen.getByTestId('activity-form-scroll')).toBeTruthy();
     expect(screen.queryByText('Form unavailable')).toBeNull();
   });
 

--- a/mobile/src/features/timeline/__tests__/RouteScreens.test.tsx
+++ b/mobile/src/features/timeline/__tests__/RouteScreens.test.tsx
@@ -1,0 +1,79 @@
+let mockParams: Record<string, string | string[] | undefined> = {};
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: () => mockParams,
+}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+
+// eslint-disable-next-line import/first
+import { render, screen } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { ActivityFormScreen } from '../screens/ActivityFormScreen';
+// eslint-disable-next-line import/first
+import { CustomTypeManagerScreen } from '../screens/CustomTypeManagerScreen';
+// eslint-disable-next-line import/first
+import { SectionFormScreen } from '../screens/SectionFormScreen';
+// eslint-disable-next-line import/first
+import { TimelineScreen } from '../screens/TimelineScreen';
+
+const TRIP_ID = '123e4567-e89b-12d3-a456-426614174000';
+const SECTION_ID = '2c1dfd8d-9c7f-43c7-9b99-71f6d1edda55';
+const ACTIVITY_ID = 'a11957b3-3329-4fcf-9c7b-673a51c1d8a7';
+
+describe('Timeline route screens', () => {
+  beforeEach(() => {
+    mockParams = {};
+  });
+
+  it('renders a neutral state for an invalid section form before mounting the valid shell', async () => {
+    mockParams = { tripId: TRIP_ID, mode: 'edit', sectionId: [SECTION_ID] };
+    await render(<SectionFormScreen />);
+
+    expect(screen.getByText('Form unavailable')).toBeTruthy();
+    expect(screen.queryByTestId('section-form-edit-route-ready')).toBeNull();
+  });
+
+  it('mounts the section form shell only for a valid explicit intent', async () => {
+    mockParams = { tripId: TRIP_ID, mode: 'create' };
+    await render(<SectionFormScreen />);
+
+    expect(screen.getByTestId('section-form-create-route-ready')).toBeTruthy();
+    expect(screen.queryByText('Form unavailable')).toBeNull();
+  });
+
+  it('renders a neutral state for a contradictory activity form intent', async () => {
+    mockParams = {
+      tripId: TRIP_ID,
+      mode: 'edit',
+      sectionId: SECTION_ID,
+      activityId: ACTIVITY_ID,
+    };
+    await render(<ActivityFormScreen />);
+
+    expect(screen.getByText('Form unavailable')).toBeTruthy();
+    expect(screen.queryByTestId('activity-form-edit-route-ready')).toBeNull();
+  });
+
+  it('mounts the activity form shell only for a valid explicit intent', async () => {
+    mockParams = { tripId: TRIP_ID, mode: 'edit', activityId: ACTIVITY_ID };
+    await render(<ActivityFormScreen />);
+
+    expect(screen.getByTestId('activity-form-edit-route-ready')).toBeTruthy();
+    expect(screen.queryByText('Form unavailable')).toBeNull();
+  });
+
+  it('guards non-form timeline routes with the same strict trip UUID parser', async () => {
+    mockParams = { tripId: [TRIP_ID] };
+    const { rerender } = await render(<TimelineScreen />);
+    expect(screen.getByText('Timeline unavailable')).toBeTruthy();
+
+    mockParams = { tripId: 'not-a-uuid' };
+    await rerender(<CustomTypeManagerScreen />);
+    expect(screen.getByText('Custom types unavailable')).toBeTruthy();
+
+    mockParams = { tripId: TRIP_ID };
+    await rerender(<TimelineScreen />);
+    expect(screen.getByTestId('timeline-route-ready')).toBeTruthy();
+  });
+});

--- a/mobile/src/features/timeline/__tests__/RouteScreens.test.tsx
+++ b/mobile/src/features/timeline/__tests__/RouteScreens.test.tsx
@@ -1,10 +1,17 @@
 let mockParams: Record<string, string | string[] | undefined> = {};
+const mockRouter = { push: jest.fn() };
+const mockUseTimeline = jest.fn();
 
 jest.mock('expo-router', () => ({
+  Stack: { Screen: () => null },
   useLocalSearchParams: () => mockParams,
+  useRouter: () => mockRouter,
 }));
 
 jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('../hooks/useTimeline', () => ({
+  useTimeline: (...args: unknown[]) => mockUseTimeline(...args),
+}));
 
 // eslint-disable-next-line import/first
 import { render, screen } from '@testing-library/react-native';
@@ -23,7 +30,26 @@ const ACTIVITY_ID = 'a11957b3-3329-4fcf-9c7b-673a51c1d8a7';
 
 describe('Timeline route screens', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     mockParams = {};
+    mockUseTimeline.mockReturnValue({
+      timeline: {
+        trip_timezone: 'UTC',
+        permissions: {
+          can_edit_timeline: false,
+          can_manage_custom_types: false,
+          can_create_sections: false,
+        },
+        system_types: [],
+        custom_types: [],
+        sections: [],
+      },
+      status: 'ready',
+      error: null,
+      refreshing: false,
+      refresh: jest.fn(),
+      invalidate: jest.fn(),
+    });
   });
 
   it('renders a neutral state for an invalid section form before mounting the valid shell', async () => {
@@ -67,6 +93,7 @@ describe('Timeline route screens', () => {
     mockParams = { tripId: [TRIP_ID] };
     const { rerender } = await render(<TimelineScreen />);
     expect(screen.getByText('Timeline unavailable')).toBeTruthy();
+    expect(mockUseTimeline).not.toHaveBeenCalled();
 
     mockParams = { tripId: 'not-a-uuid' };
     await rerender(<CustomTypeManagerScreen />);
@@ -75,5 +102,6 @@ describe('Timeline route screens', () => {
     mockParams = { tripId: TRIP_ID };
     await rerender(<TimelineScreen />);
     expect(screen.getByTestId('timeline-route-ready')).toBeTruthy();
+    expect(mockUseTimeline).toHaveBeenCalledWith(TRIP_ID);
   });
 });

--- a/mobile/src/features/timeline/__tests__/SectionFormScreen.test.tsx
+++ b/mobile/src/features/timeline/__tests__/SectionFormScreen.test.tsx
@@ -444,7 +444,7 @@ describe('SectionFormScreen', () => {
     expect(mockCreateSection).not.toHaveBeenCalled();
   });
 
-  it('creates with the trip-timezone date then reconciles once through the event before dismissing', async () => {
+  it('creates with the trip-timezone date then dismisses without self-reconciliation', async () => {
     await render(<SectionFormScreen />);
     await focusScreen();
     mockRefresh.mockClear();
@@ -475,8 +475,7 @@ describe('SectionFormScreen', () => {
       ),
     );
     expect(mockInvalidate).toHaveBeenCalledTimes(1);
-    expect(mockRefresh).toHaveBeenCalledTimes(1);
-    expect(mockRefresh).toHaveBeenCalledWith('silent');
+    expect(mockRefresh).not.toHaveBeenCalled();
     expect(mockPublishTimelineEvent).toHaveBeenCalledTimes(1);
     expect(mockPublishTimelineEvent).toHaveBeenCalledWith({
       type: 'timelineChanged',
@@ -691,7 +690,7 @@ describe('SectionFormScreen', () => {
     expect(mockRouter.dismissTo).not.toHaveBeenCalled();
   });
 
-  it('publishes one confirmed late success but does not reconcile or navigate the inactive screen', async () => {
+  it('keeps a confirmed late success terminal and dismisses on refocus without replay', async () => {
     const pending = deferred<TimelineSection>();
     mockCreateSection.mockReturnValue(pending.promise);
     await render(<SectionFormScreen />);
@@ -718,5 +717,22 @@ describe('SectionFormScreen', () => {
     );
     expect(mockRefresh).not.toHaveBeenCalled();
     expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Add day' }),
+    );
+    expect(mockCreateSection).toHaveBeenCalledTimes(1);
+
+    await focusScreen();
+    await waitFor(() =>
+      expect(mockRouter.dismissTo).toHaveBeenCalledWith(
+        `/trips/${TRIP_ID}/timeline`,
+      ),
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Add day' }),
+    );
+    expect(mockCreateSection).toHaveBeenCalledTimes(1);
+    expect(mockRefresh).not.toHaveBeenCalled();
   });
 });

--- a/mobile/src/features/timeline/__tests__/SectionFormScreen.test.tsx
+++ b/mobile/src/features/timeline/__tests__/SectionFormScreen.test.tsx
@@ -1,0 +1,593 @@
+import { Pressable, Text, View } from 'react-native';
+
+let mockParams: Record<string, string | string[] | undefined> = {};
+const mockRouter = { dismissTo: jest.fn() };
+const mockUseFocusEffect = jest.fn();
+const mockUseAppForegroundEffect = jest.fn();
+const mockUseTimeline = jest.fn();
+const mockRefresh = jest.fn();
+const mockInvalidate = jest.fn();
+const mockPublishTimelineEvent = jest.fn();
+const mockSubscribeToTimelineEvents = jest.fn();
+const mockGetTodayDateInTimeZone = jest.fn();
+let mockTimelineListener:
+  | ((event: { type: 'timelineChanged'; tripId: string }) =>
+      void | Promise<void>)
+  | undefined;
+let mockLatestStackOptions:
+  | {
+      gestureEnabled?: boolean;
+      headerLeft?: () => React.ReactNode;
+    }
+  | undefined;
+
+function mockRenderStackScreen({
+  options,
+}: {
+  options: {
+    gestureEnabled?: boolean;
+    headerLeft?: () => React.ReactNode;
+  };
+}) {
+  mockLatestStackOptions = options;
+  return <View>{options.headerLeft?.()}</View>;
+}
+
+jest.mock('expo-router', () => ({
+  Stack: { Screen: mockRenderStackScreen },
+  useFocusEffect: (effect: () => (() => void) | void) =>
+    mockUseFocusEffect(effect),
+  useLocalSearchParams: () => mockParams,
+  useRouter: () => mockRouter,
+}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('@/shared/hooks/useAppForegroundEffect', () => ({
+  useAppForegroundEffect: (listener: () => void) =>
+    mockUseAppForegroundEffect(listener),
+}));
+jest.mock('../hooks/useTimeline', () => ({
+  useTimeline: (...args: unknown[]) => mockUseTimeline(...args),
+}));
+jest.mock('../api', () => ({
+  createSection: jest.fn(),
+  patchSection: jest.fn(),
+}));
+jest.mock('../timelineEvents', () => ({
+  publishTimelineEvent: (...args: unknown[]) =>
+    mockPublishTimelineEvent(...args),
+  subscribeToTimelineEvents: (...args: unknown[]) =>
+    mockSubscribeToTimelineEvents(...args),
+}));
+jest.mock('../viewModel', () => ({
+  getTodayDateInTimeZone: (...args: unknown[]) =>
+    mockGetTodayDateInTimeZone(...args),
+}));
+
+interface MockDateFieldProps {
+  label: string;
+  value: Date;
+  onChange: (date: Date) => void;
+  error?: string;
+}
+
+function formatMockDate(date: Date): string {
+  if (Number.isNaN(date.getTime())) {
+    return 'invalid';
+  }
+  return [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, '0'),
+    String(date.getDate()).padStart(2, '0'),
+  ].join('-');
+}
+
+function MockDateField({
+  label,
+  value,
+  onChange,
+  error,
+}: MockDateFieldProps) {
+  return (
+    <View>
+      <Text>{label}</Text>
+      <Text testID="section-date-value">{formatMockDate(value)}</Text>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Choose free date"
+        onPress={() => onChange(new Date(2026, 7, 3, 12))}
+      />
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Choose occupied date"
+        onPress={() => onChange(new Date(2026, 7, 2, 12))}
+      />
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Choose invalid date"
+        onPress={() => onChange(new Date(Number.NaN))}
+      />
+      {error ? <Text>{error}</Text> : null}
+    </View>
+  );
+}
+
+jest.mock('@/shared/ui/DateField', () => ({
+  DateField: MockDateField,
+}));
+
+// eslint-disable-next-line import/first
+import { AxiosError, AxiosHeaders } from 'axios';
+// eslint-disable-next-line import/first
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { createSection, patchSection } from '../api';
+// eslint-disable-next-line import/first
+import { SectionFormScreen } from '../screens/SectionFormScreen';
+// eslint-disable-next-line import/first
+import type {
+  TimelineResponse,
+  TimelineSection,
+} from '../types';
+
+const mockCreateSection = createSection as jest.MockedFunction<
+  typeof createSection
+>;
+const mockPatchSection = patchSection as jest.MockedFunction<
+  typeof patchSection
+>;
+
+const TRIP_ID = '123e4567-e89b-12d3-a456-426614174000';
+const SECTION_ID = '2c1dfd8d-9c7f-43c7-9b99-71f6d1edda55';
+const OTHER_SECTION_ID = '78f52d4e-c187-44fa-85b8-ad4fb2dcb8bd';
+
+const section: TimelineSection = {
+  id: SECTION_ID,
+  section_date: '2026-08-01',
+  label: 'Arrival',
+  is_label_custom: true,
+  is_in_trip_range: true,
+  position: 0,
+  activities: [],
+};
+
+const otherSection: TimelineSection = {
+  ...section,
+  id: OTHER_SECTION_ID,
+  section_date: '2026-08-02',
+  label: 'Explore',
+  position: 1,
+};
+
+function timeline(
+  permissions: Partial<TimelineResponse['permissions']> = {},
+): TimelineResponse {
+  return {
+    trip_timezone: 'Asia/Ho_Chi_Minh',
+    permissions: {
+      can_edit_timeline: true,
+      can_manage_custom_types: true,
+      can_create_sections: true,
+      ...permissions,
+    },
+    system_types: [],
+    custom_types: [],
+    sections: [section, otherSection],
+  };
+}
+
+function readyHook(nextTimeline = timeline()) {
+  return {
+    timeline: nextTimeline,
+    status: 'ready' as const,
+    error: null,
+    refreshing: false,
+    refresh: mockRefresh,
+    invalidate: mockInvalidate,
+  };
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, {}, {
+    status,
+    statusText: '',
+    headers: {},
+    config,
+    data,
+  });
+}
+
+function latestFocusCallback(): () => (() => void) | void {
+  const callback = mockUseFocusEffect.mock.calls.at(-1)?.[0] as
+    | (() => (() => void) | void)
+    | undefined;
+  if (!callback) {
+    throw new Error('Expected useFocusEffect to register a callback.');
+  }
+  return callback;
+}
+
+async function focusScreen(): Promise<(() => void) | undefined> {
+  let cleanup: (() => void) | undefined;
+  await act(async () => {
+    cleanup = latestFocusCallback()() || undefined;
+  });
+  return cleanup;
+}
+
+describe('SectionFormScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockParams = { tripId: TRIP_ID, mode: 'create' };
+    mockTimelineListener = undefined;
+    mockLatestStackOptions = undefined;
+    mockRefresh.mockResolvedValue(undefined);
+    mockGetTodayDateInTimeZone.mockReturnValue('2026-08-03');
+    mockUseTimeline.mockReturnValue(readyHook());
+    mockCreateSection.mockResolvedValue({
+      ...section,
+      id: 'd347da49-671a-48ec-bcae-aa5ef33ba28f',
+      section_date: '2026-08-03',
+    });
+    mockPatchSection.mockResolvedValue(section);
+    mockSubscribeToTimelineEvents.mockImplementation(
+      (
+        _tripId: string,
+        listener: (
+          event: { type: 'timelineChanged'; tripId: string },
+        ) => void | Promise<void>,
+      ) => {
+        mockTimelineListener = listener;
+        return jest.fn();
+      },
+    );
+    mockPublishTimelineEvent.mockImplementation(
+      async (event: { type: 'timelineChanged'; tripId: string }) => {
+        await mockTimelineListener?.(event);
+      },
+    );
+  });
+
+  it('rejects malformed route intent before loading or mutating', async () => {
+    mockParams = {
+      tripId: TRIP_ID,
+      mode: 'edit',
+      sectionId: [SECTION_ID],
+    };
+
+    await render(<SectionFormScreen />);
+
+    expect(screen.getByText('Form unavailable')).toBeTruthy();
+    expect(mockUseTimeline).not.toHaveBeenCalled();
+    expect(mockCreateSection).not.toHaveBeenCalled();
+    expect(mockPatchSection).not.toHaveBeenCalled();
+  });
+
+  it('gates create and edit direct links with aggregate capabilities', async () => {
+    mockUseTimeline.mockReturnValue(
+      readyHook(
+        timeline({
+          can_create_sections: false,
+          can_edit_timeline: false,
+        }),
+      ),
+    );
+    const view = await render(<SectionFormScreen />);
+
+    expect(
+      screen.getByText(
+        'You do not have permission to manage timeline days.',
+      ),
+    ).toBeTruthy();
+    expect(mockUseTimeline).toHaveBeenCalledWith(TRIP_ID, {
+      autoReconcile: false,
+    });
+
+    mockParams = {
+      tripId: TRIP_ID,
+      mode: 'edit',
+      sectionId: SECTION_ID,
+    };
+    await view.rerender(<SectionFormScreen />);
+
+    expect(
+      screen.getByText(
+        'You do not have permission to manage timeline days.',
+      ),
+    ).toBeTruthy();
+    expect(mockCreateSection).not.toHaveBeenCalled();
+    expect(mockPatchSection).not.toHaveBeenCalled();
+  });
+
+  it('hydrates edit state once and preserves the immutable initial snapshot', async () => {
+    mockParams = {
+      tripId: TRIP_ID,
+      mode: 'edit',
+      sectionId: SECTION_ID,
+    };
+    const view = await render(<SectionFormScreen />);
+
+    expect(screen.getByLabelText('Day label').props.value).toBe('Arrival');
+    await fireEvent.changeText(
+      screen.getByLabelText('Day label'),
+      'My draft',
+    );
+
+    mockUseTimeline.mockReturnValue(
+      readyHook({
+        ...timeline(),
+        sections: [{ ...section, label: 'Server update' }, otherSection],
+      }),
+    );
+    await view.rerender(<SectionFormScreen />);
+
+    expect(screen.getByLabelText('Day label').props.value).toBe('My draft');
+  });
+
+  it('validates label and date, and blocks dates already used by another day', async () => {
+    await render(<SectionFormScreen />);
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Add day' }),
+    );
+    expect(screen.getByText('Label is required.')).toBeTruthy();
+
+    await fireEvent.changeText(
+      screen.getByLabelText('Day label'),
+      'x'.repeat(121),
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Add day' }),
+    );
+    expect(
+      screen.getByText('Label must be 120 characters or fewer.'),
+    ).toBeTruthy();
+
+    await fireEvent.changeText(
+      screen.getByLabelText('Day label'),
+      'Valid label',
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Choose invalid date' }),
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Add day' }),
+    );
+    expect(screen.getByText('Enter a valid date.')).toBeTruthy();
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Choose occupied date' }),
+    );
+    expect(
+      screen.getByText('This date already has a timeline day.'),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: 'Add day' }).props
+        .accessibilityState,
+    ).toMatchObject({ disabled: true });
+    expect(mockCreateSection).not.toHaveBeenCalled();
+  });
+
+  it('creates with the trip-timezone date then reconciles once through the event before dismissing', async () => {
+    await render(<SectionFormScreen />);
+    await focusScreen();
+    mockRefresh.mockClear();
+
+    expect(mockGetTodayDateInTimeZone).toHaveBeenCalledWith(
+      'Asia/Ho_Chi_Minh',
+    );
+    expect(screen.getByTestId('section-date-value').props.children).toBe(
+      '2026-08-03',
+    );
+    await fireEvent.changeText(
+      screen.getByLabelText('Day label'),
+      '  Extra day  ',
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Add day' }),
+    );
+
+    await waitFor(() =>
+      expect(mockCreateSection).toHaveBeenCalledWith(TRIP_ID, {
+        section_date: '2026-08-03',
+        label: 'Extra day',
+      }),
+    );
+    await waitFor(() =>
+      expect(mockRouter.dismissTo).toHaveBeenCalledWith(
+        `/trips/${TRIP_ID}/timeline`,
+      ),
+    );
+    expect(mockInvalidate).toHaveBeenCalledTimes(1);
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+    expect(mockRefresh).toHaveBeenCalledWith('silent');
+    expect(mockPublishTimelineEvent).toHaveBeenCalledTimes(1);
+    expect(mockPublishTimelineEvent).toHaveBeenCalledWith({
+      type: 'timelineChanged',
+      tripId: TRIP_ID,
+    });
+    expect(mockInvalidate.mock.invocationCallOrder[0]).toBeLessThan(
+      mockCreateSection.mock.invocationCallOrder[0]!,
+    );
+    expect(mockCreateSection.mock.invocationCallOrder[0]).toBeLessThan(
+      mockPublishTimelineEvent.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it('sends a minimal edit PATCH and locks submit, Cancel, and gestures until settled', async () => {
+    const pending = deferred<TimelineSection>();
+    mockPatchSection.mockReturnValue(pending.promise);
+    mockParams = {
+      tripId: TRIP_ID,
+      mode: 'edit',
+      sectionId: SECTION_ID,
+    };
+    await render(<SectionFormScreen />);
+    await focusScreen();
+    mockRefresh.mockClear();
+
+    expect(
+      screen.getByRole('button', { name: 'Save day' }).props
+        .accessibilityState,
+    ).toMatchObject({ disabled: true });
+    await fireEvent.changeText(
+      screen.getByLabelText('Day label'),
+      '  Updated arrival  ',
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Save day' }),
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Save day' }),
+    );
+
+    await waitFor(() => expect(mockPatchSection).toHaveBeenCalledTimes(1));
+    expect(mockPatchSection).toHaveBeenCalledWith(TRIP_ID, SECTION_ID, {
+      label: 'Updated arrival',
+    });
+    expect(mockLatestStackOptions?.gestureEnabled).toBe(false);
+    expect(
+      screen.getByRole('button', {
+        name: 'Cancel timeline day form',
+      }).props.accessibilityState,
+    ).toMatchObject({ disabled: true });
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: 'Cancel timeline day form',
+      }),
+    );
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+
+    await act(async () => {
+      pending.resolve({ ...section, label: 'Updated arrival' });
+    });
+    await waitFor(() =>
+      expect(mockRouter.dismissTo).toHaveBeenCalledWith(
+        `/trips/${TRIP_ID}/timeline`,
+      ),
+    );
+  });
+
+  it('renders backend field and conflict detail verbatim and reconciles authority failures', async () => {
+    mockCreateSection.mockRejectedValueOnce(
+      axiosErrorWith(400, {
+        label: ['Use the backend-approved day label.'],
+      }),
+    );
+    await render(<SectionFormScreen />);
+    await focusScreen();
+    mockRefresh.mockClear();
+    await fireEvent.changeText(
+      screen.getByLabelText('Day label'),
+      'First attempt',
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Add day' }),
+    );
+
+    expect(
+      await screen.findByText('Use the backend-approved day label.'),
+    ).toBeTruthy();
+    expect(mockRefresh).not.toHaveBeenCalled();
+
+    mockCreateSection.mockRejectedValueOnce(
+      axiosErrorWith(409, {
+        detail: 'A timeline day already exists on this date.',
+      }),
+    );
+    await fireEvent.changeText(
+      screen.getByLabelText('Day label'),
+      'Second attempt',
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Add day' }),
+    );
+
+    expect(
+      await screen.findByText(
+        'A timeline day already exists on this date.',
+      ),
+    ).toBeTruthy();
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+    expect(mockRefresh).toHaveBeenCalledWith('silent');
+    expect(mockPublishTimelineEvent).not.toHaveBeenCalled();
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+  });
+
+  it('ignores a late inactive failure without state, navigation, or event effects', async () => {
+    const pending = deferred<TimelineSection>();
+    mockCreateSection.mockReturnValue(pending.promise);
+    await render(<SectionFormScreen />);
+    const blur = await focusScreen();
+    mockRefresh.mockClear();
+    await fireEvent.changeText(
+      screen.getByLabelText('Day label'),
+      'Late failure',
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Add day' }),
+    );
+
+    await act(async () => {
+      blur?.();
+      pending.reject(
+        axiosErrorWith(409, {
+          detail: 'This late failure must remain invisible.',
+        }),
+      );
+    });
+
+    expect(
+      screen.queryByText('This late failure must remain invisible.'),
+    ).toBeNull();
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(mockPublishTimelineEvent).not.toHaveBeenCalled();
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+  });
+
+  it('publishes one confirmed late success but does not reconcile or navigate the inactive screen', async () => {
+    const pending = deferred<TimelineSection>();
+    mockCreateSection.mockReturnValue(pending.promise);
+    await render(<SectionFormScreen />);
+    const blur = await focusScreen();
+    mockRefresh.mockClear();
+    await fireEvent.changeText(
+      screen.getByLabelText('Day label'),
+      'Late success',
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Add day' }),
+    );
+
+    await act(async () => {
+      blur?.();
+      pending.resolve({
+        ...section,
+        id: 'c11a834e-23f9-436e-83ad-fe69cc442b60',
+      });
+    });
+
+    await waitFor(() =>
+      expect(mockPublishTimelineEvent).toHaveBeenCalledTimes(1),
+    );
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/features/timeline/__tests__/SectionFormScreen.test.tsx
+++ b/mobile/src/features/timeline/__tests__/SectionFormScreen.test.tsx
@@ -341,6 +341,65 @@ describe('SectionFormScreen', () => {
     expect(screen.getByLabelText('Day label').props.value).toBe('My draft');
   });
 
+  it('keeps the draft mounted and read-only while authority is lost, then restores editing', async () => {
+    mockParams = {
+      tripId: TRIP_ID,
+      mode: 'edit',
+      sectionId: SECTION_ID,
+    };
+    const view = await render(<SectionFormScreen />);
+    await fireEvent.changeText(
+      screen.getByLabelText('Day label'),
+      'Authority-safe draft',
+    );
+
+    mockUseTimeline.mockReturnValue(
+      readyHook(
+        timeline({
+          can_create_sections: false,
+          can_edit_timeline: false,
+        }),
+      ),
+    );
+    await view.rerender(<SectionFormScreen />);
+
+    expect(
+      screen.getByText(
+        'You do not have permission to manage timeline days.',
+      ),
+    ).toBeTruthy();
+    expect(screen.getByLabelText('Day label').props.value).toBe(
+      'Authority-safe draft',
+    );
+    expect(screen.getByLabelText('Day label').props.editable).toBe(false);
+    expect(
+      screen.getByRole('button', { name: 'Save day' }).props
+        .accessibilityState,
+    ).toMatchObject({ disabled: true });
+
+    mockUseTimeline.mockReturnValue(
+      readyHook({
+        ...timeline(),
+        sections: [{ ...section, label: 'Server update' }, otherSection],
+      }),
+    );
+    await view.rerender(<SectionFormScreen />);
+
+    expect(
+      screen.queryByText(
+        'You do not have permission to manage timeline days.',
+      ),
+    ).toBeNull();
+    expect(screen.getByLabelText('Day label').props.value).toBe(
+      'Authority-safe draft',
+    );
+    expect(screen.getByLabelText('Day label').props.editable).toBe(true);
+    expect(
+      screen.getByRole('button', { name: 'Save day' }).props
+        .accessibilityState,
+    ).toMatchObject({ disabled: false });
+  });
+
   it('validates label and date, and blocks dates already used by another day', async () => {
     await render(<SectionFormScreen />);
 
@@ -556,6 +615,76 @@ describe('SectionFormScreen', () => {
 
     expect(
       screen.queryByText('This late failure must remain invisible.'),
+    ).toBeNull();
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(mockPublishTimelineEvent).not.toHaveBeenCalled();
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole('button', {
+        name: 'Cancel timeline day form',
+      }).props.accessibilityState,
+    ).toMatchObject({ disabled: true });
+
+    await focusScreen();
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {
+          name: 'Cancel timeline day form',
+        }).props.accessibilityState,
+      ).toMatchObject({ disabled: false }),
+    );
+    expect(mockLatestStackOptions?.gestureEnabled).toBe(true);
+    expect(
+      screen.queryByText('This late failure must remain invisible.'),
+    ).toBeNull();
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+  });
+
+  it('recovers pending UI when an old mutation settles after refocus', async () => {
+    const pending = deferred<TimelineSection>();
+    mockCreateSection.mockReturnValue(pending.promise);
+    await render(<SectionFormScreen />);
+    const blur = await focusScreen();
+    await fireEvent.changeText(
+      screen.getByLabelText('Day label'),
+      'Refocused failure',
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Add day' }),
+    );
+    await waitFor(() =>
+      expect(mockCreateSection).toHaveBeenCalledTimes(1),
+    );
+
+    await act(async () => {
+      blur?.();
+    });
+    await focusScreen();
+    expect(
+      screen.getByRole('button', {
+        name: 'Cancel timeline day form',
+      }).props.accessibilityState,
+    ).toMatchObject({ disabled: true });
+    mockRefresh.mockClear();
+
+    await act(async () => {
+      pending.reject(
+        axiosErrorWith(409, {
+          detail: 'This stale generation must remain invisible.',
+        }),
+      );
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {
+          name: 'Cancel timeline day form',
+        }).props.accessibilityState,
+      ).toMatchObject({ disabled: false }),
+    );
+    expect(mockLatestStackOptions?.gestureEnabled).toBe(true);
+    expect(
+      screen.queryByText('This stale generation must remain invisible.'),
     ).toBeNull();
     expect(mockRefresh).not.toHaveBeenCalled();
     expect(mockPublishTimelineEvent).not.toHaveBeenCalled();

--- a/mobile/src/features/timeline/__tests__/TimeField.test.tsx
+++ b/mobile/src/features/timeline/__tests__/TimeField.test.tsx
@@ -1,0 +1,158 @@
+import type { ReactNode } from 'react';
+
+interface MockModifier {
+  $type: string;
+  [key: string]: unknown;
+}
+
+interface MockDatePickerProps {
+  testID?: string;
+  selection?: Date;
+  displayedComponents?: string[];
+  onDateChange?: (date: Date) => void;
+  modifiers?: MockModifier[];
+}
+
+interface MockHostProps {
+  children: ReactNode;
+  colorScheme?: string;
+  matchContents?: boolean;
+}
+
+const mockDatePicker = jest.fn((_props: MockDatePickerProps) => null);
+const mockHost = jest.fn(({ children }: MockHostProps) => children);
+
+jest.mock('@expo/ui/swift-ui', () => ({
+  DatePicker: mockDatePicker,
+  Host: mockHost,
+}));
+
+// The component must load after the native SwiftUI views are mocked.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { TimeField } = require('../components/TimeField') as typeof import('../components/TimeField');
+
+// eslint-disable-next-line import/first
+import { act, render, screen } from '@testing-library/react-native';
+
+function latestPickerProps(): MockDatePickerProps {
+  const props = mockDatePicker.mock.calls.at(-1)?.[0];
+  if (!props) {
+    throw new Error('Expected the native DatePicker to render.');
+  }
+  return props;
+}
+
+function expectFixedAnchor(date: Date | undefined, hours: number, minutes: number) {
+  expect(date).toBeInstanceOf(Date);
+  expect(date?.getFullYear()).toBe(2000);
+  expect(date?.getMonth()).toBe(0);
+  expect(date?.getDate()).toBe(1);
+  expect(date?.getHours()).toBe(hours);
+  expect(date?.getMinutes()).toBe(minutes);
+  expect(date?.getSeconds()).toBe(0);
+  expect(date?.getMilliseconds()).toBe(0);
+}
+
+describe('TimeField', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('wraps the native time picker with a fixed local-date anchor', async () => {
+    await render(<TimeField label="Start time" value="23:59" onChange={jest.fn()} />);
+
+    const picker = latestPickerProps();
+    expect(picker.testID).toBe('time-field-picker');
+    expect(picker.displayedComponents).toEqual(['hourAndMinute']);
+    expectFixedAnchor(picker.selection, 23, 59);
+    expect(mockHost.mock.calls.at(-1)?.[0]).toEqual(
+      expect.objectContaining({ colorScheme: 'light', matchContents: true }),
+    );
+  });
+
+  it.each([
+    [new Date(2035, 6, 2, 0, 5, 45, 900), '00:05'],
+    [new Date(1995, 11, 31, 23, 59, 10, 100), '23:59'],
+  ])('emits only zero-padded local time without carrying the date %#', async (date, expected) => {
+    const onChange = jest.fn();
+    await render(<TimeField label="Start time" value="12:00" onChange={onChange} />);
+
+    await act(async () => {
+      latestPickerProps().onDateChange?.(date);
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(expected);
+  });
+
+  it('updates the anchored native selection from controlled value changes', async () => {
+    const { rerender } = await render(
+      <TimeField label="End time" value="08:07" onChange={jest.fn()} />,
+    );
+    expectFixedAnchor(latestPickerProps().selection, 8, 7);
+
+    await rerender(<TimeField label="End time" value="18:42" onChange={jest.fn()} />);
+    expectFixedAnchor(latestPickerProps().selection, 18, 42);
+  });
+
+  it.each(['', '8:30', '24:00', '12:60', ' 08:30'])(
+    'uses a deterministic unset anchor and never self-emits for invalid value %p',
+    async (value) => {
+      const onChange = jest.fn();
+      await render(<TimeField label="Start time" value={value} onChange={onChange} />);
+
+      const picker = latestPickerProps();
+      expectFixedAnchor(picker.selection, 0, 0);
+      expect(picker.modifiers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ $type: 'accessibilityValue', value: 'Not set' }),
+        ]),
+      );
+      expect(onChange).not.toHaveBeenCalled();
+    },
+  );
+
+  it('does not emit duplicate or invalid native values', async () => {
+    const onChange = jest.fn();
+    await render(<TimeField label="Start time" value="09:30" onChange={onChange} />);
+    const onDateChange = latestPickerProps().onDateChange;
+
+    await act(async () => {
+      onDateChange?.(new Date(2040, 4, 5, 9, 30));
+      onDateChange?.(new Date(Number.NaN));
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('provides native accessibility metadata, disabled state, and an announced error', async () => {
+    const onChange = jest.fn();
+    await render(
+      <TimeField
+        label="End time"
+        value="17:45"
+        onChange={onChange}
+        disabled
+        error="End time must be after start time."
+      />,
+    );
+
+    expect(screen.getByText('End time')).toBeTruthy();
+    expect(screen.getByRole('alert')).toHaveTextContent('End time must be after start time.');
+    expect(latestPickerProps().modifiers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ $type: 'accessibilityLabel', label: 'End time' }),
+        expect.objectContaining({ $type: 'accessibilityValue', value: '17:45' }),
+        expect.objectContaining({
+          $type: 'accessibilityHint',
+          hint: 'Time selection is unavailable.',
+        }),
+        expect.objectContaining({ $type: 'disabled', disabled: true }),
+      ]),
+    );
+    await act(async () => {
+      latestPickerProps().onDateChange?.(new Date(2030, 0, 1, 18, 30));
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/features/timeline/__tests__/TimelineComponents.test.tsx
+++ b/mobile/src/features/timeline/__tests__/TimelineComponents.test.tsx
@@ -1,0 +1,288 @@
+const mockIonicons = jest.fn((_props: unknown) => null);
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: (props: unknown) => mockIonicons(props),
+}));
+
+// eslint-disable-next-line import/first
+import { Linking } from 'react-native';
+// eslint-disable-next-line import/first
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { ActivityRow } from '../components/ActivityRow';
+// eslint-disable-next-line import/first
+import { SectionGroup } from '../components/SectionGroup';
+// eslint-disable-next-line import/first
+import type { TimelineActivity, TimelineSection } from '../types';
+
+function buildActivity(
+  overrides: Partial<TimelineActivity> = {},
+): TimelineActivity {
+  return {
+    id: 'activity-1',
+    title: 'Airport transfer',
+    time_mode: 'TIME_RANGE',
+    start_time: '09:05:00',
+    end_time: '10:30:00',
+    status: 'UPCOMING',
+    position: 0,
+    activity_type: {
+      kind: 'SYSTEM',
+      code: 'TRANSPORTATION',
+      label: 'Transportation',
+      color_token: 'sky',
+      icon_key: 'bus',
+    },
+    assignee_scope: 'USER',
+    assignee: {
+      id: 'user-1',
+      display_name: 'Quang Minh',
+      identify_tag: 'minh#1234',
+    },
+    location: {
+      location_mode: 'STRUCTURED',
+      location_label: 'Da Nang International Airport',
+      location_note: 'Meet at column 5.',
+      place: {
+        provider: 'here',
+        provider_id: 'here:place:airport',
+        title: 'Da Nang International Airport',
+        address: 'Da Nang, Vietnam',
+        lat: 16.0439,
+        lng: 108.199,
+      },
+      open_url: 'https://maps.example/airport',
+    },
+    note: 'Driver holds a GoPlan sign.',
+    meeting_point: 'Arrival hall',
+    contact_name: 'Anh Tran',
+    contact_phone: '+84 900 000 000',
+    booking_reference: 'CAR-2026',
+    external_link: 'https://booking.example/CAR-2026',
+    reminder_offsets_minutes: [120, 30],
+    capabilities: {
+      can_edit: true,
+      can_delete: true,
+      can_update_status: true,
+    },
+    ...overrides,
+  };
+}
+
+function buildSection(
+  overrides: Partial<TimelineSection> = {},
+): TimelineSection {
+  return {
+    id: 'section-1',
+    section_date: '2026-05-31',
+    label: 'Arrival',
+    is_label_custom: true,
+    is_in_trip_range: true,
+    position: 0,
+    activities: [],
+    ...overrides,
+  };
+}
+
+describe('ActivityRow', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders unknown type tokens and icons with neutral fallbacks', async () => {
+    await render(
+      <ActivityRow
+        activity={buildActivity({
+          activity_type: {
+            kind: 'CUSTOM',
+            id: 'custom-1',
+            label: 'Future type',
+            color_token: 'future-color',
+            icon_key: 'future-icon',
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Future type')).toBeTruthy();
+    expect(screen.getByText('09:05 – 10:30')).toBeTruthy();
+    expect(
+      mockIonicons.mock.calls.some(
+        ([props]) =>
+          (props as { name?: string }).name === 'pricetag-outline',
+      ),
+    ).toBe(true);
+  });
+
+  it('expands and collapses optional activity details in place', async () => {
+    await render(<ActivityRow activity={buildActivity()} />);
+
+    expect(screen.queryByText('Driver holds a GoPlan sign.')).toBeNull();
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: 'Expand Airport transfer details',
+      }),
+    );
+
+    expect(screen.getByText('Driver holds a GoPlan sign.')).toBeTruthy();
+    expect(screen.getByText('Arrival hall')).toBeTruthy();
+    expect(screen.getByText('Anh Tran')).toBeTruthy();
+    expect(screen.getByText('CAR-2026')).toBeTruthy();
+    expect(screen.getByText('2 hours before, 30 minutes before')).toBeTruthy();
+
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: 'Collapse Airport transfer details',
+      }),
+    );
+    expect(screen.queryByText('Driver holds a GoPlan sign.')).toBeNull();
+  });
+
+  it('shows a non-blocking notice when a location URL is unsupported', async () => {
+    const canOpenUrl = jest
+      .spyOn(Linking, 'canOpenURL')
+      .mockResolvedValue(false);
+    const openUrl = jest
+      .spyOn(Linking, 'openURL')
+      .mockResolvedValue(undefined);
+    await render(<ActivityRow activity={buildActivity()} />);
+
+    await fireEvent.press(
+      screen.getByRole('link', {
+        name: 'Open directions to Da Nang International Airport',
+      }),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Could not open this link. Try again later.'),
+      ).toBeTruthy(),
+    );
+    expect(canOpenUrl).toHaveBeenCalledWith('https://maps.example/airport');
+    expect(openUrl).not.toHaveBeenCalled();
+    expect(screen.getByText('Airport transfer')).toBeTruthy();
+  });
+
+  it('shows the same notice when opening an external activity link rejects', async () => {
+    jest.spyOn(Linking, 'canOpenURL').mockResolvedValue(true);
+    const openUrl = jest
+      .spyOn(Linking, 'openURL')
+      .mockRejectedValue(new Error('Native open failed.'));
+    await render(<ActivityRow activity={buildActivity()} />);
+
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: 'Expand Airport transfer details',
+      }),
+    );
+    await fireEvent.press(
+      screen.getByRole('link', {
+        name: 'Open link for Airport transfer',
+      }),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Could not open this link. Try again later.'),
+      ).toBeTruthy(),
+    );
+    expect(openUrl).toHaveBeenCalledWith(
+      'https://booking.example/CAR-2026',
+    );
+  });
+
+  it('gates Edit and Delete independently on per-activity capabilities', async () => {
+    const onEdit = jest.fn();
+    const onDelete = jest.fn();
+    const { rerender } = await render(
+      <ActivityRow
+        activity={buildActivity({
+          capabilities: {
+            can_edit: false,
+            can_delete: true,
+            can_update_status: false,
+          },
+        })}
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Edit Airport transfer' }),
+    ).toBeNull();
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Delete Airport transfer' }),
+    );
+    expect(onDelete).toHaveBeenCalledWith('activity-1');
+
+    await rerender(
+      <ActivityRow
+        activity={buildActivity({
+          capabilities: {
+            can_edit: true,
+            can_delete: false,
+            can_update_status: false,
+          },
+        })}
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />,
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Delete Airport transfer' }),
+    ).toBeNull();
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Edit Airport transfer' }),
+    );
+    expect(onEdit).toHaveBeenCalledWith('activity-1');
+  });
+});
+
+describe('SectionGroup', () => {
+  it('formats the date and shows the section range marker', async () => {
+    const { rerender } = await render(
+      <SectionGroup section={buildSection()} />,
+    );
+
+    expect(screen.getByRole('header', { name: 'Arrival' })).toBeTruthy();
+    expect(screen.getByText('Sun, May 31, 2026')).toBeTruthy();
+    expect(screen.getByText('Trip date')).toBeTruthy();
+
+    await rerender(
+      <SectionGroup
+        section={buildSection({ is_in_trip_range: false })}
+      />,
+    );
+    expect(screen.getByText('Outside trip')).toBeTruthy();
+  });
+
+  it('gates section actions only on aggregate-level flags', async () => {
+    const onEdit = jest.fn();
+    const onDelete = jest.fn();
+    await render(
+      <SectionGroup
+        section={buildSection()}
+        canEdit={false}
+        canDelete
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Edit Arrival' }),
+    ).toBeNull();
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Delete Arrival' }),
+    );
+    expect(onDelete).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'section-1' }),
+    );
+  });
+});

--- a/mobile/src/features/timeline/__tests__/TimelineComponents.test.tsx
+++ b/mobile/src/features/timeline/__tests__/TimelineComponents.test.tsx
@@ -242,6 +242,60 @@ describe('ActivityRow', () => {
     );
     expect(onEdit).toHaveBeenCalledWith('activity-1');
   });
+
+  it('renders status controls in expanded details and forwards the activity id', async () => {
+    const onChangeStatus = jest.fn().mockResolvedValue(undefined);
+    await render(
+      <ActivityRow
+        activity={buildActivity()}
+        onChangeStatus={onChangeStatus}
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Start activity' }),
+    ).toBeNull();
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: 'Expand Airport transfer details',
+      }),
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Start activity' }),
+    );
+    await waitFor(() =>
+      expect(onChangeStatus).toHaveBeenCalledWith(
+        'activity-1',
+        'IN_PROGRESS',
+      ),
+    );
+  });
+
+  it('disables visible edit and delete controls during another mutation', async () => {
+    const onEdit = jest.fn();
+    const onDelete = jest.fn();
+    await render(
+      <ActivityRow
+        activity={buildActivity()}
+        actionsDisabled
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />,
+    );
+
+    const edit = screen.getByRole('button', {
+      name: 'Edit Airport transfer',
+    });
+    const remove = screen.getByRole('button', {
+      name: 'Delete Airport transfer',
+    });
+    expect(edit.props.accessibilityState).toEqual({ disabled: true });
+    expect(remove.props.accessibilityState).toEqual({ disabled: true });
+    await fireEvent.press(edit);
+    await fireEvent.press(remove);
+    expect(onEdit).not.toHaveBeenCalled();
+    expect(onDelete).not.toHaveBeenCalled();
+  });
 });
 
 describe('SectionGroup', () => {

--- a/mobile/src/features/timeline/__tests__/TimelineComponents.test.tsx
+++ b/mobile/src/features/timeline/__tests__/TimelineComponents.test.tsx
@@ -285,4 +285,28 @@ describe('SectionGroup', () => {
       expect.objectContaining({ id: 'section-1' }),
     );
   });
+
+  it('disables all visible section actions while a mutation is locked', async () => {
+    const onEdit = jest.fn();
+    const onDelete = jest.fn();
+    await render(
+      <SectionGroup
+        section={buildSection()}
+        canEdit
+        canDelete
+        actionsDisabled
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />,
+    );
+
+    const edit = screen.getByRole('button', { name: 'Edit Arrival' });
+    const remove = screen.getByRole('button', { name: 'Delete Arrival' });
+    expect(edit.props.accessibilityState).toEqual({ disabled: true });
+    expect(remove.props.accessibilityState).toEqual({ disabled: true });
+    await fireEvent.press(edit);
+    await fireEvent.press(remove);
+    expect(onEdit).not.toHaveBeenCalled();
+    expect(onDelete).not.toHaveBeenCalled();
+  });
 });

--- a/mobile/src/features/timeline/__tests__/TimelineScreen.test.tsx
+++ b/mobile/src/features/timeline/__tests__/TimelineScreen.test.tsx
@@ -306,7 +306,7 @@ describe('TimelineScreen', () => {
     );
     expect(alertSpy).toHaveBeenCalledWith(
       'Delete timeline day?',
-      'Delete Arrival and all activities in it? This cannot be undone.',
+      'Delete Arrival? Only empty timeline days can be deleted. This cannot be undone.',
       expect.any(Array),
       expect.objectContaining({ cancelable: true }),
     );

--- a/mobile/src/features/timeline/__tests__/TimelineScreen.test.tsx
+++ b/mobile/src/features/timeline/__tests__/TimelineScreen.test.tsx
@@ -1,0 +1,341 @@
+let mockParams: Record<string, string | string[] | undefined> = {};
+const mockRouter = { push: jest.fn() };
+const mockUseTimeline = jest.fn();
+
+jest.mock('expo-router', () => ({
+  Stack: { Screen: () => null },
+  useLocalSearchParams: () => mockParams,
+  useRouter: () => mockRouter,
+}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('../hooks/useTimeline', () => ({
+  useTimeline: (...args: unknown[]) => mockUseTimeline(...args),
+}));
+
+// eslint-disable-next-line import/first
+import { SectionList } from 'react-native';
+// eslint-disable-next-line import/first
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { TimelineScreen } from '../screens/TimelineScreen';
+// eslint-disable-next-line import/first
+import type {
+  TimelineActivity,
+  TimelineResponse,
+  TimelineSection,
+} from '../types';
+// eslint-disable-next-line import/first
+import type { ApiError } from '@/shared/api/errors';
+
+const TRIP_ID = '123e4567-e89b-12d3-a456-426614174000';
+const SECOND_TRIP_ID = '2c1dfd8d-9c7f-43c7-9b99-71f6d1edda55';
+
+function buildActivity(
+  overrides: Partial<TimelineActivity> = {},
+): TimelineActivity {
+  return {
+    id: 'activity-1',
+    title: 'Breakfast',
+    time_mode: 'AT_TIME',
+    start_time: '08:00:00',
+    end_time: null,
+    status: 'UPCOMING',
+    position: 0,
+    activity_type: {
+      kind: 'SYSTEM',
+      code: 'FOOD',
+      label: 'Food',
+      color_token: 'amber',
+      icon_key: 'utensils',
+    },
+    assignee_scope: 'EVERYONE',
+    assignee: null,
+    location: {
+      location_mode: 'MANUAL',
+      location_label: '',
+      location_note: '',
+      place: null,
+      open_url: null,
+    },
+    note: '',
+    meeting_point: '',
+    contact_name: '',
+    contact_phone: '',
+    booking_reference: '',
+    external_link: '',
+    reminder_offsets_minutes: [],
+    capabilities: {
+      can_edit: false,
+      can_delete: false,
+      can_update_status: false,
+    },
+    ...overrides,
+  };
+}
+
+function buildSection(
+  overrides: Partial<TimelineSection> = {},
+): TimelineSection {
+  return {
+    id: 'section-1',
+    section_date: '2000-01-01',
+    label: 'Day 1',
+    is_label_custom: false,
+    is_in_trip_range: true,
+    position: 0,
+    activities: [],
+    ...overrides,
+  };
+}
+
+function buildTimeline(
+  overrides: Partial<TimelineResponse> = {},
+): TimelineResponse {
+  return {
+    trip_timezone: 'UTC',
+    permissions: {
+      can_edit_timeline: false,
+      can_manage_custom_types: false,
+      can_create_sections: false,
+    },
+    system_types: [],
+    custom_types: [],
+    sections: [],
+    ...overrides,
+  };
+}
+
+function hookState({
+  timeline = buildTimeline(),
+  status = 'ready',
+  error = null,
+  refreshing = false,
+}: {
+  timeline?: TimelineResponse | null;
+  status?: 'loading' | 'ready' | 'error';
+  error?: ApiError | null;
+  refreshing?: boolean;
+} = {}) {
+  return {
+    timeline,
+    status,
+    error,
+    refreshing,
+    refresh: jest.fn().mockResolvedValue(undefined),
+    invalidate: jest.fn(),
+  };
+}
+
+describe('TimelineScreen', () => {
+  let scrollSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockParams = { tripId: TRIP_ID };
+    mockUseTimeline.mockReturnValue(hookState());
+    scrollSpy = jest
+      .spyOn(SectionList.prototype, 'scrollToLocation')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    scrollSpy.mockRestore();
+  });
+
+  it('renders the first-load spinner without mounting ready content', async () => {
+    mockUseTimeline.mockReturnValue(
+      hookState({ timeline: null, status: 'loading' }),
+    );
+    const rendered = await render(<TimelineScreen />);
+
+    expect(screen.queryByTestId('timeline-route-ready')).toBeNull();
+    expect(
+      rendered.container.queryAll((instance) =>
+        instance.type.includes('ActivityIndicator'),
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('shows a full error and retries it as an initial load', async () => {
+    const state = hookState({
+      timeline: null,
+      status: 'error',
+      error: {
+        kind: 'message',
+        message: 'Timeline service is unavailable.',
+        status: 500,
+      },
+    });
+    mockUseTimeline.mockReturnValue(state);
+    await render(<TimelineScreen />);
+
+    expect(screen.getByText('Could not load timeline')).toBeTruthy();
+    expect(screen.getByText('Timeline service is unavailable.')).toBeTruthy();
+    await fireEvent.press(screen.getByRole('button', { name: 'Try again' }));
+    expect(state.refresh).toHaveBeenCalledWith('initial');
+  });
+
+  it('renders the neutral 404 state after the hook clears complete data', async () => {
+    mockUseTimeline.mockReturnValue(
+      hookState({
+        timeline: null,
+        status: 'error',
+        error: {
+          kind: 'message',
+          message: 'Trip not found.',
+          errorCode: 'TRIP_NOT_FOUND',
+          status: 404,
+        },
+      }),
+    );
+    await render(<TimelineScreen />);
+
+    expect(screen.getByText('Timeline not found')).toBeTruthy();
+    expect(
+      screen.getByText(
+        'This trip does not exist or you no longer have access to it.',
+      ),
+    ).toBeTruthy();
+  });
+
+  it('shows the empty captain CTA and does not add an Expenses route', async () => {
+    const state = hookState({
+      timeline: buildTimeline({
+        permissions: {
+          can_edit_timeline: true,
+          can_manage_custom_types: true,
+          can_create_sections: true,
+        },
+      }),
+    });
+    mockUseTimeline.mockReturnValue(state);
+    await render(<TimelineScreen />);
+
+    expect(screen.getByText('No days yet')).toBeTruthy();
+    expect(screen.queryByText('Expenses')).toBeNull();
+    await fireEvent.press(screen.getByRole('button', { name: 'Add day' }));
+    expect(mockRouter.push).toHaveBeenCalledWith(
+      `/trips/${TRIP_ID}/timeline/section-form?mode=create`,
+    );
+  });
+
+  it('hides the empty CTA when aggregate permission denies section creation', async () => {
+    await render(<TimelineScreen />);
+
+    expect(screen.getByText('No days yet')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Add day' })).toBeNull();
+  });
+
+  it('keeps rows visible with an inline error and retries silently', async () => {
+    const state = hookState({
+      timeline: buildTimeline({
+        sections: [
+          buildSection({
+            activities: [
+              buildActivity({
+                id: 'all-day',
+                title: 'Hotel check-in',
+                time_mode: 'ALL_DAY',
+                start_time: null,
+              }),
+              buildActivity(),
+              buildActivity({
+                id: 'flexible',
+                title: 'Explore old town',
+                time_mode: 'FLEXIBLE',
+                start_time: null,
+              }),
+            ],
+          }),
+        ],
+      }),
+      error: {
+        kind: 'message',
+        message: 'Could not refresh the timeline.',
+        status: 500,
+      },
+    });
+    mockUseTimeline.mockReturnValue(state);
+    await render(<TimelineScreen />);
+
+    expect(screen.getByText('Hotel check-in')).toBeTruthy();
+    expect(screen.getByText('Breakfast')).toBeTruthy();
+    expect(screen.getByText('Explore old town')).toBeTruthy();
+    expect(screen.getAllByText('All day')).toHaveLength(2);
+    expect(screen.getByText('Scheduled')).toBeTruthy();
+    expect(screen.getAllByText('Flexible')).toHaveLength(2);
+    expect(screen.getByText('Could not refresh the timeline.')).toBeTruthy();
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Retry refreshing timeline' }),
+    );
+    expect(state.refresh).toHaveBeenCalledWith('silent');
+  });
+
+  it('uses the explicit refresh mode for pull-to-refresh', async () => {
+    const state = hookState();
+    mockUseTimeline.mockReturnValue(state);
+    const rendered = await render(<TimelineScreen />);
+
+    const refreshControl = rendered.container.queryAll(
+      (instance) => instance.type === 'RCTRefreshControl',
+    )[0];
+    if (!refreshControl) {
+      throw new Error('Expected Timeline RefreshControl.');
+    }
+    await fireEvent(refreshControl, 'refresh');
+    expect(state.refresh).toHaveBeenCalledWith('refresh');
+  });
+
+  it('scrolls to the default day only once per trip resource mount', async () => {
+    const firstTimeline = buildTimeline({
+      sections: [
+        buildSection({ id: 'day-1', section_date: '2000-01-01' }),
+        buildSection({ id: 'day-2', section_date: '2000-01-02' }),
+      ],
+    });
+    mockUseTimeline.mockReturnValue(hookState({ timeline: firstTimeline }));
+    const rendered = await render(<TimelineScreen />);
+
+    await waitFor(() =>
+      expect(scrollSpy).toHaveBeenCalledWith({
+        animated: false,
+        sectionIndex: 1,
+        itemIndex: 0,
+        viewPosition: 0,
+      }),
+    );
+
+    mockUseTimeline.mockReturnValue(
+      hookState({
+        timeline: buildTimeline({
+          sections: [
+            ...firstTimeline.sections,
+            buildSection({ id: 'day-3', section_date: '2000-01-03' }),
+          ],
+        }),
+      }),
+    );
+    await rendered.rerender(<TimelineScreen />);
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+
+    mockParams = { tripId: SECOND_TRIP_ID };
+    mockUseTimeline.mockReturnValue(
+      hookState({
+        timeline: buildTimeline({
+          sections: [
+            buildSection({ id: 'other-day', section_date: '2001-01-01' }),
+          ],
+        }),
+      }),
+    );
+    await rendered.rerender(<TimelineScreen />);
+    await waitFor(() => expect(scrollSpy).toHaveBeenCalledTimes(2));
+  });
+});

--- a/mobile/src/features/timeline/__tests__/TimelineScreen.test.tsx
+++ b/mobile/src/features/timeline/__tests__/TimelineScreen.test.tsx
@@ -149,6 +149,16 @@ function hookState({
   };
 }
 
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
 describe('TimelineScreen', () => {
   let scrollSpy: jest.SpyInstance;
   let alertSpy: jest.SpyInstance;
@@ -516,7 +526,7 @@ describe('TimelineScreen', () => {
     });
   });
 
-  it('updates status through the row capability and reconciles a rejected transition', async () => {
+  it('keeps a rejected status detail visible after reconciliation revokes the control', async () => {
     const conflict = new AxiosError(
       'Conflict',
       undefined,
@@ -534,6 +544,159 @@ describe('TimelineScreen', () => {
       },
     );
     mockUpdateActivityStatus.mockRejectedValue(conflict);
+    const initialTimeline = buildTimeline({
+      sections: [
+        buildSection({
+          activities: [
+            buildActivity({
+              title: 'Airport transfer',
+              capabilities: {
+                can_edit: false,
+                can_delete: false,
+                can_update_status: true,
+              },
+            }),
+          ],
+        }),
+      ],
+    });
+    const reconciledTimeline = buildTimeline({
+      sections: [
+        buildSection({
+          activities: [
+            buildActivity({
+              title: 'Airport transfer',
+              status: 'IN_PROGRESS',
+              capabilities: {
+                can_edit: false,
+                can_delete: false,
+                can_update_status: false,
+              },
+            }),
+          ],
+        }),
+      ],
+    });
+    const state = hookState({
+      timeline: initialTimeline,
+    });
+    const reconciledState = hookState({
+      timeline: reconciledTimeline,
+    });
+    const pendingRefresh = deferred<void>();
+    state.refresh.mockReturnValue(pendingRefresh.promise);
+    mockUseTimeline.mockReturnValue(state);
+    const rendered = await render(<TimelineScreen />);
+
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: 'Expand Airport transfer details',
+      }),
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Start activity' }),
+    );
+    await waitFor(() =>
+      expect(state.refresh).toHaveBeenCalledWith('silent'),
+    );
+    mockUseTimeline.mockReturnValue(reconciledState);
+    await rendered.rerender(<TimelineScreen />);
+    await act(async () => {
+      pendingRefresh.resolve();
+    });
+
+    expect(
+      await screen.findByText(
+        'This status transition is no longer allowed.',
+      ),
+    ).toBeTruthy();
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('button', { name: 'Start activity' }),
+      ).toBeNull(),
+    );
+    expect(mockUpdateActivityStatus).toHaveBeenCalledWith(
+      TRIP_ID,
+      'activity-1',
+      { status: 'IN_PROGRESS' },
+    );
+    expect(state.invalidate).toHaveBeenCalledTimes(1);
+    expect(state.refresh).toHaveBeenCalledWith('silent');
+    expect(mockPublishTimelineEvent).not.toHaveBeenCalled();
+  });
+
+  it('keeps a rejected status detail visible when reconciliation removes the activity', async () => {
+    mockUpdateActivityStatus.mockRejectedValue(
+      new AxiosError(
+        'Not found',
+        undefined,
+        undefined,
+        undefined,
+        {
+          status: 404,
+          statusText: 'Not Found',
+          headers: {},
+          config: {} as never,
+          data: {
+            detail: 'This activity no longer exists.',
+            error_code: 'ACTIVITY_NOT_FOUND',
+          },
+        },
+      ),
+    );
+    const state = hookState({
+      timeline: buildTimeline({
+        sections: [
+          buildSection({
+            activities: [
+              buildActivity({
+                title: 'Airport transfer',
+                capabilities: {
+                  can_edit: false,
+                  can_delete: false,
+                  can_update_status: true,
+                },
+              }),
+            ],
+          }),
+        ],
+      }),
+    });
+    const reconciledState = hookState({
+      timeline: buildTimeline({
+        sections: [buildSection({ activities: [] })],
+      }),
+    });
+    const pendingRefresh = deferred<void>();
+    state.refresh.mockReturnValue(pendingRefresh.promise);
+    mockUseTimeline.mockReturnValue(state);
+    const rendered = await render(<TimelineScreen />);
+
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: 'Expand Airport transfer details',
+      }),
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Start activity' }),
+    );
+    await waitFor(() =>
+      expect(state.refresh).toHaveBeenCalledWith('silent'),
+    );
+    mockUseTimeline.mockReturnValue(reconciledState);
+    await rendered.rerender(<TimelineScreen />);
+    await act(async () => {
+      pendingRefresh.resolve();
+    });
+
+    expect(
+      await screen.findByText('This activity no longer exists.'),
+    ).toBeTruthy();
+    expect(screen.queryByText('Airport transfer')).toBeNull();
+    expect(mockPublishTimelineEvent).not.toHaveBeenCalled();
+  });
+
+  it('updates status through the row capability and publishes success', async () => {
     const state = hookState({
       timeline: buildTimeline({
         sections: [
@@ -564,19 +727,18 @@ describe('TimelineScreen', () => {
       screen.getByRole('button', { name: 'Start activity' }),
     );
 
-    expect(
-      await screen.findByText(
-        'This status transition is no longer allowed.',
+    await waitFor(() =>
+      expect(mockUpdateActivityStatus).toHaveBeenCalledWith(
+        TRIP_ID,
+        'activity-1',
+        { status: 'IN_PROGRESS' },
       ),
-    ).toBeTruthy();
-    expect(mockUpdateActivityStatus).toHaveBeenCalledWith(
-      TRIP_ID,
-      'activity-1',
-      { status: 'IN_PROGRESS' },
     );
     expect(state.invalidate).toHaveBeenCalledTimes(1);
-    expect(state.refresh).toHaveBeenCalledWith('silent');
-    expect(mockPublishTimelineEvent).not.toHaveBeenCalled();
+    expect(mockPublishTimelineEvent).toHaveBeenCalledWith({
+      type: 'timelineChanged',
+      tripId: TRIP_ID,
+    });
   });
 
   it('keeps rows visible with an inline error and retries silently', async () => {

--- a/mobile/src/features/timeline/__tests__/TimelineScreen.test.tsx
+++ b/mobile/src/features/timeline/__tests__/TimelineScreen.test.tsx
@@ -2,6 +2,8 @@ let mockParams: Record<string, string | string[] | undefined> = {};
 const mockRouter = { push: jest.fn() };
 const mockUseTimeline = jest.fn();
 const mockDeleteSection = jest.fn();
+const mockDeleteActivity = jest.fn();
+const mockUpdateActivityStatus = jest.fn();
 const mockPublishTimelineEvent = jest.fn();
 
 jest.mock('expo-router', () => ({
@@ -16,6 +18,9 @@ jest.mock('../hooks/useTimeline', () => ({
 }));
 jest.mock('../api', () => ({
   deleteSection: (...args: unknown[]) => mockDeleteSection(...args),
+  deleteActivity: (...args: unknown[]) => mockDeleteActivity(...args),
+  updateActivityStatus: (...args: unknown[]) =>
+    mockUpdateActivityStatus(...args),
 }));
 jest.mock('../timelineEvents', () => ({
   publishTimelineEvent: (...args: unknown[]) =>
@@ -153,6 +158,8 @@ describe('TimelineScreen', () => {
     mockParams = { tripId: TRIP_ID };
     mockUseTimeline.mockReturnValue(hookState());
     mockDeleteSection.mockResolvedValue(undefined);
+    mockDeleteActivity.mockResolvedValue(undefined);
+    mockUpdateActivityStatus.mockResolvedValue(undefined);
     mockPublishTimelineEvent.mockResolvedValue(undefined);
     scrollSpy = jest
       .spyOn(SectionList.prototype, 'scrollToLocation')
@@ -404,6 +411,170 @@ describe('TimelineScreen', () => {
         screen.getByText('This timeline day changed on another device.'),
       ).toBeTruthy(),
     );
+    expect(state.refresh).toHaveBeenCalledWith('silent');
+    expect(mockPublishTimelineEvent).not.toHaveBeenCalled();
+  });
+
+  it('opens create and edit activity forms from the authoritative section data', async () => {
+    mockUseTimeline.mockReturnValue(
+      hookState({
+        timeline: buildTimeline({
+          permissions: {
+            can_edit_timeline: true,
+            can_manage_custom_types: false,
+            can_create_sections: false,
+          },
+          sections: [
+            buildSection({
+              label: 'Arrival',
+              activities: [
+                buildActivity({
+                  title: 'Airport transfer',
+                  capabilities: {
+                    can_edit: true,
+                    can_delete: false,
+                    can_update_status: false,
+                  },
+                }),
+              ],
+            }),
+          ],
+        }),
+      }),
+    );
+    await render(<TimelineScreen />);
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Add activity to Arrival' }),
+    );
+    expect(mockRouter.push).toHaveBeenCalledWith(
+      `/trips/${TRIP_ID}/timeline/activity-form?mode=create&sectionId=section-1`,
+    );
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Edit Airport transfer' }),
+    );
+    expect(mockRouter.push).toHaveBeenLastCalledWith(
+      `/trips/${TRIP_ID}/timeline/activity-form?mode=edit&activityId=activity-1`,
+    );
+  });
+
+  it('deletes an activity only after confirmation and publishes one authoritative refresh event', async () => {
+    const state = hookState({
+      timeline: buildTimeline({
+        permissions: {
+          can_edit_timeline: true,
+          can_manage_custom_types: false,
+          can_create_sections: false,
+        },
+        sections: [
+          buildSection({
+            label: 'Arrival',
+            activities: [
+              buildActivity({
+                title: 'Airport transfer',
+                capabilities: {
+                  can_edit: false,
+                  can_delete: true,
+                  can_update_status: false,
+                },
+              }),
+            ],
+          }),
+        ],
+      }),
+    });
+    mockUseTimeline.mockReturnValue(state);
+    await render(<TimelineScreen />);
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Delete Airport transfer' }),
+    );
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Delete activity?',
+      'Delete Airport transfer? This cannot be undone.',
+      expect.any(Array),
+      expect.objectContaining({ cancelable: true }),
+    );
+    const buttons = alertSpy.mock.calls[0]?.[2] as
+      | { text?: string; onPress?: () => void }[]
+      | undefined;
+    await act(async () => {
+      buttons?.find((button) => button.text === 'Delete')?.onPress?.();
+    });
+
+    await waitFor(() =>
+      expect(mockDeleteActivity).toHaveBeenCalledWith(
+        TRIP_ID,
+        'activity-1',
+      ),
+    );
+    expect(state.invalidate).toHaveBeenCalledTimes(1);
+    expect(mockPublishTimelineEvent).toHaveBeenCalledWith({
+      type: 'timelineChanged',
+      tripId: TRIP_ID,
+    });
+  });
+
+  it('updates status through the row capability and reconciles a rejected transition', async () => {
+    const conflict = new AxiosError(
+      'Conflict',
+      undefined,
+      undefined,
+      undefined,
+      {
+        status: 409,
+        statusText: 'Conflict',
+        headers: {},
+        config: {} as never,
+        data: {
+          detail: 'This status transition is no longer allowed.',
+          error_code: 'INVALID_STATUS_TRANSITION',
+        },
+      },
+    );
+    mockUpdateActivityStatus.mockRejectedValue(conflict);
+    const state = hookState({
+      timeline: buildTimeline({
+        sections: [
+          buildSection({
+            activities: [
+              buildActivity({
+                title: 'Airport transfer',
+                capabilities: {
+                  can_edit: false,
+                  can_delete: false,
+                  can_update_status: true,
+                },
+              }),
+            ],
+          }),
+        ],
+      }),
+    });
+    mockUseTimeline.mockReturnValue(state);
+    await render(<TimelineScreen />);
+
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: 'Expand Airport transfer details',
+      }),
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Start activity' }),
+    );
+
+    expect(
+      await screen.findByText(
+        'This status transition is no longer allowed.',
+      ),
+    ).toBeTruthy();
+    expect(mockUpdateActivityStatus).toHaveBeenCalledWith(
+      TRIP_ID,
+      'activity-1',
+      { status: 'IN_PROGRESS' },
+    );
+    expect(state.invalidate).toHaveBeenCalledTimes(1);
     expect(state.refresh).toHaveBeenCalledWith('silent');
     expect(mockPublishTimelineEvent).not.toHaveBeenCalled();
   });

--- a/mobile/src/features/timeline/__tests__/TimelineScreen.test.tsx
+++ b/mobile/src/features/timeline/__tests__/TimelineScreen.test.tsx
@@ -1,6 +1,8 @@
 let mockParams: Record<string, string | string[] | undefined> = {};
 const mockRouter = { push: jest.fn() };
 const mockUseTimeline = jest.fn();
+const mockDeleteSection = jest.fn();
+const mockPublishTimelineEvent = jest.fn();
 
 jest.mock('expo-router', () => ({
   Stack: { Screen: () => null },
@@ -12,16 +14,26 @@ jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
 jest.mock('../hooks/useTimeline', () => ({
   useTimeline: (...args: unknown[]) => mockUseTimeline(...args),
 }));
+jest.mock('../api', () => ({
+  deleteSection: (...args: unknown[]) => mockDeleteSection(...args),
+}));
+jest.mock('../timelineEvents', () => ({
+  publishTimelineEvent: (...args: unknown[]) =>
+    mockPublishTimelineEvent(...args),
+}));
 
 // eslint-disable-next-line import/first
-import { SectionList } from 'react-native';
+import { Alert, SectionList } from 'react-native';
 // eslint-disable-next-line import/first
 import {
+  act,
   fireEvent,
   render,
   screen,
   waitFor,
 } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { AxiosError } from 'axios';
 // eslint-disable-next-line import/first
 import { TimelineScreen } from '../screens/TimelineScreen';
 // eslint-disable-next-line import/first
@@ -134,18 +146,25 @@ function hookState({
 
 describe('TimelineScreen', () => {
   let scrollSpy: jest.SpyInstance;
+  let alertSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockParams = { tripId: TRIP_ID };
     mockUseTimeline.mockReturnValue(hookState());
+    mockDeleteSection.mockResolvedValue(undefined);
+    mockPublishTimelineEvent.mockResolvedValue(undefined);
     scrollSpy = jest
       .spyOn(SectionList.prototype, 'scrollToLocation')
+      .mockImplementation(() => undefined);
+    alertSpy = jest
+      .spyOn(Alert, 'alert')
       .mockImplementation(() => undefined);
   });
 
   afterEach(() => {
     scrollSpy.mockRestore();
+    alertSpy.mockRestore();
   });
 
   it('renders the first-load spinner without mounting ready content', async () => {
@@ -230,6 +249,163 @@ describe('TimelineScreen', () => {
 
     expect(screen.getByText('No days yet')).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Add day' })).toBeNull();
+  });
+
+  it('wires section controls and the non-empty add-day action from aggregate permissions', async () => {
+    mockUseTimeline.mockReturnValue(
+      hookState({
+        timeline: buildTimeline({
+          permissions: {
+            can_edit_timeline: true,
+            can_manage_custom_types: false,
+            can_create_sections: true,
+          },
+          sections: [buildSection({ label: 'Arrival' })],
+        }),
+      }),
+    );
+    await render(<TimelineScreen />);
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Edit Arrival' }),
+    );
+    expect(mockRouter.push).toHaveBeenCalledWith(
+      `/trips/${TRIP_ID}/timeline/section-form?mode=edit&sectionId=section-1`,
+    );
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Add day' }));
+    expect(mockRouter.push).toHaveBeenLastCalledWith(
+      `/trips/${TRIP_ID}/timeline/section-form?mode=create`,
+    );
+  });
+
+  it('cancels section deletion without calling the API', async () => {
+    mockUseTimeline.mockReturnValue(
+      hookState({
+        timeline: buildTimeline({
+          permissions: {
+            can_edit_timeline: true,
+            can_manage_custom_types: false,
+            can_create_sections: false,
+          },
+          sections: [buildSection({ label: 'Arrival' })],
+        }),
+      }),
+    );
+    await render(<TimelineScreen />);
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Delete Arrival' }),
+    );
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Delete timeline day?',
+      'Delete Arrival and all activities in it? This cannot be undone.',
+      expect.any(Array),
+      expect.objectContaining({ cancelable: true }),
+    );
+    const buttons = alertSpy.mock.calls[0]?.[2] as
+      | { text?: string; onPress?: () => void }[]
+      | undefined;
+    await act(async () => {
+      buttons?.find((button) => button.text === 'Cancel')?.onPress?.();
+    });
+
+    expect(mockDeleteSection).not.toHaveBeenCalled();
+  });
+
+  it('invalidates, deletes, publishes, and keeps a ref lock across duplicate confirmation', async () => {
+    let resolveDelete: (() => void) | undefined;
+    mockDeleteSection.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDelete = resolve;
+        }),
+    );
+    const state = hookState({
+      timeline: buildTimeline({
+        permissions: {
+          can_edit_timeline: true,
+          can_manage_custom_types: false,
+          can_create_sections: false,
+        },
+        sections: [buildSection({ label: 'Arrival' })],
+      }),
+    });
+    mockUseTimeline.mockReturnValue(state);
+    await render(<TimelineScreen />);
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Delete Arrival' }),
+    );
+    const buttons = alertSpy.mock.calls[0]?.[2] as
+      | { text?: string; onPress?: () => void }[]
+      | undefined;
+    const confirm = buttons?.find((button) => button.text === 'Delete');
+    await act(async () => {
+      confirm?.onPress?.();
+      confirm?.onPress?.();
+    });
+
+    expect(state.invalidate).toHaveBeenCalledTimes(1);
+    expect(mockDeleteSection).toHaveBeenCalledTimes(1);
+    expect(mockDeleteSection).toHaveBeenCalledWith(TRIP_ID, 'section-1');
+
+    await act(async () => {
+      resolveDelete?.();
+    });
+    await waitFor(() =>
+      expect(mockPublishTimelineEvent).toHaveBeenCalledWith({
+        type: 'timelineChanged',
+        tripId: TRIP_ID,
+      }),
+    );
+  });
+
+  it('shows a verbatim conflict and silently reconciles after delete failure', async () => {
+    const conflict = new AxiosError(
+      'Conflict',
+      undefined,
+      undefined,
+      undefined,
+      {
+        status: 409,
+        statusText: 'Conflict',
+        headers: {},
+        config: {} as never,
+        data: { detail: 'This timeline day changed on another device.' },
+      },
+    );
+    mockDeleteSection.mockRejectedValue(conflict);
+    const state = hookState({
+      timeline: buildTimeline({
+        permissions: {
+          can_edit_timeline: true,
+          can_manage_custom_types: false,
+          can_create_sections: false,
+        },
+        sections: [buildSection({ label: 'Arrival' })],
+      }),
+    });
+    mockUseTimeline.mockReturnValue(state);
+    await render(<TimelineScreen />);
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Delete Arrival' }),
+    );
+    const buttons = alertSpy.mock.calls[0]?.[2] as
+      | { text?: string; onPress?: () => void }[]
+      | undefined;
+    await act(async () => {
+      buttons?.find((button) => button.text === 'Delete')?.onPress?.();
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('This timeline day changed on another device.'),
+      ).toBeTruthy(),
+    );
+    expect(state.refresh).toHaveBeenCalledWith('silent');
+    expect(mockPublishTimelineEvent).not.toHaveBeenCalled();
   });
 
   it('keeps rows visible with an inline error and retries silently', async () => {

--- a/mobile/src/features/timeline/__tests__/api.test.ts
+++ b/mobile/src/features/timeline/__tests__/api.test.ts
@@ -1,0 +1,275 @@
+jest.mock('@/shared/api/client', () => ({
+  apiClient: {
+    delete: jest.fn(),
+    get: jest.fn(),
+    patch: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { apiClient } from '@/shared/api/client';
+// eslint-disable-next-line import/first
+import {
+  createActivity,
+  createCustomType,
+  createSection,
+  deleteActivity,
+  deleteCustomType,
+  deleteSection,
+  getTimeline,
+  lookupLocation,
+  patchActivity,
+  patchCustomType,
+  patchSection,
+  suggestLocations,
+  updateActivityStatus,
+} from '../api';
+
+const mockDelete = apiClient.delete as jest.MockedFunction<
+  typeof apiClient.delete
+>;
+const mockGet = apiClient.get as jest.MockedFunction<typeof apiClient.get>;
+const mockPatch = apiClient.patch as jest.MockedFunction<
+  typeof apiClient.patch
+>;
+const mockPost = apiClient.post as jest.MockedFunction<typeof apiClient.post>;
+
+describe('timeline api', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('gets the aggregate timeline directly with cancellation support', async () => {
+    const controller = new AbortController();
+    const timeline = {
+      trip_timezone: 'Asia/Ho_Chi_Minh',
+      permissions: {
+        can_edit_timeline: true,
+        can_manage_custom_types: true,
+        can_create_sections: true,
+      },
+      system_types: [],
+      custom_types: [],
+      sections: [],
+    };
+    mockGet.mockResolvedValue({ data: timeline } as never);
+
+    await expect(
+      getTimeline('trip-1', controller.signal),
+    ).resolves.toEqual(timeline);
+    expect(mockGet).toHaveBeenCalledWith('/trips/trip-1/timeline', {
+      signal: controller.signal,
+    });
+  });
+
+  it('creates a section and unwraps the runtime section envelope', async () => {
+    const section = {
+      id: 'section-1',
+      section_date: '2026-08-01',
+      label: 'Day 1',
+    };
+    const payload = {
+      section_date: '2026-08-01',
+      label: 'Arrival',
+    };
+    mockPost.mockResolvedValue({ data: { section } } as never);
+
+    await expect(createSection('trip-1', payload)).resolves.toEqual(section);
+    expect(mockPost).toHaveBeenCalledWith(
+      '/trips/trip-1/timeline/sections',
+      payload,
+    );
+  });
+
+  it('patches a section and unwraps the runtime section envelope', async () => {
+    const section = { id: 'section-1', label: 'Arrival day' };
+    const payload = { label: 'Arrival day' };
+    mockPatch.mockResolvedValue({ data: { section } } as never);
+
+    await expect(
+      patchSection('trip-1', 'section-1', payload),
+    ).resolves.toEqual(section);
+    expect(mockPatch).toHaveBeenCalledWith(
+      '/trips/trip-1/timeline/sections/section-1',
+      payload,
+    );
+  });
+
+  it('deletes a section through the endpoint that returns HTTP 200 with an empty object', async () => {
+    mockDelete.mockResolvedValue({ data: {} } as never);
+
+    await expect(
+      deleteSection('trip-1', 'section-1'),
+    ).resolves.toBeUndefined();
+    expect(mockDelete).toHaveBeenCalledWith(
+      '/trips/trip-1/timeline/sections/section-1',
+    );
+  });
+
+  it('creates an activity and unwraps the runtime activity envelope', async () => {
+    const activity = { id: 'activity-1', title: 'Breakfast' };
+    const payload = {
+      title: 'Breakfast',
+      time_mode: 'AT_TIME' as const,
+      start_time: '08:00',
+      system_type: 'FOOD' as const,
+    };
+    mockPost.mockResolvedValue({ data: { activity } } as never);
+
+    await expect(
+      createActivity('trip-1', 'section-1', payload),
+    ).resolves.toEqual(activity);
+    expect(mockPost).toHaveBeenCalledWith(
+      '/trips/trip-1/timeline/sections/section-1/activities',
+      payload,
+    );
+  });
+
+  it('patches an activity and unwraps the runtime activity envelope', async () => {
+    const activity = { id: 'activity-1', title: 'Brunch' };
+    const payload = { title: 'Brunch', start_time: null };
+    mockPatch.mockResolvedValue({ data: { activity } } as never);
+
+    await expect(
+      patchActivity('trip-1', 'activity-1', payload),
+    ).resolves.toEqual(activity);
+    expect(mockPatch).toHaveBeenCalledWith(
+      '/trips/trip-1/timeline/activities/activity-1',
+      payload,
+    );
+  });
+
+  it('deletes an activity through the endpoint that returns HTTP 200 with an empty object', async () => {
+    mockDelete.mockResolvedValue({ data: {} } as never);
+
+    await expect(
+      deleteActivity('trip-1', 'activity-1'),
+    ).resolves.toBeUndefined();
+    expect(mockDelete).toHaveBeenCalledWith(
+      '/trips/trip-1/timeline/activities/activity-1',
+    );
+  });
+
+  it('updates activity status and returns the direct status response', async () => {
+    const payload = { status: 'DONE' as const };
+    const result = { activity_id: 'activity-1', status: 'DONE' as const };
+    mockPost.mockResolvedValue({ data: result } as never);
+
+    await expect(
+      updateActivityStatus('trip-1', 'activity-1', payload),
+    ).resolves.toEqual(result);
+    expect(mockPost).toHaveBeenCalledWith(
+      '/trips/trip-1/timeline/activities/activity-1/status',
+      payload,
+    );
+  });
+
+  it('creates a custom type and unwraps the runtime custom_type envelope', async () => {
+    const customType = {
+      id: 'type-1',
+      name: 'Coffee stop',
+      normalized_name: 'coffee-stop',
+      color_token: 'amber',
+      icon_key: 'cafe',
+      is_active: true,
+    };
+    const payload = {
+      name: 'Coffee stop',
+      color_token: 'amber',
+      icon_key: 'cafe',
+    };
+    mockPost.mockResolvedValue({
+      data: { custom_type: customType },
+    } as never);
+
+    await expect(createCustomType('trip-1', payload)).resolves.toEqual(
+      customType,
+    );
+    expect(mockPost).toHaveBeenCalledWith(
+      '/trips/trip-1/timeline/custom-types',
+      payload,
+    );
+  });
+
+  it('patches a custom type and unwraps the runtime custom_type envelope', async () => {
+    const customType = {
+      id: 'type-1',
+      name: 'Cafe',
+      normalized_name: 'cafe',
+      color_token: 'amber',
+      icon_key: 'cafe',
+      is_active: false,
+    };
+    const payload = { name: 'Cafe', is_active: false };
+    mockPatch.mockResolvedValue({
+      data: { custom_type: customType },
+    } as never);
+
+    await expect(
+      patchCustomType('trip-1', 'type-1', payload),
+    ).resolves.toEqual(customType);
+    expect(mockPatch).toHaveBeenCalledWith(
+      '/trips/trip-1/timeline/custom-types/type-1',
+      payload,
+    );
+  });
+
+  it('deletes a custom type through the endpoint that returns HTTP 200 with an empty object', async () => {
+    mockDelete.mockResolvedValue({ data: {} } as never);
+
+    await expect(
+      deleteCustomType('trip-1', 'type-1'),
+    ).resolves.toBeUndefined();
+    expect(mockDelete).toHaveBeenCalledWith(
+      '/trips/trip-1/timeline/custom-types/type-1',
+    );
+  });
+
+  it('suggests locations and unwraps suggestions with cancellation support', async () => {
+    const controller = new AbortController();
+    const suggestions = [
+      {
+        provider: 'here',
+        provider_id: 'here:place:1',
+        title: 'Da Nang',
+        subtitle: 'Vietnam',
+      },
+    ];
+    mockGet.mockResolvedValue({ data: { suggestions } } as never);
+
+    await expect(
+      suggestLocations('Da Nang', controller.signal),
+    ).resolves.toEqual(suggestions);
+    expect(mockGet).toHaveBeenCalledWith('/location-search/suggest', {
+      params: { q: 'Da Nang' },
+      signal: controller.signal,
+    });
+  });
+
+  it('looks up a canonical location from the direct response with cancellation support', async () => {
+    const controller = new AbortController();
+    const lookup = {
+      destination: 'Da Nang, Vietnam',
+      destination_provider: 'here',
+      destination_provider_id: 'here:place:canonical',
+      destination_lat: 16.0544,
+      destination_lng: 108.2022,
+      destination_country_code: 'VN',
+    };
+    mockGet.mockResolvedValue({ data: lookup } as never);
+
+    await expect(
+      lookupLocation('here:place:1', controller.signal),
+    ).resolves.toEqual(lookup);
+    expect(mockGet).toHaveBeenCalledWith('/location-search/lookup', {
+      params: { id: 'here:place:1' },
+      signal: controller.signal,
+    });
+  });
+
+  it('lets API failures propagate for callers to normalize', async () => {
+    const failure = new Error('request failed');
+    mockGet.mockRejectedValue(failure);
+
+    await expect(getTimeline('trip-1')).rejects.toBe(failure);
+  });
+});

--- a/mobile/src/features/timeline/__tests__/customTypeModel.test.ts
+++ b/mobile/src/features/timeline/__tests__/customTypeModel.test.ts
@@ -1,0 +1,105 @@
+import {
+  buildCreateCustomTypePayload,
+  buildPatchCustomTypePayload,
+  createCustomTypeDraft,
+  hydrateCustomTypeDraft,
+  validateCustomTypeDraft,
+} from '../customTypeModel';
+import {
+  DEFAULT_TIMELINE_COLOR_TOKEN,
+  DEFAULT_TIMELINE_ICON_KEY,
+} from '../tokenMaps';
+import type { TimelineCustomTypeMeta } from '../types';
+
+const customType: TimelineCustomTypeMeta = {
+  id: 'a0a81541-080e-4f33-ac10-b5e994e41c69',
+  name: 'Coffee stop',
+  normalized_name: 'coffee-stop',
+  color_token: 'brand-gold',
+  icon_key: 'rocket',
+  is_active: false,
+};
+
+describe('customTypeModel', () => {
+  it('creates a draft from the centralized supported defaults', () => {
+    expect(createCustomTypeDraft()).toEqual({
+      name: '',
+      color_token: DEFAULT_TIMELINE_COLOR_TOKEN,
+      icon_key: DEFAULT_TIMELINE_ICON_KEY,
+    });
+  });
+
+  it('validates required and code-point name limits', () => {
+    expect(
+      validateCustomTypeDraft({
+        ...createCustomTypeDraft(),
+        name: '   ',
+      }),
+    ).toEqual({
+      isValid: false,
+      fieldErrors: { name: 'Name is required.' },
+    });
+    expect(
+      validateCustomTypeDraft({
+        ...createCustomTypeDraft(),
+        name: '😀'.repeat(41),
+      }).fieldErrors.name,
+    ).toBe('Name must be 40 characters or fewer.');
+  });
+
+  it('normalizes a create payload and includes only supported picker values', () => {
+    expect(
+      buildCreateCustomTypePayload({
+        name: '  Coffee break  ',
+        color_token: 'amber',
+        icon_key: 'utensils',
+      }),
+    ).toEqual({
+      name: 'Coffee break',
+      color_token: 'amber',
+      icon_key: 'utensils',
+    });
+    expect(
+      buildCreateCustomTypePayload({
+        name: 'Coffee break',
+        color_token: 'unknown',
+        icon_key: 'utensils',
+      }),
+    ).toBeNull();
+  });
+
+  it('hydrates unknown server tokens without replacing them', () => {
+    expect(hydrateCustomTypeDraft(customType)).toEqual({
+      name: 'Coffee stop',
+      color_token: 'brand-gold',
+      icon_key: 'rocket',
+    });
+  });
+
+  it('omits unchanged unknown tokens from a minimal rename PATCH', () => {
+    const initial = hydrateCustomTypeDraft(customType);
+
+    expect(
+      buildPatchCustomTypePayload(initial, {
+        ...initial,
+        name: '  Coffee and tea  ',
+      }),
+    ).toEqual({ name: 'Coffee and tea' });
+  });
+
+  it('includes supported token replacements and returns an empty no-op PATCH', () => {
+    const initial = hydrateCustomTypeDraft(customType);
+
+    expect(
+      buildPatchCustomTypePayload(initial, {
+        ...initial,
+        color_token: 'rose',
+        icon_key: 'bus',
+      }),
+    ).toEqual({
+      color_token: 'rose',
+      icon_key: 'bus',
+    });
+    expect(buildPatchCustomTypePayload(initial, { ...initial })).toEqual({});
+  });
+});

--- a/mobile/src/features/timeline/__tests__/formModel.test.ts
+++ b/mobile/src/features/timeline/__tests__/formModel.test.ts
@@ -114,7 +114,7 @@ describe('activity draft hydration and immutable transitions', () => {
     expect(first).toEqual({
       title: '',
       time_mode: 'AT_TIME',
-      start_time: '',
+      start_time: '00:00',
       end_time: '',
       system_type: 'OTHER',
       custom_type_id: null,
@@ -199,6 +199,35 @@ describe('activity draft hydration and immutable transitions', () => {
     expect(manual.place).toBeNull();
     expect(draft.start_time).toBe('08:30');
     expect(draft.place).not.toBeNull();
+  });
+
+  it('keeps timed-mode defaults aligned with the native picker display', () => {
+    const untimed = validDraft({
+      time_mode: 'ALL_DAY',
+      start_time: '',
+      end_time: '',
+    });
+
+    expect(applyActivityTimeMode(untimed, 'AT_TIME')).toMatchObject({
+      time_mode: 'AT_TIME',
+      start_time: '00:00',
+      end_time: '',
+    });
+    expect(applyActivityTimeMode(untimed, 'TIME_RANGE')).toMatchObject({
+      time_mode: 'TIME_RANGE',
+      start_time: '00:00',
+      end_time: '01:00',
+    });
+    expect(
+      applyActivityTimeMode(
+        validDraft({ start_time: '08:30', end_time: '' }),
+        'TIME_RANGE',
+      ),
+    ).toMatchObject({
+      time_mode: 'TIME_RANGE',
+      start_time: '08:30',
+      end_time: '09:30',
+    });
   });
 });
 
@@ -320,6 +349,26 @@ describe('activity type, assignee, and location validation', () => {
       validateActivityDraft(both).fieldErrors.activity_type,
     ).toBeDefined();
     expect(validateActivityDraft(custom).isValid).toBe(true);
+  });
+
+  it('rejects a custom type that is no longer selectable', () => {
+    const custom = validDraft({
+      system_type: null,
+      custom_type_id: 'custom-1',
+    });
+
+    expect(
+      validateActivityDraft(custom, {
+        selectableCustomTypeIds: new Set(['custom-1']),
+      }).isValid,
+    ).toBe(true);
+    expect(
+      validateActivityDraft(custom, {
+        selectableCustomTypeIds: ['custom-2'],
+      }).fieldErrors.activity_type,
+    ).toBe(
+      'The selected custom type is no longer available. Choose another activity type.',
+    );
   });
 
   it('requires USER to reference an active member and forbids ids for other scopes', () => {

--- a/mobile/src/features/timeline/__tests__/formModel.test.ts
+++ b/mobile/src/features/timeline/__tests__/formModel.test.ts
@@ -610,6 +610,40 @@ describe('activity payloads', () => {
     });
   });
 
+  it('rounds structured coordinates to the backend precision for create and patch', () => {
+    const initial = validDraft({
+      location_mode: 'STRUCTURED',
+      location_label: 'Da Nang',
+      place: {
+        provider: 'here',
+        provider_id: 'canonical-id',
+        title: 'Da Nang',
+        address: 'Vietnam',
+        lat: 16,
+        lng: 108,
+      },
+    });
+    const draft = {
+      ...initial,
+      place: {
+        ...initial.place!,
+        lat: 16.0470791,
+        lng: 108.2062309,
+      },
+    };
+
+    expect(buildCreateActivityPayload(draft)?.place).toMatchObject({
+      lat: 16.047079,
+      lng: 108.206231,
+    });
+    expect(
+      buildPatchActivityPayload(initial, draft, { place: true })?.place,
+    ).toMatchObject({
+      lat: 16.047079,
+      lng: 108.206231,
+    });
+  });
+
   it('serializes non-timed values with explicit null times and no reminders', () => {
     const payload = buildCreateActivityPayload(
       validDraft({

--- a/mobile/src/features/timeline/__tests__/formModel.test.ts
+++ b/mobile/src/features/timeline/__tests__/formModel.test.ts
@@ -1,0 +1,699 @@
+import {
+  ACTIVITY_FIELD_LIMITS,
+  MAX_REMINDER_OFFSETS,
+  REMINDER_PRESETS,
+  applyActivityLocationMode,
+  applyActivityTimeMode,
+  buildCreateActivityPayload,
+  buildCreateSectionPayload,
+  buildPatchActivityPayload,
+  buildPatchSectionPayload,
+  createActivityDraft,
+  createSectionDraft,
+  getActivityDirtyFields,
+  getSectionDirtyFields,
+  getSelectableCustomTypes,
+  hydrateActivityDraft,
+  hydrateSectionDraft,
+  toggleActivityReminder,
+  validateActivityDraft,
+  validateSectionDraft,
+  type ActivityFormDraft,
+} from '../formModel';
+import type {
+  TimelineActivity,
+  TimelineCustomTypeMeta,
+  TimelineSection,
+} from '../types';
+
+function buildActivity(
+  overrides: Partial<TimelineActivity> = {},
+): TimelineActivity {
+  return {
+    id: 'activity-1',
+    title: 'Breakfast',
+    time_mode: 'AT_TIME',
+    start_time: '08:30:00',
+    end_time: null,
+    status: 'UPCOMING',
+    position: 0,
+    activity_type: {
+      kind: 'SYSTEM',
+      code: 'FOOD',
+      label: 'Food',
+      color_token: 'amber',
+      icon_key: 'restaurant',
+    },
+    assignee_scope: 'USER',
+    assignee: {
+      id: 'member-1',
+      display_name: 'Minh',
+      identify_tag: 'minh',
+    },
+    location: {
+      location_mode: 'STRUCTURED',
+      location_label: 'Morning Market',
+      location_note: 'Meet at the main gate',
+      place: {
+        provider: 'here',
+        provider_id: 'canonical-place-id',
+        title: 'Morning Market',
+        address: '1 Market Street',
+        lat: 16.01,
+        lng: 108.2,
+      },
+      open_url: 'https://share.here.com/example',
+    },
+    note: 'Try the local noodles',
+    meeting_point: 'Main gate',
+    contact_name: 'Lan',
+    contact_phone: '0900000000',
+    booking_reference: 'BOOK-1',
+    external_link: 'https://example.com/booking',
+    reminder_offsets_minutes: [1440, 30],
+    capabilities: {
+      can_edit: true,
+      can_delete: true,
+      can_update_status: true,
+    },
+    ...overrides,
+  };
+}
+
+function buildSection(
+  overrides: Partial<TimelineSection> = {},
+): TimelineSection {
+  return {
+    id: 'section-1',
+    section_date: '2026-06-01',
+    label: 'Arrival day',
+    is_label_custom: true,
+    is_in_trip_range: true,
+    position: 0,
+    activities: [],
+    ...overrides,
+  };
+}
+
+function validDraft(
+  overrides: Partial<ActivityFormDraft> = {},
+): ActivityFormDraft {
+  return {
+    ...createActivityDraft(),
+    title: 'Breakfast',
+    start_time: '08:30',
+    ...overrides,
+  };
+}
+
+describe('activity draft hydration and immutable transitions', () => {
+  it('provides explicit independent create defaults', () => {
+    const first = createActivityDraft();
+    const second = createActivityDraft();
+
+    expect(first).toEqual({
+      title: '',
+      time_mode: 'AT_TIME',
+      start_time: '',
+      end_time: '',
+      system_type: 'OTHER',
+      custom_type_id: null,
+      assignee_scope: 'NONE',
+      assignee_user_id: null,
+      location_mode: 'MANUAL',
+      location_label: '',
+      location_note: '',
+      place: null,
+      note: '',
+      meeting_point: '',
+      contact_name: '',
+      contact_phone: '',
+      booking_reference: '',
+      external_link: '',
+      reminder_offsets_minutes: [],
+    });
+    expect(first).not.toBe(second);
+    expect(first.reminder_offsets_minutes).not.toBe(
+      second.reminder_offsets_minutes,
+    );
+  });
+
+  it('hydrates a fresh draft without retaining mutable activity references', () => {
+    const activity = buildActivity();
+    const draft = hydrateActivityDraft(activity);
+
+    expect(draft.start_time).toBe('08:30');
+    expect(draft.system_type).toBe('FOOD');
+    expect(draft.custom_type_id).toBeNull();
+    expect(draft.assignee_user_id).toBe('member-1');
+    expect(draft.place).toEqual(activity.location.place);
+    expect(draft.place).not.toBe(activity.location.place);
+    expect(draft.reminder_offsets_minutes).not.toBe(
+      activity.reminder_offsets_minutes,
+    );
+
+    if (draft.place) {
+      draft.place.title = 'Changed';
+    }
+    draft.reminder_offsets_minutes.push(15);
+
+    expect(activity.location.place?.title).toBe('Morning Market');
+    expect(activity.reminder_offsets_minutes).toEqual([1440, 30]);
+  });
+
+  it('does not invent a type when a defensive read has a null activity_type', () => {
+    const draft = hydrateActivityDraft(
+      buildActivity({ activity_type: null }),
+    );
+
+    expect(draft.system_type).toBeNull();
+    expect(draft.custom_type_id).toBeNull();
+    expect(validateActivityDraft(draft).fieldErrors.activity_type).toBeDefined();
+  });
+
+  it('clears incompatible time and location values immutably', () => {
+    const draft = validDraft({
+      end_time: '09:30',
+      reminder_offsets_minutes: [30],
+      location_mode: 'STRUCTURED',
+      place: {
+        provider: 'here',
+        provider_id: 'canonical',
+        title: 'Cafe',
+        address: '',
+        lat: null,
+        lng: null,
+      },
+    });
+
+    const allDay = applyActivityTimeMode(draft, 'ALL_DAY');
+    const manual = applyActivityLocationMode(draft, 'MANUAL');
+
+    expect(allDay).toMatchObject({
+      time_mode: 'ALL_DAY',
+      start_time: '',
+      end_time: '',
+      reminder_offsets_minutes: [],
+    });
+    expect(manual.location_mode).toBe('MANUAL');
+    expect(manual.place).toBeNull();
+    expect(draft.start_time).toBe('08:30');
+    expect(draft.place).not.toBeNull();
+  });
+});
+
+describe('activity time and reminder validation', () => {
+  it.each([
+    [
+      validDraft({ time_mode: 'AT_TIME', start_time: '' }),
+      'start_time',
+    ],
+    [
+      validDraft({ time_mode: 'AT_TIME', end_time: '09:00' }),
+      'end_time',
+    ],
+    [
+      validDraft({
+        time_mode: 'TIME_RANGE',
+        start_time: '08:30',
+        end_time: '',
+      }),
+      'end_time',
+    ],
+    [
+      validDraft({
+        time_mode: 'TIME_RANGE',
+        start_time: '08:30',
+        end_time: '08:30',
+      }),
+      'end_time',
+    ],
+    [
+      validDraft({
+        time_mode: 'ALL_DAY',
+        start_time: '08:30',
+      }),
+      'time_mode',
+    ],
+    [
+      validDraft({
+        time_mode: 'FLEXIBLE',
+        start_time: '',
+        reminder_offsets_minutes: [30],
+      }),
+      'reminder_offsets_minutes',
+    ],
+  ])('rejects invalid time-mode combinations', (draft, errorField) => {
+    expect(validateActivityDraft(draft).fieldErrors).toHaveProperty(errorField);
+  });
+
+  it('accepts strict increasing ranges and all-day drafts without times', () => {
+    expect(
+      validateActivityDraft(
+        validDraft({
+          time_mode: 'TIME_RANGE',
+          end_time: '08:31',
+        }),
+      ).isValid,
+    ).toBe(true);
+    expect(
+      validateActivityDraft(
+        validDraft({
+          time_mode: 'ALL_DAY',
+          start_time: '',
+        }),
+      ).isValid,
+    ).toBe(true);
+  });
+
+  it.each([
+    [[30, 30], 'duplicate'],
+    [[60], 'unsupported'],
+    [
+      [10080, 1440, 120, 30, 15, 15],
+      'over maximum',
+    ],
+  ])('rejects %s reminder sets', (reminders) => {
+    const result = validateActivityDraft(
+      validDraft({ reminder_offsets_minutes: reminders }),
+    );
+    expect(result.fieldErrors.reminder_offsets_minutes).toBeDefined();
+  });
+
+  it('exports the exact five server presets and enforces the toggle limit', () => {
+    expect(REMINDER_PRESETS.map((preset) => preset.value)).toEqual([
+      10080, 1440, 120, 30, 15,
+    ]);
+    expect(MAX_REMINDER_OFFSETS).toBe(5);
+
+    let draft = validDraft();
+    for (const preset of [...REMINDER_PRESETS].reverse()) {
+      draft = toggleActivityReminder(draft, preset.value);
+    }
+
+    expect(draft.reminder_offsets_minutes).toEqual([
+      10080, 1440, 120, 30, 15,
+    ]);
+    expect(toggleActivityReminder(draft, 60)).toBe(draft);
+  });
+});
+
+describe('activity type, assignee, and location validation', () => {
+  it('requires exactly one system or custom activity type', () => {
+    const neither = validDraft({
+      system_type: null,
+      custom_type_id: null,
+    });
+    const both = validDraft({
+      system_type: 'FOOD',
+      custom_type_id: 'custom-1',
+    });
+    const custom = validDraft({
+      system_type: null,
+      custom_type_id: 'custom-1',
+    });
+
+    expect(
+      validateActivityDraft(neither).fieldErrors.activity_type,
+    ).toBeDefined();
+    expect(
+      validateActivityDraft(both).fieldErrors.activity_type,
+    ).toBeDefined();
+    expect(validateActivityDraft(custom).isValid).toBe(true);
+  });
+
+  it('requires USER to reference an active member and forbids ids for other scopes', () => {
+    const missing = validDraft({
+      assignee_scope: 'USER',
+      assignee_user_id: null,
+    });
+    const inactive = validDraft({
+      assignee_scope: 'USER',
+      assignee_user_id: 'member-2',
+    });
+    const active = validDraft({
+      assignee_scope: 'USER',
+      assignee_user_id: 'member-1',
+    });
+    const noneWithId = validDraft({
+      assignee_scope: 'NONE',
+      assignee_user_id: 'member-1',
+    });
+
+    expect(
+      validateActivityDraft(missing).fieldErrors.assignee_user_id,
+    ).toBeDefined();
+    expect(
+      validateActivityDraft(inactive, {
+        activeAssigneeIds: ['member-1'],
+      }).fieldErrors.assignee_user_id,
+    ).toBeDefined();
+    expect(
+      validateActivityDraft(active, {
+        activeAssigneeIds: new Set(['member-1']),
+      }).isValid,
+    ).toBe(true);
+    expect(
+      validateActivityDraft(noneWithId).fieldErrors.assignee_user_id,
+    ).toBeDefined();
+  });
+
+  it('enforces MANUAL null-place and STRUCTURED required-place rules', () => {
+    const place = {
+      provider: 'here',
+      provider_id: 'canonical-id',
+      title: 'Cafe',
+      address: 'Da Nang',
+      lat: 16,
+      lng: 108,
+    };
+
+    expect(
+      validateActivityDraft(
+        validDraft({ location_mode: 'MANUAL', place }),
+      ).fieldErrors.place,
+    ).toBeDefined();
+    expect(
+      validateActivityDraft(
+        validDraft({ location_mode: 'STRUCTURED', place: null }),
+      ).fieldErrors.place,
+    ).toBeDefined();
+    expect(
+      validateActivityDraft(
+        validDraft({ location_mode: 'STRUCTURED', place }),
+      ).isValid,
+    ).toBe(true);
+  });
+
+  it('keeps the inactive current custom type selectable only for edit hydration', () => {
+    const customTypes: TimelineCustomTypeMeta[] = [
+      {
+        id: 'active',
+        name: 'Active',
+        normalized_name: 'active',
+        color_token: 'slate',
+        icon_key: 'tag',
+        is_active: true,
+      },
+      {
+        id: 'inactive-current',
+        name: 'Inactive current',
+        normalized_name: 'inactive-current',
+        color_token: 'slate',
+        icon_key: 'tag',
+        is_active: false,
+      },
+      {
+        id: 'inactive-other',
+        name: 'Inactive other',
+        normalized_name: 'inactive-other',
+        color_token: 'slate',
+        icon_key: 'tag',
+        is_active: false,
+      },
+    ];
+    const initial = buildActivity({
+      activity_type: {
+        kind: 'CUSTOM',
+        id: 'inactive-current',
+        label: 'Inactive current',
+        color_token: 'slate',
+        icon_key: 'tag',
+      },
+    });
+
+    expect(
+      getSelectableCustomTypes(customTypes, initial).map((type) => type.id),
+    ).toEqual(['active', 'inactive-current']);
+    expect(getSelectableCustomTypes(customTypes).map((type) => type.id)).toEqual([
+      'active',
+    ]);
+  });
+});
+
+describe('activity field caps', () => {
+  it('counts Unicode code points and enforces title boundaries', () => {
+    expect(
+      validateActivityDraft(
+        validDraft({ title: '😀'.repeat(ACTIVITY_FIELD_LIMITS.title) }),
+      ).isValid,
+    ).toBe(true);
+    expect(
+      validateActivityDraft(
+        validDraft({ title: '😀'.repeat(ACTIVITY_FIELD_LIMITS.title + 1) }),
+      ).fieldErrors.title,
+    ).toBeDefined();
+  });
+
+  it.each([
+    ['location_label', ACTIVITY_FIELD_LIMITS.location_label],
+    ['location_note', ACTIVITY_FIELD_LIMITS.location_note],
+    ['meeting_point', ACTIVITY_FIELD_LIMITS.meeting_point],
+    ['contact_name', ACTIVITY_FIELD_LIMITS.contact_name],
+    ['contact_phone', ACTIVITY_FIELD_LIMITS.contact_phone],
+    ['booking_reference', ACTIVITY_FIELD_LIMITS.booking_reference],
+    ['external_link', ACTIVITY_FIELD_LIMITS.external_link],
+  ] as const)('enforces the %s cap', (field, limit) => {
+    const result = validateActivityDraft(
+      validDraft({ [field]: 'x'.repeat(limit + 1) }),
+    );
+    expect(result.fieldErrors).toHaveProperty(field);
+  });
+
+  it.each([
+    ['provider', ACTIVITY_FIELD_LIMITS.place_provider, 'place.provider'],
+    [
+      'provider_id',
+      ACTIVITY_FIELD_LIMITS.place_provider_id,
+      'place.provider_id',
+    ],
+    ['title', ACTIVITY_FIELD_LIMITS.place_title, 'place.title'],
+    ['address', ACTIVITY_FIELD_LIMITS.place_address, 'place.address'],
+  ] as const)('enforces the structured place %s cap', (field, limit, errorKey) => {
+    const result = validateActivityDraft(
+      validDraft({
+        location_mode: 'STRUCTURED',
+        place: {
+          provider: 'here',
+          provider_id: 'canonical',
+          title: 'Cafe',
+          address: '',
+          lat: null,
+          lng: null,
+          [field]: 'x'.repeat(limit + 1),
+        },
+      }),
+    );
+
+    expect(result.fieldErrors[errorKey]).toBeDefined();
+  });
+
+  it('rejects malformed external links within the cap', () => {
+    expect(
+      validateActivityDraft(
+        validDraft({ external_link: 'not a URL' }),
+      ).fieldErrors.external_link,
+    ).toBeDefined();
+  });
+});
+
+describe('activity payloads', () => {
+  it('builds a complete normalized create payload', () => {
+    const payload = buildCreateActivityPayload(
+      validDraft({
+        title: '  Dinner  ',
+        time_mode: 'TIME_RANGE',
+        start_time: '18:00',
+        end_time: '20:00',
+        system_type: null,
+        custom_type_id: 'custom-food',
+        assignee_scope: 'USER',
+        assignee_user_id: 'member-1',
+        location_mode: 'STRUCTURED',
+        location_label: '  Riverside  ',
+        location_note: '  Meet outside  ',
+        place: {
+          provider: ' here ',
+          provider_id: 'canonical-id',
+          title: ' Riverside ',
+          address: ' River Road ',
+          lat: 16,
+          lng: 108,
+        },
+        note: '  Bring cash  ',
+        meeting_point: '  Entrance  ',
+        contact_name: '  Lan  ',
+        contact_phone: '  0900  ',
+        booking_reference: '  REF-1  ',
+        external_link: '  https://example.com/dinner  ',
+        reminder_offsets_minutes: [15, 1440, 30],
+      }),
+      { activeAssigneeIds: ['member-1'] },
+    );
+
+    expect(payload).toEqual({
+      title: 'Dinner',
+      time_mode: 'TIME_RANGE',
+      start_time: '18:00',
+      end_time: '20:00',
+      system_type: '',
+      custom_type_id: 'custom-food',
+      assignee_scope: 'USER',
+      assignee_user_id: 'member-1',
+      location_mode: 'STRUCTURED',
+      location_label: 'Riverside',
+      location_note: 'Meet outside',
+      place: {
+        provider: 'here',
+        provider_id: 'canonical-id',
+        title: 'Riverside',
+        address: 'River Road',
+        lat: 16,
+        lng: 108,
+      },
+      note: 'Bring cash',
+      meeting_point: 'Entrance',
+      contact_name: 'Lan',
+      contact_phone: '0900',
+      booking_reference: 'REF-1',
+      external_link: 'https://example.com/dinner',
+      reminder_offsets_minutes: [1440, 30, 15],
+    });
+  });
+
+  it('serializes non-timed values with explicit null times and no reminders', () => {
+    const payload = buildCreateActivityPayload(
+      validDraft({
+        time_mode: 'ALL_DAY',
+        start_time: '',
+      }),
+    );
+
+    expect(payload).toMatchObject({
+      time_mode: 'ALL_DAY',
+      start_time: null,
+      end_time: null,
+      reminder_offsets_minutes: [],
+    });
+  });
+
+  it('returns null instead of producing an invalid payload', () => {
+    expect(buildCreateActivityPayload(createActivityDraft())).toBeNull();
+  });
+
+  it('builds a dirty-field minimal title PATCH', () => {
+    const initial = hydrateActivityDraft(buildActivity());
+    const draft = { ...initial, title: 'Brunch', note: 'Changed but untouched' };
+
+    expect(
+      buildPatchActivityPayload(initial, draft, { title: true }),
+    ).toEqual({ title: 'Brunch' });
+  });
+
+  it('omits fields changed back to their normalized initial value', () => {
+    const initial = validDraft({ title: 'Breakfast' });
+    const draft = { ...initial, title: ' Breakfast ' };
+
+    expect(getActivityDirtyFields(initial, draft)).toEqual({ title: true });
+    expect(buildPatchActivityPayload(initial, draft)).toEqual({});
+  });
+
+  it('sends both xor fields when switching activity type', () => {
+    const initial = validDraft({ system_type: 'FOOD' });
+    const draft = {
+      ...initial,
+      system_type: null,
+      custom_type_id: 'custom-food',
+    };
+
+    expect(buildPatchActivityPayload(initial, draft)).toEqual({
+      system_type: '',
+      custom_type_id: 'custom-food',
+    });
+  });
+
+  it('sends linked time fields that actually change with a mode transition', () => {
+    const initial = validDraft({
+      start_time: '08:30',
+      reminder_offsets_minutes: [30],
+    });
+    const draft = applyActivityTimeMode(initial, 'FLEXIBLE');
+
+    expect(buildPatchActivityPayload(initial, draft)).toEqual({
+      time_mode: 'FLEXIBLE',
+      start_time: null,
+      reminder_offsets_minutes: [],
+    });
+  });
+
+  it('clears canonical place only on an explicit dirty switch to MANUAL', () => {
+    const initial = hydrateActivityDraft(buildActivity());
+    const draft = applyActivityLocationMode(initial, 'MANUAL');
+
+    expect(buildPatchActivityPayload(initial, draft)).toEqual({
+      location_mode: 'MANUAL',
+      place: null,
+    });
+  });
+});
+
+describe('section form model', () => {
+  it('creates and hydrates independent section drafts', () => {
+    expect(createSectionDraft('2026-06-01')).toEqual({
+      section_date: '2026-06-01',
+      label: '',
+    });
+    expect(hydrateSectionDraft(buildSection())).toEqual({
+      section_date: '2026-06-01',
+      label: 'Arrival day',
+    });
+  });
+
+  it.each([
+    [{ section_date: '', label: 'Day' }, 'section_date'],
+    [{ section_date: '2026-02-30', label: 'Day' }, 'section_date'],
+    [{ section_date: '2026-06-01', label: '   ' }, 'label'],
+    [
+      { section_date: '2026-06-01', label: 'x'.repeat(121) },
+      'label',
+    ],
+  ])('validates date and label rules', (draft, errorField) => {
+    expect(validateSectionDraft(draft).fieldErrors).toHaveProperty(errorField);
+  });
+
+  it('builds a trimmed create payload', () => {
+    expect(
+      buildCreateSectionPayload({
+        section_date: '2026-06-01',
+        label: '  Arrival day  ',
+      }),
+    ).toEqual({
+      section_date: '2026-06-01',
+      label: 'Arrival day',
+    });
+  });
+
+  it('builds only the explicitly dirty changed section fields', () => {
+    const initial = hydrateSectionDraft(buildSection());
+    const draft = {
+      section_date: '2026-06-02',
+      label: 'Departure day',
+    };
+
+    expect(getSectionDirtyFields(initial, draft)).toEqual({
+      section_date: true,
+      label: true,
+    });
+    expect(
+      buildPatchSectionPayload(initial, draft, { label: true }),
+    ).toEqual({
+      label: 'Departure day',
+    });
+  });
+
+  it('returns null for invalid section payloads and an empty patch for no change', () => {
+    const initial = hydrateSectionDraft(buildSection());
+    expect(buildCreateSectionPayload(createSectionDraft())).toBeNull();
+    expect(buildPatchSectionPayload(initial, initial)).toEqual({});
+  });
+});

--- a/mobile/src/features/timeline/__tests__/routeIntent.test.ts
+++ b/mobile/src/features/timeline/__tests__/routeIntent.test.ts
@@ -1,0 +1,153 @@
+import {
+  parseActivityFormRouteIntent,
+  parseSectionFormRouteIntent,
+  parseTimelineRouteIntent,
+  type ActivityFormRouteParams,
+  type SectionFormRouteParams,
+  type TimelineRouteParam,
+} from '../routeIntent';
+
+const TRIP_ID = '123e4567-e89b-12d3-a456-426614174000';
+const SECTION_ID = '2c1dfd8d-9c7f-43c7-9b99-71f6d1edda55';
+const ACTIVITY_ID = 'a11957b3-3329-4fcf-9c7b-673a51c1d8a7';
+
+const INVALID_UUID_PARAMS: TimelineRouteParam[] = [
+  undefined,
+  '',
+  '   ',
+  ` ${TRIP_ID}`,
+  `${TRIP_ID} `,
+  'not-a-uuid',
+  '123e4567e89b12d3a456426614174000',
+  [TRIP_ID],
+];
+
+describe('parseTimelineRouteIntent', () => {
+  it('accepts one canonical UUID string', () => {
+    expect(parseTimelineRouteIntent({ tripId: TRIP_ID })).toEqual({ tripId: TRIP_ID });
+    expect(parseTimelineRouteIntent({ tripId: TRIP_ID.toUpperCase() })).toEqual({
+      tripId: TRIP_ID.toUpperCase(),
+    });
+  });
+
+  it.each(INVALID_UUID_PARAMS)('rejects invalid tripId %#', (tripId) => {
+    expect(parseTimelineRouteIntent({ tripId })).toBeNull();
+  });
+});
+
+describe('parseSectionFormRouteIntent', () => {
+  const createParams: SectionFormRouteParams = {
+    tripId: TRIP_ID,
+    mode: 'create',
+    sectionId: undefined,
+  };
+  const editParams: SectionFormRouteParams = {
+    tripId: TRIP_ID,
+    mode: 'edit',
+    sectionId: SECTION_ID,
+  };
+
+  it('returns strict create and edit discriminants', () => {
+    expect(parseSectionFormRouteIntent(createParams)).toEqual({
+      mode: 'create',
+      tripId: TRIP_ID,
+    });
+    expect(parseSectionFormRouteIntent(editParams)).toEqual({
+      mode: 'edit',
+      tripId: TRIP_ID,
+      sectionId: SECTION_ID,
+    });
+  });
+
+  it.each(INVALID_UUID_PARAMS)('rejects invalid tripId %#', (tripId) => {
+    expect(parseSectionFormRouteIntent({ ...createParams, tripId })).toBeNull();
+  });
+
+  it.each([undefined, '', 'CREATE', 'unknown', ['create']] as TimelineRouteParam[])(
+    'rejects missing, blank, unknown, or array mode %#',
+    (mode) => {
+      expect(parseSectionFormRouteIntent({ ...createParams, mode })).toBeNull();
+    },
+  );
+
+  it.each(['', 'not-a-uuid', SECTION_ID, [SECTION_ID]] as TimelineRouteParam[])(
+    'rejects create intent with any sectionId %#',
+    (sectionId) => {
+      expect(parseSectionFormRouteIntent({ ...createParams, sectionId })).toBeNull();
+    },
+  );
+
+  it.each(INVALID_UUID_PARAMS)(
+    'rejects edit intent without exactly one valid sectionId %#',
+    (sectionId) => {
+      expect(parseSectionFormRouteIntent({ ...editParams, sectionId })).toBeNull();
+    },
+  );
+});
+
+describe('parseActivityFormRouteIntent', () => {
+  const createParams: ActivityFormRouteParams = {
+    tripId: TRIP_ID,
+    mode: 'create',
+    sectionId: SECTION_ID,
+    activityId: undefined,
+  };
+  const editParams: ActivityFormRouteParams = {
+    tripId: TRIP_ID,
+    mode: 'edit',
+    sectionId: undefined,
+    activityId: ACTIVITY_ID,
+  };
+
+  it('returns strict create and edit discriminants', () => {
+    expect(parseActivityFormRouteIntent(createParams)).toEqual({
+      mode: 'create',
+      tripId: TRIP_ID,
+      sectionId: SECTION_ID,
+    });
+    expect(parseActivityFormRouteIntent(editParams)).toEqual({
+      mode: 'edit',
+      tripId: TRIP_ID,
+      activityId: ACTIVITY_ID,
+    });
+  });
+
+  it.each(INVALID_UUID_PARAMS)('rejects invalid tripId %#', (tripId) => {
+    expect(parseActivityFormRouteIntent({ ...createParams, tripId })).toBeNull();
+  });
+
+  it.each([undefined, '', 'EDIT', 'unknown', ['edit']] as TimelineRouteParam[])(
+    'rejects missing, blank, unknown, or array mode %#',
+    (mode) => {
+      expect(parseActivityFormRouteIntent({ ...createParams, mode })).toBeNull();
+    },
+  );
+
+  it.each(INVALID_UUID_PARAMS)(
+    'rejects create intent without exactly one valid sectionId %#',
+    (sectionId) => {
+      expect(parseActivityFormRouteIntent({ ...createParams, sectionId })).toBeNull();
+    },
+  );
+
+  it.each(['', 'not-a-uuid', ACTIVITY_ID, [ACTIVITY_ID]] as TimelineRouteParam[])(
+    'rejects create intent with any activityId %#',
+    (activityId) => {
+      expect(parseActivityFormRouteIntent({ ...createParams, activityId })).toBeNull();
+    },
+  );
+
+  it.each(INVALID_UUID_PARAMS)(
+    'rejects edit intent without exactly one valid activityId %#',
+    (activityId) => {
+      expect(parseActivityFormRouteIntent({ ...editParams, activityId })).toBeNull();
+    },
+  );
+
+  it.each(['', 'not-a-uuid', SECTION_ID, [SECTION_ID]] as TimelineRouteParam[])(
+    'rejects edit intent with any sectionId %#',
+    (sectionId) => {
+      expect(parseActivityFormRouteIntent({ ...editParams, sectionId })).toBeNull();
+    },
+  );
+});

--- a/mobile/src/features/timeline/__tests__/routeIntent.test.ts
+++ b/mobile/src/features/timeline/__tests__/routeIntent.test.ts
@@ -26,7 +26,7 @@ describe('parseTimelineRouteIntent', () => {
   it('accepts one canonical UUID string', () => {
     expect(parseTimelineRouteIntent({ tripId: TRIP_ID })).toEqual({ tripId: TRIP_ID });
     expect(parseTimelineRouteIntent({ tripId: TRIP_ID.toUpperCase() })).toEqual({
-      tripId: TRIP_ID.toUpperCase(),
+      tripId: TRIP_ID,
     });
   });
 
@@ -53,6 +53,17 @@ describe('parseSectionFormRouteIntent', () => {
       tripId: TRIP_ID,
     });
     expect(parseSectionFormRouteIntent(editParams)).toEqual({
+      mode: 'edit',
+      tripId: TRIP_ID,
+      sectionId: SECTION_ID,
+    });
+    expect(
+      parseSectionFormRouteIntent({
+        ...editParams,
+        tripId: TRIP_ID.toUpperCase(),
+        sectionId: SECTION_ID.toUpperCase(),
+      }),
+    ).toEqual({
       mode: 'edit',
       tripId: TRIP_ID,
       sectionId: SECTION_ID,
@@ -106,6 +117,28 @@ describe('parseActivityFormRouteIntent', () => {
       sectionId: SECTION_ID,
     });
     expect(parseActivityFormRouteIntent(editParams)).toEqual({
+      mode: 'edit',
+      tripId: TRIP_ID,
+      activityId: ACTIVITY_ID,
+    });
+    expect(
+      parseActivityFormRouteIntent({
+        ...createParams,
+        tripId: TRIP_ID.toUpperCase(),
+        sectionId: SECTION_ID.toUpperCase(),
+      }),
+    ).toEqual({
+      mode: 'create',
+      tripId: TRIP_ID,
+      sectionId: SECTION_ID,
+    });
+    expect(
+      parseActivityFormRouteIntent({
+        ...editParams,
+        tripId: TRIP_ID.toUpperCase(),
+        activityId: ACTIVITY_ID.toUpperCase(),
+      }),
+    ).toEqual({
       mode: 'edit',
       tripId: TRIP_ID,
       activityId: ACTIVITY_ID,

--- a/mobile/src/features/timeline/__tests__/timelineEvents.test.ts
+++ b/mobile/src/features/timeline/__tests__/timelineEvents.test.ts
@@ -1,0 +1,60 @@
+import {
+  publishTimelineEvent,
+  subscribeToTimelineEvents,
+  type TimelineEvent,
+} from '../timelineEvents';
+
+describe('timeline events', () => {
+  it('publishes only to listeners keyed to the changed trip', () => {
+    const tripOneListener = jest.fn();
+    const tripTwoListener = jest.fn();
+    const unsubscribeTripOne = subscribeToTimelineEvents(
+      'trip-1',
+      tripOneListener,
+    );
+    const unsubscribeTripTwo = subscribeToTimelineEvents(
+      'trip-2',
+      tripTwoListener,
+    );
+    const event: TimelineEvent = {
+      type: 'timelineChanged',
+      tripId: 'trip-1',
+    };
+
+    publishTimelineEvent(event);
+
+    expect(tripOneListener).toHaveBeenCalledTimes(1);
+    expect(tripOneListener).toHaveBeenCalledWith(event);
+    expect(tripTwoListener).not.toHaveBeenCalled();
+
+    unsubscribeTripOne();
+    unsubscribeTripTwo();
+  });
+
+  it('notifies every listener for one trip and stops after unsubscribe', () => {
+    const firstListener = jest.fn();
+    const secondListener = jest.fn();
+    const unsubscribeFirst = subscribeToTimelineEvents(
+      'trip-1',
+      firstListener,
+    );
+    const unsubscribeSecond = subscribeToTimelineEvents(
+      'trip-1',
+      secondListener,
+    );
+    const event: TimelineEvent = {
+      type: 'timelineChanged',
+      tripId: 'trip-1',
+    };
+
+    publishTimelineEvent(event);
+    unsubscribeFirst();
+    publishTimelineEvent(event);
+    unsubscribeFirst();
+    unsubscribeSecond();
+    publishTimelineEvent(event);
+
+    expect(firstListener).toHaveBeenCalledTimes(1);
+    expect(secondListener).toHaveBeenCalledTimes(2);
+  });
+});

--- a/mobile/src/features/timeline/__tests__/timelineEvents.test.ts
+++ b/mobile/src/features/timeline/__tests__/timelineEvents.test.ts
@@ -5,7 +5,7 @@ import {
 } from '../timelineEvents';
 
 describe('timeline events', () => {
-  it('publishes only to listeners keyed to the changed trip', () => {
+  it('publishes only to listeners keyed to the changed trip', async () => {
     const tripOneListener = jest.fn();
     const tripTwoListener = jest.fn();
     const unsubscribeTripOne = subscribeToTimelineEvents(
@@ -21,7 +21,7 @@ describe('timeline events', () => {
       tripId: 'trip-1',
     };
 
-    publishTimelineEvent(event);
+    await publishTimelineEvent(event);
 
     expect(tripOneListener).toHaveBeenCalledTimes(1);
     expect(tripOneListener).toHaveBeenCalledWith(event);
@@ -31,7 +31,7 @@ describe('timeline events', () => {
     unsubscribeTripTwo();
   });
 
-  it('notifies every listener for one trip and stops after unsubscribe', () => {
+  it('notifies every listener for one trip and stops after unsubscribe', async () => {
     const firstListener = jest.fn();
     const secondListener = jest.fn();
     const unsubscribeFirst = subscribeToTimelineEvents(
@@ -47,14 +47,40 @@ describe('timeline events', () => {
       tripId: 'trip-1',
     };
 
-    publishTimelineEvent(event);
+    await publishTimelineEvent(event);
     unsubscribeFirst();
-    publishTimelineEvent(event);
+    await publishTimelineEvent(event);
     unsubscribeFirst();
     unsubscribeSecond();
-    publishTimelineEvent(event);
+    await publishTimelineEvent(event);
 
     expect(firstListener).toHaveBeenCalledTimes(1);
     expect(secondListener).toHaveBeenCalledTimes(2);
+  });
+
+  it('waits for asynchronous listeners before resolving', async () => {
+    let resolveListener: () => void = () => undefined;
+    const listener = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveListener = resolve;
+        }),
+    );
+    const unsubscribe = subscribeToTimelineEvents('trip-1', listener);
+    let settled = false;
+
+    const published = publishTimelineEvent({
+      type: 'timelineChanged',
+      tripId: 'trip-1',
+    }).then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    resolveListener();
+    await published;
+    expect(settled).toBe(true);
+    unsubscribe();
   });
 });

--- a/mobile/src/features/timeline/__tests__/tokenMaps.test.ts
+++ b/mobile/src/features/timeline/__tests__/tokenMaps.test.ts
@@ -1,0 +1,34 @@
+import {
+  getTimelineIconName,
+  getTimelineTokenColors,
+  TIMELINE_COLOR_OPTIONS,
+  TIMELINE_COLOR_TOKENS,
+  TIMELINE_ICON_KEYS,
+  TIMELINE_ICON_OPTIONS,
+} from '../tokenMaps';
+
+describe('timeline token maps', () => {
+  it('offers each supported color and icon exactly once', () => {
+    expect(TIMELINE_COLOR_OPTIONS.map((option) => option.value)).toEqual(
+      TIMELINE_COLOR_TOKENS,
+    );
+    expect(TIMELINE_ICON_OPTIONS.map((option) => option.value)).toEqual(
+      TIMELINE_ICON_KEYS,
+    );
+    expect(new Set(TIMELINE_COLOR_TOKENS).size).toBe(8);
+    expect(new Set(TIMELINE_ICON_KEYS).size).toBe(8);
+  });
+
+  it('falls back to a neutral slate token and tag icon for unknown values', () => {
+    expect(getTimelineTokenColors('future-token')).toEqual(
+      getTimelineTokenColors('slate'),
+    );
+    expect(getTimelineIconName('future-icon')).toBe('pricetag-outline');
+  });
+
+  it('maps the known server icon keys to Ionicons names', () => {
+    expect(getTimelineIconName('bus')).toBe('bus-outline');
+    expect(getTimelineIconName('utensils')).toBe('restaurant-outline');
+    expect(getTimelineIconName('shopping-bag')).toBe('bag-outline');
+  });
+});

--- a/mobile/src/features/timeline/__tests__/useLocationSearch.test.tsx
+++ b/mobile/src/features/timeline/__tests__/useLocationSearch.test.tsx
@@ -1,0 +1,393 @@
+jest.mock('../api', () => ({
+  lookupLocation: jest.fn(),
+  suggestLocations: jest.fn(),
+}));
+
+// eslint-disable-next-line import/first
+import { AxiosError, AxiosHeaders } from 'axios';
+// eslint-disable-next-line import/first
+import { act, renderHook } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { lookupLocation, suggestLocations } from '../api';
+// eslint-disable-next-line import/first
+import {
+  LOCATION_SEARCH_DEBOUNCE_MS,
+  MANUAL_LOCATION_GUIDANCE,
+  useLocationSearch,
+} from '../hooks/useLocationSearch';
+// eslint-disable-next-line import/first
+import type {
+  LocationSuggestion,
+  ResolvedLocationLookup,
+} from '../types';
+
+const mockSuggestLocations = suggestLocations as jest.MockedFunction<
+  typeof suggestLocations
+>;
+const mockLookupLocation = lookupLocation as jest.MockedFunction<
+  typeof lookupLocation
+>;
+
+const suggestion: LocationSuggestion = {
+  provider: 'here',
+  provider_id: 'suggestion-id',
+  title: 'Da Nang International Airport',
+  subtitle: 'Da Nang, Vietnam',
+};
+
+const lookup: ResolvedLocationLookup = {
+  destination: 'Duy Tan, Hoa Thuan Tay, Da Nang, Vietnam',
+  destination_provider: 'here',
+  destination_provider_id: 'canonical-id',
+  destination_lat: 16.0439,
+  destination_lng: 108.199,
+  destination_country_code: 'VN',
+};
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, {}, {
+    status,
+    statusText: '',
+    headers: {},
+    config,
+    data,
+  });
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
+async function setQuery(
+  result: { current: ReturnType<typeof useLocationSearch> },
+  query: string,
+) {
+  await act(async () => {
+    result.current.setQuery(query);
+  });
+}
+
+async function advanceDebounce(milliseconds = LOCATION_SEARCH_DEBOUNCE_MS) {
+  await act(async () => {
+    jest.advanceTimersByTime(milliseconds);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('useLocationSearch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('waits 300 ms and ignores queries shorter than two trimmed characters', async () => {
+    mockSuggestLocations.mockResolvedValue([]);
+    const { result, unmount } = await renderHook(() => useLocationSearch());
+
+    await setQuery(result, ' a ');
+    await advanceDebounce(LOCATION_SEARCH_DEBOUNCE_MS + 1);
+    expect(mockSuggestLocations).not.toHaveBeenCalled();
+    expect(result.current.searchStatus).toBe('idle');
+
+    await setQuery(result, '  Da  ');
+    expect(result.current.searchStatus).toBe('debouncing');
+    await advanceDebounce(LOCATION_SEARCH_DEBOUNCE_MS - 1);
+    expect(mockSuggestLocations).not.toHaveBeenCalled();
+
+    await advanceDebounce(1);
+    expect(mockSuggestLocations).toHaveBeenCalledWith(
+      'Da',
+      expect.any(AbortSignal),
+    );
+    expect(result.current.searchStatus).toBe('ready');
+    unmount();
+  });
+
+  it('drops opaque provider ids over 255 code points without truncating valid ids', async () => {
+    const validId = 'a'.repeat(255);
+    const invalidId = 'b'.repeat(256);
+    mockSuggestLocations.mockResolvedValue([
+      { ...suggestion, provider_id: validId },
+      { ...suggestion, provider_id: invalidId, title: 'Unpickable result' },
+    ]);
+    const { result, unmount } = await renderHook(() => useLocationSearch());
+
+    await setQuery(result, 'Da Nang');
+    await advanceDebounce();
+
+    expect(result.current.suggestions).toEqual([
+      { ...suggestion, provider_id: validId },
+    ]);
+    expect(result.current.suggestions[0]?.provider_id).toHaveLength(255);
+    unmount();
+  });
+
+  it.each([
+    'LOCATION_SEARCH_DISABLED',
+    'LOCATION_SEARCH_NOT_CONFIGURED',
+  ])('marks 503 %s as unavailable for manual degradation', async (errorCode) => {
+    mockSuggestLocations.mockRejectedValue(
+      axiosErrorWith(503, {
+        detail: 'Place search is unavailable.',
+        error_code: errorCode,
+      }),
+    );
+    const { result, unmount } = await renderHook(() => useLocationSearch());
+
+    await setQuery(result, 'Da Nang');
+    await advanceDebounce();
+
+    expect(result.current.searchUnavailable).toBe(true);
+    expect(result.current.searchError).toMatchObject({
+      status: 503,
+      errorCode,
+    });
+    expect(result.current.searchStatus).toBe('error');
+    unmount();
+  });
+
+  it('retains the current input and suggestions after a 429 response', async () => {
+    mockSuggestLocations
+      .mockResolvedValueOnce([suggestion])
+      .mockRejectedValueOnce(
+        axiosErrorWith(429, { detail: 'Provider quota reached.' }),
+      );
+    const { result, unmount } = await renderHook(() => useLocationSearch());
+
+    await setQuery(result, 'Da');
+    await advanceDebounce();
+    expect(result.current.suggestions).toEqual([suggestion]);
+
+    await setQuery(result, 'Da Nang');
+    expect(result.current.suggestions).toEqual([suggestion]);
+    await advanceDebounce();
+
+    expect(result.current.query).toBe('Da Nang');
+    expect(result.current.suggestions).toEqual([suggestion]);
+    expect(result.current.searchError).toMatchObject({
+      kind: 'throttled',
+      status: 429,
+    });
+    unmount();
+  });
+
+  it('aborts an older suggest request and lets only the latest request update state', async () => {
+    const first = deferred<LocationSuggestion[]>();
+    const second = deferred<LocationSuggestion[]>();
+    const latestSuggestion = {
+      ...suggestion,
+      provider_id: 'latest-id',
+      title: 'Latest place',
+    };
+    mockSuggestLocations
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const { result, unmount } = await renderHook(() => useLocationSearch());
+
+    await setQuery(result, 'Da');
+    await advanceDebounce();
+    const firstSignal = mockSuggestLocations.mock.calls[0]?.[1];
+
+    await setQuery(result, 'Da Nang');
+    expect(firstSignal?.aborted).toBe(true);
+    await advanceDebounce();
+
+    await act(async () => {
+      second.resolve([latestSuggestion]);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      first.resolve([suggestion]);
+      await Promise.resolve();
+    });
+
+    expect(result.current.suggestions).toEqual([latestSuggestion]);
+    expect(result.current.searchStatus).toBe('ready');
+    unmount();
+  });
+
+  it('creates structured data only from a successful canonical lookup', async () => {
+    mockLookupLocation.mockResolvedValue(lookup);
+    const { result, unmount } = await renderHook(() => useLocationSearch());
+    let selectionResult:
+      | Awaited<ReturnType<typeof result.current.selectSuggestion>>
+      | undefined;
+
+    await act(async () => {
+      selectionResult = await result.current.selectSuggestion(suggestion);
+    });
+
+    expect(mockLookupLocation).toHaveBeenCalledWith(
+      suggestion.provider_id,
+      expect.any(AbortSignal),
+    );
+    expect(selectionResult).toEqual({
+      kind: 'success',
+      selection: {
+        location_mode: 'STRUCTURED',
+        location_label: suggestion.title,
+        place: {
+          provider: 'here',
+          provider_id: lookup.destination_provider_id,
+          title: suggestion.title,
+          address: lookup.destination,
+          lat: lookup.destination_lat,
+          lng: lookup.destination_lng,
+        },
+      },
+    });
+    expect(
+      selectionResult?.kind === 'success'
+        ? selectionResult.selection.place.provider_id
+        : undefined,
+    ).not.toBe(suggestion.provider_id);
+    unmount();
+  });
+
+  it('returns stale without a failure state when lookup is aborted by new input', async () => {
+    const pending = deferred<ResolvedLocationLookup>();
+    mockLookupLocation.mockReturnValue(pending.promise);
+    const { result, unmount } = await renderHook(() => useLocationSearch());
+    let lookupPromise:
+      | ReturnType<typeof result.current.selectSuggestion>
+      | undefined;
+
+    await act(async () => {
+      lookupPromise = result.current.selectSuggestion(suggestion);
+    });
+    const lookupSignal = mockLookupLocation.mock.calls[0]?.[1];
+    expect(result.current.lookupStatus).toBe('loading');
+
+    await setQuery(result, 'Another place');
+    expect(lookupSignal?.aborted).toBe(true);
+
+    let selectionResult:
+      | Awaited<ReturnType<typeof result.current.selectSuggestion>>
+      | undefined;
+    await act(async () => {
+      pending.resolve(lookup);
+      selectionResult = await lookupPromise;
+    });
+
+    expect(selectionResult).toEqual({ kind: 'stale' });
+    expect(result.current.lookupStatus).toBe('idle');
+    expect(result.current.lookupError).toBeNull();
+    expect(result.current.manualEntrySuggested).toBe(false);
+    unmount();
+  });
+
+  it('aborts lookup and returns stale when the picker becomes disabled', async () => {
+    const pending = deferred<ResolvedLocationLookup>();
+    mockLookupLocation.mockReturnValue(pending.promise);
+    const { result, rerender, unmount } = await renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useLocationSearch({ enabled }),
+      { initialProps: { enabled: true } },
+    );
+    let lookupPromise:
+      | ReturnType<typeof result.current.selectSuggestion>
+      | undefined;
+
+    await act(async () => {
+      lookupPromise = result.current.selectSuggestion(suggestion);
+    });
+    const lookupSignal = mockLookupLocation.mock.calls[0]?.[1];
+
+    await rerender({ enabled: false });
+    expect(lookupSignal?.aborted).toBe(true);
+
+    let selectionResult:
+      | Awaited<ReturnType<typeof result.current.selectSuggestion>>
+      | undefined;
+    await act(async () => {
+      pending.resolve(lookup);
+      selectionResult = await lookupPromise;
+    });
+
+    expect(selectionResult).toEqual({ kind: 'stale' });
+    expect(result.current.lookupStatus).toBe('idle');
+    expect(result.current.lookupError).toBeNull();
+    unmount();
+  });
+
+  it('returns a manual fallback with the selected label after a settled lookup failure', async () => {
+    mockLookupLocation.mockRejectedValue(
+      axiosErrorWith(502, {
+        detail: 'Could not verify this place.',
+        error_code: 'LOCATION_LOOKUP_FAILED',
+      }),
+    );
+    const { result, unmount } = await renderHook(() => useLocationSearch());
+    let selectionResult:
+      | Awaited<ReturnType<typeof result.current.selectSuggestion>>
+      | undefined;
+
+    await act(async () => {
+      selectionResult = await result.current.selectSuggestion(suggestion);
+    });
+
+    expect(selectionResult).toEqual({
+      kind: 'failure',
+      fallback: {
+        location_mode: 'MANUAL',
+        location_label: suggestion.title,
+        place: null,
+        guidance: MANUAL_LOCATION_GUIDANCE,
+        error: {
+          kind: 'message',
+          message: 'Could not verify this place.',
+          status: 502,
+          errorCode: 'LOCATION_LOOKUP_FAILED',
+        },
+      },
+    });
+    expect(result.current.lookupStatus).toBe('error');
+    expect(result.current.manualEntrySuggested).toBe(true);
+    expect(
+      selectionResult?.kind === 'failure'
+        ? selectionResult.fallback.place
+        : undefined,
+    ).toBeNull();
+    unmount();
+  });
+
+  it('never falls back to the suggestion id when the canonical id is invalid', async () => {
+    mockLookupLocation.mockResolvedValue({
+      ...lookup,
+      destination_provider_id: 'c'.repeat(256),
+    });
+    const { result, unmount } = await renderHook(() => useLocationSearch());
+    let selectionResult:
+      | Awaited<ReturnType<typeof result.current.selectSuggestion>>
+      | undefined;
+
+    await act(async () => {
+      selectionResult = await result.current.selectSuggestion(suggestion);
+    });
+
+    expect(selectionResult?.kind).toBe('failure');
+    expect(
+      selectionResult?.kind === 'failure'
+        ? selectionResult.fallback
+        : undefined,
+    ).toMatchObject({
+      location_mode: 'MANUAL',
+      location_label: suggestion.title,
+      place: null,
+    });
+    expect(result.current.lookupStatus).toBe('error');
+    unmount();
+  });
+});

--- a/mobile/src/features/timeline/__tests__/useLocationSearch.test.tsx
+++ b/mobile/src/features/timeline/__tests__/useLocationSearch.test.tsx
@@ -379,6 +379,35 @@ describe('useLocationSearch', () => {
     unmount();
   });
 
+  it('caps a failed lookup fallback label by Unicode code points', async () => {
+    mockLookupLocation.mockRejectedValue(
+      axiosErrorWith(502, {
+        detail: 'Could not verify this place.',
+        error_code: 'LOCATION_LOOKUP_FAILED',
+      }),
+    );
+    const { result, unmount } = await renderHook(() => useLocationSearch());
+
+    let selectionResult:
+      | Awaited<ReturnType<typeof result.current.selectSuggestion>>
+      | undefined;
+    await act(async () => {
+      selectionResult = await result.current.selectSuggestion({
+        ...suggestion,
+        title: '😀'.repeat(201),
+      });
+    });
+
+    expect(selectionResult?.kind).toBe('failure');
+    const label =
+      selectionResult?.kind === 'failure'
+        ? selectionResult.fallback.location_label
+        : '';
+    expect(Array.from(label)).toHaveLength(200);
+    expect(label).toBe('😀'.repeat(200));
+    unmount();
+  });
+
   it('never falls back to the suggestion id when the canonical id is invalid', async () => {
     mockLookupLocation.mockResolvedValue({
       ...lookup,

--- a/mobile/src/features/timeline/__tests__/useLocationSearch.test.tsx
+++ b/mobile/src/features/timeline/__tests__/useLocationSearch.test.tsx
@@ -158,7 +158,7 @@ describe('useLocationSearch', () => {
     unmount();
   });
 
-  it('retains the current input and suggestions after a 429 response', async () => {
+  it('retains the current input but clears stale suggestions after a 429 response', async () => {
     mockSuggestLocations
       .mockResolvedValueOnce([suggestion])
       .mockRejectedValueOnce(
@@ -171,15 +171,31 @@ describe('useLocationSearch', () => {
     expect(result.current.suggestions).toEqual([suggestion]);
 
     await setQuery(result, 'Da Nang');
-    expect(result.current.suggestions).toEqual([suggestion]);
+    expect(result.current.suggestions).toEqual([]);
     await advanceDebounce();
 
     expect(result.current.query).toBe('Da Nang');
-    expect(result.current.suggestions).toEqual([suggestion]);
+    expect(result.current.suggestions).toEqual([]);
     expect(result.current.searchError).toMatchObject({
       kind: 'throttled',
       status: 429,
     });
+    unmount();
+  });
+
+  it('clears old suggestions as soon as a different searchable query is entered', async () => {
+    mockSuggestLocations.mockResolvedValue([suggestion]);
+    const { result, unmount } = await renderHook(() => useLocationSearch());
+
+    await setQuery(result, 'Da');
+    await advanceDebounce();
+    expect(result.current.suggestions).toEqual([suggestion]);
+
+    await setQuery(result, 'Hanoi');
+
+    expect(result.current.query).toBe('Hanoi');
+    expect(result.current.searchStatus).toBe('debouncing');
+    expect(result.current.suggestions).toEqual([]);
     unmount();
   });
 

--- a/mobile/src/features/timeline/__tests__/useTimeline.test.tsx
+++ b/mobile/src/features/timeline/__tests__/useTimeline.test.tsx
@@ -285,12 +285,18 @@ describe('useTimeline', () => {
     await waitFor(() => expect(result.current.status).toBe('ready'));
 
     await act(async () => {
-      publishTimelineEvent({ type: 'timelineChanged', tripId: 'trip-2' });
+      await publishTimelineEvent({
+        type: 'timelineChanged',
+        tripId: 'trip-2',
+      });
     });
     expect(mockGetTimeline).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      publishTimelineEvent({ type: 'timelineChanged', tripId: 'trip-1' });
+      await publishTimelineEvent({
+        type: 'timelineChanged',
+        tripId: 'trip-1',
+      });
     });
     await waitFor(() =>
       expect(result.current.timeline?.sections[0]?.label).toBe('Event update'),
@@ -308,7 +314,10 @@ describe('useTimeline', () => {
     await act(async () => {
       latestFocusCallback()();
       latestForegroundCallback()();
-      publishTimelineEvent({ type: 'timelineChanged', tripId: 'trip-1' });
+      await publishTimelineEvent({
+        type: 'timelineChanged',
+        tripId: 'trip-1',
+      });
     });
     expect(mockGetTimeline).not.toHaveBeenCalled();
 

--- a/mobile/src/features/timeline/__tests__/useTimeline.test.tsx
+++ b/mobile/src/features/timeline/__tests__/useTimeline.test.tsx
@@ -1,0 +1,405 @@
+const mockUseFocusEffect = jest.fn();
+const mockUseAppForegroundEffect = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useFocusEffect: (effect: () => (() => void) | void) =>
+    mockUseFocusEffect(effect),
+}));
+
+jest.mock('@/shared/hooks/useAppForegroundEffect', () => ({
+  useAppForegroundEffect: (listener: () => void) =>
+    mockUseAppForegroundEffect(listener),
+}));
+
+jest.mock('../api', () => ({
+  getTimeline: jest.fn(),
+}));
+
+// eslint-disable-next-line import/first
+import { AxiosError, AxiosHeaders } from 'axios';
+// eslint-disable-next-line import/first
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { getTimeline } from '../api';
+// eslint-disable-next-line import/first
+import { useTimeline } from '../hooks/useTimeline';
+// eslint-disable-next-line import/first
+import { publishTimelineEvent } from '../timelineEvents';
+// eslint-disable-next-line import/first
+import type { TimelineResponse } from '../types';
+
+const mockGetTimeline = getTimeline as jest.MockedFunction<typeof getTimeline>;
+
+function timeline(label: string): TimelineResponse {
+  return {
+    trip_timezone: 'Asia/Ho_Chi_Minh',
+    permissions: {
+      can_edit_timeline: true,
+      can_manage_custom_types: true,
+      can_create_sections: true,
+    },
+    system_types: [],
+    custom_types: [],
+    sections: [
+      {
+        id: 'section-1',
+        section_date: '2026-08-01',
+        label,
+        is_label_custom: true,
+        is_in_trip_range: true,
+        position: 1,
+        activities: [],
+      },
+    ],
+  };
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, {}, {
+    status,
+    statusText: '',
+    headers: {},
+    config,
+    data,
+  });
+}
+
+function latestFocusCallback(): () => (() => void) | void {
+  const callback = mockUseFocusEffect.mock.calls.at(-1)?.[0] as
+    | (() => (() => void) | void)
+    | undefined;
+  if (!callback) {
+    throw new Error('Expected useFocusEffect to register a callback.');
+  }
+  return callback;
+}
+
+function latestForegroundCallback(): () => void {
+  const callback = mockUseAppForegroundEffect.mock.calls.at(-1)?.[0] as
+    | (() => void)
+    | undefined;
+  if (!callback) {
+    throw new Error('Expected useAppForegroundEffect to register a callback.');
+  }
+  return callback;
+}
+
+describe('useTimeline', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads initially on focus and silently reconciles complete data', async () => {
+    const silent = deferred<TimelineResponse>();
+    mockGetTimeline
+      .mockResolvedValueOnce(timeline('Arrival'))
+      .mockReturnValueOnce(silent.promise);
+    const { result, unmount } = await renderHook(() => useTimeline('trip-1'));
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() =>
+      expect(result.current.timeline?.sections[0]?.label).toBe('Arrival'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    expect(result.current.status).toBe('ready');
+    expect(result.current.refreshing).toBe(false);
+    expect(result.current.timeline?.sections[0]?.label).toBe('Arrival');
+
+    await act(async () => {
+      silent.resolve(timeline('Updated arrival'));
+    });
+    expect(result.current.timeline?.sections[0]?.label).toBe('Updated arrival');
+    unmount();
+  });
+
+  it('sets refreshing only for explicit refresh and keeps complete data visible', async () => {
+    const explicit = deferred<TimelineResponse>();
+    mockGetTimeline
+      .mockResolvedValueOnce(timeline('Arrival'))
+      .mockReturnValueOnce(explicit.promise);
+    const { result, unmount } = await renderHook(() => useTimeline('trip-1'));
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      void result.current.refresh('refresh');
+    });
+    expect(result.current.refreshing).toBe(true);
+    expect(result.current.timeline?.sections[0]?.label).toBe('Arrival');
+
+    await act(async () => {
+      explicit.resolve(timeline('Refreshed'));
+    });
+    expect(result.current.refreshing).toBe(false);
+    expect(result.current.timeline?.sections[0]?.label).toBe('Refreshed');
+    unmount();
+  });
+
+  it('lets a newer silent request own refresh completion and stale finally cleanup', async () => {
+    const explicit = deferred<TimelineResponse>();
+    const silent = deferred<TimelineResponse>();
+    mockGetTimeline
+      .mockResolvedValueOnce(timeline('Arrival'))
+      .mockReturnValueOnce(explicit.promise)
+      .mockReturnValueOnce(silent.promise);
+    const { result, unmount } = await renderHook(() => useTimeline('trip-1'));
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      void result.current.refresh('refresh');
+      void result.current.refresh('silent');
+    });
+    await act(async () => {
+      explicit.resolve(timeline('Stale refresh'));
+    });
+    expect(result.current.refreshing).toBe(true);
+    expect(result.current.timeline?.sections[0]?.label).toBe('Arrival');
+
+    await act(async () => {
+      silent.resolve(timeline('Latest silent'));
+    });
+    expect(result.current.refreshing).toBe(false);
+    expect(result.current.timeline?.sections[0]?.label).toBe('Latest silent');
+    unmount();
+  });
+
+  it('ignores stale catch and finally branches after a newer request starts', async () => {
+    const stale = deferred<TimelineResponse>();
+    const latest = deferred<TimelineResponse>();
+    mockGetTimeline
+      .mockResolvedValueOnce(timeline('Arrival'))
+      .mockReturnValueOnce(stale.promise)
+      .mockReturnValueOnce(latest.promise);
+    const { result, unmount } = await renderHook(() => useTimeline('trip-1'));
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      void result.current.refresh('refresh');
+      void result.current.refresh('silent');
+    });
+    await act(async () => {
+      stale.reject(axiosErrorWith(500, { detail: 'Stale failure.' }));
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.refreshing).toBe(true);
+
+    await act(async () => {
+      latest.resolve(timeline('Latest'));
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.refreshing).toBe(false);
+    unmount();
+  });
+
+  it('retains a complete timeline after a non-404 foreground failure', async () => {
+    mockGetTimeline
+      .mockResolvedValueOnce(timeline('Arrival'))
+      .mockRejectedValueOnce(
+        axiosErrorWith(500, { detail: 'Timeline is temporarily unavailable.' }),
+      );
+    const { result, unmount } = await renderHook(() => useTimeline('trip-1'));
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    await act(async () => {
+      latestForegroundCallback()();
+    });
+
+    await waitFor(() =>
+      expect(result.current.error?.message).toBe(
+        'Timeline is temporarily unavailable.',
+      ),
+    );
+    expect(result.current.status).toBe('ready');
+    expect(result.current.timeline?.sections[0]?.label).toBe('Arrival');
+    unmount();
+  });
+
+  it('clears a complete timeline when the current trip becomes unavailable', async () => {
+    mockGetTimeline
+      .mockResolvedValueOnce(timeline('Arrival'))
+      .mockRejectedValueOnce(
+        axiosErrorWith(404, {
+          detail: 'Trip not found.',
+          error_code: 'TRIP_NOT_FOUND',
+        }),
+      );
+    const { result, unmount } = await renderHook(() => useTimeline('trip-1'));
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    await act(async () => {
+      latestForegroundCallback()();
+    });
+
+    await waitFor(() => expect(result.current.status).toBe('error'));
+    expect(result.current.timeline).toBeNull();
+    expect(result.current.error).toMatchObject({
+      message: 'Trip not found.',
+      errorCode: 'TRIP_NOT_FOUND',
+      status: 404,
+    });
+    unmount();
+  });
+
+  it('reconciles only same-trip timeline events', async () => {
+    mockGetTimeline
+      .mockResolvedValueOnce(timeline('Arrival'))
+      .mockResolvedValueOnce(timeline('Event update'));
+    const { result, unmount } = await renderHook(() => useTimeline('trip-1'));
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      publishTimelineEvent({ type: 'timelineChanged', tripId: 'trip-2' });
+    });
+    expect(mockGetTimeline).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      publishTimelineEvent({ type: 'timelineChanged', tripId: 'trip-1' });
+    });
+    await waitFor(() =>
+      expect(result.current.timeline?.sections[0]?.label).toBe('Event update'),
+    );
+    expect(mockGetTimeline).toHaveBeenCalledTimes(2);
+    unmount();
+  });
+
+  it('does not own focus, foreground, or events when auto reconciliation is disabled', async () => {
+    mockGetTimeline.mockResolvedValue(timeline('Manual load'));
+    const { result, unmount } = await renderHook(() =>
+      useTimeline('trip-1', { autoReconcile: false }),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+      latestForegroundCallback()();
+      publishTimelineEvent({ type: 'timelineChanged', tripId: 'trip-1' });
+    });
+    expect(mockGetTimeline).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.refresh('initial');
+    });
+    expect(result.current.timeline?.sections[0]?.label).toBe('Manual load');
+    unmount();
+  });
+
+  it('invalidates a pending coordinator request when the screen blurs', async () => {
+    const pending = deferred<TimelineResponse>();
+    mockGetTimeline.mockReturnValue(pending.promise);
+    const { result, unmount } = await renderHook(() =>
+      useTimeline('trip-1', { autoReconcile: false }),
+    );
+
+    let cleanup: (() => void) | void;
+    await act(async () => {
+      cleanup = latestFocusCallback()();
+      void result.current.refresh('initial');
+    });
+    await act(async () => {
+      cleanup?.();
+      pending.resolve(timeline('Stale'));
+    });
+
+    expect(result.current.timeline).toBeNull();
+    expect(result.current.status).toBe('loading');
+    unmount();
+  });
+
+  it('hides the old resource immediately and ignores its late completion after a key change', async () => {
+    const first = deferred<TimelineResponse>();
+    const second = deferred<TimelineResponse>();
+    mockGetTimeline
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const { result, rerender, unmount } = await renderHook(
+      ({ tripId }: { tripId: string }) => useTimeline(tripId),
+      { initialProps: { tripId: 'trip-1' } },
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await rerender({ tripId: 'trip-2' });
+    expect(result.current.timeline).toBeNull();
+    expect(result.current.status).toBe('loading');
+
+    await act(async () => {
+      latestFocusCallback()();
+      first.resolve(timeline('Wrong trip'));
+    });
+    expect(result.current.timeline).toBeNull();
+
+    await act(async () => {
+      second.resolve(timeline('Right trip'));
+    });
+    expect(result.current.timeline?.sections[0]?.label).toBe('Right trip');
+    unmount();
+  });
+
+  it('mutation invalidation prevents a pre-mutation response from overwriting reconciliation', async () => {
+    const preMutation = deferred<TimelineResponse>();
+    const postMutation = deferred<TimelineResponse>();
+    mockGetTimeline
+      .mockResolvedValueOnce(timeline('Before mutation'))
+      .mockReturnValueOnce(preMutation.promise)
+      .mockReturnValueOnce(postMutation.promise);
+    const { result, unmount } = await renderHook(() => useTimeline('trip-1'));
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      void result.current.refresh('silent');
+      result.current.invalidate();
+      void result.current.refresh('silent');
+    });
+    await act(async () => {
+      preMutation.resolve(timeline('Stale before mutation'));
+    });
+    expect(result.current.timeline?.sections[0]?.label).toBe('Before mutation');
+
+    await act(async () => {
+      postMutation.resolve(timeline('After mutation'));
+    });
+    expect(result.current.timeline?.sections[0]?.label).toBe('After mutation');
+    unmount();
+  });
+});

--- a/mobile/src/features/timeline/__tests__/useTimeline.test.tsx
+++ b/mobile/src/features/timeline/__tests__/useTimeline.test.tsx
@@ -305,6 +305,38 @@ describe('useTimeline', () => {
     unmount();
   });
 
+  it('ignores reconciliation while blurred and refreshes once on refocus', async () => {
+    mockGetTimeline
+      .mockResolvedValueOnce(timeline('Arrival'))
+      .mockResolvedValueOnce(timeline('Refocused'));
+    const { result, unmount } = await renderHook(() => useTimeline('trip-1'));
+
+    let blur: (() => void) | void;
+    await act(async () => {
+      blur = latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      blur?.();
+      latestForegroundCallback()();
+      await publishTimelineEvent({
+        type: 'timelineChanged',
+        tripId: 'trip-1',
+      });
+    });
+    expect(mockGetTimeline).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() =>
+      expect(result.current.timeline?.sections[0]?.label).toBe('Refocused'),
+    );
+    expect(mockGetTimeline).toHaveBeenCalledTimes(2);
+    unmount();
+  });
+
   it('does not own focus, foreground, or events when auto reconciliation is disabled', async () => {
     mockGetTimeline.mockResolvedValue(timeline('Manual load'));
     const { result, unmount } = await renderHook(() =>

--- a/mobile/src/features/timeline/__tests__/viewModel.test.ts
+++ b/mobile/src/features/timeline/__tests__/viewModel.test.ts
@@ -1,0 +1,420 @@
+import type {
+  LocationSuggestion,
+  ResolvedLookup,
+  TimelineActivity,
+  TimelineSection,
+} from '../types';
+import {
+  buildStructuredLocation,
+  buildTimelineListSections,
+  formatActivityTime,
+  formatSectionDate,
+  getDefaultFocusedSectionId,
+  getDefaultFocusedSectionIndex,
+  getTimelineRowKey,
+  getTodayDateInTimeZone,
+  groupActivitiesForDay,
+  sortTimelineSections,
+} from '../viewModel';
+
+function buildActivity(
+  overrides: Partial<TimelineActivity> = {},
+): TimelineActivity {
+  return {
+    id: 'activity-1',
+    title: 'Sample activity',
+    time_mode: 'AT_TIME',
+    start_time: '09:00:00',
+    end_time: null,
+    status: 'UPCOMING',
+    position: 0,
+    activity_type: {
+      kind: 'SYSTEM',
+      code: 'OTHER',
+      label: 'Other',
+      color_token: 'slate',
+      icon_key: 'tag',
+    },
+    assignee_scope: 'NONE',
+    assignee: null,
+    location: {
+      location_mode: 'MANUAL',
+      location_label: '',
+      location_note: '',
+      place: null,
+      open_url: null,
+    },
+    note: '',
+    meeting_point: '',
+    contact_name: '',
+    contact_phone: '',
+    booking_reference: '',
+    external_link: '',
+    reminder_offsets_minutes: [],
+    capabilities: {
+      can_edit: false,
+      can_delete: false,
+      can_update_status: false,
+    },
+    ...overrides,
+  };
+}
+
+function buildSection(
+  overrides: Partial<TimelineSection> = {},
+): TimelineSection {
+  return {
+    id: 'section-1',
+    section_date: '2026-06-01',
+    label: 'Day 1',
+    is_label_custom: false,
+    is_in_trip_range: true,
+    position: 0,
+    activities: [],
+    ...overrides,
+  };
+}
+
+const suggestion: LocationSuggestion = {
+  provider: 'here',
+  provider_id: 'unverified-suggestion-id',
+  title: 'Hội An',
+  subtitle: 'Quảng Nam, Việt Nam',
+};
+
+function buildLookup(
+  overrides: Partial<ResolvedLookup> = {},
+): ResolvedLookup {
+  return {
+    destination: 'Hội An, Quảng Nam, Việt Nam',
+    destination_provider: 'here',
+    destination_provider_id: 'canonical-here-id',
+    destination_lat: 15.8801,
+    destination_lng: 108.338,
+    destination_country_code: 'VN',
+    ...overrides,
+  };
+}
+
+describe('timeline view model ordering', () => {
+  it('sorts sections by date, position, then original aggregate order', () => {
+    const sections = [
+      buildSection({
+        id: 'same-first',
+        section_date: '2026-06-02',
+        position: 1,
+        label: 'Zulu',
+      }),
+      buildSection({
+        id: 'later-position',
+        section_date: '2026-06-02',
+        position: 2,
+        label: 'Alpha',
+      }),
+      buildSection({
+        id: 'earlier-date',
+        section_date: '2026-06-01',
+        position: 99,
+      }),
+      buildSection({
+        id: 'same-second',
+        section_date: '2026-06-02',
+        position: 1,
+        label: 'Alpha',
+      }),
+    ];
+
+    expect(sortTimelineSections(sections).map((section) => section.id)).toEqual([
+      'earlier-date',
+      'same-first',
+      'same-second',
+      'later-position',
+    ]);
+    expect(sections.map((section) => section.id)).toEqual([
+      'same-first',
+      'later-position',
+      'earlier-date',
+      'same-second',
+    ]);
+  });
+
+  it('groups and stably sorts all-day, scheduled, and flexible activities', () => {
+    const activities = [
+      buildActivity({
+        id: 'flex-first',
+        title: 'Zulu',
+        time_mode: 'FLEXIBLE',
+        start_time: null,
+        position: 2,
+      }),
+      buildActivity({
+        id: 'scheduled-same-first',
+        title: 'Zulu',
+        start_time: '09:00:00',
+        position: 1,
+      }),
+      buildActivity({
+        id: 'all-day-later',
+        time_mode: 'ALL_DAY',
+        start_time: null,
+        position: 5,
+      }),
+      buildActivity({
+        id: 'scheduled-null',
+        start_time: null,
+        position: 0,
+      }),
+      buildActivity({
+        id: 'all-day-earlier',
+        time_mode: 'ALL_DAY',
+        start_time: null,
+        position: 1,
+      }),
+      buildActivity({
+        id: 'scheduled-earlier',
+        start_time: '08:00:00',
+        position: 9,
+      }),
+      buildActivity({
+        id: 'scheduled-same-second',
+        title: 'Alpha',
+        start_time: '09:00:00',
+        position: 1,
+      }),
+      buildActivity({
+        id: 'flex-second',
+        title: 'Alpha',
+        time_mode: 'FLEXIBLE',
+        start_time: null,
+        position: 2,
+      }),
+    ];
+
+    const groups = groupActivitiesForDay(activities);
+
+    expect(groups.allDay.map((activity) => activity.id)).toEqual([
+      'all-day-earlier',
+      'all-day-later',
+    ]);
+    expect(groups.scheduled.map((activity) => activity.id)).toEqual([
+      'scheduled-earlier',
+      'scheduled-same-first',
+      'scheduled-same-second',
+      'scheduled-null',
+    ]);
+    expect(groups.flexible.map((activity) => activity.id)).toEqual([
+      'flex-first',
+      'flex-second',
+    ]);
+  });
+
+  it('builds typed SectionList rows with deterministic stable keys', () => {
+    const listSections = buildTimelineListSections([
+      buildSection({
+        id: 'day-2',
+        section_date: '2026-06-02',
+        activities: [],
+      }),
+      buildSection({
+        id: 'day-1',
+        section_date: '2026-06-01',
+        activities: [
+          buildActivity({
+            id: 'all-day',
+            time_mode: 'ALL_DAY',
+            start_time: null,
+          }),
+          buildActivity({ id: 'breakfast', start_time: '08:00:00' }),
+          buildActivity({
+            id: 'shopping',
+            time_mode: 'FLEXIBLE',
+            start_time: null,
+          }),
+        ],
+      }),
+    ]);
+
+    expect(listSections.map((section) => section.key)).toEqual([
+      'section:day-1',
+      'section:day-2',
+    ]);
+    expect(listSections[0].data.map(getTimelineRowKey)).toEqual([
+      'group:day-1:all-day',
+      'activity:day-1:all-day',
+      'group:day-1:scheduled',
+      'activity:day-1:breakfast',
+      'group:day-1:flexible',
+      'activity:day-1:shopping',
+    ]);
+    expect(listSections[1].data).toEqual([
+      { type: 'empty', key: 'empty:day-2' },
+    ]);
+  });
+});
+
+describe('timeline today target', () => {
+  it('computes today in the trip timezone at a UTC date boundary', () => {
+    const now = new Date('2026-06-01T17:30:00.000Z');
+
+    expect(getTodayDateInTimeZone('Asia/Ho_Chi_Minh', now)).toBe('2026-06-02');
+    expect(getTodayDateInTimeZone('America/Los_Angeles', now)).toBe(
+      '2026-06-01',
+    );
+  });
+
+  it('focuses today before applying in-range boundaries', () => {
+    const sections = [
+      buildSection({ id: 'day-1', section_date: '2026-06-01' }),
+      buildSection({
+        id: 'extra-day',
+        section_date: '2026-06-02',
+        is_in_trip_range: false,
+      }),
+    ];
+
+    expect(
+      getDefaultFocusedSectionId(
+        sections,
+        'Asia/Ho_Chi_Minh',
+        new Date('2026-06-01T17:30:00.000Z'),
+      ),
+    ).toBe('extra-day');
+  });
+
+  it('targets the nearest in-range boundary before and after the trip', () => {
+    const sections = [
+      buildSection({
+        id: 'pre-trip',
+        section_date: '2026-05-31',
+        is_in_trip_range: false,
+      }),
+      buildSection({ id: 'day-1', section_date: '2026-06-01' }),
+      buildSection({ id: 'day-2', section_date: '2026-06-02' }),
+      buildSection({
+        id: 'post-trip',
+        section_date: '2026-06-03',
+        is_in_trip_range: false,
+      }),
+    ];
+
+    expect(
+      getDefaultFocusedSectionId(
+        sections,
+        'UTC',
+        new Date('2026-05-20T12:00:00.000Z'),
+      ),
+    ).toBe('day-1');
+    expect(
+      getDefaultFocusedSectionId(
+        sections,
+        'UTC',
+        new Date('2026-06-20T12:00:00.000Z'),
+      ),
+    ).toBe('day-2');
+  });
+
+  it('returns an index aligned with the sorted SectionList sections', () => {
+    const listSections = buildTimelineListSections([
+      buildSection({ id: 'day-2', section_date: '2026-06-02' }),
+      buildSection({ id: 'day-1', section_date: '2026-06-01' }),
+    ]);
+
+    expect(
+      getDefaultFocusedSectionIndex(
+        listSections,
+        'UTC',
+        new Date('2026-06-02T12:00:00.000Z'),
+      ),
+    ).toBe(1);
+    expect(getDefaultFocusedSectionIndex([], 'UTC')).toBeNull();
+  });
+});
+
+describe('timeline formatting', () => {
+  it('formats date-only values without shifting them through a local timezone', () => {
+    expect(formatSectionDate('2026-05-31')).toBe('Sun, May 31, 2026');
+    expect(formatSectionDate('not-a-date')).toBe('not-a-date');
+  });
+
+  it.each([
+    [
+      buildActivity({
+        time_mode: 'ALL_DAY',
+        start_time: null,
+        end_time: null,
+      }),
+      'All day',
+    ],
+    [
+      buildActivity({
+        time_mode: 'FLEXIBLE',
+        start_time: null,
+        end_time: null,
+      }),
+      'Flexible',
+    ],
+    [buildActivity({ start_time: '09:05:00' }), '09:05'],
+    [
+      buildActivity({
+        time_mode: 'TIME_RANGE',
+        start_time: '09:05:00',
+        end_time: '10:45:00',
+      }),
+      '09:05 – 10:45',
+    ],
+  ])('formats activity time labels', (activity, expected) => {
+    expect(formatActivityTime(activity)).toBe(expected);
+  });
+});
+
+describe('buildStructuredLocation', () => {
+  it('uses only the successful canonical lookup id and canonical lookup values', () => {
+    expect(buildStructuredLocation(suggestion, buildLookup())).toEqual({
+      location_label: 'Hội An',
+      place: {
+        provider: 'here',
+        provider_id: 'canonical-here-id',
+        title: 'Hội An',
+        address: 'Hội An, Quảng Nam, Việt Nam',
+        lat: 15.8801,
+        lng: 108.338,
+      },
+    });
+  });
+
+  it('truncates title and address to backend code-point caps', () => {
+    const title = '😀'.repeat(201);
+    const destination = 'Đ'.repeat(256);
+    const result = buildStructuredLocation(
+      { ...suggestion, title },
+      buildLookup({ destination }),
+    );
+
+    expect(Array.from(result?.location_label ?? '')).toHaveLength(200);
+    expect(Array.from(result?.place.title ?? '')).toHaveLength(200);
+    expect(Array.from(result?.place.address ?? '')).toHaveLength(255);
+  });
+
+  it.each([
+    '',
+    '   ',
+    'x'.repeat(256),
+  ])('rejects invalid canonical id %p without suggestion-id fallback', (id) => {
+    expect(
+      buildStructuredLocation(
+        suggestion,
+        buildLookup({ destination_provider_id: id }),
+      ),
+    ).toBeNull();
+  });
+
+  it('accepts a canonical id exactly at the 255-character cap', () => {
+    const id = 'x'.repeat(255);
+    expect(
+      buildStructuredLocation(
+        suggestion,
+        buildLookup({ destination_provider_id: id }),
+      )?.place.provider_id,
+    ).toBe(id);
+  });
+});

--- a/mobile/src/features/timeline/api.ts
+++ b/mobile/src/features/timeline/api.ts
@@ -1,0 +1,177 @@
+import { apiClient } from '@/shared/api/client';
+import type {
+  CreateActivityPayload,
+  CreateCustomTypePayload,
+  CreateSectionPayload,
+  LocationSuggestion,
+  PatchActivityPayload,
+  PatchCustomTypePayload,
+  PatchSectionPayload,
+  ResolvedLocationLookup,
+  TimelineActivity,
+  TimelineCustomTypeMeta,
+  TimelineResponse,
+  TimelineSection,
+  UpdateActivityStatusPayload,
+  UpdateActivityStatusResult,
+} from './types';
+
+interface SectionResponse {
+  section: TimelineSection;
+}
+
+interface ActivityResponse {
+  activity: TimelineActivity;
+}
+
+interface CustomTypeResponse {
+  custom_type: TimelineCustomTypeMeta;
+}
+
+interface LocationSuggestionsResponse {
+  suggestions: LocationSuggestion[];
+}
+
+export async function getTimeline(
+  tripId: string,
+  signal?: AbortSignal,
+): Promise<TimelineResponse> {
+  const { data } = await apiClient.get<TimelineResponse>(
+    `/trips/${tripId}/timeline`,
+    { signal },
+  );
+  return data;
+}
+
+export async function createSection(
+  tripId: string,
+  payload: CreateSectionPayload,
+): Promise<TimelineSection> {
+  const { data } = await apiClient.post<SectionResponse>(
+    `/trips/${tripId}/timeline/sections`,
+    payload,
+  );
+  return data.section;
+}
+
+export async function patchSection(
+  tripId: string,
+  sectionId: string,
+  payload: PatchSectionPayload,
+): Promise<TimelineSection> {
+  const { data } = await apiClient.patch<SectionResponse>(
+    `/trips/${tripId}/timeline/sections/${sectionId}`,
+    payload,
+  );
+  return data.section;
+}
+
+export async function deleteSection(
+  tripId: string,
+  sectionId: string,
+): Promise<void> {
+  await apiClient.delete(`/trips/${tripId}/timeline/sections/${sectionId}`);
+}
+
+export async function createActivity(
+  tripId: string,
+  sectionId: string,
+  payload: CreateActivityPayload,
+): Promise<TimelineActivity> {
+  const { data } = await apiClient.post<ActivityResponse>(
+    `/trips/${tripId}/timeline/sections/${sectionId}/activities`,
+    payload,
+  );
+  return data.activity;
+}
+
+export async function patchActivity(
+  tripId: string,
+  activityId: string,
+  payload: PatchActivityPayload,
+): Promise<TimelineActivity> {
+  const { data } = await apiClient.patch<ActivityResponse>(
+    `/trips/${tripId}/timeline/activities/${activityId}`,
+    payload,
+  );
+  return data.activity;
+}
+
+export async function deleteActivity(
+  tripId: string,
+  activityId: string,
+): Promise<void> {
+  await apiClient.delete(
+    `/trips/${tripId}/timeline/activities/${activityId}`,
+  );
+}
+
+export async function updateActivityStatus(
+  tripId: string,
+  activityId: string,
+  payload: UpdateActivityStatusPayload,
+): Promise<UpdateActivityStatusResult> {
+  const { data } = await apiClient.post<UpdateActivityStatusResult>(
+    `/trips/${tripId}/timeline/activities/${activityId}/status`,
+    payload,
+  );
+  return data;
+}
+
+export async function createCustomType(
+  tripId: string,
+  payload: CreateCustomTypePayload,
+): Promise<TimelineCustomTypeMeta> {
+  const { data } = await apiClient.post<CustomTypeResponse>(
+    `/trips/${tripId}/timeline/custom-types`,
+    payload,
+  );
+  return data.custom_type;
+}
+
+export async function patchCustomType(
+  tripId: string,
+  typeId: string,
+  payload: PatchCustomTypePayload,
+): Promise<TimelineCustomTypeMeta> {
+  const { data } = await apiClient.patch<CustomTypeResponse>(
+    `/trips/${tripId}/timeline/custom-types/${typeId}`,
+    payload,
+  );
+  return data.custom_type;
+}
+
+export async function deleteCustomType(
+  tripId: string,
+  typeId: string,
+): Promise<void> {
+  await apiClient.delete(`/trips/${tripId}/timeline/custom-types/${typeId}`);
+}
+
+export async function suggestLocations(
+  query: string,
+  signal?: AbortSignal,
+): Promise<LocationSuggestion[]> {
+  const { data } = await apiClient.get<LocationSuggestionsResponse>(
+    '/location-search/suggest',
+    {
+      params: { q: query },
+      signal,
+    },
+  );
+  return data.suggestions;
+}
+
+export async function lookupLocation(
+  providerId: string,
+  signal?: AbortSignal,
+): Promise<ResolvedLocationLookup> {
+  const { data } = await apiClient.get<ResolvedLocationLookup>(
+    '/location-search/lookup',
+    {
+      params: { id: providerId },
+      signal,
+    },
+  );
+  return data;
+}

--- a/mobile/src/features/timeline/components/ActivityForm.tsx
+++ b/mobile/src/features/timeline/components/ActivityForm.tsx
@@ -50,10 +50,11 @@ const TIME_MODE_OPTIONS: readonly {
 
 export interface StructuredLocationEditorProps {
   value: StructuredLocationValue | null;
+  locationLabel: string;
   disabled: boolean;
   fieldErrors: Readonly<Record<string, string>>;
   onChange: (value: StructuredLocationValue) => void;
-  onUseManual: () => void;
+  onUseManual: (locationLabel?: string) => void;
 }
 
 interface ActivityFormProps {
@@ -320,12 +321,21 @@ export function ActivityForm({
     [draft, onDraftChange],
   );
 
-  const useManualLocation = useCallback(() => {
-    onDraftChange(applyActivityLocationMode(draft, 'MANUAL'), [
-      'location_mode',
-      'place',
-    ]);
-  }, [draft, onDraftChange]);
+  const useManualLocation = useCallback(
+    (locationLabel?: string) => {
+      const nextDraft = applyActivityLocationMode(draft, 'MANUAL');
+      if (locationLabel !== undefined) {
+        nextDraft.location_label = locationLabel;
+      }
+      onDraftChange(
+        nextDraft,
+        locationLabel === undefined
+          ? ['location_mode', 'place']
+          : ['location_mode', 'location_label', 'place'],
+      );
+    },
+    [draft, onDraftChange],
+  );
 
   const commitStructuredLocation = useCallback(
     (value: StructuredLocationValue) => {
@@ -388,6 +398,7 @@ export function ActivityForm({
 
   const structuredEditorProps: StructuredLocationEditorProps = {
     value: structuredValue,
+    locationLabel: draft.location_label,
     disabled,
     fieldErrors: fieldErrors as Readonly<Record<string, string>>,
     onChange: commitStructuredLocation,
@@ -594,9 +605,11 @@ export function ActivityForm({
               <InlineError message={fieldErrors.location_label} />
             ) : null}
 
-            {placeErrors.map((message) => (
-              <InlineError key={message} message={message} />
-            ))}
+            {!renderStructuredLocationEditor
+              ? placeErrors.map((message) => (
+                  <InlineError key={message} message={message} />
+                ))
+              : null}
 
             <TextField
               label="Location note"
@@ -759,7 +772,7 @@ function DefaultStructuredLocation({
         accessibilityLabel="Use manual location"
         accessibilityState={{ disabled }}
         disabled={disabled}
-        onPress={onUseManual}
+        onPress={() => onUseManual()}
         style={({ pressed }) => [
           styles.manualAction,
           disabled ? styles.disabled : null,

--- a/mobile/src/features/timeline/components/ActivityForm.tsx
+++ b/mobile/src/features/timeline/components/ActivityForm.tsx
@@ -1,0 +1,902 @@
+import { memo, type ReactNode, useCallback, useMemo } from 'react';
+import {
+  FlatList,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  type ListRenderItemInfo,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import type { ApiError } from '@/shared/api/errors';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { Button } from '@/shared/ui/Button';
+import { FormError } from '@/shared/ui/FormError';
+import { TextField } from '@/shared/ui/TextField';
+import type { TripMember } from '@/features/trips/types';
+import {
+  ACTIVITY_FIELD_LIMITS,
+  applyActivityLocationMode,
+  applyActivityTimeMode,
+  getSelectableCustomTypes,
+  toggleActivityReminder,
+  type ActivityDraftField,
+  type ActivityFormDraft,
+  type ActivityFormFieldErrors,
+} from '../formModel';
+import type {
+  TimelineActivity,
+  TimelineActivityTimeMode,
+  TimelineCustomTypeMeta,
+  TimelineSystemTypeMeta,
+} from '../types';
+import type { StructuredLocationValue } from '../viewModel';
+import { ReminderPicker } from './ReminderPicker';
+import { TimeField } from './TimeField';
+
+const TIME_MODE_OPTIONS: readonly {
+  value: TimelineActivityTimeMode;
+  label: string;
+}[] = [
+  { value: 'AT_TIME', label: 'At time' },
+  { value: 'TIME_RANGE', label: 'Time range' },
+  { value: 'ALL_DAY', label: 'All day' },
+  { value: 'FLEXIBLE', label: 'Flexible' },
+];
+
+export interface StructuredLocationEditorProps {
+  value: StructuredLocationValue | null;
+  disabled: boolean;
+  fieldErrors: Readonly<Record<string, string>>;
+  onChange: (value: StructuredLocationValue) => void;
+  onUseManual: () => void;
+}
+
+interface ActivityFormProps {
+  mode: 'create' | 'edit';
+  draft: ActivityFormDraft;
+  initialActivity?: TimelineActivity;
+  systemTypes: readonly TimelineSystemTypeMeta[];
+  customTypes: readonly TimelineCustomTypeMeta[];
+  members: readonly TripMember[];
+  canManageCustomTypes: boolean;
+  canSubmit: boolean;
+  authorityMessage?: string;
+  submitting: boolean;
+  refreshing: boolean;
+  localFieldErrors: ActivityFormFieldErrors;
+  submitError: ApiError | null;
+  backgroundError: ApiError | null;
+  onDraftChange: (
+    draft: ActivityFormDraft,
+    changedFields: readonly ActivityDraftField[],
+  ) => void;
+  onSubmit: () => void;
+  onRefresh: () => void;
+  onRetryBackground: () => void;
+  onManageCustomTypes: () => void;
+  renderStructuredLocationEditor?: (
+    props: StructuredLocationEditorProps,
+  ) => ReactNode;
+}
+
+interface ChoiceChipProps {
+  label: string;
+  accessibilityLabel: string;
+  selected: boolean;
+  disabled: boolean;
+  onPress: () => void;
+}
+
+const ChoiceChip = memo(function ChoiceChip({
+  label,
+  accessibilityLabel,
+  selected,
+  disabled,
+  onPress,
+}: ChoiceChipProps) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      accessibilityState={{ disabled, selected }}
+      disabled={disabled}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.chip,
+        selected ? styles.chipSelected : null,
+        disabled ? styles.disabled : null,
+        pressed && !disabled ? styles.pressed : null,
+      ]}
+    >
+      <Text
+        style={[styles.chipText, selected ? styles.chipTextSelected : null]}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+});
+
+interface CustomTypeChoiceProps {
+  item: TimelineCustomTypeMeta;
+  selected: boolean;
+  disabled: boolean;
+  onSelect: (id: string) => void;
+}
+
+const CustomTypeChoice = memo(function CustomTypeChoice({
+  item,
+  selected,
+  disabled,
+  onSelect,
+}: CustomTypeChoiceProps) {
+  const select = useCallback(() => onSelect(item.id), [item.id, onSelect]);
+  return (
+    <ChoiceChip
+      label={`${item.name}${item.is_active ? '' : ' · inactive'}`}
+      accessibilityLabel={`Custom type ${item.name}${item.is_active ? '' : ', inactive'}`}
+      selected={selected}
+      disabled={disabled}
+      onPress={select}
+    />
+  );
+});
+
+interface MemberChoiceProps {
+  item: TripMember;
+  selected: boolean;
+  disabled: boolean;
+  onSelect: (id: string) => void;
+}
+
+const MemberChoice = memo(function MemberChoice({
+  item,
+  selected,
+  disabled,
+  onSelect,
+}: MemberChoiceProps) {
+  const select = useCallback(
+    () => onSelect(item.user.id),
+    [item.user.id, onSelect],
+  );
+  return (
+    <ChoiceChip
+      label={item.user.display_name}
+      accessibilityLabel={`Assign to ${item.user.display_name}`}
+      selected={selected}
+      disabled={disabled}
+      onPress={select}
+    />
+  );
+});
+
+function EmptyCustomTypes() {
+  return <Text style={styles.emptyChoice}>No custom types available.</Text>;
+}
+
+function EmptyMembers() {
+  return <Text style={styles.emptyChoice}>No active members available.</Text>;
+}
+
+export function ActivityForm({
+  mode,
+  draft,
+  initialActivity,
+  systemTypes,
+  customTypes,
+  members,
+  canManageCustomTypes,
+  canSubmit,
+  authorityMessage,
+  submitting,
+  refreshing,
+  localFieldErrors,
+  submitError,
+  backgroundError,
+  onDraftChange,
+  onSubmit,
+  onRefresh,
+  onRetryBackground,
+  onManageCustomTypes,
+  renderStructuredLocationEditor,
+}: ActivityFormProps) {
+  const fieldErrors = useMemo<ActivityFormFieldErrors>(
+    () => ({
+      ...(submitError?.fieldErrors ?? {}),
+      ...localFieldErrors,
+    }),
+    [localFieldErrors, submitError?.fieldErrors],
+  );
+  const selectableCustomTypes = useMemo(
+    () => getSelectableCustomTypes(customTypes, initialActivity),
+    [customTypes, initialActivity],
+  );
+  const disabled = submitting || !canSubmit;
+  const activityTypeError = firstError(
+    fieldErrors,
+    'activity_type',
+    'system_type',
+    'custom_type_id',
+  );
+  const assigneeError = firstError(
+    fieldErrors,
+    'assignee_user_id',
+    'assignee_scope',
+  );
+  const placeErrors = useMemo(
+    () => collectPlaceErrors(fieldErrors),
+    [fieldErrors],
+  );
+  const structuredValue = useMemo<StructuredLocationValue | null>(() => {
+    if (draft.location_mode !== 'STRUCTURED' || draft.place === null) {
+      return null;
+    }
+    return {
+      location_label: draft.location_label,
+      place: { ...draft.place },
+    };
+  }, [draft.location_label, draft.location_mode, draft.place]);
+
+  const changeField = useCallback(
+    <K extends ActivityDraftField>(
+      field: K,
+      value: ActivityFormDraft[K],
+    ) => {
+      onDraftChange({ ...draft, [field]: value }, [field]);
+    },
+    [draft, onDraftChange],
+  );
+
+  const selectTimeMode = useCallback(
+    (timeMode: TimelineActivityTimeMode) => {
+      onDraftChange(applyActivityTimeMode(draft, timeMode), [
+        'time_mode',
+        'start_time',
+        'end_time',
+        'reminder_offsets_minutes',
+      ]);
+    },
+    [draft, onDraftChange],
+  );
+
+  const selectSystemType = useCallback(
+    (code: TimelineSystemTypeMeta['code']) => {
+      onDraftChange(
+        {
+          ...draft,
+          system_type: code,
+          custom_type_id: null,
+        },
+        ['system_type', 'custom_type_id'],
+      );
+    },
+    [draft, onDraftChange],
+  );
+
+  const selectCustomType = useCallback(
+    (id: string) => {
+      onDraftChange(
+        {
+          ...draft,
+          system_type: null,
+          custom_type_id: id,
+        },
+        ['system_type', 'custom_type_id'],
+      );
+    },
+    [draft, onDraftChange],
+  );
+
+  const selectAssigneeScope = useCallback(
+    (scope: 'NONE' | 'EVERYONE') => {
+      onDraftChange(
+        {
+          ...draft,
+          assignee_scope: scope,
+          assignee_user_id: null,
+        },
+        ['assignee_scope', 'assignee_user_id'],
+      );
+    },
+    [draft, onDraftChange],
+  );
+
+  const selectMember = useCallback(
+    (id: string) => {
+      onDraftChange(
+        {
+          ...draft,
+          assignee_scope: 'USER',
+          assignee_user_id: id,
+        },
+        ['assignee_scope', 'assignee_user_id'],
+      );
+    },
+    [draft, onDraftChange],
+  );
+
+  const useManualLocation = useCallback(() => {
+    onDraftChange(applyActivityLocationMode(draft, 'MANUAL'), [
+      'location_mode',
+      'place',
+    ]);
+  }, [draft, onDraftChange]);
+
+  const commitStructuredLocation = useCallback(
+    (value: StructuredLocationValue) => {
+      onDraftChange(
+        {
+          ...draft,
+          location_mode: 'STRUCTURED',
+          location_label: value.location_label,
+          place: { ...value.place },
+        },
+        ['location_mode', 'location_label', 'place'],
+      );
+    },
+    [draft, onDraftChange],
+  );
+
+  const toggleReminder = useCallback(
+    (value: number) => {
+      const nextDraft = toggleActivityReminder(draft, value);
+      if (nextDraft !== draft) {
+        onDraftChange(nextDraft, ['reminder_offsets_minutes']);
+      }
+    },
+    [draft, onDraftChange],
+  );
+
+  const renderCustomType = useCallback(
+    ({ item }: ListRenderItemInfo<TimelineCustomTypeMeta>) => (
+      <CustomTypeChoice
+        item={item}
+        selected={
+          draft.system_type === null && draft.custom_type_id === item.id
+        }
+        disabled={disabled}
+        onSelect={selectCustomType}
+      />
+    ),
+    [disabled, draft.custom_type_id, draft.system_type, selectCustomType],
+  );
+
+  const renderMember = useCallback(
+    ({ item }: ListRenderItemInfo<TripMember>) => (
+      <MemberChoice
+        item={item}
+        selected={
+          draft.assignee_scope === 'USER' &&
+          draft.assignee_user_id === item.user.id
+        }
+        disabled={disabled}
+        onSelect={selectMember}
+      />
+    ),
+    [
+      disabled,
+      draft.assignee_scope,
+      draft.assignee_user_id,
+      selectMember,
+    ],
+  );
+
+  const structuredEditorProps: StructuredLocationEditorProps = {
+    value: structuredValue,
+    disabled,
+    fieldErrors: fieldErrors as Readonly<Record<string, string>>,
+    onChange: commitStructuredLocation,
+    onUseManual: useManualLocation,
+  };
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['left', 'right', 'bottom']}>
+      <KeyboardAvoidingView
+        style={styles.fill}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ScrollView
+          testID="activity-form-scroll"
+          contentContainerStyle={styles.content}
+          contentInsetAdjustmentBehavior="automatic"
+          keyboardShouldPersistTaps="handled"
+          refreshControl={
+            <RefreshControl
+              testID="activity-form-refresh-control"
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+            />
+          }
+        >
+          {backgroundError ? (
+            <View accessibilityRole="alert" style={styles.errorBanner}>
+              <Text style={styles.errorBannerText}>
+                {backgroundError.message}
+              </Text>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Retry refreshing activity form"
+                onPress={onRetryBackground}
+                style={({ pressed }) => [
+                  styles.retry,
+                  pressed ? styles.pressed : null,
+                ]}
+              >
+                <Text style={styles.retryText}>Retry</Text>
+              </Pressable>
+            </View>
+          ) : null}
+
+          <FormSection title="Basics">
+            <TextField
+              label="Title *"
+              accessibilityLabel="Activity title"
+              value={draft.title}
+              onChangeText={(value) => changeField('title', value)}
+              maxLength={ACTIVITY_FIELD_LIMITS.title}
+              editable={!disabled}
+              error={fieldErrors.title}
+            />
+          </FormSection>
+
+          <FormSection title="Schedule">
+            <View style={styles.chipWrap}>
+              {TIME_MODE_OPTIONS.map((option) => (
+                <ChoiceChip
+                  key={option.value}
+                  label={option.label}
+                  accessibilityLabel={`Schedule ${option.label}`}
+                  selected={draft.time_mode === option.value}
+                  disabled={disabled}
+                  onPress={() => selectTimeMode(option.value)}
+                />
+              ))}
+            </View>
+            {fieldErrors.time_mode ? (
+              <InlineError message={fieldErrors.time_mode} />
+            ) : null}
+            {draft.time_mode === 'AT_TIME' ||
+            draft.time_mode === 'TIME_RANGE' ? (
+              <TimeField
+                label="Start time *"
+                value={draft.start_time}
+                onChange={(value) => changeField('start_time', value)}
+                disabled={disabled}
+                error={fieldErrors.start_time}
+              />
+            ) : null}
+            {draft.time_mode === 'TIME_RANGE' ? (
+              <TimeField
+                label="End time *"
+                value={draft.end_time}
+                onChange={(value) => changeField('end_time', value)}
+                disabled={disabled}
+                error={fieldErrors.end_time}
+              />
+            ) : null}
+          </FormSection>
+
+          <FormSection title="Activity type *">
+            <Text style={styles.optionLabel}>System types</Text>
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.choiceRow}
+            >
+              {systemTypes.map((systemType) => (
+                <ChoiceChip
+                  key={systemType.code}
+                  label={systemType.label}
+                  accessibilityLabel={`System type ${systemType.label}`}
+                  selected={draft.system_type === systemType.code}
+                  disabled={disabled}
+                  onPress={() => selectSystemType(systemType.code)}
+                />
+              ))}
+            </ScrollView>
+
+            <View style={styles.optionHeading}>
+              <Text style={styles.optionLabel}>Custom types</Text>
+              {canManageCustomTypes ? (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Manage custom types"
+                  disabled={submitting}
+                  onPress={onManageCustomTypes}
+                  style={({ pressed }) => [
+                    styles.textAction,
+                    pressed && !submitting ? styles.pressed : null,
+                  ]}
+                >
+                  <Text style={styles.textActionLabel}>Manage</Text>
+                </Pressable>
+              ) : null}
+            </View>
+            <FlatList
+              testID="custom-type-list"
+              horizontal
+              data={selectableCustomTypes}
+              keyExtractor={customTypeKey}
+              renderItem={renderCustomType}
+              ListEmptyComponent={EmptyCustomTypes}
+              contentContainerStyle={styles.choiceRow}
+              showsHorizontalScrollIndicator={false}
+              keyboardShouldPersistTaps="handled"
+            />
+            {activityTypeError ? (
+              <InlineError message={activityTypeError} />
+            ) : null}
+          </FormSection>
+
+          <FormSection title="Assignee">
+            <View style={styles.chipWrap}>
+              <ChoiceChip
+                label="None"
+                accessibilityLabel="Assign to no one"
+                selected={draft.assignee_scope === 'NONE'}
+                disabled={disabled}
+                onPress={() => selectAssigneeScope('NONE')}
+              />
+              <ChoiceChip
+                label="Everyone"
+                accessibilityLabel="Assign to everyone"
+                selected={draft.assignee_scope === 'EVERYONE'}
+                disabled={disabled}
+                onPress={() => selectAssigneeScope('EVERYONE')}
+              />
+            </View>
+            <FlatList
+              testID="assignee-member-list"
+              horizontal
+              data={members}
+              keyExtractor={memberKey}
+              renderItem={renderMember}
+              ListEmptyComponent={EmptyMembers}
+              contentContainerStyle={styles.choiceRow}
+              showsHorizontalScrollIndicator={false}
+              keyboardShouldPersistTaps="handled"
+            />
+            {assigneeError ? <InlineError message={assigneeError} /> : null}
+          </FormSection>
+
+          <FormSection title="Location">
+            {renderStructuredLocationEditor
+              ? renderStructuredLocationEditor(structuredEditorProps)
+              : null}
+
+            {draft.location_mode === 'STRUCTURED' &&
+            !renderStructuredLocationEditor ? (
+              <DefaultStructuredLocation
+                value={structuredValue}
+                disabled={disabled}
+                onUseManual={useManualLocation}
+              />
+            ) : null}
+
+            {draft.location_mode === 'MANUAL' ? (
+              <TextField
+                label="Location label"
+                accessibilityLabel="Location label"
+                value={draft.location_label}
+                onChangeText={(value) =>
+                  changeField('location_label', value)
+                }
+                maxLength={ACTIVITY_FIELD_LIMITS.location_label}
+                editable={!disabled}
+                error={fieldErrors.location_label}
+              />
+            ) : fieldErrors.location_label ? (
+              <InlineError message={fieldErrors.location_label} />
+            ) : null}
+
+            {placeErrors.map((message) => (
+              <InlineError key={message} message={message} />
+            ))}
+
+            <TextField
+              label="Location note"
+              accessibilityLabel="Location note"
+              value={draft.location_note}
+              onChangeText={(value) => changeField('location_note', value)}
+              maxLength={ACTIVITY_FIELD_LIMITS.location_note}
+              editable={!disabled}
+              error={fieldErrors.location_note}
+            />
+          </FormSection>
+
+          <FormSection title="Details">
+            <TextField
+              label="Note"
+              accessibilityLabel="Activity note"
+              value={draft.note}
+              onChangeText={(value) => changeField('note', value)}
+              multiline
+              numberOfLines={4}
+              editable={!disabled}
+              error={fieldErrors.note}
+            />
+            <TextField
+              label="Meeting point"
+              accessibilityLabel="Meeting point"
+              value={draft.meeting_point}
+              onChangeText={(value) => changeField('meeting_point', value)}
+              maxLength={ACTIVITY_FIELD_LIMITS.meeting_point}
+              editable={!disabled}
+              error={fieldErrors.meeting_point}
+            />
+            <TextField
+              label="Contact name"
+              accessibilityLabel="Contact name"
+              value={draft.contact_name}
+              onChangeText={(value) => changeField('contact_name', value)}
+              maxLength={ACTIVITY_FIELD_LIMITS.contact_name}
+              editable={!disabled}
+              error={fieldErrors.contact_name}
+            />
+            <TextField
+              label="Contact phone"
+              accessibilityLabel="Contact phone"
+              value={draft.contact_phone}
+              onChangeText={(value) => changeField('contact_phone', value)}
+              maxLength={ACTIVITY_FIELD_LIMITS.contact_phone}
+              keyboardType="phone-pad"
+              editable={!disabled}
+              error={fieldErrors.contact_phone}
+            />
+            <TextField
+              label="Booking reference"
+              accessibilityLabel="Booking reference"
+              value={draft.booking_reference}
+              onChangeText={(value) =>
+                changeField('booking_reference', value)
+              }
+              maxLength={ACTIVITY_FIELD_LIMITS.booking_reference}
+              editable={!disabled}
+              error={fieldErrors.booking_reference}
+            />
+            <TextField
+              label="External link"
+              accessibilityLabel="External link"
+              value={draft.external_link}
+              onChangeText={(value) => changeField('external_link', value)}
+              maxLength={ACTIVITY_FIELD_LIMITS.external_link}
+              keyboardType="url"
+              autoCapitalize="none"
+              autoCorrect={false}
+              editable={!disabled}
+              error={fieldErrors.external_link}
+            />
+          </FormSection>
+
+          <FormSection title="Notifications">
+            <ReminderPicker
+              value={draft.reminder_offsets_minutes}
+              enabled={
+                (draft.time_mode === 'AT_TIME' ||
+                  draft.time_mode === 'TIME_RANGE') &&
+                draft.start_time.length > 0
+              }
+              disabled={disabled}
+              error={fieldErrors.reminder_offsets_minutes}
+              onToggle={toggleReminder}
+            />
+            <Text style={styles.notificationBoundary}>
+              Reminders are delivered by GoPlan through the existing
+              Notifications tab. This form does not schedule device
+              notifications.
+            </Text>
+          </FormSection>
+        </ScrollView>
+
+        <View style={styles.footer}>
+          <FormError error={submitError} />
+          {authorityMessage ? (
+            <Text accessibilityRole="alert" style={styles.authorityMessage}>
+              {authorityMessage}
+            </Text>
+          ) : null}
+          <Button
+            title={mode === 'create' ? 'Create activity' : 'Save changes'}
+            onPress={onSubmit}
+            loading={submitting}
+            disabled={!canSubmit}
+          />
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+function FormSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <View style={styles.section}>
+      <Text accessibilityRole="header" style={styles.sectionTitle}>
+        {title}
+      </Text>
+      {children}
+    </View>
+  );
+}
+
+function InlineError({ message }: { message: string }) {
+  return (
+    <Text accessibilityRole="alert" style={styles.inlineError}>
+      {message}
+    </Text>
+  );
+}
+
+function DefaultStructuredLocation({
+  value,
+  disabled,
+  onUseManual,
+}: {
+  value: StructuredLocationValue | null;
+  disabled: boolean;
+  onUseManual: () => void;
+}) {
+  return (
+    <View style={styles.structuredCard}>
+      <Text style={styles.structuredTitle}>
+        {value?.place.title || value?.location_label || 'Verified place'}
+      </Text>
+      {value?.place.address ? (
+        <Text style={styles.structuredAddress}>{value.place.address}</Text>
+      ) : null}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Use manual location"
+        accessibilityState={{ disabled }}
+        disabled={disabled}
+        onPress={onUseManual}
+        style={({ pressed }) => [
+          styles.manualAction,
+          disabled ? styles.disabled : null,
+          pressed && !disabled ? styles.pressed : null,
+        ]}
+      >
+        <Text style={styles.manualActionText}>Use manual location</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function firstError(
+  errors: ActivityFormFieldErrors,
+  ...fields: (keyof ActivityFormFieldErrors)[]
+): string | undefined {
+  for (const field of fields) {
+    const message = errors[field];
+    if (message) {
+      return message;
+    }
+  }
+  return undefined;
+}
+
+function collectPlaceErrors(errors: ActivityFormFieldErrors): string[] {
+  const messages = new Set<string>();
+  for (const [field, message] of Object.entries(errors)) {
+    if ((field === 'place' || field.startsWith('place.')) && message) {
+      messages.add(message);
+    }
+  }
+  return [...messages];
+}
+
+function customTypeKey(item: TimelineCustomTypeMeta): string {
+  return item.id;
+}
+
+function memberKey(item: TripMember): string {
+  return item.user.id;
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.background },
+  fill: { flex: 1 },
+  content: { gap: spacing.md, padding: spacing.lg },
+  section: {
+    gap: spacing.md,
+    padding: spacing.md,
+    borderRadius: radii.lg,
+    backgroundColor: colors.surface,
+  },
+  sectionTitle: { ...typography.heading, color: colors.text },
+  optionHeading: {
+    minHeight: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
+  },
+  optionLabel: { ...typography.label, color: colors.text },
+  choiceRow: { gap: spacing.sm },
+  chipWrap: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm },
+  chip: {
+    minHeight: 44,
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    paddingHorizontal: spacing.md,
+    backgroundColor: colors.background,
+  },
+  chipSelected: {
+    borderColor: colors.primary,
+    backgroundColor: colors.primarySoft,
+  },
+  chipText: { ...typography.label, color: colors.textMuted },
+  chipTextSelected: { color: colors.primary },
+  disabled: { opacity: 0.55 },
+  pressed: { opacity: 0.55 },
+  emptyChoice: {
+    ...typography.caption,
+    color: colors.textMuted,
+    minHeight: 44,
+    textAlignVertical: 'center',
+  },
+  textAction: {
+    minHeight: 44,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.sm,
+  },
+  textActionLabel: { ...typography.label, color: colors.primary },
+  structuredCard: {
+    gap: spacing.xs,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    backgroundColor: colors.background,
+  },
+  structuredTitle: { ...typography.body, color: colors.text },
+  structuredAddress: { ...typography.caption, color: colors.textMuted },
+  manualAction: {
+    minHeight: 44,
+    alignSelf: 'flex-start',
+    justifyContent: 'center',
+  },
+  manualActionText: { ...typography.label, color: colors.primary },
+  notificationBoundary: { ...typography.caption, color: colors.textMuted },
+  inlineError: { ...typography.caption, color: colors.danger },
+  errorBanner: {
+    minHeight: 56,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.dangerBorder,
+    borderRadius: radii.md,
+    backgroundColor: colors.dangerSoft,
+  },
+  errorBannerText: { ...typography.caption, color: colors.danger, flex: 1 },
+  retry: { minHeight: 44, justifyContent: 'center' },
+  retryText: { ...typography.label, color: colors.danger },
+  footer: {
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.sm,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    backgroundColor: colors.background,
+  },
+  authorityMessage: {
+    ...typography.caption,
+    color: colors.danger,
+    textAlign: 'center',
+  },
+});

--- a/mobile/src/features/timeline/components/ActivityRow.tsx
+++ b/mobile/src/features/timeline/components/ActivityRow.tsx
@@ -7,6 +7,7 @@ import {
   Text,
   View,
 } from 'react-native';
+import type { ApiError } from '@/shared/api/errors';
 import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
 import { ActivityStatusControls } from './ActivityStatusControls';
 import { getTimelineIconName, getTimelineTokenColors } from '../tokenMaps';
@@ -25,6 +26,7 @@ interface ActivityRowProps {
     activityId: string,
     nextStatus: TimelineActivityStatus,
   ) => Promise<void>;
+  statusError?: ApiError | null;
 }
 
 interface DetailLineProps {
@@ -97,6 +99,7 @@ function ActivityRowComponent({
   onEdit,
   onDelete,
   onChangeStatus,
+  statusError,
 }: ActivityRowProps) {
   const [expanded, setExpanded] = useState(false);
   const [linkNotice, setLinkNotice] = useState<string | null>(null);
@@ -311,9 +314,17 @@ function ActivityRowComponent({
             <ActivityStatusControls
               activity={activity}
               disabled={actionsDisabled}
+              error={statusError === undefined ? undefined : null}
               onChangeStatus={changeStatus}
             />
           ) : null}
+        </View>
+      ) : null}
+
+      {statusError ? (
+        <View accessibilityRole="alert" style={styles.linkNotice}>
+          <Ionicons name="alert-circle-outline" size={16} color={colors.danger} />
+          <Text style={styles.linkNoticeText}>{statusError.message}</Text>
         </View>
       ) : null}
 

--- a/mobile/src/features/timeline/components/ActivityRow.tsx
+++ b/mobile/src/features/timeline/components/ActivityRow.tsx
@@ -8,6 +8,7 @@ import {
   View,
 } from 'react-native';
 import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { ActivityStatusControls } from './ActivityStatusControls';
 import { getTimelineIconName, getTimelineTokenColors } from '../tokenMaps';
 import type {
   TimelineActivity,
@@ -17,8 +18,13 @@ import { formatActivityTime } from '../viewModel';
 
 interface ActivityRowProps {
   activity: TimelineActivity;
+  actionsDisabled?: boolean;
   onEdit?: (activityId: string) => void;
   onDelete?: (activityId: string) => void;
+  onChangeStatus?: (
+    activityId: string,
+    nextStatus: TimelineActivityStatus,
+  ) => Promise<void>;
 }
 
 interface DetailLineProps {
@@ -87,8 +93,10 @@ function DetailLine({ icon, label, value }: DetailLineProps) {
 
 function ActivityRowComponent({
   activity,
+  actionsDisabled = false,
   onEdit,
   onDelete,
+  onChangeStatus,
 }: ActivityRowProps) {
   const [expanded, setExpanded] = useState(false);
   const [linkNotice, setLinkNotice] = useState<string | null>(null);
@@ -163,6 +171,12 @@ function ActivityRowComponent({
   const deleteActivity = useCallback(() => {
     onDelete?.(activity.id);
   }, [activity.id, onDelete]);
+
+  const changeStatus = useCallback(
+    (nextStatus: TimelineActivityStatus) =>
+      onChangeStatus?.(activity.id, nextStatus) ?? Promise.resolve(),
+    [activity.id, onChangeStatus],
+  );
 
   return (
     <View
@@ -293,6 +307,13 @@ function ActivityRowComponent({
               <Ionicons name="open-outline" size={14} color={colors.primary} />
             </Pressable>
           ) : null}
+          {onChangeStatus ? (
+            <ActivityStatusControls
+              activity={activity}
+              disabled={actionsDisabled}
+              onChangeStatus={changeStatus}
+            />
+          ) : null}
         </View>
       ) : null}
 
@@ -310,10 +331,12 @@ function ActivityRowComponent({
             <Pressable
               accessibilityRole="button"
               accessibilityLabel={`Edit ${activity.title}`}
+              accessibilityState={{ disabled: actionsDisabled }}
+              disabled={actionsDisabled}
               onPress={editActivity}
               style={({ pressed }) => [
                 styles.actionButton,
-                pressed ? styles.pressed : null,
+                pressed || actionsDisabled ? styles.pressed : null,
               ]}
             >
               <Ionicons name="create-outline" size={16} color={colors.primary} />
@@ -324,10 +347,12 @@ function ActivityRowComponent({
             <Pressable
               accessibilityRole="button"
               accessibilityLabel={`Delete ${activity.title}`}
+              accessibilityState={{ disabled: actionsDisabled }}
+              disabled={actionsDisabled}
               onPress={deleteActivity}
               style={({ pressed }) => [
                 styles.actionButton,
-                pressed ? styles.pressed : null,
+                pressed || actionsDisabled ? styles.pressed : null,
               ]}
             >
               <Ionicons name="trash-outline" size={16} color={colors.danger} />

--- a/mobile/src/features/timeline/components/ActivityRow.tsx
+++ b/mobile/src/features/timeline/components/ActivityRow.tsx
@@ -1,0 +1,459 @@
+import { Ionicons } from '@expo/vector-icons';
+import { memo, useCallback, useMemo, useState } from 'react';
+import {
+  Linking,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { getTimelineIconName, getTimelineTokenColors } from '../tokenMaps';
+import type {
+  TimelineActivity,
+  TimelineActivityStatus,
+} from '../types';
+import { formatActivityTime } from '../viewModel';
+
+interface ActivityRowProps {
+  activity: TimelineActivity;
+  onEdit?: (activityId: string) => void;
+  onDelete?: (activityId: string) => void;
+}
+
+interface DetailLineProps {
+  icon: React.ComponentProps<typeof Ionicons>['name'];
+  label: string;
+  value: string;
+}
+
+const STATUS_META: Record<
+  TimelineActivityStatus,
+  { label: string; color: string; backgroundColor: string }
+> = {
+  UPCOMING: {
+    label: 'Upcoming',
+    color: colors.completedText,
+    backgroundColor: colors.completedSoft,
+  },
+  IN_PROGRESS: {
+    label: 'In progress',
+    color: colors.primary,
+    backgroundColor: colors.primarySoft,
+  },
+  DONE: {
+    label: 'Done',
+    color: colors.success,
+    backgroundColor: colors.successSoft,
+  },
+  CANCELLED: {
+    label: 'Cancelled',
+    color: colors.danger,
+    backgroundColor: colors.dangerSoft,
+  },
+};
+
+function formatReminder(minutes: number): string {
+  if (minutes % 10_080 === 0) {
+    const weeks = minutes / 10_080;
+    return `${weeks} ${weeks === 1 ? 'week' : 'weeks'} before`;
+  }
+  if (minutes % 1_440 === 0) {
+    const days = minutes / 1_440;
+    return `${days} ${days === 1 ? 'day' : 'days'} before`;
+  }
+  if (minutes % 60 === 0) {
+    const hours = minutes / 60;
+    return `${hours} ${hours === 1 ? 'hour' : 'hours'} before`;
+  }
+  return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'} before`;
+}
+
+function DetailLine({ icon, label, value }: DetailLineProps) {
+  if (!value) {
+    return null;
+  }
+
+  return (
+    <View style={styles.detailLine}>
+      <Ionicons name={icon} size={16} color={colors.textMuted} />
+      <View style={styles.detailText}>
+        <Text style={styles.detailLabel}>{label}</Text>
+        <Text style={styles.detailValue}>{value}</Text>
+      </View>
+    </View>
+  );
+}
+
+function ActivityRowComponent({
+  activity,
+  onEdit,
+  onDelete,
+}: ActivityRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [linkNotice, setLinkNotice] = useState<string | null>(null);
+  const typeColors = getTimelineTokenColors(
+    activity.activity_type?.color_token,
+  );
+  const typeIcon = getTimelineIconName(activity.activity_type?.icon_key);
+  const typeLabel = activity.activity_type?.label || 'Other';
+  const statusMeta = STATUS_META[activity.status];
+  const assigneeLabel =
+    activity.assignee_scope === 'EVERYONE'
+      ? 'Everyone'
+      : activity.assignee?.display_name ?? '';
+  const locationLabel =
+    activity.location.location_label || activity.location.place?.title || '';
+  const reminders = useMemo(
+    () => activity.reminder_offsets_minutes.map(formatReminder).join(', '),
+    [activity.reminder_offsets_minutes],
+  );
+  const typeBadgeStyle = useMemo(
+    () => ({ backgroundColor: typeColors.backgroundColor }),
+    [typeColors.backgroundColor],
+  );
+  const typeBadgeTextStyle = useMemo(
+    () => ({ color: typeColors.color }),
+    [typeColors.color],
+  );
+  const statusBadgeStyle = useMemo(
+    () => ({ backgroundColor: statusMeta.backgroundColor }),
+    [statusMeta.backgroundColor],
+  );
+  const statusBadgeTextStyle = useMemo(
+    () => ({ color: statusMeta.color }),
+    [statusMeta.color],
+  );
+
+  const toggleExpanded = useCallback(() => {
+    setExpanded((current) => !current);
+  }, []);
+
+  const openExternalUrl = useCallback(async (url: string) => {
+    setLinkNotice(null);
+    try {
+      const supported = await Linking.canOpenURL(url);
+      if (!supported) {
+        setLinkNotice('Could not open this link. Try again later.');
+        return;
+      }
+      await Linking.openURL(url);
+    } catch {
+      setLinkNotice('Could not open this link. Try again later.');
+    }
+  }, []);
+
+  const openLocation = useCallback(() => {
+    const url = activity.location.open_url;
+    if (url) {
+      void openExternalUrl(url);
+    }
+  }, [activity.location.open_url, openExternalUrl]);
+
+  const openActivityLink = useCallback(() => {
+    if (activity.external_link) {
+      void openExternalUrl(activity.external_link);
+    }
+  }, [activity.external_link, openExternalUrl]);
+
+  const editActivity = useCallback(() => {
+    onEdit?.(activity.id);
+  }, [activity.id, onEdit]);
+
+  const deleteActivity = useCallback(() => {
+    onDelete?.(activity.id);
+  }, [activity.id, onDelete]);
+
+  return (
+    <View
+      style={[
+        styles.card,
+        activity.status === 'CANCELLED' ? styles.cancelledCard : null,
+      ]}
+    >
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`${expanded ? 'Collapse' : 'Expand'} ${activity.title} details`}
+        accessibilityState={{ expanded }}
+        onPress={toggleExpanded}
+        style={({ pressed }) => [
+          styles.summary,
+          pressed ? styles.pressed : null,
+        ]}
+      >
+        <View style={styles.summaryTop}>
+          <View style={styles.titleBlock}>
+            <Text style={styles.time}>{formatActivityTime(activity)}</Text>
+            <Text style={styles.title}>{activity.title}</Text>
+          </View>
+          <Ionicons
+            name={expanded ? 'chevron-up' : 'chevron-down'}
+            size={18}
+            color={colors.textMuted}
+          />
+        </View>
+
+        <View style={styles.badgeRow}>
+          <View style={[styles.typeBadge, typeBadgeStyle]}>
+            <Ionicons name={typeIcon} size={14} color={typeColors.color} />
+            <Text style={[styles.badgeText, typeBadgeTextStyle]}>
+              {typeLabel}
+            </Text>
+          </View>
+          <View style={[styles.statusBadge, statusBadgeStyle]}>
+            <Text style={[styles.badgeText, statusBadgeTextStyle]}>
+              {statusMeta.label}
+            </Text>
+          </View>
+          {assigneeLabel ? (
+            <View style={styles.assignee}>
+              <Ionicons
+                name="person-outline"
+                size={14}
+                color={colors.textMuted}
+              />
+              <Text style={styles.assigneeText}>{assigneeLabel}</Text>
+            </View>
+          ) : null}
+        </View>
+      </Pressable>
+
+      {locationLabel ? (
+        activity.location.open_url ? (
+          <Pressable
+            accessibilityRole="link"
+            accessibilityLabel={`Open directions to ${locationLabel}`}
+            onPress={openLocation}
+            style={({ pressed }) => [
+              styles.locationChip,
+              pressed ? styles.pressed : null,
+            ]}
+          >
+            <Ionicons name="location-outline" size={17} color={colors.primary} />
+            <Text numberOfLines={2} style={styles.locationText}>
+              {locationLabel}
+            </Text>
+            <Ionicons name="open-outline" size={15} color={colors.primary} />
+          </Pressable>
+        ) : (
+          <View style={styles.locationChip}>
+            <Ionicons name="location-outline" size={17} color={colors.primary} />
+            <Text numberOfLines={2} style={styles.locationText}>
+              {locationLabel}
+            </Text>
+          </View>
+        )
+      ) : null}
+
+      {expanded ? (
+        <View style={styles.details}>
+          <DetailLine icon="document-text-outline" label="Note" value={activity.note} />
+          <DetailLine
+            icon="navigate-outline"
+            label="Meeting point"
+            value={activity.meeting_point}
+          />
+          <DetailLine
+            icon="person-circle-outline"
+            label="Contact"
+            value={activity.contact_name}
+          />
+          <DetailLine
+            icon="call-outline"
+            label="Phone"
+            value={activity.contact_phone}
+          />
+          <DetailLine
+            icon="ticket-outline"
+            label="Booking reference"
+            value={activity.booking_reference}
+          />
+          <DetailLine
+            icon="information-circle-outline"
+            label="Location note"
+            value={activity.location.location_note}
+          />
+          <DetailLine
+            icon="notifications-outline"
+            label="Reminders"
+            value={reminders}
+          />
+          {activity.external_link ? (
+            <Pressable
+              accessibilityRole="link"
+              accessibilityLabel={`Open link for ${activity.title}`}
+              onPress={openActivityLink}
+              style={({ pressed }) => [
+                styles.externalLink,
+                pressed ? styles.pressed : null,
+              ]}
+            >
+              <Ionicons name="link-outline" size={16} color={colors.primary} />
+              <Text style={styles.externalLinkText}>Open link</Text>
+              <Ionicons name="open-outline" size={14} color={colors.primary} />
+            </Pressable>
+          ) : null}
+        </View>
+      ) : null}
+
+      {linkNotice ? (
+        <View accessibilityRole="alert" style={styles.linkNotice}>
+          <Ionicons name="alert-circle-outline" size={16} color={colors.danger} />
+          <Text style={styles.linkNoticeText}>{linkNotice}</Text>
+        </View>
+      ) : null}
+
+      {(activity.capabilities.can_edit && onEdit) ||
+      (activity.capabilities.can_delete && onDelete) ? (
+        <View style={styles.actionRow}>
+          {activity.capabilities.can_edit && onEdit ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={`Edit ${activity.title}`}
+              onPress={editActivity}
+              style={({ pressed }) => [
+                styles.actionButton,
+                pressed ? styles.pressed : null,
+              ]}
+            >
+              <Ionicons name="create-outline" size={16} color={colors.primary} />
+              <Text style={styles.editText}>Edit</Text>
+            </Pressable>
+          ) : null}
+          {activity.capabilities.can_delete && onDelete ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={`Delete ${activity.title}`}
+              onPress={deleteActivity}
+              style={({ pressed }) => [
+                styles.actionButton,
+                pressed ? styles.pressed : null,
+              ]}
+            >
+              <Ionicons name="trash-outline" size={16} color={colors.danger} />
+              <Text style={styles.deleteText}>Delete</Text>
+            </Pressable>
+          ) : null}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+export const ActivityRow = memo(ActivityRowComponent);
+
+const styles = StyleSheet.create({
+  card: {
+    marginHorizontal: spacing.md,
+    marginBottom: spacing.sm,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.lg,
+    backgroundColor: colors.background,
+  },
+  cancelledCard: { opacity: 0.68 },
+  summary: { gap: spacing.sm, padding: spacing.md },
+  summaryTop: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
+  },
+  titleBlock: { flex: 1, gap: spacing.xs },
+  time: { ...typography.label, color: colors.textMuted },
+  title: { ...typography.body, color: colors.text, fontWeight: '600' },
+  badgeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  typeBadge: {
+    minHeight: 28,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    borderRadius: radii.full,
+  },
+  statusBadge: {
+    minHeight: 28,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.sm,
+    borderRadius: radii.full,
+  },
+  badgeText: { ...typography.label },
+  assignee: {
+    minHeight: 28,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  assigneeText: { ...typography.caption, color: colors.textMuted },
+  locationChip: {
+    minHeight: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    marginHorizontal: spacing.md,
+    marginBottom: spacing.md,
+    paddingHorizontal: spacing.sm,
+    borderRadius: radii.md,
+    backgroundColor: colors.primarySoft,
+  },
+  locationText: { ...typography.caption, color: colors.primary, flex: 1 },
+  details: {
+    gap: spacing.md,
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.md,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    paddingTop: spacing.md,
+  },
+  detailLine: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.sm,
+  },
+  detailText: { flex: 1, gap: spacing.xs },
+  detailLabel: { ...typography.label, color: colors.textMuted },
+  detailValue: { ...typography.body, color: colors.text },
+  externalLink: {
+    minHeight: 44,
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  externalLinkText: { ...typography.label, color: colors.primary },
+  linkNotice: {
+    minHeight: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    marginHorizontal: spacing.md,
+    marginBottom: spacing.md,
+    paddingHorizontal: spacing.sm,
+    borderRadius: radii.md,
+    backgroundColor: colors.dangerSoft,
+  },
+  linkNoticeText: { ...typography.caption, color: colors.danger, flex: 1 },
+  actionRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.sm,
+  },
+  actionButton: {
+    minHeight: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.sm,
+  },
+  editText: { ...typography.label, color: colors.primary },
+  deleteText: { ...typography.label, color: colors.danger },
+  pressed: { opacity: 0.55 },
+});

--- a/mobile/src/features/timeline/components/ActivityStatusControls.tsx
+++ b/mobile/src/features/timeline/components/ActivityStatusControls.tsx
@@ -22,7 +22,7 @@ interface StatusAction {
 }
 
 interface OwnedErrorState {
-  activityStateKey: string;
+  activityId: string;
   error: ApiError;
 }
 
@@ -110,7 +110,6 @@ export function ActivityStatusControls({
   const inFlightRef = useRef(false);
   const mountedRef = useRef(false);
   const ownsError = error === undefined;
-  const activityStateKey = `${activity.id}:${activity.status}`;
   const actions = useMemo(
     () => getActivityStatusActions(activity),
     [activity],
@@ -141,7 +140,7 @@ export function ActivityStatusControls({
         const nextError = normalizeApiError(caught);
         if (mountedRef.current) {
           if (ownsError) {
-            setOwnedError({ activityStateKey, error: nextError });
+            setOwnedError({ activityId: activity.id, error: nextError });
           }
           onSettledFailure?.(nextError);
         }
@@ -153,7 +152,7 @@ export function ActivityStatusControls({
       }
     },
     [
-      activityStateKey,
+      activity.id,
       disabled,
       onChangeStatus,
       onSettledFailure,
@@ -161,33 +160,35 @@ export function ActivityStatusControls({
     ],
   );
 
-  if (actions.length === 0) {
-    return null;
-  }
-
   const displayError = ownsError
-    ? ownedError?.activityStateKey === activityStateKey
+    ? ownedError?.activityId === activity.id
       ? ownedError.error
       : null
     : error;
 
+  if (actions.length === 0 && !displayError) {
+    return null;
+  }
+
   return (
     <View accessibilityLabel="Activity status controls" style={styles.wrap}>
-      <View style={styles.actions}>
-        {actions.map((action) => (
-          <View key={action.status} style={styles.action}>
-            <Button
-              title={action.label}
-              variant="secondary"
-              disabled={disabled || pendingStatus !== null}
-              loading={pendingStatus === action.status}
-              onPress={() => {
-                void requestStatusChange(action.status);
-              }}
-            />
-          </View>
-        ))}
-      </View>
+      {actions.length > 0 ? (
+        <View style={styles.actions}>
+          {actions.map((action) => (
+            <View key={action.status} style={styles.action}>
+              <Button
+                title={action.label}
+                variant="secondary"
+                disabled={disabled || pendingStatus !== null}
+                loading={pendingStatus === action.status}
+                onPress={() => {
+                  void requestStatusChange(action.status);
+                }}
+              />
+            </View>
+          ))}
+        </View>
+      ) : null}
       {displayError ? (
         <View accessibilityRole="alert" style={styles.error}>
           <Text style={styles.errorText}>{displayError.message}</Text>

--- a/mobile/src/features/timeline/components/ActivityStatusControls.tsx
+++ b/mobile/src/features/timeline/components/ActivityStatusControls.tsx
@@ -1,0 +1,219 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { type ApiError, normalizeApiError } from '@/shared/api/errors';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { Button } from '@/shared/ui/Button';
+import type {
+  TimelineActivity,
+  TimelineActivityStatus,
+} from '../types';
+
+interface ActivityStatusControlsProps {
+  activity: TimelineActivity;
+  onChangeStatus: (nextStatus: TimelineActivityStatus) => Promise<void>;
+  disabled?: boolean;
+  error?: ApiError | null;
+  onSettledFailure?: (error: ApiError) => void;
+}
+
+interface StatusAction {
+  status: TimelineActivityStatus;
+  label: string;
+}
+
+interface OwnedErrorState {
+  activityStateKey: string;
+  error: ApiError;
+}
+
+const BASE_TRANSITIONS: Record<
+  TimelineActivityStatus,
+  readonly TimelineActivityStatus[]
+> = {
+  UPCOMING: ['IN_PROGRESS'],
+  IN_PROGRESS: ['UPCOMING', 'DONE'],
+  DONE: [],
+  CANCELLED: [],
+};
+
+const EDIT_TRANSITIONS: Record<
+  TimelineActivityStatus,
+  readonly TimelineActivityStatus[]
+> = {
+  UPCOMING: ['DONE', 'CANCELLED'],
+  IN_PROGRESS: ['CANCELLED'],
+  DONE: ['IN_PROGRESS', 'UPCOMING', 'CANCELLED'],
+  CANCELLED: ['UPCOMING'],
+};
+
+function getActionLabel(
+  currentStatus: TimelineActivityStatus,
+  nextStatus: TimelineActivityStatus,
+): string {
+  if (nextStatus === 'DONE') {
+    return 'Mark done';
+  }
+  if (nextStatus === 'CANCELLED') {
+    return 'Cancel activity';
+  }
+  if (currentStatus === 'UPCOMING' && nextStatus === 'IN_PROGRESS') {
+    return 'Start activity';
+  }
+  if (currentStatus === 'DONE' && nextStatus === 'IN_PROGRESS') {
+    return 'Reopen activity';
+  }
+  if (currentStatus === 'CANCELLED' && nextStatus === 'UPCOMING') {
+    return 'Restore activity';
+  }
+  return 'Reset to upcoming';
+}
+
+export function getActivityStatusActions(
+  activity: Pick<TimelineActivity, 'status' | 'capabilities'>,
+): StatusAction[] {
+  if (!activity.capabilities.can_update_status) {
+    return [];
+  }
+
+  const statuses = activity.capabilities.can_edit
+    ? [
+        ...BASE_TRANSITIONS[activity.status],
+        ...EDIT_TRANSITIONS[activity.status],
+      ]
+    : BASE_TRANSITIONS[activity.status];
+  const seen = new Set<TimelineActivityStatus>();
+
+  return statuses.flatMap((status) => {
+    if (seen.has(status)) {
+      return [];
+    }
+    seen.add(status);
+    return [
+      {
+        status,
+        label: getActionLabel(activity.status, status),
+      },
+    ];
+  });
+}
+
+export function ActivityStatusControls({
+  activity,
+  onChangeStatus,
+  disabled = false,
+  error,
+  onSettledFailure,
+}: ActivityStatusControlsProps) {
+  const [ownedError, setOwnedError] = useState<OwnedErrorState | null>(null);
+  const [pendingStatus, setPendingStatus] =
+    useState<TimelineActivityStatus | null>(null);
+  const inFlightRef = useRef(false);
+  const mountedRef = useRef(false);
+  const ownsError = error === undefined;
+  const activityStateKey = `${activity.id}:${activity.status}`;
+  const actions = useMemo(
+    () => getActivityStatusActions(activity),
+    [activity],
+  );
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const requestStatusChange = useCallback(
+    async (nextStatus: TimelineActivityStatus) => {
+      if (disabled || inFlightRef.current) {
+        return;
+      }
+
+      inFlightRef.current = true;
+      if (ownsError) {
+        setOwnedError(null);
+      }
+      setPendingStatus(nextStatus);
+
+      try {
+        await onChangeStatus(nextStatus);
+      } catch (caught) {
+        const nextError = normalizeApiError(caught);
+        if (mountedRef.current) {
+          if (ownsError) {
+            setOwnedError({ activityStateKey, error: nextError });
+          }
+          onSettledFailure?.(nextError);
+        }
+      } finally {
+        inFlightRef.current = false;
+        if (mountedRef.current) {
+          setPendingStatus(null);
+        }
+      }
+    },
+    [
+      activityStateKey,
+      disabled,
+      onChangeStatus,
+      onSettledFailure,
+      ownsError,
+    ],
+  );
+
+  if (actions.length === 0) {
+    return null;
+  }
+
+  const displayError = ownsError
+    ? ownedError?.activityStateKey === activityStateKey
+      ? ownedError.error
+      : null
+    : error;
+
+  return (
+    <View accessibilityLabel="Activity status controls" style={styles.wrap}>
+      <View style={styles.actions}>
+        {actions.map((action) => (
+          <View key={action.status} style={styles.action}>
+            <Button
+              title={action.label}
+              variant="secondary"
+              disabled={disabled || pendingStatus !== null}
+              loading={pendingStatus === action.status}
+              onPress={() => {
+                void requestStatusChange(action.status);
+              }}
+            />
+          </View>
+        ))}
+      </View>
+      {displayError ? (
+        <View accessibilityRole="alert" style={styles.error}>
+          <Text style={styles.errorText}>{displayError.message}</Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { gap: spacing.sm },
+  actions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  action: { minWidth: 132, flexGrow: 1 },
+  error: {
+    minHeight: 44,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.dangerBorder,
+    borderRadius: radii.md,
+    backgroundColor: colors.dangerSoft,
+  },
+  errorText: { ...typography.caption, color: colors.danger },
+});

--- a/mobile/src/features/timeline/components/CustomTypeManager.tsx
+++ b/mobile/src/features/timeline/components/CustomTypeManager.tsx
@@ -1,0 +1,683 @@
+import { Ionicons } from '@expo/vector-icons';
+import { memo, useCallback } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  type ListRenderItemInfo,
+} from 'react-native';
+import type { ApiError } from '@/shared/api/errors';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { Button } from '@/shared/ui/Button';
+import { FormError } from '@/shared/ui/FormError';
+import { TextField } from '@/shared/ui/TextField';
+import {
+  CUSTOM_TYPE_NAME_MAX_LENGTH,
+  type CustomTypeDraft,
+  type CustomTypeFieldErrors,
+} from '../customTypeModel';
+import {
+  getTimelineIconName,
+  getTimelineTokenColors,
+  isTimelineColorToken,
+  isTimelineIconKey,
+  TIMELINE_COLOR_OPTIONS,
+  TIMELINE_ICON_OPTIONS,
+  type TimelineColorToken,
+  type TimelineIconKey,
+} from '../tokenMaps';
+import type { TimelineCustomTypeMeta } from '../types';
+
+export type CustomTypeMutationScope =
+  | { kind: 'create' }
+  | {
+      kind: 'edit' | 'toggle' | 'delete';
+      typeId: string;
+    };
+
+export interface CustomTypeMutationError {
+  scope: CustomTypeMutationScope;
+  error: ApiError;
+}
+
+interface CustomTypeManagerProps {
+  customTypes: readonly TimelineCustomTypeMeta[];
+  createDraft: CustomTypeDraft;
+  createFieldErrors: CustomTypeFieldErrors;
+  editTypeId: string | null;
+  editDraft: CustomTypeDraft | null;
+  editFieldErrors: CustomTypeFieldErrors;
+  editDirty: boolean;
+  mutationKey: string | null;
+  mutationError: CustomTypeMutationError | null;
+  onChangeCreate: (changes: Partial<CustomTypeDraft>) => void;
+  onCreate: () => void;
+  onStartEdit: (customType: TimelineCustomTypeMeta) => void;
+  onChangeEdit: (changes: Partial<CustomTypeDraft>) => void;
+  onSaveEdit: () => void;
+  onCancelEdit: () => void;
+  onToggleActive: (customType: TimelineCustomTypeMeta) => void;
+  onDelete: (customType: TimelineCustomTypeMeta) => void;
+}
+
+interface ColorPickerProps {
+  value: string;
+  disabled: boolean;
+  error?: string;
+  accessibilityPrefix: string;
+  onSelect: (value: TimelineColorToken) => void;
+}
+
+interface IconPickerProps {
+  value: string;
+  disabled: boolean;
+  error?: string;
+  accessibilityPrefix: string;
+  onSelect: (value: TimelineIconKey) => void;
+}
+
+interface RowActionProps {
+  label: string;
+  disabled: boolean;
+  danger?: boolean;
+  onPress: () => void;
+}
+
+interface CustomTypeRowProps {
+  customType: TimelineCustomTypeMeta;
+  editing: boolean;
+  editDraft: CustomTypeDraft | null;
+  editFieldErrors: CustomTypeFieldErrors;
+  editDirty: boolean;
+  actionsDisabled: boolean;
+  mutationKey: string | null;
+  mutationError: ApiError | null;
+  onStartEdit: (customType: TimelineCustomTypeMeta) => void;
+  onChangeEdit: (changes: Partial<CustomTypeDraft>) => void;
+  onSaveEdit: () => void;
+  onCancelEdit: () => void;
+  onToggleActive: (customType: TimelineCustomTypeMeta) => void;
+  onDelete: (customType: TimelineCustomTypeMeta) => void;
+}
+
+function RowAction({
+  label,
+  disabled,
+  danger = false,
+  onPress,
+}: RowActionProps) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.rowAction,
+        danger ? styles.rowActionDanger : null,
+        disabled ? styles.disabled : null,
+        pressed && !disabled ? styles.pressed : null,
+      ]}
+    >
+      <Text
+        style={[
+          styles.rowActionText,
+          danger ? styles.rowActionDangerText : null,
+        ]}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function ColorPicker({
+  value,
+  disabled,
+  error,
+  accessibilityPrefix,
+  onSelect,
+}: ColorPickerProps) {
+  const hasUnknownValue = !isTimelineColorToken(value);
+
+  return (
+    <View style={styles.pickerGroup}>
+      <Text style={styles.fieldLabel}>Color</Text>
+      {hasUnknownValue ? (
+        <Text style={styles.unknownValue}>
+          Current unsupported color token: {value || '(blank)'}. It stays
+          unchanged until you choose a supported color.
+        </Text>
+      ) : null}
+      <View style={styles.optionWrap}>
+        {TIMELINE_COLOR_OPTIONS.map((option) => {
+          const selected = value === option.value;
+          return (
+            <Pressable
+              key={option.value}
+              accessibilityRole="button"
+              accessibilityLabel={`${accessibilityPrefix} color ${option.label}`}
+              accessibilityState={{ disabled, selected }}
+              disabled={disabled}
+              onPress={() => onSelect(option.value)}
+              style={({ pressed }) => [
+                styles.colorOption,
+                {
+                  backgroundColor: option.backgroundColor,
+                  borderColor: selected ? option.color : colors.border,
+                },
+                disabled ? styles.disabled : null,
+                pressed && !disabled ? styles.pressed : null,
+              ]}
+            >
+              <View
+                style={[
+                  styles.colorSwatch,
+                  { backgroundColor: option.color },
+                ]}
+              />
+              <Text style={[styles.colorLabel, { color: option.color }]}>
+                {option.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+      {error ? (
+        <Text accessibilityRole="alert" style={styles.errorText}>
+          {error}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+function IconPicker({
+  value,
+  disabled,
+  error,
+  accessibilityPrefix,
+  onSelect,
+}: IconPickerProps) {
+  const hasUnknownValue = !isTimelineIconKey(value);
+
+  return (
+    <View style={styles.pickerGroup}>
+      <Text style={styles.fieldLabel}>Icon</Text>
+      {hasUnknownValue ? (
+        <Text style={styles.unknownValue}>
+          Current unsupported icon key: {value || '(blank)'}. It stays
+          unchanged until you choose a supported icon.
+        </Text>
+      ) : null}
+      <View style={styles.optionWrap}>
+        {TIMELINE_ICON_OPTIONS.map((option) => {
+          const selected = value === option.value;
+          return (
+            <Pressable
+              key={option.value}
+              accessibilityRole="button"
+              accessibilityLabel={`${accessibilityPrefix} icon ${option.label}`}
+              accessibilityState={{ disabled, selected }}
+              disabled={disabled}
+              onPress={() => onSelect(option.value)}
+              style={({ pressed }) => [
+                styles.iconOption,
+                selected ? styles.iconOptionSelected : null,
+                disabled ? styles.disabled : null,
+                pressed && !disabled ? styles.pressed : null,
+              ]}
+            >
+              <Ionicons
+                name={option.icon}
+                size={20}
+                color={selected ? colors.primary : colors.textMuted}
+              />
+              <Text
+                style={[
+                  styles.iconLabel,
+                  selected ? styles.iconLabelSelected : null,
+                ]}
+              >
+                {option.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+      {error ? (
+        <Text accessibilityRole="alert" style={styles.errorText}>
+          {error}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+function CustomTypeEditor({
+  customType,
+  draft,
+  fieldErrors,
+  dirty,
+  disabled,
+  saving,
+  error,
+  onChange,
+  onSave,
+  onCancel,
+}: {
+  customType: TimelineCustomTypeMeta;
+  draft: CustomTypeDraft;
+  fieldErrors: CustomTypeFieldErrors;
+  dirty: boolean;
+  disabled: boolean;
+  saving: boolean;
+  error: ApiError | null;
+  onChange: (changes: Partial<CustomTypeDraft>) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <View style={styles.editor}>
+      <TextField
+        label="Name *"
+        accessibilityLabel={`Name for ${customType.name}`}
+        value={draft.name}
+        editable={!disabled}
+        maxLength={CUSTOM_TYPE_NAME_MAX_LENGTH}
+        onChangeText={(name) => onChange({ name })}
+        error={fieldErrors.name ?? error?.fieldErrors?.name}
+      />
+      <ColorPicker
+        value={draft.color_token}
+        disabled={disabled}
+        accessibilityPrefix={customType.name}
+        onSelect={(color_token) => onChange({ color_token })}
+        error={error?.fieldErrors?.color_token}
+      />
+      <IconPicker
+        value={draft.icon_key}
+        disabled={disabled}
+        accessibilityPrefix={customType.name}
+        onSelect={(icon_key) => onChange({ icon_key })}
+        error={error?.fieldErrors?.icon_key}
+      />
+      <FormError error={error} />
+      <View style={styles.editorActions}>
+        <View style={styles.editorAction}>
+          <Button
+            title="Cancel edit"
+            variant="secondary"
+            disabled={disabled}
+            onPress={onCancel}
+          />
+        </View>
+        <View style={styles.editorAction}>
+          <Button
+            title="Save type"
+            disabled={disabled || !dirty}
+            loading={saving}
+            onPress={onSave}
+          />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function CustomTypeRowComponent({
+  customType,
+  editing,
+  editDraft,
+  editFieldErrors,
+  editDirty,
+  actionsDisabled,
+  mutationKey,
+  mutationError,
+  onStartEdit,
+  onChangeEdit,
+  onSaveEdit,
+  onCancelEdit,
+  onToggleActive,
+  onDelete,
+}: CustomTypeRowProps) {
+  const tokenColors = getTimelineTokenColors(customType.color_token);
+  const iconName = getTimelineIconName(customType.icon_key);
+  const rowBusy =
+    mutationKey === `edit:${customType.id}` ||
+    mutationKey === `toggle:${customType.id}` ||
+    mutationKey === `delete:${customType.id}`;
+
+  if (editing && editDraft) {
+    return (
+      <View style={styles.card}>
+        <CustomTypeEditor
+          customType={customType}
+          draft={editDraft}
+          fieldErrors={editFieldErrors}
+          dirty={editDirty}
+          disabled={actionsDisabled}
+          saving={mutationKey === `edit:${customType.id}`}
+          error={mutationError}
+          onChange={onChangeEdit}
+          onSave={onSaveEdit}
+          onCancel={onCancelEdit}
+        />
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.card, !customType.is_active ? styles.inactiveCard : null]}>
+      <View style={styles.rowSummary}>
+        <View
+          style={[
+            styles.typeIcon,
+            { backgroundColor: tokenColors.backgroundColor },
+          ]}
+        >
+          <Ionicons name={iconName} size={20} color={tokenColors.color} />
+        </View>
+        <View style={styles.rowText}>
+          <Text
+            style={[
+              styles.typeName,
+              !customType.is_active ? styles.inactiveName : null,
+            ]}
+          >
+            {customType.name}
+          </Text>
+          <Text style={styles.typeState}>
+            {customType.is_active ? 'Active' : 'Inactive'}
+          </Text>
+        </View>
+        {rowBusy ? (
+          <ActivityIndicator color={colors.primary} />
+        ) : null}
+      </View>
+      {mutationError ? <FormError error={mutationError} /> : null}
+      <View style={styles.rowActions}>
+        <RowAction
+          label={`Edit ${customType.name}`}
+          disabled={actionsDisabled}
+          onPress={() => onStartEdit(customType)}
+        />
+        <RowAction
+          label={`${customType.is_active ? 'Deactivate' : 'Activate'} ${customType.name}`}
+          disabled={actionsDisabled}
+          onPress={() => onToggleActive(customType)}
+        />
+        <RowAction
+          label={`Delete ${customType.name}`}
+          disabled={actionsDisabled}
+          danger
+          onPress={() => onDelete(customType)}
+        />
+      </View>
+    </View>
+  );
+}
+
+const CustomTypeRow = memo(CustomTypeRowComponent);
+
+export function CustomTypeManager({
+  customTypes,
+  createDraft,
+  createFieldErrors,
+  editTypeId,
+  editDraft,
+  editFieldErrors,
+  editDirty,
+  mutationKey,
+  mutationError,
+  onChangeCreate,
+  onCreate,
+  onStartEdit,
+  onChangeEdit,
+  onSaveEdit,
+  onCancelEdit,
+  onToggleActive,
+  onDelete,
+}: CustomTypeManagerProps) {
+  const actionsDisabled = mutationKey !== null;
+  const createError =
+    mutationError?.scope.kind === 'create'
+      ? mutationError.error
+      : null;
+
+  const renderItem = useCallback(
+    ({ item }: ListRenderItemInfo<TimelineCustomTypeMeta>) => {
+      const itemError =
+        mutationError?.scope.kind !== 'create' &&
+        mutationError?.scope.typeId === item.id
+          ? mutationError.error
+          : null;
+      return (
+        <CustomTypeRow
+          customType={item}
+          editing={editTypeId === item.id}
+          editDraft={editTypeId === item.id ? editDraft : null}
+          editFieldErrors={editFieldErrors}
+          editDirty={editDirty}
+          actionsDisabled={actionsDisabled}
+          mutationKey={mutationKey}
+          mutationError={itemError}
+          onStartEdit={onStartEdit}
+          onChangeEdit={onChangeEdit}
+          onSaveEdit={onSaveEdit}
+          onCancelEdit={onCancelEdit}
+          onToggleActive={onToggleActive}
+          onDelete={onDelete}
+        />
+      );
+    },
+    [
+      actionsDisabled,
+      editDraft,
+      editDirty,
+      editFieldErrors,
+      editTypeId,
+      mutationError,
+      mutationKey,
+      onCancelEdit,
+      onChangeEdit,
+      onDelete,
+      onSaveEdit,
+      onStartEdit,
+      onToggleActive,
+    ],
+  );
+
+  const header = (
+    <View style={styles.header}>
+      <View style={styles.intro}>
+        <Text accessibilityRole="header" style={styles.title}>
+          Custom activity types
+        </Text>
+        <Text style={styles.body}>
+          Create trip-specific labels and keep inactive types available for
+          existing activities.
+        </Text>
+      </View>
+      <View style={styles.createCard}>
+        <Text style={styles.sectionTitle}>Add a custom type</Text>
+        <TextField
+          label="Name *"
+          accessibilityLabel="New custom type name"
+          value={createDraft.name}
+          editable={!actionsDisabled}
+          maxLength={CUSTOM_TYPE_NAME_MAX_LENGTH}
+          onChangeText={(name) => onChangeCreate({ name })}
+          error={createFieldErrors.name ?? createError?.fieldErrors?.name}
+        />
+        <ColorPicker
+          value={createDraft.color_token}
+          disabled={actionsDisabled}
+          accessibilityPrefix="New custom type"
+          onSelect={(color_token) => onChangeCreate({ color_token })}
+          error={createError?.fieldErrors?.color_token}
+        />
+        <IconPicker
+          value={createDraft.icon_key}
+          disabled={actionsDisabled}
+          accessibilityPrefix="New custom type"
+          onSelect={(icon_key) => onChangeCreate({ icon_key })}
+          error={createError?.fieldErrors?.icon_key}
+        />
+        <FormError error={createError} />
+        <Button
+          title="Add custom type"
+          loading={mutationKey === 'create'}
+          disabled={actionsDisabled || !createDraft.name.trim()}
+          onPress={onCreate}
+        />
+      </View>
+      <Text accessibilityRole="header" style={styles.sectionTitle}>
+        Existing types
+      </Text>
+    </View>
+  );
+
+  return (
+    <FlatList
+      testID="custom-type-manager-list"
+      data={customTypes}
+      keyExtractor={(item) => item.id}
+      renderItem={renderItem}
+      ListHeaderComponent={header}
+      ListEmptyComponent={
+        <View style={styles.emptyState}>
+          <Ionicons
+            name="pricetags-outline"
+            size={40}
+            color={colors.textMuted}
+          />
+          <Text style={styles.emptyTitle}>No custom types yet</Text>
+          <Text style={styles.emptyBody}>
+            Add one above to use it on timeline activities.
+          </Text>
+        </View>
+      }
+      contentContainerStyle={styles.listContent}
+      keyboardShouldPersistTaps="handled"
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  listContent: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.xl,
+    gap: spacing.sm,
+  },
+  header: { gap: spacing.md, paddingBottom: spacing.sm },
+  intro: { gap: spacing.xs },
+  title: { ...typography.heading, color: colors.text },
+  body: { ...typography.body, color: colors.textMuted },
+  sectionTitle: { ...typography.label, color: colors.text },
+  createCard: {
+    gap: spacing.md,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.lg,
+    backgroundColor: colors.background,
+  },
+  card: {
+    gap: spacing.md,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.lg,
+    backgroundColor: colors.background,
+  },
+  inactiveCard: { backgroundColor: colors.surface },
+  rowSummary: {
+    minHeight: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  typeIcon: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.full,
+  },
+  rowText: { flex: 1, gap: spacing.xs },
+  typeName: { ...typography.body, color: colors.text, fontWeight: '600' },
+  inactiveName: {
+    color: colors.textMuted,
+    textDecorationLine: 'line-through',
+  },
+  typeState: { ...typography.caption, color: colors.textMuted },
+  rowActions: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm },
+  rowAction: {
+    minHeight: 44,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    backgroundColor: colors.background,
+  },
+  rowActionDanger: { borderColor: colors.dangerBorder },
+  rowActionText: { ...typography.label, color: colors.primary },
+  rowActionDangerText: { color: colors.danger },
+  pickerGroup: { gap: spacing.sm },
+  fieldLabel: { ...typography.label, color: colors.text },
+  optionWrap: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm },
+  colorOption: {
+    minHeight: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    borderWidth: 1,
+    borderRadius: radii.md,
+  },
+  colorSwatch: { width: 12, height: 12, borderRadius: radii.full },
+  colorLabel: { ...typography.label },
+  iconOption: {
+    minHeight: 56,
+    minWidth: 76,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    backgroundColor: colors.background,
+  },
+  iconOptionSelected: {
+    borderColor: colors.primary,
+    backgroundColor: colors.primarySoft,
+  },
+  iconLabel: { ...typography.caption, color: colors.textMuted },
+  iconLabelSelected: { color: colors.primary },
+  unknownValue: { ...typography.caption, color: colors.textMuted },
+  errorText: { ...typography.caption, color: colors.danger },
+  editor: { gap: spacing.md },
+  editorActions: { flexDirection: 'row', gap: spacing.sm },
+  editorAction: { flex: 1 },
+  emptyState: {
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingVertical: spacing.xl,
+  },
+  emptyTitle: { ...typography.heading, color: colors.text },
+  emptyBody: {
+    ...typography.body,
+    color: colors.textMuted,
+    textAlign: 'center',
+  },
+  disabled: { opacity: 0.55 },
+  pressed: { opacity: 0.55 },
+});

--- a/mobile/src/features/timeline/components/PlacePicker.tsx
+++ b/mobile/src/features/timeline/components/PlacePicker.tsx
@@ -1,0 +1,309 @@
+import { memo, useCallback } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  type ListRenderItemInfo,
+} from 'react-native';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { TextField } from '@/shared/ui/TextField';
+import {
+  MANUAL_LOCATION_GUIDANCE,
+  PLACE_SEARCH_UNAVAILABLE_MESSAGE,
+  type ManualLocationValue,
+  type PlacePickerValue,
+  type SettledLocationLookupFailure,
+  type StructuredLocationSelection,
+  useLocationSearch,
+} from '../hooks/useLocationSearch';
+import type { LocationSuggestion } from '../types';
+
+export interface PlacePickerProps {
+  value: PlacePickerValue | null;
+  disabled?: boolean;
+  error?: string;
+  onSelectLocation: (selection: StructuredLocationSelection) => void;
+  onUseManualEntry: (value: ManualLocationValue) => void;
+  onLookupFailure: (failure: SettledLocationLookupFailure) => void;
+}
+
+interface SuggestionChoiceProps {
+  suggestion: LocationSuggestion;
+  disabled: boolean;
+  onSelect: (suggestion: LocationSuggestion) => void;
+}
+
+const SuggestionChoice = memo(function SuggestionChoice({
+  suggestion,
+  disabled,
+  onSelect,
+}: SuggestionChoiceProps) {
+  const select = useCallback(
+    () => onSelect(suggestion),
+    [onSelect, suggestion],
+  );
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`Select ${suggestion.title}`}
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      onPress={select}
+      style={({ pressed }) => [
+        styles.suggestion,
+        disabled ? styles.disabled : null,
+        pressed && !disabled ? styles.pressed : null,
+      ]}
+    >
+      <Text numberOfLines={1} style={styles.suggestionTitle}>
+        {suggestion.title}
+      </Text>
+      {suggestion.subtitle ? (
+        <Text numberOfLines={2} style={styles.suggestionSubtitle}>
+          {suggestion.subtitle}
+        </Text>
+      ) : null}
+    </Pressable>
+  );
+});
+
+export function PlacePicker({
+  value,
+  disabled = false,
+  error,
+  onSelectLocation,
+  onUseManualEntry,
+  onLookupFailure,
+}: PlacePickerProps) {
+  const {
+    query,
+    setQuery,
+    clear,
+    suggestions,
+    searchStatus,
+    searchError,
+    searchUnavailable,
+    lookupStatus,
+    lookupError,
+    manualEntrySuggested,
+    selectSuggestion,
+    createManualValue,
+  } = useLocationSearch({ enabled: !disabled });
+  const lookupPending = lookupStatus === 'loading';
+
+  const chooseSuggestion = useCallback(
+    (suggestion: LocationSuggestion) => {
+      void selectSuggestion(suggestion).then((result) => {
+        if (result.kind === 'success') {
+          onSelectLocation(result.selection);
+          clear();
+        } else if (result.kind === 'failure') {
+          onLookupFailure(result.fallback);
+        }
+      });
+    },
+    [clear, onLookupFailure, onSelectLocation, selectSuggestion],
+  );
+
+  const useManualEntry = useCallback(() => {
+    const manualValue = createManualValue(value?.location_label ?? '');
+    clear();
+    onUseManualEntry(manualValue);
+  }, [clear, createManualValue, onUseManualEntry, value?.location_label]);
+
+  const renderSuggestion = useCallback(
+    ({ item }: ListRenderItemInfo<LocationSuggestion>) => (
+      <SuggestionChoice
+        suggestion={item}
+        disabled={disabled || lookupPending}
+        onSelect={chooseSuggestion}
+      />
+    ),
+    [chooseSuggestion, disabled, lookupPending],
+  );
+
+  const searchMessage = searchUnavailable
+    ? PLACE_SEARCH_UNAVAILABLE_MESSAGE
+    : searchError?.message;
+
+  return (
+    <View style={styles.wrap}>
+      {value?.place ? (
+        <View
+          accessibilityLabel={`Selected place ${value.location_label}`}
+          style={styles.selected}
+        >
+          <Text style={styles.selectedEyebrow}>Selected place</Text>
+          <Text style={styles.selectedTitle}>
+            {value.place.title || value.location_label}
+          </Text>
+          {value.place.address ? (
+            <Text style={styles.selectedAddress}>{value.place.address}</Text>
+          ) : null}
+        </View>
+      ) : null}
+
+      <View style={styles.search}>
+        <TextField
+          label={value?.place ? 'Search for another place' : 'Search for a place'}
+          accessibilityLabel="Search places"
+          value={query}
+          onChangeText={setQuery}
+          placeholder="Enter at least 2 characters"
+          maxLength={120}
+          editable={!disabled}
+          autoCorrect={false}
+          error={error}
+        />
+        {searchStatus === 'debouncing' ||
+        searchStatus === 'searching' ||
+        lookupPending ? (
+          <View
+            accessibilityLabel={
+              lookupPending ? 'Verifying place' : 'Searching places'
+            }
+            accessibilityRole="progressbar"
+            style={styles.loading}
+          >
+            <ActivityIndicator color={colors.primary} size="small" />
+            <Text style={styles.loadingText}>
+              {lookupPending ? 'Verifying place…' : 'Searching…'}
+            </Text>
+          </View>
+        ) : null}
+      </View>
+
+      {suggestions.length > 0 ? (
+        <FlatList
+          testID="place-suggestion-list"
+          horizontal
+          data={suggestions}
+          keyExtractor={suggestionKey}
+          renderItem={renderSuggestion}
+          contentContainerStyle={styles.suggestionList}
+          showsHorizontalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        />
+      ) : null}
+
+      {searchMessage ? (
+        <Text
+          accessibilityLiveRegion="polite"
+          accessibilityRole="alert"
+          style={styles.notice}
+        >
+          {searchMessage}
+        </Text>
+      ) : null}
+
+      {manualEntrySuggested && lookupError ? (
+        <View accessibilityRole="alert" style={styles.lookupNotice}>
+          <Text style={styles.lookupGuidance}>
+            {MANUAL_LOCATION_GUIDANCE}
+          </Text>
+          <Text style={styles.lookupError}>{lookupError.message}</Text>
+        </View>
+      ) : null}
+
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Enter location manually"
+        accessibilityState={{ disabled }}
+        disabled={disabled}
+        onPress={useManualEntry}
+        style={({ pressed }) => [
+          styles.manualAction,
+          disabled ? styles.disabled : null,
+          pressed && !disabled ? styles.pressed : null,
+        ]}
+      >
+        <Text style={styles.manualActionText}>Enter manually</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function suggestionKey(suggestion: LocationSuggestion): string {
+  return suggestion.provider_id;
+}
+
+const styles = StyleSheet.create({
+  wrap: { gap: spacing.sm },
+  selected: {
+    gap: spacing.xs,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    backgroundColor: colors.surface,
+  },
+  selectedEyebrow: {
+    ...typography.label,
+    color: colors.success,
+    textTransform: 'uppercase',
+  },
+  selectedTitle: { ...typography.body, fontWeight: '600', color: colors.text },
+  selectedAddress: { ...typography.caption, color: colors.textMuted },
+  search: { gap: spacing.xs },
+  loading: {
+    minHeight: 28,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  loadingText: { ...typography.caption, color: colors.textMuted },
+  suggestionList: { gap: spacing.sm, paddingVertical: spacing.xs },
+  suggestion: {
+    width: 248,
+    minHeight: 72,
+    justifyContent: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    backgroundColor: colors.background,
+  },
+  suggestionTitle: {
+    ...typography.body,
+    fontWeight: '600',
+    color: colors.text,
+  },
+  suggestionSubtitle: { ...typography.caption, color: colors.textMuted },
+  notice: {
+    ...typography.caption,
+    color: colors.textMuted,
+  },
+  lookupNotice: {
+    gap: spacing.xs,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.dangerBorder,
+    borderRadius: radii.md,
+    backgroundColor: colors.dangerSoft,
+  },
+  lookupGuidance: { ...typography.body, color: colors.text },
+  lookupError: { ...typography.caption, color: colors.danger },
+  manualAction: {
+    minHeight: 44,
+    alignSelf: 'flex-start',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    backgroundColor: colors.surface,
+  },
+  manualActionText: {
+    ...typography.body,
+    fontWeight: '600',
+    color: colors.primary,
+  },
+  pressed: { opacity: 0.72 },
+  disabled: { opacity: 0.55 },
+});

--- a/mobile/src/features/timeline/components/ReminderPicker.tsx
+++ b/mobile/src/features/timeline/components/ReminderPicker.tsx
@@ -1,0 +1,108 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import {
+  MAX_REMINDER_OFFSETS,
+  REMINDER_PRESETS,
+} from '../formModel';
+
+interface ReminderPickerProps {
+  value: readonly number[];
+  enabled: boolean;
+  disabled?: boolean;
+  error?: string;
+  onToggle: (value: number) => void;
+}
+
+export function ReminderPicker({
+  value,
+  enabled,
+  disabled = false,
+  error,
+  onToggle,
+}: ReminderPickerProps) {
+  const blocked = disabled || !enabled;
+
+  return (
+    <View style={styles.group}>
+      <View style={styles.heading}>
+        <Text style={styles.label}>Reminders</Text>
+        <Text style={styles.hint}>
+          {enabled
+            ? `Choose up to ${MAX_REMINDER_OFFSETS}`
+            : 'Set a start time to enable reminders'}
+        </Text>
+      </View>
+      <View style={styles.chips}>
+        {REMINDER_PRESETS.map((preset) => {
+          const selected = value.includes(preset.value);
+          return (
+            <Pressable
+              key={preset.value}
+              accessibilityRole="button"
+              accessibilityLabel={`Reminder ${preset.label} before`}
+              accessibilityState={{ disabled: blocked, selected }}
+              disabled={blocked}
+              onPress={() => onToggle(preset.value)}
+              style={({ pressed }) => [
+                styles.chip,
+                selected ? styles.chipSelected : null,
+                blocked ? styles.chipDisabled : null,
+                pressed && !blocked ? styles.pressed : null,
+              ]}
+            >
+              <Text
+                style={[
+                  styles.chipText,
+                  selected ? styles.chipTextSelected : null,
+                ]}
+              >
+                {preset.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+      {error ? (
+        <Text accessibilityRole="alert" style={styles.error}>
+          {error}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  group: { gap: spacing.sm },
+  heading: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
+  },
+  label: { ...typography.label, color: colors.text },
+  hint: {
+    ...typography.caption,
+    color: colors.textMuted,
+    flexShrink: 1,
+    textAlign: 'right',
+  },
+  chips: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm },
+  chip: {
+    minHeight: 44,
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    paddingHorizontal: spacing.md,
+    backgroundColor: colors.background,
+  },
+  chipSelected: {
+    borderColor: colors.primary,
+    backgroundColor: colors.primarySoft,
+  },
+  chipDisabled: { opacity: 0.55 },
+  chipText: { ...typography.label, color: colors.textMuted },
+  chipTextSelected: { color: colors.primary },
+  error: { ...typography.caption, color: colors.danger },
+  pressed: { opacity: 0.55 },
+});

--- a/mobile/src/features/timeline/components/SectionForm.tsx
+++ b/mobile/src/features/timeline/components/SectionForm.tsx
@@ -20,6 +20,8 @@ interface SectionFormProps {
   dateUnavailable: boolean;
   dirty: boolean;
   submitting: boolean;
+  disabled: boolean;
+  authorityMessage?: string;
   onChange: (changes: Partial<SectionFormDraft>) => void;
   onSubmit: () => void;
 }
@@ -40,6 +42,8 @@ export function SectionForm({
   dateUnavailable,
   dirty,
   submitting,
+  disabled,
+  authorityMessage,
   onChange,
   onSubmit,
 }: SectionFormProps) {
@@ -57,6 +61,11 @@ export function SectionForm({
       footer={
         <>
           <FormError error={submitError} />
+          {authorityMessage ? (
+            <Text accessibilityRole="alert" style={styles.authorityMessage}>
+              {authorityMessage}
+            </Text>
+          ) : null}
           {unchanged ? (
             <Text style={styles.submitHint}>Change the label or date to save.</Text>
           ) : null}
@@ -64,7 +73,7 @@ export function SectionForm({
             title={mode === 'create' ? 'Add day' : 'Save day'}
             onPress={onSubmit}
             loading={submitting}
-            disabled={dateUnavailable || unchanged}
+            disabled={disabled || dateUnavailable || unchanged}
           />
         </>
       }
@@ -82,13 +91,13 @@ export function SectionForm({
         accessibilityLabel="Day label"
         value={draft.label}
         onChangeText={(label) => onChange({ label })}
-        editable={!submitting}
+        editable={!submitting && !disabled}
         maxLength={120}
         error={labelError}
       />
       <View
-        pointerEvents={submitting ? 'none' : 'auto'}
-        style={submitting ? styles.disabledField : null}
+        pointerEvents={submitting || disabled ? 'none' : 'auto'}
+        style={submitting || disabled ? styles.disabledField : null}
       >
         <DateField
           label="Date *"
@@ -112,6 +121,11 @@ const styles = StyleSheet.create({
   title: { ...typography.heading, color: colors.text },
   body: { ...typography.body, color: colors.textMuted },
   disabledField: { opacity: 0.55 },
+  authorityMessage: {
+    ...typography.body,
+    color: colors.danger,
+    textAlign: 'center',
+  },
   submitHint: {
     ...typography.caption,
     color: colors.textMuted,

--- a/mobile/src/features/timeline/components/SectionForm.tsx
+++ b/mobile/src/features/timeline/components/SectionForm.tsx
@@ -1,0 +1,120 @@
+import { StyleSheet, Text, View } from 'react-native';
+import type { ApiError } from '@/shared/api/errors';
+import { colors, spacing, typography } from '@/shared/theme/tokens';
+import { Button } from '@/shared/ui/Button';
+import { DateField } from '@/shared/ui/DateField';
+import { FormError } from '@/shared/ui/FormError';
+import { Screen } from '@/shared/ui/Screen';
+import { TextField } from '@/shared/ui/TextField';
+import { formatDateParam, parseDateOnly } from '@/features/trips/dates';
+import type {
+  SectionFormDraft,
+  SectionFormFieldErrors,
+} from '../formModel';
+
+interface SectionFormProps {
+  mode: 'create' | 'edit';
+  draft: SectionFormDraft;
+  fieldErrors: SectionFormFieldErrors;
+  submitError: ApiError | null;
+  dateUnavailable: boolean;
+  dirty: boolean;
+  submitting: boolean;
+  onChange: (changes: Partial<SectionFormDraft>) => void;
+  onSubmit: () => void;
+}
+
+const DATE_UNAVAILABLE_MESSAGE = 'This date already has a timeline day.';
+const FALLBACK_DATE = new Date(2000, 0, 1, 12, 0, 0, 0);
+
+function dateForPicker(value: string): Date {
+  const parsed = parseDateOnly(value);
+  return Number.isNaN(parsed.getTime()) ? FALLBACK_DATE : parsed;
+}
+
+export function SectionForm({
+  mode,
+  draft,
+  fieldErrors,
+  submitError,
+  dateUnavailable,
+  dirty,
+  submitting,
+  onChange,
+  onSubmit,
+}: SectionFormProps) {
+  const labelError = fieldErrors.label ?? submitError?.fieldErrors?.label;
+  const dateError =
+    fieldErrors.section_date ??
+    (dateUnavailable ? DATE_UNAVAILABLE_MESSAGE : undefined) ??
+    submitError?.fieldErrors?.section_date;
+  const unchanged = mode === 'edit' && !dirty;
+
+  return (
+    <Screen
+      scroll
+      edges={['left', 'right', 'bottom']}
+      footer={
+        <>
+          <FormError error={submitError} />
+          {unchanged ? (
+            <Text style={styles.submitHint}>Change the label or date to save.</Text>
+          ) : null}
+          <Button
+            title={mode === 'create' ? 'Add day' : 'Save day'}
+            onPress={onSubmit}
+            loading={submitting}
+            disabled={dateUnavailable || unchanged}
+          />
+        </>
+      }
+    >
+      <View style={styles.intro}>
+        <Text accessibilityRole="header" style={styles.title}>
+          {mode === 'create' ? 'Add a timeline day' : 'Edit timeline day'}
+        </Text>
+        <Text style={styles.body}>
+          Choose the date and the label shown in the trip timeline.
+        </Text>
+      </View>
+      <TextField
+        label="Label *"
+        accessibilityLabel="Day label"
+        value={draft.label}
+        onChangeText={(label) => onChange({ label })}
+        editable={!submitting}
+        maxLength={120}
+        error={labelError}
+      />
+      <View
+        pointerEvents={submitting ? 'none' : 'auto'}
+        style={submitting ? styles.disabledField : null}
+      >
+        <DateField
+          label="Date *"
+          value={dateForPicker(draft.section_date)}
+          onChange={(date) =>
+            onChange({
+              section_date: Number.isNaN(date.getTime())
+                ? ''
+                : formatDateParam(date),
+            })
+          }
+          error={dateError}
+        />
+      </View>
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  intro: { gap: spacing.xs },
+  title: { ...typography.heading, color: colors.text },
+  body: { ...typography.body, color: colors.textMuted },
+  disabledField: { opacity: 0.55 },
+  submitHint: {
+    ...typography.caption,
+    color: colors.textMuted,
+    textAlign: 'center',
+  },
+});

--- a/mobile/src/features/timeline/components/SectionGroup.tsx
+++ b/mobile/src/features/timeline/components/SectionGroup.tsx
@@ -1,0 +1,141 @@
+import { Ionicons } from '@expo/vector-icons';
+import { memo, useCallback } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import type { TimelineSection } from '../types';
+import { formatSectionDate } from '../viewModel';
+
+interface SectionGroupProps {
+  section: TimelineSection;
+  canEdit?: boolean;
+  canDelete?: boolean;
+  onEdit?: (section: TimelineSection) => void;
+  onDelete?: (section: TimelineSection) => void;
+}
+
+function SectionGroupComponent({
+  section,
+  canEdit = false,
+  canDelete = false,
+  onEdit,
+  onDelete,
+}: SectionGroupProps) {
+  const editSection = useCallback(() => {
+    onEdit?.(section);
+  }, [onEdit, section]);
+  const deleteSection = useCallback(() => {
+    onDelete?.(section);
+  }, [onDelete, section]);
+
+  return (
+    <View style={styles.header}>
+      <View style={styles.copy}>
+        <View style={styles.labelRow}>
+          <Text accessibilityRole="header" style={styles.title}>
+            {section.label}
+          </Text>
+          <View
+            style={[
+              styles.rangeBadge,
+              section.is_in_trip_range
+                ? styles.inRangeBadge
+                : styles.outOfRangeBadge,
+            ]}
+          >
+            <Text
+              style={[
+                styles.rangeText,
+                section.is_in_trip_range
+                  ? styles.inRangeText
+                  : styles.outOfRangeText,
+              ]}
+            >
+              {section.is_in_trip_range ? 'Trip date' : 'Outside trip'}
+            </Text>
+          </View>
+        </View>
+        <Text style={styles.date}>{formatSectionDate(section.section_date)}</Text>
+      </View>
+
+      {(canEdit && onEdit) || (canDelete && onDelete) ? (
+        <View style={styles.actions}>
+          {canEdit && onEdit ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={`Edit ${section.label}`}
+              hitSlop={spacing.sm}
+              onPress={editSection}
+              style={({ pressed }) => [
+                styles.actionButton,
+                pressed ? styles.pressed : null,
+              ]}
+            >
+              <Ionicons name="create-outline" size={18} color={colors.primary} />
+            </Pressable>
+          ) : null}
+          {canDelete && onDelete ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={`Delete ${section.label}`}
+              hitSlop={spacing.sm}
+              onPress={deleteSection}
+              style={({ pressed }) => [
+                styles.actionButton,
+                pressed ? styles.pressed : null,
+              ]}
+            >
+              <Ionicons name="trash-outline" size={18} color={colors.danger} />
+            </Pressable>
+          ) : null}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+export const SectionGroup = memo(SectionGroupComponent);
+
+const styles = StyleSheet.create({
+  header: {
+    minHeight: 84,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    backgroundColor: colors.surface,
+  },
+  copy: { flex: 1, gap: spacing.xs },
+  labelRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  title: { ...typography.heading, color: colors.text, flexShrink: 1 },
+  date: { ...typography.caption, color: colors.textMuted },
+  rangeBadge: {
+    minHeight: 24,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.sm,
+    borderRadius: radii.full,
+  },
+  inRangeBadge: { backgroundColor: colors.successSoft },
+  outOfRangeBadge: { backgroundColor: colors.completedSoft },
+  rangeText: { ...typography.label },
+  inRangeText: { color: colors.success },
+  outOfRangeText: { color: colors.completedText },
+  actions: { flexDirection: 'row', alignItems: 'center', gap: spacing.xs },
+  actionButton: {
+    width: 44,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.md,
+    backgroundColor: colors.background,
+  },
+  pressed: { opacity: 0.55 },
+});

--- a/mobile/src/features/timeline/components/SectionGroup.tsx
+++ b/mobile/src/features/timeline/components/SectionGroup.tsx
@@ -9,6 +9,7 @@ interface SectionGroupProps {
   section: TimelineSection;
   canEdit?: boolean;
   canDelete?: boolean;
+  actionsDisabled?: boolean;
   onEdit?: (section: TimelineSection) => void;
   onDelete?: (section: TimelineSection) => void;
 }
@@ -17,6 +18,7 @@ function SectionGroupComponent({
   section,
   canEdit = false,
   canDelete = false,
+  actionsDisabled = false,
   onEdit,
   onDelete,
 }: SectionGroupProps) {
@@ -63,11 +65,13 @@ function SectionGroupComponent({
             <Pressable
               accessibilityRole="button"
               accessibilityLabel={`Edit ${section.label}`}
+              accessibilityState={{ disabled: actionsDisabled }}
+              disabled={actionsDisabled}
               hitSlop={spacing.sm}
               onPress={editSection}
               style={({ pressed }) => [
                 styles.actionButton,
-                pressed ? styles.pressed : null,
+                pressed || actionsDisabled ? styles.pressed : null,
               ]}
             >
               <Ionicons name="create-outline" size={18} color={colors.primary} />
@@ -77,11 +81,13 @@ function SectionGroupComponent({
             <Pressable
               accessibilityRole="button"
               accessibilityLabel={`Delete ${section.label}`}
+              accessibilityState={{ disabled: actionsDisabled }}
+              disabled={actionsDisabled}
               hitSlop={spacing.sm}
               onPress={deleteSection}
               style={({ pressed }) => [
                 styles.actionButton,
-                pressed ? styles.pressed : null,
+                pressed || actionsDisabled ? styles.pressed : null,
               ]}
             >
               <Ionicons name="trash-outline" size={18} color={colors.danger} />

--- a/mobile/src/features/timeline/components/TimeField.tsx
+++ b/mobile/src/features/timeline/components/TimeField.tsx
@@ -1,0 +1,140 @@
+import { DatePicker, Host } from '@expo/ui/swift-ui';
+import {
+  accessibilityHint,
+  accessibilityLabel,
+  accessibilityValue,
+  disabled as disabledModifier,
+} from '@expo/ui/swift-ui/modifiers';
+import { Ionicons } from '@expo/vector-icons';
+import { useCallback, useMemo } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+
+interface TimeFieldProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  error?: string;
+}
+
+const TIME_PATTERN = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
+const ANCHOR_YEAR = 2000;
+const ANCHOR_MONTH = 0;
+const ANCHOR_DAY = 1;
+
+function parseTime(value: string): { hours: number; minutes: number } | null {
+  if (!TIME_PATTERN.test(value)) {
+    return null;
+  }
+
+  const [hours, minutes] = value.split(':').map(Number);
+  return { hours, minutes };
+}
+
+function createAnchoredDate(value: string): { date: Date; valid: boolean } {
+  const parsed = parseTime(value);
+  const date = new Date(
+    ANCHOR_YEAR,
+    ANCHOR_MONTH,
+    ANCHOR_DAY,
+    parsed?.hours ?? 0,
+    parsed?.minutes ?? 0,
+    0,
+    0,
+  );
+  return { date, valid: parsed !== null };
+}
+
+function formatLocalTime(date: Date): string | null {
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${hours}:${minutes}`;
+}
+
+export function TimeField({
+  label,
+  value,
+  onChange,
+  disabled = false,
+  error,
+}: TimeFieldProps) {
+  const anchored = useMemo(() => createAnchoredDate(value), [value]);
+  const pickerModifiers = useMemo(
+    () => [
+      accessibilityLabel(label),
+      accessibilityValue(anchored.valid ? value : 'Not set'),
+      accessibilityHint(
+        disabled ? 'Time selection is unavailable.' : 'Adjust the hour and minute.',
+      ),
+      ...(disabled ? [disabledModifier()] : []),
+    ],
+    [anchored.valid, disabled, label, value],
+  );
+  const handleDateChange = useCallback(
+    (date: Date) => {
+      if (disabled) {
+        return;
+      }
+      const nextValue = formatLocalTime(date);
+      if (nextValue !== null && nextValue !== value) {
+        onChange(nextValue);
+      }
+    },
+    [disabled, onChange, value],
+  );
+
+  return (
+    <View style={styles.wrap}>
+      <Text style={styles.label}>{label}</Text>
+      <View
+        style={[
+          styles.field,
+          error ? styles.fieldError : null,
+          disabled ? styles.fieldDisabled : null,
+        ]}
+      >
+        <Ionicons name="time-outline" size={20} color={colors.textMuted} />
+        <Host matchContents colorScheme="light" style={styles.picker}>
+          <DatePicker
+            testID="time-field-picker"
+            selection={anchored.date}
+            onDateChange={handleDateChange}
+            displayedComponents={['hourAndMinute']}
+            modifiers={pickerModifiers}
+          />
+        </Host>
+      </View>
+      {error ? (
+        <Text accessibilityRole="alert" style={styles.error}>
+          {error}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { gap: spacing.xs },
+  label: { ...typography.label, color: colors.text },
+  field: {
+    minHeight: 48,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    backgroundColor: colors.background,
+  },
+  fieldError: { borderColor: colors.danger },
+  fieldDisabled: { opacity: 0.55 },
+  picker: { minHeight: 40 },
+  error: { ...typography.caption, color: colors.danger },
+});

--- a/mobile/src/features/timeline/customTypeModel.ts
+++ b/mobile/src/features/timeline/customTypeModel.ts
@@ -1,0 +1,119 @@
+import {
+  DEFAULT_TIMELINE_COLOR_TOKEN,
+  DEFAULT_TIMELINE_ICON_KEY,
+  isTimelineColorToken,
+  isTimelineIconKey,
+} from './tokenMaps';
+import type {
+  CreateCustomTypePayload,
+  PatchCustomTypePayload,
+  TimelineCustomTypeMeta,
+} from './types';
+
+export const CUSTOM_TYPE_NAME_MAX_LENGTH = 40;
+
+export interface CustomTypeDraft {
+  name: string;
+  color_token: string;
+  icon_key: string;
+}
+
+export type CustomTypeField = keyof CustomTypeDraft;
+export type CustomTypeFieldErrors = Partial<
+  Record<CustomTypeField, string>
+>;
+
+export interface CustomTypeValidationResult {
+  isValid: boolean;
+  fieldErrors: CustomTypeFieldErrors;
+}
+
+function normalizeName(value: string): string {
+  return value.trim();
+}
+
+export function createCustomTypeDraft(): CustomTypeDraft {
+  return {
+    name: '',
+    color_token: DEFAULT_TIMELINE_COLOR_TOKEN,
+    icon_key: DEFAULT_TIMELINE_ICON_KEY,
+  };
+}
+
+export function hydrateCustomTypeDraft(
+  customType: TimelineCustomTypeMeta,
+): CustomTypeDraft {
+  return {
+    name: customType.name,
+    color_token: customType.color_token,
+    icon_key: customType.icon_key,
+  };
+}
+
+export function validateCustomTypeDraft(
+  draft: CustomTypeDraft,
+): CustomTypeValidationResult {
+  const fieldErrors: CustomTypeFieldErrors = {};
+  const name = normalizeName(draft.name);
+
+  if (!name) {
+    fieldErrors.name = 'Name is required.';
+  } else if (Array.from(name).length > CUSTOM_TYPE_NAME_MAX_LENGTH) {
+    fieldErrors.name =
+      `Name must be ${CUSTOM_TYPE_NAME_MAX_LENGTH} characters or fewer.`;
+  }
+
+  return {
+    isValid: Object.keys(fieldErrors).length === 0,
+    fieldErrors,
+  };
+}
+
+export function buildCreateCustomTypePayload(
+  draft: CustomTypeDraft,
+): CreateCustomTypePayload | null {
+  if (
+    !validateCustomTypeDraft(draft).isValid ||
+    !isTimelineColorToken(draft.color_token) ||
+    !isTimelineIconKey(draft.icon_key)
+  ) {
+    return null;
+  }
+
+  return {
+    name: normalizeName(draft.name),
+    color_token: draft.color_token,
+    icon_key: draft.icon_key,
+  };
+}
+
+export function buildPatchCustomTypePayload(
+  initialDraft: CustomTypeDraft,
+  draft: CustomTypeDraft,
+): PatchCustomTypePayload | null {
+  if (!validateCustomTypeDraft(draft).isValid) {
+    return null;
+  }
+
+  const payload: PatchCustomTypePayload = {};
+  const initialName = normalizeName(initialDraft.name);
+  const currentName = normalizeName(draft.name);
+
+  if (initialName !== currentName) {
+    payload.name = currentName;
+  }
+  if (
+    initialDraft.color_token !== draft.color_token &&
+    isTimelineColorToken(draft.color_token)
+  ) {
+    payload.color_token = draft.color_token;
+  }
+  if (
+    initialDraft.icon_key !== draft.icon_key &&
+    isTimelineIconKey(draft.icon_key)
+  ) {
+    payload.icon_key = draft.icon_key;
+  }
+
+  return payload;
+}

--- a/mobile/src/features/timeline/formModel.ts
+++ b/mobile/src/features/timeline/formModel.ts
@@ -137,6 +137,7 @@ export type SectionFormFieldErrors = Partial<
 
 export interface ActivityValidationOptions {
   activeAssigneeIds?: ReadonlySet<string> | readonly string[];
+  selectableCustomTypeIds?: ReadonlySet<string> | readonly string[];
 }
 
 export interface FormValidationResult<TField extends string> {
@@ -148,7 +149,7 @@ export function createActivityDraft(): ActivityFormDraft {
   return {
     title: '',
     time_mode: 'AT_TIME',
-    start_time: '',
+    start_time: '00:00',
     end_time: '',
     system_type: 'OTHER',
     custom_type_id: null,
@@ -222,7 +223,17 @@ export function applyActivityTimeMode(
   next.time_mode = timeMode;
 
   if (timeMode === 'AT_TIME') {
+    if (!isValidTime(next.start_time)) {
+      next.start_time = '00:00';
+    }
     next.end_time = '';
+  } else if (timeMode === 'TIME_RANGE') {
+    if (!isValidTime(next.start_time)) {
+      next.start_time = '00:00';
+    }
+    if (!isValidTime(next.end_time)) {
+      next.end_time = defaultRangeEndTime(next.start_time);
+    }
   } else if (timeMode === 'ALL_DAY' || timeMode === 'FLEXIBLE') {
     next.start_time = '';
     next.end_time = '';
@@ -307,7 +318,7 @@ export function validateActivityDraft(
   }
 
   validateTimeFields(draft, fieldErrors);
-  validateActivityType(draft, fieldErrors);
+  validateActivityType(draft, options, fieldErrors);
   validateAssignee(draft, options, fieldErrors);
   validateLocation(draft, fieldErrors);
   validateActivityTextFields(draft, fieldErrors);
@@ -586,6 +597,7 @@ function validateTimeFields(
 
 function validateActivityType(
   draft: ActivityFormDraft,
+  options: ActivityValidationOptions,
   fieldErrors: ActivityFormFieldErrors,
 ): void {
   const hasSystem = draft.system_type !== null;
@@ -604,6 +616,22 @@ function validateActivityType(
 
   if (hasSystem && !SYSTEM_TYPE_CODES.has(draft.system_type ?? '')) {
     addError(fieldErrors, 'activity_type', 'Choose a valid activity type.');
+    return;
+  }
+
+  if (
+    hasCustom &&
+    options.selectableCustomTypeIds &&
+    !containsId(
+      options.selectableCustomTypeIds,
+      normalizeText(draft.custom_type_id ?? ''),
+    )
+  ) {
+    addError(
+      fieldErrors,
+      'activity_type',
+      'The selected custom type is no longer available. Choose another activity type.',
+    );
   }
 }
 
@@ -974,6 +1002,13 @@ function isValidTime(value: string): boolean {
 function timeToMinutes(value: string): number {
   const [hour, minute] = value.split(':').map(Number);
   return hour * 60 + minute;
+}
+
+function defaultRangeEndTime(startTime: string): string {
+  const minutes = Math.min(timeToMinutes(startTime) + 60, 23 * 60 + 59);
+  const hours = String(Math.floor(minutes / 60)).padStart(2, '0');
+  const remainder = String(minutes % 60).padStart(2, '0');
+  return `${hours}:${remainder}`;
 }
 
 function isValidIsoDate(value: string): boolean {

--- a/mobile/src/features/timeline/formModel.ts
+++ b/mobile/src/features/timeline/formModel.ts
@@ -22,6 +22,7 @@ export const REMINDER_PRESETS = [
 ] as const;
 
 export const MAX_REMINDER_OFFSETS = 5;
+const ACTIVITY_COORDINATE_DECIMAL_PLACES = 6;
 
 export const ACTIVITY_FIELD_LIMITS = {
   title: 140,
@@ -924,9 +925,16 @@ function normalizePlace(
     provider_id: place.provider_id,
     title: normalizeText(place.title),
     address: normalizeText(place.address ?? ''),
-    lat: place.lat ?? null,
-    lng: place.lng ?? null,
+    lat: normalizeCoordinate(place.lat),
+    lng: normalizeCoordinate(place.lng),
   };
+}
+
+function normalizeCoordinate(value: number | null | undefined): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return Number(value.toFixed(ACTIVITY_COORDINATE_DECIMAL_PLACES));
 }
 
 function clonePlace(

--- a/mobile/src/features/timeline/formModel.ts
+++ b/mobile/src/features/timeline/formModel.ts
@@ -1,0 +1,1056 @@
+import type {
+  ActivityPlacePayload,
+  CreateActivityPayload,
+  CreateSectionPayload,
+  PatchActivityPayload,
+  PatchSectionPayload,
+  TimelineActivity,
+  TimelineActivityAssigneeScope,
+  TimelineActivityTimeMode,
+  TimelineCustomTypeMeta,
+  TimelineLocationMode,
+  TimelineSection,
+  TimelineSystemTypeCode,
+} from './types';
+
+export const REMINDER_PRESETS = [
+  { value: 10080, label: '7 days' },
+  { value: 1440, label: '1 day' },
+  { value: 120, label: '2 h' },
+  { value: 30, label: '30 min' },
+  { value: 15, label: '15 min' },
+] as const;
+
+export const MAX_REMINDER_OFFSETS = 5;
+
+export const ACTIVITY_FIELD_LIMITS = {
+  title: 140,
+  location_label: 200,
+  location_note: 200,
+  place_provider: 16,
+  place_provider_id: 255,
+  place_title: 200,
+  place_address: 255,
+  meeting_point: 200,
+  contact_name: 120,
+  contact_phone: 32,
+  booking_reference: 120,
+  external_link: 500,
+} as const;
+
+export const SECTION_FIELD_LIMITS = {
+  label: 120,
+} as const;
+
+const SYSTEM_TYPE_CODES = new Set<string>([
+  'TRANSPORTATION',
+  'ACCOMMODATION',
+  'FOOD',
+  'SIGHTSEEING',
+  'SHOPPING',
+  'CHECKIN_OUT',
+  'FREE_TIME',
+  'OTHER',
+] satisfies TimelineSystemTypeCode[]);
+
+const REMINDER_VALUES = new Set<number>(
+  REMINDER_PRESETS.map((preset) => preset.value),
+);
+
+const ACTIVITY_DRAFT_FIELDS = [
+  'title',
+  'time_mode',
+  'start_time',
+  'end_time',
+  'system_type',
+  'custom_type_id',
+  'assignee_scope',
+  'assignee_user_id',
+  'location_mode',
+  'location_label',
+  'location_note',
+  'place',
+  'note',
+  'meeting_point',
+  'contact_name',
+  'contact_phone',
+  'booking_reference',
+  'external_link',
+  'reminder_offsets_minutes',
+] as const;
+
+const SECTION_DRAFT_FIELDS = ['section_date', 'label'] as const;
+
+export interface ActivityFormDraft {
+  title: string;
+  time_mode: TimelineActivityTimeMode;
+  start_time: string;
+  end_time: string;
+  system_type: TimelineSystemTypeCode | null;
+  custom_type_id: string | null;
+  assignee_scope: TimelineActivityAssigneeScope;
+  assignee_user_id: string | null;
+  location_mode: TimelineLocationMode;
+  location_label: string;
+  location_note: string;
+  place: ActivityPlacePayload | null;
+  note: string;
+  meeting_point: string;
+  contact_name: string;
+  contact_phone: string;
+  booking_reference: string;
+  external_link: string;
+  reminder_offsets_minutes: number[];
+}
+
+export interface SectionFormDraft {
+  section_date: string;
+  label: string;
+}
+
+export type ActivityDraftField = (typeof ACTIVITY_DRAFT_FIELDS)[number];
+export type SectionDraftField = (typeof SECTION_DRAFT_FIELDS)[number];
+
+export type ActivityFormDirtyFields = Readonly<
+  Partial<Record<ActivityDraftField, boolean>>
+>;
+export type SectionFormDirtyFields = Readonly<
+  Partial<Record<SectionDraftField, boolean>>
+>;
+
+export type ActivityFormErrorField =
+  | ActivityDraftField
+  | 'activity_type'
+  | 'place.provider'
+  | 'place.provider_id'
+  | 'place.title'
+  | 'place.address'
+  | 'place.lat'
+  | 'place.lng';
+
+export type ActivityFormFieldErrors = Partial<
+  Record<ActivityFormErrorField, string>
+>;
+export type SectionFormFieldErrors = Partial<
+  Record<SectionDraftField, string>
+>;
+
+export interface ActivityValidationOptions {
+  activeAssigneeIds?: ReadonlySet<string> | readonly string[];
+}
+
+export interface FormValidationResult<TField extends string> {
+  isValid: boolean;
+  fieldErrors: Partial<Record<TField, string>>;
+}
+
+export function createActivityDraft(): ActivityFormDraft {
+  return {
+    title: '',
+    time_mode: 'AT_TIME',
+    start_time: '',
+    end_time: '',
+    system_type: 'OTHER',
+    custom_type_id: null,
+    assignee_scope: 'NONE',
+    assignee_user_id: null,
+    location_mode: 'MANUAL',
+    location_label: '',
+    location_note: '',
+    place: null,
+    note: '',
+    meeting_point: '',
+    contact_name: '',
+    contact_phone: '',
+    booking_reference: '',
+    external_link: '',
+    reminder_offsets_minutes: [],
+  };
+}
+
+export function hydrateActivityDraft(
+  activity: TimelineActivity,
+): ActivityFormDraft {
+  const systemType =
+    activity.activity_type?.kind === 'SYSTEM'
+      ? activity.activity_type.code
+      : null;
+  const customTypeId =
+    activity.activity_type?.kind === 'CUSTOM'
+      ? activity.activity_type.id
+      : null;
+
+  return {
+    title: activity.title,
+    time_mode: activity.time_mode,
+    start_time: activity.start_time?.slice(0, 5) ?? '',
+    end_time: activity.end_time?.slice(0, 5) ?? '',
+    system_type: systemType,
+    custom_type_id: customTypeId,
+    assignee_scope: activity.assignee_scope,
+    assignee_user_id:
+      activity.assignee_scope === 'USER' ? activity.assignee?.id ?? null : null,
+    location_mode: activity.location.location_mode,
+    location_label: activity.location.location_label,
+    location_note: activity.location.location_note,
+    place: clonePlace(activity.location.place),
+    note: activity.note,
+    meeting_point: activity.meeting_point,
+    contact_name: activity.contact_name,
+    contact_phone: activity.contact_phone,
+    booking_reference: activity.booking_reference,
+    external_link: activity.external_link,
+    reminder_offsets_minutes: [...activity.reminder_offsets_minutes],
+  };
+}
+
+export function cloneActivityDraft(
+  draft: ActivityFormDraft,
+): ActivityFormDraft {
+  return {
+    ...draft,
+    place: clonePlace(draft.place),
+    reminder_offsets_minutes: [...draft.reminder_offsets_minutes],
+  };
+}
+
+export function applyActivityTimeMode(
+  draft: ActivityFormDraft,
+  timeMode: TimelineActivityTimeMode,
+): ActivityFormDraft {
+  const next = cloneActivityDraft(draft);
+  next.time_mode = timeMode;
+
+  if (timeMode === 'AT_TIME') {
+    next.end_time = '';
+  } else if (timeMode === 'ALL_DAY' || timeMode === 'FLEXIBLE') {
+    next.start_time = '';
+    next.end_time = '';
+    next.reminder_offsets_minutes = [];
+  }
+
+  return next;
+}
+
+export function applyActivityLocationMode(
+  draft: ActivityFormDraft,
+  locationMode: TimelineLocationMode,
+): ActivityFormDraft {
+  const next = cloneActivityDraft(draft);
+  next.location_mode = locationMode;
+  if (locationMode === 'MANUAL') {
+    next.place = null;
+  }
+  return next;
+}
+
+export function toggleActivityReminder(
+  draft: ActivityFormDraft,
+  reminderOffset: number,
+): ActivityFormDraft {
+  if (
+    !REMINDER_VALUES.has(reminderOffset) ||
+    !isTimedMode(draft.time_mode) ||
+    !isValidTime(draft.start_time)
+  ) {
+    return draft;
+  }
+
+  const reminders = new Set(draft.reminder_offsets_minutes);
+  if (reminders.has(reminderOffset)) {
+    reminders.delete(reminderOffset);
+  } else if (reminders.size < MAX_REMINDER_OFFSETS) {
+    reminders.add(reminderOffset);
+  } else {
+    return draft;
+  }
+
+  return {
+    ...draft,
+    place: clonePlace(draft.place),
+    reminder_offsets_minutes: [...reminders].sort((left, right) => right - left),
+  };
+}
+
+export function getSelectableCustomTypes(
+  customTypes: readonly TimelineCustomTypeMeta[],
+  initialActivity?: TimelineActivity,
+): TimelineCustomTypeMeta[] {
+  const initialCustomTypeId =
+    initialActivity?.activity_type?.kind === 'CUSTOM'
+      ? initialActivity.activity_type.id
+      : null;
+
+  return customTypes.filter(
+    (customType) =>
+      customType.is_active || customType.id === initialCustomTypeId,
+  );
+}
+
+export function validateActivityDraft(
+  draft: ActivityFormDraft,
+  options: ActivityValidationOptions = {},
+): FormValidationResult<ActivityFormErrorField> {
+  const fieldErrors: ActivityFormFieldErrors = {};
+  const normalizedTitle = normalizeText(draft.title);
+
+  if (!normalizedTitle) {
+    addError(fieldErrors, 'title', 'Title is required.');
+  } else if (
+    codePointLength(normalizedTitle) > ACTIVITY_FIELD_LIMITS.title
+  ) {
+    addError(
+      fieldErrors,
+      'title',
+      `Title must be ${ACTIVITY_FIELD_LIMITS.title} characters or fewer.`,
+    );
+  }
+
+  validateTimeFields(draft, fieldErrors);
+  validateActivityType(draft, fieldErrors);
+  validateAssignee(draft, options, fieldErrors);
+  validateLocation(draft, fieldErrors);
+  validateActivityTextFields(draft, fieldErrors);
+  validateReminders(draft, fieldErrors);
+
+  return {
+    isValid: Object.keys(fieldErrors).length === 0,
+    fieldErrors,
+  };
+}
+
+export function buildCreateActivityPayload(
+  draft: ActivityFormDraft,
+  options: ActivityValidationOptions = {},
+): CreateActivityPayload | null {
+  if (!validateActivityDraft(draft, options).isValid) {
+    return null;
+  }
+  return serializeActivityDraft(draft);
+}
+
+export function getActivityDirtyFields(
+  initialDraft: ActivityFormDraft,
+  draft: ActivityFormDraft,
+): ActivityFormDirtyFields {
+  const dirtyFields: Partial<Record<ActivityDraftField, boolean>> = {};
+  for (const field of ACTIVITY_DRAFT_FIELDS) {
+    if (!valuesEqual(initialDraft[field], draft[field])) {
+      dirtyFields[field] = true;
+    }
+  }
+  return dirtyFields;
+}
+
+export function buildPatchActivityPayload(
+  initialDraft: ActivityFormDraft,
+  draft: ActivityFormDraft,
+  dirtyFields: ActivityFormDirtyFields = getActivityDirtyFields(
+    initialDraft,
+    draft,
+  ),
+  options: ActivityValidationOptions = {},
+): PatchActivityPayload | null {
+  if (!validateActivityDraft(draft, options).isValid) {
+    return null;
+  }
+
+  const initialPayload = serializeActivityDraft(initialDraft);
+  const currentPayload = serializeActivityDraft(draft);
+  const patch: PatchActivityPayload = {};
+
+  if (dirtyFields.title) {
+    assignChanged(patch, initialPayload, currentPayload, 'title');
+  }
+
+  if (dirtyFields.time_mode) {
+    assignChanged(patch, initialPayload, currentPayload, 'time_mode');
+  }
+  if (dirtyFields.time_mode || dirtyFields.start_time) {
+    assignChanged(patch, initialPayload, currentPayload, 'start_time');
+  }
+  if (dirtyFields.time_mode || dirtyFields.end_time) {
+    assignChanged(patch, initialPayload, currentPayload, 'end_time');
+  }
+  if (
+    dirtyFields.time_mode ||
+    dirtyFields.start_time ||
+    dirtyFields.reminder_offsets_minutes
+  ) {
+    assignChanged(
+      patch,
+      initialPayload,
+      currentPayload,
+      'reminder_offsets_minutes',
+    );
+  }
+
+  if (dirtyFields.system_type || dirtyFields.custom_type_id) {
+    assignChanged(patch, initialPayload, currentPayload, 'system_type');
+    assignChanged(patch, initialPayload, currentPayload, 'custom_type_id');
+  }
+
+  if (dirtyFields.assignee_scope || dirtyFields.assignee_user_id) {
+    assignChanged(patch, initialPayload, currentPayload, 'assignee_scope');
+    assignChanged(patch, initialPayload, currentPayload, 'assignee_user_id');
+  }
+
+  if (dirtyFields.location_mode || dirtyFields.place) {
+    assignChanged(patch, initialPayload, currentPayload, 'location_mode');
+    assignChanged(patch, initialPayload, currentPayload, 'place');
+  }
+  if (dirtyFields.location_label) {
+    assignChanged(patch, initialPayload, currentPayload, 'location_label');
+  }
+  if (dirtyFields.location_note) {
+    assignChanged(patch, initialPayload, currentPayload, 'location_note');
+  }
+
+  assignDirectDraftField(
+    patch,
+    initialPayload,
+    currentPayload,
+    dirtyFields,
+    'note',
+  );
+  assignDirectDraftField(
+    patch,
+    initialPayload,
+    currentPayload,
+    dirtyFields,
+    'meeting_point',
+  );
+  assignDirectDraftField(
+    patch,
+    initialPayload,
+    currentPayload,
+    dirtyFields,
+    'contact_name',
+  );
+  assignDirectDraftField(
+    patch,
+    initialPayload,
+    currentPayload,
+    dirtyFields,
+    'contact_phone',
+  );
+  assignDirectDraftField(
+    patch,
+    initialPayload,
+    currentPayload,
+    dirtyFields,
+    'booking_reference',
+  );
+  assignDirectDraftField(
+    patch,
+    initialPayload,
+    currentPayload,
+    dirtyFields,
+    'external_link',
+  );
+
+  return patch;
+}
+
+export function createSectionDraft(sectionDate = ''): SectionFormDraft {
+  return {
+    section_date: sectionDate,
+    label: '',
+  };
+}
+
+export function hydrateSectionDraft(section: TimelineSection): SectionFormDraft {
+  return {
+    section_date: section.section_date,
+    label: section.label,
+  };
+}
+
+export function validateSectionDraft(
+  draft: SectionFormDraft,
+): FormValidationResult<SectionDraftField> {
+  const fieldErrors: SectionFormFieldErrors = {};
+  const label = normalizeText(draft.label);
+
+  if (!isValidIsoDate(draft.section_date)) {
+    addError(fieldErrors, 'section_date', 'Enter a valid date.');
+  }
+  if (!label) {
+    addError(fieldErrors, 'label', 'Label is required.');
+  } else if (codePointLength(label) > SECTION_FIELD_LIMITS.label) {
+    addError(
+      fieldErrors,
+      'label',
+      `Label must be ${SECTION_FIELD_LIMITS.label} characters or fewer.`,
+    );
+  }
+
+  return {
+    isValid: Object.keys(fieldErrors).length === 0,
+    fieldErrors,
+  };
+}
+
+export function buildCreateSectionPayload(
+  draft: SectionFormDraft,
+): CreateSectionPayload | null {
+  if (!validateSectionDraft(draft).isValid) {
+    return null;
+  }
+  return serializeSectionDraft(draft);
+}
+
+export function getSectionDirtyFields(
+  initialDraft: SectionFormDraft,
+  draft: SectionFormDraft,
+): SectionFormDirtyFields {
+  const dirtyFields: Partial<Record<SectionDraftField, boolean>> = {};
+  for (const field of SECTION_DRAFT_FIELDS) {
+    if (initialDraft[field] !== draft[field]) {
+      dirtyFields[field] = true;
+    }
+  }
+  return dirtyFields;
+}
+
+export function buildPatchSectionPayload(
+  initialDraft: SectionFormDraft,
+  draft: SectionFormDraft,
+  dirtyFields: SectionFormDirtyFields = getSectionDirtyFields(
+    initialDraft,
+    draft,
+  ),
+): PatchSectionPayload | null {
+  if (!validateSectionDraft(draft).isValid) {
+    return null;
+  }
+
+  const initialPayload = serializeSectionDraft(initialDraft);
+  const currentPayload = serializeSectionDraft(draft);
+  const patch: PatchSectionPayload = {};
+
+  if (
+    dirtyFields.section_date &&
+    initialPayload.section_date !== currentPayload.section_date
+  ) {
+    patch.section_date = currentPayload.section_date;
+  }
+  if (dirtyFields.label && initialPayload.label !== currentPayload.label) {
+    patch.label = currentPayload.label;
+  }
+  return patch;
+}
+
+function validateTimeFields(
+  draft: ActivityFormDraft,
+  fieldErrors: ActivityFormFieldErrors,
+): void {
+  if (draft.time_mode === 'ALL_DAY' || draft.time_mode === 'FLEXIBLE') {
+    if (draft.start_time || draft.end_time) {
+      addError(
+        fieldErrors,
+        'time_mode',
+        `${draft.time_mode === 'ALL_DAY' ? 'All-day' : 'Flexible'} activities cannot have times.`,
+      );
+    }
+    return;
+  }
+
+  if (!isValidTime(draft.start_time)) {
+    addError(fieldErrors, 'start_time', 'Enter a valid start time.');
+  }
+
+  if (draft.time_mode === 'AT_TIME') {
+    if (draft.end_time) {
+      addError(
+        fieldErrors,
+        'end_time',
+        'At-time activities cannot have an end time.',
+      );
+    }
+    return;
+  }
+
+  if (!isValidTime(draft.end_time)) {
+    addError(fieldErrors, 'end_time', 'Enter a valid end time.');
+    return;
+  }
+
+  if (
+    isValidTime(draft.start_time) &&
+    timeToMinutes(draft.end_time) <= timeToMinutes(draft.start_time)
+  ) {
+    addError(fieldErrors, 'end_time', 'End time must be after start time.');
+  }
+}
+
+function validateActivityType(
+  draft: ActivityFormDraft,
+  fieldErrors: ActivityFormFieldErrors,
+): void {
+  const hasSystem = draft.system_type !== null;
+  const hasCustom =
+    draft.custom_type_id !== null &&
+    normalizeText(draft.custom_type_id).length > 0;
+
+  if (hasSystem === hasCustom) {
+    addError(
+      fieldErrors,
+      'activity_type',
+      'Choose exactly one activity type.',
+    );
+    return;
+  }
+
+  if (hasSystem && !SYSTEM_TYPE_CODES.has(draft.system_type ?? '')) {
+    addError(fieldErrors, 'activity_type', 'Choose a valid activity type.');
+  }
+}
+
+function validateAssignee(
+  draft: ActivityFormDraft,
+  options: ActivityValidationOptions,
+  fieldErrors: ActivityFormFieldErrors,
+): void {
+  if (draft.assignee_scope === 'USER') {
+    const assigneeId = normalizeText(draft.assignee_user_id ?? '');
+    if (!assigneeId) {
+      addError(
+        fieldErrors,
+        'assignee_user_id',
+        'Choose an active trip member.',
+      );
+      return;
+    }
+
+    const activeIds = options.activeAssigneeIds;
+    if (activeIds && !containsId(activeIds, assigneeId)) {
+      addError(
+        fieldErrors,
+        'assignee_user_id',
+        'Choose an active trip member.',
+      );
+    }
+    return;
+  }
+
+  if (draft.assignee_user_id !== null) {
+    addError(
+      fieldErrors,
+      'assignee_user_id',
+      'An individual assignee is only allowed for the User scope.',
+    );
+  }
+}
+
+function validateLocation(
+  draft: ActivityFormDraft,
+  fieldErrors: ActivityFormFieldErrors,
+): void {
+  if (
+    codePointLength(normalizeText(draft.location_label)) >
+    ACTIVITY_FIELD_LIMITS.location_label
+  ) {
+    addError(
+      fieldErrors,
+      'location_label',
+      `Location label must be ${ACTIVITY_FIELD_LIMITS.location_label} characters or fewer.`,
+    );
+  }
+  if (
+    codePointLength(normalizeText(draft.location_note)) >
+    ACTIVITY_FIELD_LIMITS.location_note
+  ) {
+    addError(
+      fieldErrors,
+      'location_note',
+      `Location note must be ${ACTIVITY_FIELD_LIMITS.location_note} characters or fewer.`,
+    );
+  }
+
+  if (draft.location_mode === 'MANUAL') {
+    if (draft.place !== null) {
+      addError(
+        fieldErrors,
+        'place',
+        'Manual locations cannot include structured place data.',
+      );
+    }
+    return;
+  }
+
+  if (draft.place === null) {
+    addError(
+      fieldErrors,
+      'place',
+      'Choose a verified place for a structured location.',
+    );
+    return;
+  }
+
+  validatePlace(draft.place, fieldErrors);
+}
+
+function validatePlace(
+  place: ActivityPlacePayload,
+  fieldErrors: ActivityFormFieldErrors,
+): void {
+  validateRequiredCappedText(
+    place.provider,
+    ACTIVITY_FIELD_LIMITS.place_provider,
+    'place.provider',
+    'Provider',
+    fieldErrors,
+  );
+  validateRequiredCappedText(
+    place.provider_id,
+    ACTIVITY_FIELD_LIMITS.place_provider_id,
+    'place.provider_id',
+    'Provider id',
+    fieldErrors,
+  );
+  validateRequiredCappedText(
+    place.title,
+    ACTIVITY_FIELD_LIMITS.place_title,
+    'place.title',
+    'Place title',
+    fieldErrors,
+  );
+
+  if (
+    codePointLength(normalizeText(place.address ?? '')) >
+    ACTIVITY_FIELD_LIMITS.place_address
+  ) {
+    addError(
+      fieldErrors,
+      'place.address',
+      `Place address must be ${ACTIVITY_FIELD_LIMITS.place_address} characters or fewer.`,
+    );
+  }
+
+  if (place.lat !== null && place.lat !== undefined && !Number.isFinite(place.lat)) {
+    addError(fieldErrors, 'place.lat', 'Latitude must be a finite number.');
+  }
+  if (place.lng !== null && place.lng !== undefined && !Number.isFinite(place.lng)) {
+    addError(fieldErrors, 'place.lng', 'Longitude must be a finite number.');
+  }
+}
+
+function validateActivityTextFields(
+  draft: ActivityFormDraft,
+  fieldErrors: ActivityFormFieldErrors,
+): void {
+  validateOptionalCappedText(
+    draft.meeting_point,
+    ACTIVITY_FIELD_LIMITS.meeting_point,
+    'meeting_point',
+    'Meeting point',
+    fieldErrors,
+  );
+  validateOptionalCappedText(
+    draft.contact_name,
+    ACTIVITY_FIELD_LIMITS.contact_name,
+    'contact_name',
+    'Contact name',
+    fieldErrors,
+  );
+  validateOptionalCappedText(
+    draft.contact_phone,
+    ACTIVITY_FIELD_LIMITS.contact_phone,
+    'contact_phone',
+    'Contact phone',
+    fieldErrors,
+  );
+  validateOptionalCappedText(
+    draft.booking_reference,
+    ACTIVITY_FIELD_LIMITS.booking_reference,
+    'booking_reference',
+    'Booking reference',
+    fieldErrors,
+  );
+  validateOptionalCappedText(
+    draft.external_link,
+    ACTIVITY_FIELD_LIMITS.external_link,
+    'external_link',
+    'External link',
+    fieldErrors,
+  );
+
+  const externalLink = normalizeText(draft.external_link);
+  if (externalLink && !isValidExternalUrl(externalLink)) {
+    addError(fieldErrors, 'external_link', 'Enter a valid URL.');
+  }
+}
+
+function validateReminders(
+  draft: ActivityFormDraft,
+  fieldErrors: ActivityFormFieldErrors,
+): void {
+  const reminders = draft.reminder_offsets_minutes;
+  if (!Array.isArray(reminders)) {
+    addError(fieldErrors, 'reminder_offsets_minutes', 'Invalid reminders.');
+    return;
+  }
+  if (reminders.length > MAX_REMINDER_OFFSETS) {
+    addError(
+      fieldErrors,
+      'reminder_offsets_minutes',
+      `Choose at most ${MAX_REMINDER_OFFSETS} reminders.`,
+    );
+    return;
+  }
+
+  const uniqueReminders = new Set<number>();
+  for (const reminder of reminders) {
+    if (
+      !Number.isInteger(reminder) ||
+      !REMINDER_VALUES.has(reminder) ||
+      uniqueReminders.has(reminder)
+    ) {
+      addError(
+        fieldErrors,
+        'reminder_offsets_minutes',
+        'Use each supported reminder preset at most once.',
+      );
+      return;
+    }
+    uniqueReminders.add(reminder);
+  }
+
+  if (!isTimedMode(draft.time_mode) && reminders.length > 0) {
+    addError(
+      fieldErrors,
+      'reminder_offsets_minutes',
+      'All-day and flexible activities cannot have reminders.',
+    );
+  } else if (
+    reminders.length > 0 &&
+    !isValidTime(draft.start_time)
+  ) {
+    addError(
+      fieldErrors,
+      'reminder_offsets_minutes',
+      'Set a valid start time before adding reminders.',
+    );
+  }
+}
+
+function serializeActivityDraft(
+  draft: ActivityFormDraft,
+): CreateActivityPayload {
+  const timed = isTimedMode(draft.time_mode);
+  const place =
+    draft.location_mode === 'STRUCTURED' ? normalizePlace(draft.place) : null;
+
+  return {
+    title: normalizeText(draft.title),
+    time_mode: draft.time_mode,
+    start_time: timed ? normalizeText(draft.start_time) || null : null,
+    end_time:
+      draft.time_mode === 'TIME_RANGE'
+        ? normalizeText(draft.end_time) || null
+        : null,
+    system_type: draft.system_type ?? '',
+    custom_type_id:
+      draft.system_type === null
+        ? normalizeText(draft.custom_type_id ?? '') || null
+        : null,
+    assignee_scope: draft.assignee_scope,
+    assignee_user_id:
+      draft.assignee_scope === 'USER'
+        ? normalizeText(draft.assignee_user_id ?? '') || null
+        : null,
+    location_mode: draft.location_mode,
+    location_label: normalizeText(draft.location_label),
+    location_note: normalizeText(draft.location_note),
+    place,
+    note: normalizeText(draft.note),
+    meeting_point: normalizeText(draft.meeting_point),
+    contact_name: normalizeText(draft.contact_name),
+    contact_phone: normalizeText(draft.contact_phone),
+    booking_reference: normalizeText(draft.booking_reference),
+    external_link: normalizeText(draft.external_link),
+    reminder_offsets_minutes: timed
+      ? [...draft.reminder_offsets_minutes].sort((left, right) => right - left)
+      : [],
+  };
+}
+
+function serializeSectionDraft(
+  draft: SectionFormDraft,
+): CreateSectionPayload {
+  return {
+    section_date: draft.section_date,
+    label: normalizeText(draft.label),
+  };
+}
+
+function normalizePlace(
+  place: ActivityPlacePayload | null,
+): ActivityPlacePayload | null {
+  if (place === null) {
+    return null;
+  }
+  return {
+    provider: normalizeText(place.provider),
+    provider_id: place.provider_id,
+    title: normalizeText(place.title),
+    address: normalizeText(place.address ?? ''),
+    lat: place.lat ?? null,
+    lng: place.lng ?? null,
+  };
+}
+
+function clonePlace(
+  place: ActivityPlacePayload | null,
+): ActivityPlacePayload | null {
+  return place ? { ...place } : null;
+}
+
+function assignDirectDraftField(
+  patch: PatchActivityPayload,
+  initialPayload: CreateActivityPayload,
+  currentPayload: CreateActivityPayload,
+  dirtyFields: ActivityFormDirtyFields,
+  field:
+    | 'note'
+    | 'meeting_point'
+    | 'contact_name'
+    | 'contact_phone'
+    | 'booking_reference'
+    | 'external_link',
+): void {
+  if (dirtyFields[field]) {
+    assignChanged(patch, initialPayload, currentPayload, field);
+  }
+}
+
+function assignChanged<K extends keyof CreateActivityPayload>(
+  patch: PatchActivityPayload,
+  initialPayload: CreateActivityPayload,
+  currentPayload: CreateActivityPayload,
+  field: K,
+): void {
+  if (!valuesEqual(initialPayload[field], currentPayload[field])) {
+    patch[field] = currentPayload[field];
+  }
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (
+    typeof left !== 'object' ||
+    left === null ||
+    typeof right !== 'object' ||
+    right === null
+  ) {
+    return false;
+  }
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function containsId(
+  ids: ReadonlySet<string> | readonly string[],
+  id: string,
+): boolean {
+  for (const candidate of ids) {
+    if (candidate === id) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isTimedMode(timeMode: TimelineActivityTimeMode): boolean {
+  return timeMode === 'AT_TIME' || timeMode === 'TIME_RANGE';
+}
+
+function isValidTime(value: string): boolean {
+  return /^([01]\d|2[0-3]):[0-5]\d$/.test(value);
+}
+
+function timeToMinutes(value: string): number {
+  const [hour, minute] = value.split(':').map(Number);
+  return hour * 60 + minute;
+}
+
+function isValidIsoDate(value: string): boolean {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) {
+    return false;
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
+}
+
+function isValidExternalUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return ['http:', 'https:', 'ftp:', 'ftps:'].includes(url.protocol);
+  } catch {
+    return false;
+  }
+}
+
+function validateRequiredCappedText(
+  value: string,
+  maxLength: number,
+  field: ActivityFormErrorField,
+  label: string,
+  fieldErrors: ActivityFormFieldErrors,
+): void {
+  const normalized = normalizeText(value);
+  if (!normalized) {
+    addError(fieldErrors, field, `${label} is required.`);
+  } else if (codePointLength(normalized) > maxLength) {
+    addError(
+      fieldErrors,
+      field,
+      `${label} must be ${maxLength} characters or fewer.`,
+    );
+  }
+}
+
+function validateOptionalCappedText(
+  value: string,
+  maxLength: number,
+  field: ActivityFormErrorField,
+  label: string,
+  fieldErrors: ActivityFormFieldErrors,
+): void {
+  if (codePointLength(normalizeText(value)) > maxLength) {
+    addError(
+      fieldErrors,
+      field,
+      `${label} must be ${maxLength} characters or fewer.`,
+    );
+  }
+}
+
+function addError<TField extends string>(
+  fieldErrors: Partial<Record<TField, string>>,
+  field: TField,
+  message: string,
+): void {
+  if (fieldErrors[field] === undefined) {
+    fieldErrors[field] = message;
+  }
+}
+
+function normalizeText(value: string): string {
+  return value.trim();
+}
+
+function codePointLength(value: string): number {
+  return Array.from(value).length;
+}

--- a/mobile/src/features/timeline/hooks/useLocationSearch.ts
+++ b/mobile/src/features/timeline/hooks/useLocationSearch.ts
@@ -174,6 +174,7 @@ export function useLocationSearch({
           }
 
           const nextError = normalizeApiError(caught);
+          setSuggestions([]);
           setSearchError(nextError);
           setSearchUnavailable(isLocationSearchUnavailable(nextError));
           setSearchStatus('error');
@@ -205,6 +206,7 @@ export function useLocationSearch({
       cancelSuggest();
       cancelLookup();
       setQueryValue(nextQuery);
+      setSuggestions([]);
       setSearchError(null);
       setSearchUnavailable(false);
       setLookupError(null);
@@ -212,7 +214,6 @@ export function useLocationSearch({
       setManualEntrySuggested(false);
 
       if (nextQuery.trim().length < 2) {
-        setSuggestions([]);
         setSearchStatus('idle');
       } else {
         setSearchStatus('debouncing');

--- a/mobile/src/features/timeline/hooks/useLocationSearch.ts
+++ b/mobile/src/features/timeline/hooks/useLocationSearch.ts
@@ -73,6 +73,10 @@ function staleLookupResult(): LocationLookupResult {
   return { kind: 'stale' };
 }
 
+function truncateCodePoints(value: string, maxLength: number): string {
+  return Array.from(value).slice(0, maxLength).join('');
+}
+
 export function useLocationSearch({
   enabled = true,
 }: UseLocationSearchOptions = {}) {
@@ -242,7 +246,10 @@ export function useLocationSearch({
     ): LocationLookupResult => {
       const fallback: SettledLocationLookupFailure = {
         location_mode: 'MANUAL',
-        location_label: suggestion.title,
+        location_label: truncateCodePoints(
+          suggestion.title,
+          ACTIVITY_FIELD_LIMITS.location_label,
+        ),
         place: null,
         error: nextError,
         guidance: MANUAL_LOCATION_GUIDANCE,

--- a/mobile/src/features/timeline/hooks/useLocationSearch.ts
+++ b/mobile/src/features/timeline/hooks/useLocationSearch.ts
@@ -1,0 +1,360 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { type ApiError, normalizeApiError } from '@/shared/api/errors';
+import { lookupLocation, suggestLocations } from '../api';
+import { ACTIVITY_FIELD_LIMITS } from '../formModel';
+import type {
+  ActivityPlacePayload,
+  LocationSuggestion,
+} from '../types';
+import {
+  buildStructuredLocation,
+  type StructuredLocationValue,
+} from '../viewModel';
+
+export const LOCATION_SEARCH_DEBOUNCE_MS = 300;
+export const PLACE_SEARCH_UNAVAILABLE_MESSAGE =
+  'Place search is unavailable — enter the location manually.';
+export const MANUAL_LOCATION_GUIDANCE =
+  "We couldn't verify this place — enter the location manually.";
+
+export type LocationSearchStatus =
+  | 'idle'
+  | 'debouncing'
+  | 'searching'
+  | 'ready'
+  | 'error';
+export type LocationLookupStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface StructuredLocationSelection extends StructuredLocationValue {
+  location_mode: 'STRUCTURED';
+}
+
+export interface ManualLocationValue {
+  location_mode: 'MANUAL';
+  location_label: string;
+  place: null;
+}
+
+export interface SettledLocationLookupFailure extends ManualLocationValue {
+  error: ApiError;
+  guidance: string;
+}
+
+export type LocationLookupResult =
+  | { kind: 'success'; selection: StructuredLocationSelection }
+  | { kind: 'failure'; fallback: SettledLocationLookupFailure }
+  | { kind: 'stale' };
+
+interface UseLocationSearchOptions {
+  enabled?: boolean;
+}
+
+const INVALID_CANONICAL_PLACE_ERROR: ApiError = {
+  kind: 'message',
+  message: 'The selected place could not be verified.',
+};
+
+function isLocationSearchUnavailable(error: ApiError): boolean {
+  return (
+    error.status === 503 &&
+    (error.errorCode === 'LOCATION_SEARCH_DISABLED' ||
+      error.errorCode === 'LOCATION_SEARCH_NOT_CONFIGURED')
+  );
+}
+
+function withinProviderIdLimit(suggestion: LocationSuggestion): boolean {
+  return (
+    Array.from(suggestion.provider_id).length <=
+    ACTIVITY_FIELD_LIMITS.place_provider_id
+  );
+}
+
+function staleLookupResult(): LocationLookupResult {
+  return { kind: 'stale' };
+}
+
+export function useLocationSearch({
+  enabled = true,
+}: UseLocationSearchOptions = {}) {
+  const [query, setQueryValue] = useState('');
+  const [suggestions, setSuggestions] = useState<LocationSuggestion[]>([]);
+  const [searchStatus, setSearchStatus] =
+    useState<LocationSearchStatus>('idle');
+  const [searchError, setSearchError] = useState<ApiError | null>(null);
+  const [searchUnavailable, setSearchUnavailable] = useState(false);
+  const [lookupStatus, setLookupStatus] =
+    useState<LocationLookupStatus>('idle');
+  const [lookupError, setLookupError] = useState<ApiError | null>(null);
+  const [manualEntrySuggested, setManualEntrySuggested] = useState(false);
+
+  const mountedRef = useRef(false);
+  const suggestRequestIdRef = useRef(0);
+  const lookupRequestIdRef = useRef(0);
+  const suggestTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const suggestControllerRef = useRef<AbortController | null>(null);
+  const lookupControllerRef = useRef<AbortController | null>(null);
+
+  const cancelSuggest = useCallback(() => {
+    suggestRequestIdRef.current += 1;
+    if (suggestTimerRef.current) {
+      clearTimeout(suggestTimerRef.current);
+      suggestTimerRef.current = null;
+    }
+    suggestControllerRef.current?.abort();
+    suggestControllerRef.current = null;
+  }, []);
+
+  const cancelLookup = useCallback(() => {
+    lookupRequestIdRef.current += 1;
+    lookupControllerRef.current?.abort();
+    lookupControllerRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      cancelSuggest();
+      cancelLookup();
+    };
+  }, [cancelLookup, cancelSuggest]);
+
+  useEffect(() => {
+    if (!enabled) {
+      cancelSuggest();
+      cancelLookup();
+    }
+  }, [cancelLookup, cancelSuggest, enabled]);
+
+  useEffect(() => {
+    const normalizedQuery = query.trim();
+    if (!enabled || normalizedQuery.length < 2) {
+      return undefined;
+    }
+
+    const requestId = suggestRequestIdRef.current + 1;
+    suggestRequestIdRef.current = requestId;
+    let controller: AbortController | null = null;
+
+    suggestTimerRef.current = setTimeout(() => {
+      suggestTimerRef.current = null;
+      controller = new AbortController();
+      suggestControllerRef.current = controller;
+      if (
+        !mountedRef.current ||
+        requestId !== suggestRequestIdRef.current
+      ) {
+        controller.abort();
+        return;
+      }
+
+      setSearchStatus('searching');
+      void suggestLocations(normalizedQuery, controller.signal)
+        .then((results) => {
+          if (
+            !mountedRef.current ||
+            controller?.signal.aborted ||
+            requestId !== suggestRequestIdRef.current
+          ) {
+            return;
+          }
+
+          setSuggestions(results.filter(withinProviderIdLimit));
+          setSearchError(null);
+          setSearchUnavailable(false);
+          setSearchStatus('ready');
+        })
+        .catch((caught: unknown) => {
+          if (
+            !mountedRef.current ||
+            controller?.signal.aborted ||
+            requestId !== suggestRequestIdRef.current
+          ) {
+            return;
+          }
+
+          const nextError = normalizeApiError(caught);
+          setSearchError(nextError);
+          setSearchUnavailable(isLocationSearchUnavailable(nextError));
+          setSearchStatus('error');
+        })
+        .finally(() => {
+          if (suggestControllerRef.current === controller) {
+            suggestControllerRef.current = null;
+          }
+        });
+    }, LOCATION_SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      if (suggestTimerRef.current) {
+        clearTimeout(suggestTimerRef.current);
+        suggestTimerRef.current = null;
+      }
+      controller?.abort();
+      if (suggestControllerRef.current === controller) {
+        suggestControllerRef.current = null;
+      }
+      if (suggestRequestIdRef.current === requestId) {
+        suggestRequestIdRef.current += 1;
+      }
+    };
+  }, [enabled, query]);
+
+  const setQuery = useCallback(
+    (nextQuery: string) => {
+      cancelSuggest();
+      cancelLookup();
+      setQueryValue(nextQuery);
+      setSearchError(null);
+      setSearchUnavailable(false);
+      setLookupError(null);
+      setLookupStatus('idle');
+      setManualEntrySuggested(false);
+
+      if (nextQuery.trim().length < 2) {
+        setSuggestions([]);
+        setSearchStatus('idle');
+      } else {
+        setSearchStatus('debouncing');
+      }
+    },
+    [cancelLookup, cancelSuggest],
+  );
+
+  const clear = useCallback(() => {
+    cancelSuggest();
+    cancelLookup();
+    setQueryValue('');
+    setSuggestions([]);
+    setSearchStatus('idle');
+    setSearchError(null);
+    setSearchUnavailable(false);
+    setLookupStatus('idle');
+    setLookupError(null);
+    setManualEntrySuggested(false);
+  }, [cancelLookup, cancelSuggest]);
+
+  const commitLookupFailure = useCallback(
+    (
+      suggestion: LocationSuggestion,
+      nextError: ApiError,
+    ): LocationLookupResult => {
+      const fallback: SettledLocationLookupFailure = {
+        location_mode: 'MANUAL',
+        location_label: suggestion.title,
+        place: null,
+        error: nextError,
+        guidance: MANUAL_LOCATION_GUIDANCE,
+      };
+      setLookupError(nextError);
+      setLookupStatus('error');
+      setManualEntrySuggested(true);
+      return { kind: 'failure', fallback };
+    },
+    [],
+  );
+
+  const selectSuggestion = useCallback(
+    async (
+      suggestion: LocationSuggestion,
+    ): Promise<LocationLookupResult> => {
+      if (!enabled || !mountedRef.current) {
+        return staleLookupResult();
+      }
+
+      cancelSuggest();
+      cancelLookup();
+      setSuggestions([]);
+      setSearchStatus('idle');
+      setSearchError(null);
+      setSearchUnavailable(false);
+      setLookupError(null);
+      setManualEntrySuggested(false);
+      setLookupStatus('loading');
+
+      const controller = new AbortController();
+      lookupControllerRef.current = controller;
+      const requestId = lookupRequestIdRef.current + 1;
+      lookupRequestIdRef.current = requestId;
+
+      try {
+        const lookup = await lookupLocation(
+          suggestion.provider_id,
+          controller.signal,
+        );
+        if (
+          !mountedRef.current ||
+          controller.signal.aborted ||
+          requestId !== lookupRequestIdRef.current
+        ) {
+          return staleLookupResult();
+        }
+
+        const value = buildStructuredLocation(suggestion, lookup);
+        if (!value) {
+          return commitLookupFailure(
+            suggestion,
+            INVALID_CANONICAL_PLACE_ERROR,
+          );
+        }
+
+        setLookupStatus('ready');
+        return {
+          kind: 'success',
+          selection: {
+            location_mode: 'STRUCTURED',
+            ...value,
+          },
+        };
+      } catch (caught) {
+        if (
+          !mountedRef.current ||
+          controller.signal.aborted ||
+          requestId !== lookupRequestIdRef.current
+        ) {
+          return staleLookupResult();
+        }
+        return commitLookupFailure(suggestion, normalizeApiError(caught));
+      } finally {
+        if (lookupControllerRef.current === controller) {
+          lookupControllerRef.current = null;
+        }
+      }
+    },
+    [
+      cancelLookup,
+      cancelSuggest,
+      commitLookupFailure,
+      enabled,
+    ],
+  );
+
+  const createManualValue = useCallback(
+    (existingLabel = ''): ManualLocationValue => ({
+      location_mode: 'MANUAL',
+      location_label: query.trim() || existingLabel,
+      place: null,
+    }),
+    [query],
+  );
+
+  return {
+    query,
+    setQuery,
+    clear,
+    suggestions,
+    searchStatus: enabled ? searchStatus : 'idle',
+    searchError: enabled ? searchError : null,
+    searchUnavailable: enabled ? searchUnavailable : false,
+    lookupStatus: enabled ? lookupStatus : 'idle',
+    lookupError: enabled ? lookupError : null,
+    manualEntrySuggested: enabled ? manualEntrySuggested : false,
+    selectSuggestion,
+    createManualValue,
+  };
+}
+
+export type PlacePickerValue = {
+  location_label: string;
+  place: ActivityPlacePayload | null;
+};

--- a/mobile/src/features/timeline/hooks/useTimeline.ts
+++ b/mobile/src/features/timeline/hooks/useTimeline.ts
@@ -38,6 +38,7 @@ export function useTimeline(
   const snapshotRef = useRef<TimelineSnapshot | null>(null);
   const requestIdRef = useRef(0);
   const activeTripIdRef = useRef(tripId);
+  const focusedRef = useRef(false);
 
   useEffect(() => {
     activeTripIdRef.current = tripId;
@@ -137,11 +138,16 @@ export function useTimeline(
       return undefined;
     }
 
-    return subscribeToTimelineEvents(tripId, () => refresh('silent'));
+    return subscribeToTimelineEvents(tripId, () => {
+      if (focusedRef.current) {
+        return refresh('silent');
+      }
+      return undefined;
+    });
   }, [autoReconcile, refresh, tripId]);
 
   const reconcileOnForeground = useCallback(() => {
-    if (autoReconcile) {
+    if (autoReconcile && focusedRef.current) {
       void refresh(snapshotRef.current?.tripId === tripId ? 'silent' : 'initial');
     }
   }, [autoReconcile, refresh, tripId]);
@@ -150,11 +156,13 @@ export function useTimeline(
 
   useFocusEffect(
     useCallback(() => {
+      focusedRef.current = true;
       if (autoReconcile) {
         void refresh(snapshotRef.current?.tripId === tripId ? 'silent' : 'initial');
       }
 
       return () => {
+        focusedRef.current = false;
         requestIdRef.current += 1;
       };
     }, [autoReconcile, refresh, tripId]),

--- a/mobile/src/features/timeline/hooks/useTimeline.ts
+++ b/mobile/src/features/timeline/hooks/useTimeline.ts
@@ -1,0 +1,177 @@
+import { useFocusEffect } from 'expo-router';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { type ApiError, normalizeApiError } from '@/shared/api/errors';
+import { useAppForegroundEffect } from '@/shared/hooks/useAppForegroundEffect';
+import { getTimeline } from '../api';
+import { subscribeToTimelineEvents } from '../timelineEvents';
+import type { TimelineResponse } from '../types';
+
+export type TimelineLoadStatus = 'loading' | 'ready' | 'error';
+export type TimelineLoadMode = 'initial' | 'refresh' | 'silent';
+
+interface UseTimelineOptions {
+  autoReconcile?: boolean;
+}
+
+interface TimelineSnapshot {
+  tripId: string;
+  timeline: TimelineResponse;
+}
+
+const MISSING_TIMELINE_ERROR: ApiError = {
+  kind: 'message',
+  message: 'Timeline not found.',
+  errorCode: 'TRIP_NOT_FOUND',
+  status: 404,
+};
+
+export function useTimeline(
+  tripId: string | undefined,
+  { autoReconcile = true }: UseTimelineOptions = {},
+) {
+  const [timeline, setTimeline] = useState<TimelineResponse | null>(null);
+  const [status, setStatus] = useState<TimelineLoadStatus>('loading');
+  const [error, setError] = useState<ApiError | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [stateTripId, setStateTripId] = useState<string | undefined>(tripId);
+  const [timelineTripId, setTimelineTripId] = useState<string | undefined>();
+  const snapshotRef = useRef<TimelineSnapshot | null>(null);
+  const requestIdRef = useRef(0);
+  const activeTripIdRef = useRef(tripId);
+
+  useEffect(() => {
+    activeTripIdRef.current = tripId;
+    requestIdRef.current += 1;
+  }, [tripId]);
+
+  const isCurrentRequest = useCallback((requestId: number, resourceKey: string) => {
+    return (
+      requestId === requestIdRef.current &&
+      resourceKey === activeTripIdRef.current
+    );
+  }, []);
+
+  const commitTimeline = useCallback(
+    (resourceKey: string, nextTimeline: TimelineResponse) => {
+      snapshotRef.current = { tripId: resourceKey, timeline: nextTimeline };
+      setStateTripId(resourceKey);
+      setTimelineTripId(resourceKey);
+      setTimeline(nextTimeline);
+      setError(null);
+      setStatus('ready');
+    },
+    [],
+  );
+
+  const refresh = useCallback(
+    async (mode: TimelineLoadMode = 'silent') => {
+      const requestId = requestIdRef.current + 1;
+      requestIdRef.current = requestId;
+
+      if (!tripId) {
+        snapshotRef.current = null;
+        setStateTripId(tripId);
+        setTimelineTripId(undefined);
+        setTimeline(null);
+        setError(MISSING_TIMELINE_ERROR);
+        setStatus('error');
+        setRefreshing(false);
+        return;
+      }
+
+      const resourceKey = tripId;
+      const hasTimeline = snapshotRef.current?.tripId === resourceKey;
+      setStateTripId(resourceKey);
+
+      if (!hasTimeline) {
+        snapshotRef.current = null;
+        setTimelineTripId(undefined);
+        setTimeline(null);
+        setError(null);
+        setStatus('loading');
+        setRefreshing(false);
+      } else if (mode === 'refresh') {
+        setRefreshing(true);
+      }
+
+      try {
+        const nextTimeline = await getTimeline(resourceKey);
+        if (!isCurrentRequest(requestId, resourceKey)) {
+          return;
+        }
+        commitTimeline(resourceKey, nextTimeline);
+      } catch (caught) {
+        if (!isCurrentRequest(requestId, resourceKey)) {
+          return;
+        }
+
+        const nextError = normalizeApiError(caught);
+        const hasCurrentTimeline = snapshotRef.current?.tripId === resourceKey;
+        setStateTripId(resourceKey);
+
+        if (nextError.status === 404 || !hasCurrentTimeline) {
+          snapshotRef.current = null;
+          setTimelineTripId(undefined);
+          setTimeline(null);
+          setStatus('error');
+        } else {
+          setStatus('ready');
+        }
+        setError(nextError);
+      } finally {
+        if (isCurrentRequest(requestId, resourceKey)) {
+          setRefreshing(false);
+        }
+      }
+    },
+    [commitTimeline, isCurrentRequest, tripId],
+  );
+
+  const invalidate = useCallback(() => {
+    requestIdRef.current += 1;
+    setRefreshing(false);
+  }, []);
+
+  useEffect(() => {
+    if (!autoReconcile || !tripId) {
+      return undefined;
+    }
+
+    return subscribeToTimelineEvents(tripId, () => {
+      void refresh('silent');
+    });
+  }, [autoReconcile, refresh, tripId]);
+
+  const reconcileOnForeground = useCallback(() => {
+    if (autoReconcile) {
+      void refresh(snapshotRef.current?.tripId === tripId ? 'silent' : 'initial');
+    }
+  }, [autoReconcile, refresh, tripId]);
+
+  useAppForegroundEffect(reconcileOnForeground);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (autoReconcile) {
+        void refresh(snapshotRef.current?.tripId === tripId ? 'silent' : 'initial');
+      }
+
+      return () => {
+        requestIdRef.current += 1;
+      };
+    }, [autoReconcile, refresh, tripId]),
+  );
+
+  const stateMatchesTrip = stateTripId === tripId;
+  const visibleTimeline =
+    stateMatchesTrip && timelineTripId === tripId ? timeline : null;
+
+  return {
+    timeline: visibleTimeline,
+    status: stateMatchesTrip ? status : 'loading',
+    error: stateMatchesTrip ? error : null,
+    refreshing: stateMatchesTrip ? refreshing : false,
+    refresh,
+    invalidate,
+  };
+}

--- a/mobile/src/features/timeline/hooks/useTimeline.ts
+++ b/mobile/src/features/timeline/hooks/useTimeline.ts
@@ -137,9 +137,7 @@ export function useTimeline(
       return undefined;
     }
 
-    return subscribeToTimelineEvents(tripId, () => {
-      void refresh('silent');
-    });
+    return subscribeToTimelineEvents(tripId, () => refresh('silent'));
   }, [autoReconcile, refresh, tripId]);
 
   const reconcileOnForeground = useCallback(() => {

--- a/mobile/src/features/timeline/routeIntent.ts
+++ b/mobile/src/features/timeline/routeIntent.ts
@@ -1,0 +1,89 @@
+export type TimelineRouteParam = string | string[] | undefined;
+
+export interface TimelineRouteParams {
+  tripId: TimelineRouteParam;
+}
+
+export interface SectionFormRouteParams extends TimelineRouteParams {
+  mode: TimelineRouteParam;
+  sectionId: TimelineRouteParam;
+}
+
+export interface ActivityFormRouteParams extends TimelineRouteParams {
+  mode: TimelineRouteParam;
+  sectionId: TimelineRouteParam;
+  activityId: TimelineRouteParam;
+}
+
+export interface TimelineRouteIntent {
+  tripId: string;
+}
+
+export type SectionFormRouteIntent =
+  | { mode: 'create'; tripId: string }
+  | { mode: 'edit'; tripId: string; sectionId: string };
+
+export type ActivityFormRouteIntent =
+  | { mode: 'create'; tripId: string; sectionId: string }
+  | { mode: 'edit'; tripId: string; activityId: string };
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function parseUuid(value: TimelineRouteParam): string | null {
+  if (typeof value !== 'string' || value.length === 0 || value.trim() !== value) {
+    return null;
+  }
+  return UUID_PATTERN.test(value) ? value : null;
+}
+
+export function parseTimelineRouteIntent({
+  tripId,
+}: TimelineRouteParams): TimelineRouteIntent | null {
+  const parsedTripId = parseUuid(tripId);
+  return parsedTripId ? { tripId: parsedTripId } : null;
+}
+
+export function parseSectionFormRouteIntent({
+  tripId,
+  mode,
+  sectionId,
+}: SectionFormRouteParams): SectionFormRouteIntent | null {
+  const parsedTripId = parseUuid(tripId);
+  if (!parsedTripId || (mode !== 'create' && mode !== 'edit')) {
+    return null;
+  }
+
+  if (mode === 'create') {
+    return sectionId === undefined ? { mode, tripId: parsedTripId } : null;
+  }
+
+  const parsedSectionId = parseUuid(sectionId);
+  return parsedSectionId
+    ? { mode, tripId: parsedTripId, sectionId: parsedSectionId }
+    : null;
+}
+
+export function parseActivityFormRouteIntent({
+  tripId,
+  mode,
+  sectionId,
+  activityId,
+}: ActivityFormRouteParams): ActivityFormRouteIntent | null {
+  const parsedTripId = parseUuid(tripId);
+  if (!parsedTripId || (mode !== 'create' && mode !== 'edit')) {
+    return null;
+  }
+
+  if (mode === 'create') {
+    const parsedSectionId = parseUuid(sectionId);
+    return parsedSectionId && activityId === undefined
+      ? { mode, tripId: parsedTripId, sectionId: parsedSectionId }
+      : null;
+  }
+
+  const parsedActivityId = parseUuid(activityId);
+  return parsedActivityId && sectionId === undefined
+    ? { mode, tripId: parsedTripId, activityId: parsedActivityId }
+    : null;
+}

--- a/mobile/src/features/timeline/routeIntent.ts
+++ b/mobile/src/features/timeline/routeIntent.ts
@@ -34,7 +34,7 @@ function parseUuid(value: TimelineRouteParam): string | null {
   if (typeof value !== 'string' || value.length === 0 || value.trim() !== value) {
     return null;
   }
-  return UUID_PATTERN.test(value) ? value : null;
+  return UUID_PATTERN.test(value) ? value.toLowerCase() : null;
 }
 
 export function parseTimelineRouteIntent({

--- a/mobile/src/features/timeline/screens/ActivityFormScreen.tsx
+++ b/mobile/src/features/timeline/screens/ActivityFormScreen.tsx
@@ -26,7 +26,11 @@ import { colors, spacing, typography } from '@/shared/theme/tokens';
 import { Button } from '@/shared/ui/Button';
 import { LoadingScreen } from '@/shared/ui/LoadingScreen';
 import { createActivity, patchActivity } from '../api';
-import { ActivityForm } from '../components/ActivityForm';
+import {
+  ActivityForm,
+  type StructuredLocationEditorProps,
+} from '../components/ActivityForm';
+import { PlacePicker } from '../components/PlacePicker';
 import {
   buildCreateActivityPayload,
   buildPatchActivityPayload,
@@ -87,6 +91,50 @@ interface HydratedActivityFormProps {
   isActiveGeneration: (generation: number) => boolean;
   getGeneration: () => number;
   onCancel: () => void;
+}
+
+function getPlaceEditorError(
+  fieldErrors: Readonly<Record<string, string>>,
+): string | undefined {
+  const messages = new Set<string>();
+  for (const [field, message] of Object.entries(fieldErrors)) {
+    if ((field === 'place' || field.startsWith('place.')) && message) {
+      messages.add(message);
+    }
+  }
+  return messages.size > 0 ? [...messages].join(' ') : undefined;
+}
+
+function renderStructuredLocationEditor({
+  value,
+  locationLabel,
+  disabled,
+  fieldErrors,
+  onChange,
+  onUseManual,
+}: StructuredLocationEditorProps) {
+  return (
+    <PlacePicker
+      value={{
+        location_label: locationLabel,
+        place: value?.place ?? null,
+      }}
+      disabled={disabled}
+      error={getPlaceEditorError(fieldErrors)}
+      onSelectLocation={(selection) =>
+        onChange({
+          location_label: selection.location_label,
+          place: selection.place,
+        })
+      }
+      onUseManualEntry={(manual) =>
+        onUseManual(manual.location_label)
+      }
+      onLookupFailure={(failure) =>
+        onUseManual(failure.location_label)
+      }
+    />
+  );
 }
 
 function HeaderCancelAction({
@@ -405,6 +453,7 @@ function HydratedActivityForm({
         onRefresh={pullToRefresh}
         onRetryBackground={retryBackground}
         onManageCustomTypes={manageCustomTypes}
+        renderStructuredLocationEditor={renderStructuredLocationEditor}
       />
     </>
   );

--- a/mobile/src/features/timeline/screens/ActivityFormScreen.tsx
+++ b/mobile/src/features/timeline/screens/ActivityFormScreen.tsx
@@ -1,0 +1,29 @@
+import { useLocalSearchParams } from 'expo-router';
+import type { ActivityFormRouteIntent } from '../routeIntent';
+import { parseActivityFormRouteIntent } from '../routeIntent';
+import { RouteReadyState, RouteUnavailableState } from './RouteState';
+
+function ValidActivityFormScreen({ intent }: { intent: ActivityFormRouteIntent }) {
+  return <RouteReadyState testID={`activity-form-${intent.mode}-route-ready`} />;
+}
+
+export function ActivityFormScreen() {
+  const { tripId, mode, sectionId, activityId } = useLocalSearchParams();
+  const intent = parseActivityFormRouteIntent({
+    tripId,
+    mode,
+    sectionId,
+    activityId,
+  });
+
+  if (!intent) {
+    return (
+      <RouteUnavailableState
+        title="Form unavailable"
+        message="This form link is invalid or incomplete."
+      />
+    );
+  }
+
+  return <ValidActivityFormScreen intent={intent} />;
+}

--- a/mobile/src/features/timeline/screens/ActivityFormScreen.tsx
+++ b/mobile/src/features/timeline/screens/ActivityFormScreen.tsx
@@ -36,6 +36,7 @@ import {
   buildPatchActivityPayload,
   cloneActivityDraft,
   createActivityDraft,
+  getSelectableCustomTypes,
   hydrateActivityDraft,
   validateActivityDraft,
   type ActivityDraftField,
@@ -88,6 +89,10 @@ interface HydratedActivityFormProps {
   refreshAll: (mode: 'initial' | 'refresh' | 'silent') => Promise<void>;
   requestReconcile: (forceInitial?: boolean) => Promise<void>;
   invalidateTimeline: () => void;
+  submitLockRef: { current: boolean };
+  submitting: boolean;
+  setSubmitting: (submitting: boolean) => void;
+  isScreenActive: () => boolean;
   isActiveGeneration: (generation: number) => boolean;
   getGeneration: () => number;
   onCancel: () => void;
@@ -202,6 +207,10 @@ function HydratedActivityForm({
   refreshAll,
   requestReconcile,
   invalidateTimeline,
+  submitLockRef,
+  submitting,
+  setSubmitting,
+  isScreenActive,
   isActiveGeneration,
   getGeneration,
   onCancel,
@@ -220,8 +229,6 @@ function HydratedActivityForm({
   const [localFieldErrors, setLocalFieldErrors] =
     useState<ActivityFormFieldErrors>({});
   const [submitError, setSubmitError] = useState<ApiError | null>(null);
-  const [submitting, setSubmitting] = useState(false);
-  const submitLockRef = useRef(false);
   const parentHref = `/trips/${intent.tripId}/timeline` as const;
 
   const terminal =
@@ -256,6 +263,18 @@ function HydratedActivityForm({
     () => new Set(detail.members.map((member) => member.user.id)),
     [detail.members],
   );
+  const selectableCustomTypeIds = useMemo(
+    () =>
+      new Set(
+        getSelectableCustomTypes(
+          timeline.custom_types,
+          initialState.kind === 'ready'
+            ? initialState.initialActivity
+            : undefined,
+        ).map((customType) => customType.id),
+      ),
+    [initialState, timeline.custom_types],
+  );
 
   const changeDraft = useCallback(
     (
@@ -276,14 +295,14 @@ function HydratedActivityForm({
       setLocalFieldErrors({});
       setSubmitError(null);
     },
-    [],
+    [submitLockRef],
   );
 
   const manageCustomTypes = useCallback(() => {
     if (!submitLockRef.current && canManageCustomTypes) {
       router.push(`/trips/${intent.tripId}/timeline/custom-types`);
     }
-  }, [canManageCustomTypes, intent.tripId, router]);
+  }, [canManageCustomTypes, intent.tripId, router, submitLockRef]);
 
   const submit = useCallback(async () => {
     if (
@@ -297,6 +316,7 @@ function HydratedActivityForm({
 
     const validation = validateActivityDraft(draft, {
       activeAssigneeIds,
+      selectableCustomTypeIds,
     });
     setLocalFieldErrors(validation.fieldErrors);
     setSubmitError(null);
@@ -306,7 +326,10 @@ function HydratedActivityForm({
 
     const createPayload =
       intent.mode === 'create'
-        ? buildCreateActivityPayload(draft, { activeAssigneeIds })
+        ? buildCreateActivityPayload(draft, {
+            activeAssigneeIds,
+            selectableCustomTypeIds,
+          })
         : null;
     const patchPayload =
       intent.mode === 'edit'
@@ -314,7 +337,10 @@ function HydratedActivityForm({
             initialState.initialDraft,
             draft,
             dirtyFields,
-            { activeAssigneeIds },
+            {
+              activeAssigneeIds,
+              selectableCustomTypeIds,
+            },
           )
         : null;
 
@@ -366,7 +392,7 @@ function HydratedActivityForm({
       }
     } finally {
       submitLockRef.current = false;
-      if (isActiveGeneration(generation)) {
+      if (isScreenActive()) {
         setSubmitting(false);
       }
     }
@@ -380,9 +406,13 @@ function HydratedActivityForm({
     intent,
     invalidateTimeline,
     isActiveGeneration,
+    isScreenActive,
     parentHref,
     refreshAll,
     router,
+    selectableCustomTypeIds,
+    setSubmitting,
+    submitLockRef,
   ]);
 
   const pullToRefresh = useCallback(() => {
@@ -484,6 +514,8 @@ function ValidActivityFormScreen({
   } = useTripDetail(intent.tripId, {
     autoReconcile: false,
   });
+  const [submitting, setSubmitting] = useState(false);
+  const submitLockRef = useRef(false);
   const activeRef = useRef(false);
   const mountedRef = useRef(true);
   const generationRef = useRef(0);
@@ -513,6 +545,9 @@ function ValidActivityFormScreen({
     useCallback(() => {
       activeRef.current = true;
       generationRef.current += 1;
+      if (!submitLockRef.current) {
+        setSubmitting(false);
+      }
       void requestReconcile();
 
       return () => {
@@ -571,10 +606,17 @@ function ValidActivityFormScreen({
     );
   }, []);
 
+  const isScreenActive = useCallback(
+    () => mountedRef.current && activeRef.current,
+    [],
+  );
+
   const getGeneration = useCallback(() => generationRef.current, []);
 
   const cancel = useCallback(() => {
-    router.dismissTo(parentHref);
+    if (!submitLockRef.current) {
+      router.dismissTo(parentHref);
+    }
   }, [parentHref, router]);
 
   const retryInitial = useCallback(() => {
@@ -604,9 +646,12 @@ function ValidActivityFormScreen({
         <Stack.Screen
           options={{
             title,
-            gestureEnabled: true,
+            gestureEnabled: !submitting,
             headerLeft: () => (
-              <HeaderCancelAction disabled={false} onPress={cancel} />
+              <HeaderCancelAction
+                disabled={submitting}
+                onPress={cancel}
+              />
             ),
           }}
         />
@@ -636,6 +681,10 @@ function ValidActivityFormScreen({
       refreshAll={refreshAll}
       requestReconcile={requestReconcile}
       invalidateTimeline={invalidateTimeline}
+      submitLockRef={submitLockRef}
+      submitting={submitting}
+      setSubmitting={setSubmitting}
+      isScreenActive={isScreenActive}
       isActiveGeneration={isActiveGeneration}
       getGeneration={getGeneration}
       onCancel={cancel}

--- a/mobile/src/features/timeline/screens/ActivityFormScreen.tsx
+++ b/mobile/src/features/timeline/screens/ActivityFormScreen.tsx
@@ -90,6 +90,7 @@ interface HydratedActivityFormProps {
   requestReconcile: (forceInitial?: boolean) => Promise<void>;
   invalidateTimeline: () => void;
   submitLockRef: { current: boolean };
+  submissionCommittedRef: { current: boolean };
   submitting: boolean;
   setSubmitting: (submitting: boolean) => void;
   isScreenActive: () => boolean;
@@ -208,6 +209,7 @@ function HydratedActivityForm({
   requestReconcile,
   invalidateTimeline,
   submitLockRef,
+  submissionCommittedRef,
   submitting,
   setSubmitting,
   isScreenActive,
@@ -372,16 +374,23 @@ function HydratedActivityForm({
       } else if (intent.mode === 'edit' && patchPayload) {
         await patchActivity(intent.tripId, intent.activityId, patchPayload);
       }
+      submissionCommittedRef.current = true;
 
       await publishTimelineEvent({
         type: 'timelineChanged',
         tripId: intent.tripId,
       });
 
-      if (isActiveGeneration(generation)) {
+      if (isScreenActive()) {
         router.dismissTo(parentHref);
       }
     } catch (caught) {
+      if (submissionCommittedRef.current) {
+        if (isScreenActive()) {
+          router.dismissTo(parentHref);
+        }
+        return;
+      }
       if (!isActiveGeneration(generation)) {
         return;
       }
@@ -391,8 +400,10 @@ function HydratedActivityForm({
         await refreshAll('silent');
       }
     } finally {
-      submitLockRef.current = false;
-      if (isScreenActive()) {
+      if (!submissionCommittedRef.current) {
+        submitLockRef.current = false;
+      }
+      if (!submissionCommittedRef.current && isScreenActive()) {
         setSubmitting(false);
       }
     }
@@ -413,6 +424,7 @@ function HydratedActivityForm({
     selectableCustomTypeIds,
     setSubmitting,
     submitLockRef,
+    submissionCommittedRef,
   ]);
 
   const pullToRefresh = useCallback(() => {
@@ -477,7 +489,10 @@ function HydratedActivityForm({
         refreshing={timelineRefreshing || tripRefreshing}
         localFieldErrors={localFieldErrors}
         submitError={submitError}
-        backgroundError={timelineError ?? tripError}
+        backgroundError={selectActivityFormError(
+          timelineError,
+          tripError,
+        )}
         onDraftChange={changeDraft}
         onSubmit={() => void submit()}
         onRefresh={pullToRefresh}
@@ -516,6 +531,7 @@ function ValidActivityFormScreen({
   });
   const [submitting, setSubmitting] = useState(false);
   const submitLockRef = useRef(false);
+  const submissionCommittedRef = useRef(false);
   const activeRef = useRef(false);
   const mountedRef = useRef(true);
   const generationRef = useRef(0);
@@ -545,16 +561,20 @@ function ValidActivityFormScreen({
     useCallback(() => {
       activeRef.current = true;
       generationRef.current += 1;
-      if (!submitLockRef.current) {
-        setSubmitting(false);
+      if (submissionCommittedRef.current) {
+        router.dismissTo(parentHref);
+      } else {
+        if (!submitLockRef.current) {
+          setSubmitting(false);
+        }
+        void requestReconcile();
       }
-      void requestReconcile();
 
       return () => {
         activeRef.current = false;
         generationRef.current += 1;
       };
-    }, [requestReconcile]),
+    }, [parentHref, requestReconcile, router]),
   );
 
   useEffect(
@@ -568,7 +588,7 @@ function ValidActivityFormScreen({
 
   useAppForegroundEffect(
     useCallback(() => {
-      if (activeRef.current) {
+      if (activeRef.current && !submissionCommittedRef.current) {
         void requestReconcile();
       }
     }, [requestReconcile]),
@@ -577,7 +597,7 @@ function ValidActivityFormScreen({
   useEffect(
     () =>
       subscribeToTimelineEvents(intent.tripId, () => {
-        if (!activeRef.current) {
+        if (!activeRef.current || submissionCommittedRef.current) {
           return;
         }
         return requestReconcile();
@@ -590,6 +610,7 @@ function ValidActivityFormScreen({
       subscribeToTripEvents((event) => {
         if (
           activeRef.current &&
+          !submissionCommittedRef.current &&
           isEventForTrip(event, intent.tripId)
         ) {
           void requestReconcile();
@@ -636,7 +657,12 @@ function ValidActivityFormScreen({
       : undefined;
 
   if (!timeline || !detail) {
-    const loadError = timelineError ?? tripError;
+    const loadError = selectActivityFormError(
+      timelineError,
+      tripError,
+      !timeline,
+      !detail,
+    );
     const loading =
       !loadError &&
       (timelineStatus === 'loading' || tripStatus === 'loading');
@@ -682,6 +708,7 @@ function ValidActivityFormScreen({
       requestReconcile={requestReconcile}
       invalidateTimeline={invalidateTimeline}
       submitLockRef={submitLockRef}
+      submissionCommittedRef={submissionCommittedRef}
       submitting={submitting}
       setSubmitting={setSubmitting}
       isScreenActive={isScreenActive}
@@ -773,6 +800,27 @@ function isEventForTrip(event: TripEvent, tripId: string): boolean {
 
 function shouldReconcileAfterFailure(error: ApiError): boolean {
   return error.status === 403 || error.status === 404 || error.status === 409;
+}
+
+function selectActivityFormError(
+  timelineError: ApiError | null,
+  tripError: ApiError | null,
+  timelineMissing = false,
+  tripMissing = false,
+): ApiError | null {
+  if (timelineError?.status === 404) {
+    return timelineError;
+  }
+  if (tripError?.status === 404) {
+    return tripError;
+  }
+  if (timelineMissing && timelineError) {
+    return timelineError;
+  }
+  if (tripMissing && tripError) {
+    return tripError;
+  }
+  return timelineError ?? tripError;
 }
 
 function getAuthorityMessage({

--- a/mobile/src/features/timeline/screens/ActivityFormScreen.tsx
+++ b/mobile/src/features/timeline/screens/ActivityFormScreen.tsx
@@ -1,14 +1,602 @@
-import { useLocalSearchParams } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import {
+  Stack,
+  useFocusEffect,
+  useLocalSearchParams,
+  useRouter,
+} from 'expo-router';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTripDetail } from '@/features/trips/hooks/useTripDetail';
+import {
+  subscribeToTripEvents,
+  type TripEvent,
+} from '@/features/trips/tripEvents';
+import type { TripDetailResponse } from '@/features/trips/types';
+import { normalizeApiError, type ApiError } from '@/shared/api/errors';
+import { useAppForegroundEffect } from '@/shared/hooks/useAppForegroundEffect';
+import { colors, spacing, typography } from '@/shared/theme/tokens';
+import { Button } from '@/shared/ui/Button';
+import { LoadingScreen } from '@/shared/ui/LoadingScreen';
+import { createActivity, patchActivity } from '../api';
+import { ActivityForm } from '../components/ActivityForm';
+import {
+  buildCreateActivityPayload,
+  buildPatchActivityPayload,
+  cloneActivityDraft,
+  createActivityDraft,
+  hydrateActivityDraft,
+  validateActivityDraft,
+  type ActivityDraftField,
+  type ActivityFormDirtyFields,
+  type ActivityFormDraft,
+  type ActivityFormFieldErrors,
+} from '../formModel';
+import { useTimeline } from '../hooks/useTimeline';
 import type { ActivityFormRouteIntent } from '../routeIntent';
 import { parseActivityFormRouteIntent } from '../routeIntent';
-import { RouteReadyState, RouteUnavailableState } from './RouteState';
+import {
+  publishTimelineEvent,
+  subscribeToTimelineEvents,
+} from '../timelineEvents';
+import type {
+  TimelineActivity,
+  TimelineResponse,
+  TimelineSection,
+} from '../types';
+import { RouteUnavailableState } from './RouteState';
 
-function ValidActivityFormScreen({ intent }: { intent: ActivityFormRouteIntent }) {
-  return <RouteReadyState testID={`activity-form-${intent.mode}-route-ready`} />;
+interface ResolvedActivityTarget {
+  section: TimelineSection;
+  activity: TimelineActivity;
+}
+
+interface HeaderCancelActionProps {
+  disabled: boolean;
+  onPress: () => void;
+}
+
+type InitialFormState =
+  | { kind: 'missing' }
+  | {
+      kind: 'ready';
+      initialDraft: ActivityFormDraft;
+      initialActivity?: TimelineActivity;
+    };
+
+interface HydratedActivityFormProps {
+  intent: ActivityFormRouteIntent;
+  timeline: TimelineResponse;
+  detail: TripDetailResponse;
+  timelineError: ApiError | null;
+  tripError: ApiError | null;
+  timelineRefreshing: boolean;
+  tripRefreshing: boolean;
+  currentCreateSection: TimelineSection | undefined;
+  currentEditTarget: ResolvedActivityTarget | undefined;
+  refreshAll: (mode: 'initial' | 'refresh' | 'silent') => Promise<void>;
+  requestReconcile: (forceInitial?: boolean) => Promise<void>;
+  invalidateTimeline: () => void;
+  isActiveGeneration: (generation: number) => boolean;
+  getGeneration: () => number;
+  onCancel: () => void;
+}
+
+function HeaderCancelAction({
+  disabled,
+  onPress,
+}: HeaderCancelActionProps) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel="Cancel timeline activity form"
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.headerAction,
+        disabled ? styles.disabled : null,
+        pressed && !disabled ? styles.pressed : null,
+      ]}
+    >
+      <Text style={styles.headerActionText}>Cancel</Text>
+    </Pressable>
+  );
+}
+
+function ActivityFormLoadError({
+  error,
+  onRetry,
+}: {
+  error: ApiError | null;
+  onRetry: () => void;
+}) {
+  const notFound = error?.status === 404;
+  return (
+    <SafeAreaView style={styles.safe} edges={['left', 'right', 'bottom']}>
+      <View style={styles.centered}>
+        <Ionicons
+          name={notFound ? 'help-circle-outline' : 'cloud-offline-outline'}
+          size={44}
+          color={colors.textMuted}
+        />
+        <Text accessibilityRole="header" style={styles.stateTitle}>
+          {notFound ? 'Activity form unavailable' : 'Could not load activity'}
+        </Text>
+        <Text style={styles.stateMessage}>
+          {notFound
+            ? 'This trip or activity no longer exists, or you no longer have access.'
+            : error?.message ?? 'Activity information is unavailable.'}
+        </Text>
+        {notFound ? null : <Button title="Try again" onPress={onRetry} />}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+function HydratedActivityForm({
+  intent,
+  timeline,
+  detail,
+  timelineError,
+  tripError,
+  timelineRefreshing,
+  tripRefreshing,
+  currentCreateSection,
+  currentEditTarget,
+  refreshAll,
+  requestReconcile,
+  invalidateTimeline,
+  isActiveGeneration,
+  getGeneration,
+  onCancel,
+}: HydratedActivityFormProps) {
+  const router = useRouter();
+  const [initialState] = useState<InitialFormState>(() =>
+    buildInitialFormState(intent, currentCreateSection, currentEditTarget),
+  );
+  const [draft, setDraft] = useState<ActivityFormDraft | null>(() =>
+    initialState.kind === 'ready'
+      ? cloneActivityDraft(initialState.initialDraft)
+      : null,
+  );
+  const [dirtyFields, setDirtyFields] =
+    useState<ActivityFormDirtyFields>({});
+  const [localFieldErrors, setLocalFieldErrors] =
+    useState<ActivityFormFieldErrors>({});
+  const [submitError, setSubmitError] = useState<ApiError | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const submitLockRef = useRef(false);
+  const parentHref = `/trips/${intent.tripId}/timeline` as const;
+
+  const terminal =
+    detail.trip.status === 'COMPLETED' ||
+    detail.trip.status === 'CANCELLED';
+  const activeMembership = detail.my_membership.status === 'ACTIVE';
+  const targetStillExists =
+    intent.mode === 'create'
+      ? currentCreateSection !== undefined
+      : currentEditTarget !== undefined;
+  const serverAllowsMutation =
+    intent.mode === 'create'
+      ? timeline.permissions.can_edit_timeline
+      : currentEditTarget?.activity.capabilities.can_edit === true;
+  const canMutate =
+    activeMembership &&
+    !terminal &&
+    targetStillExists &&
+    serverAllowsMutation;
+  const canManageCustomTypes =
+    activeMembership &&
+    !terminal &&
+    timeline.permissions.can_manage_custom_types;
+  const authorityMessage = getAuthorityMessage({
+    activeMembership,
+    terminal,
+    targetStillExists,
+    serverAllowsMutation,
+    mode: intent.mode,
+  });
+  const activeAssigneeIds = useMemo(
+    () => new Set(detail.members.map((member) => member.user.id)),
+    [detail.members],
+  );
+
+  const changeDraft = useCallback(
+    (
+      nextDraft: ActivityFormDraft,
+      changedFields: readonly ActivityDraftField[],
+    ) => {
+      if (submitLockRef.current) {
+        return;
+      }
+      setDraft(nextDraft);
+      setDirtyFields((current) => {
+        const next = { ...current };
+        for (const field of changedFields) {
+          next[field] = true;
+        }
+        return next;
+      });
+      setLocalFieldErrors({});
+      setSubmitError(null);
+    },
+    [],
+  );
+
+  const manageCustomTypes = useCallback(() => {
+    if (!submitLockRef.current && canManageCustomTypes) {
+      router.push(`/trips/${intent.tripId}/timeline/custom-types`);
+    }
+  }, [canManageCustomTypes, intent.tripId, router]);
+
+  const submit = useCallback(async () => {
+    if (
+      submitLockRef.current ||
+      !draft ||
+      initialState.kind !== 'ready' ||
+      !canMutate
+    ) {
+      return;
+    }
+
+    const validation = validateActivityDraft(draft, {
+      activeAssigneeIds,
+    });
+    setLocalFieldErrors(validation.fieldErrors);
+    setSubmitError(null);
+    if (!validation.isValid) {
+      return;
+    }
+
+    const createPayload =
+      intent.mode === 'create'
+        ? buildCreateActivityPayload(draft, { activeAssigneeIds })
+        : null;
+    const patchPayload =
+      intent.mode === 'edit'
+        ? buildPatchActivityPayload(
+            initialState.initialDraft,
+            draft,
+            dirtyFields,
+            { activeAssigneeIds },
+          )
+        : null;
+
+    if (intent.mode === 'create' && !createPayload) {
+      return;
+    }
+    if (intent.mode === 'edit' && !patchPayload) {
+      return;
+    }
+    if (
+      intent.mode === 'edit' &&
+      patchPayload &&
+      Object.keys(patchPayload).length === 0
+    ) {
+      if (isActiveGeneration(getGeneration())) {
+        router.dismissTo(parentHref);
+      }
+      return;
+    }
+
+    const generation = getGeneration();
+    submitLockRef.current = true;
+    setSubmitting(true);
+    invalidateTimeline();
+
+    try {
+      if (intent.mode === 'create' && createPayload) {
+        await createActivity(intent.tripId, intent.sectionId, createPayload);
+      } else if (intent.mode === 'edit' && patchPayload) {
+        await patchActivity(intent.tripId, intent.activityId, patchPayload);
+      }
+
+      await publishTimelineEvent({
+        type: 'timelineChanged',
+        tripId: intent.tripId,
+      });
+
+      if (isActiveGeneration(generation)) {
+        router.dismissTo(parentHref);
+      }
+    } catch (caught) {
+      if (!isActiveGeneration(generation)) {
+        return;
+      }
+      const normalized = normalizeApiError(caught);
+      setSubmitError(normalized);
+      if (shouldReconcileAfterFailure(normalized)) {
+        await refreshAll('silent');
+      }
+    } finally {
+      submitLockRef.current = false;
+      if (isActiveGeneration(generation)) {
+        setSubmitting(false);
+      }
+    }
+  }, [
+    activeAssigneeIds,
+    canMutate,
+    dirtyFields,
+    draft,
+    getGeneration,
+    initialState,
+    intent,
+    invalidateTimeline,
+    isActiveGeneration,
+    parentHref,
+    refreshAll,
+    router,
+  ]);
+
+  const pullToRefresh = useCallback(() => {
+    void refreshAll('refresh');
+  }, [refreshAll]);
+
+  const retryBackground = useCallback(() => {
+    void requestReconcile();
+  }, [requestReconcile]);
+
+  const title = intent.mode === 'create' ? 'Add Activity' : 'Edit Activity';
+
+  if (initialState.kind === 'missing' || draft === null) {
+    return (
+      <>
+        <Stack.Screen
+          options={{
+            title,
+            gestureEnabled: true,
+            headerLeft: () => (
+              <HeaderCancelAction disabled={false} onPress={onCancel} />
+            ),
+          }}
+        />
+        <RouteUnavailableState
+          title="Activity unavailable"
+          message={
+            intent.mode === 'create'
+              ? 'The selected timeline day no longer exists.'
+              : 'This activity no longer exists.'
+          }
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          title,
+          gestureEnabled: !submitting,
+          headerLeft: () => (
+            <HeaderCancelAction
+              disabled={submitting}
+              onPress={onCancel}
+            />
+          ),
+        }}
+      />
+      <ActivityForm
+        mode={intent.mode}
+        draft={draft}
+        initialActivity={initialState.initialActivity}
+        systemTypes={timeline.system_types}
+        customTypes={timeline.custom_types}
+        members={detail.members}
+        canManageCustomTypes={canManageCustomTypes}
+        canSubmit={canMutate}
+        authorityMessage={authorityMessage}
+        submitting={submitting}
+        refreshing={timelineRefreshing || tripRefreshing}
+        localFieldErrors={localFieldErrors}
+        submitError={submitError}
+        backgroundError={timelineError ?? tripError}
+        onDraftChange={changeDraft}
+        onSubmit={() => void submit()}
+        onRefresh={pullToRefresh}
+        onRetryBackground={retryBackground}
+        onManageCustomTypes={manageCustomTypes}
+      />
+    </>
+  );
+}
+
+function ValidActivityFormScreen({
+  intent,
+}: {
+  intent: ActivityFormRouteIntent;
+}) {
+  const router = useRouter();
+  const {
+    timeline,
+    status: timelineStatus,
+    error: timelineError,
+    refreshing: timelineRefreshing,
+    refresh: refreshTimeline,
+    invalidate: invalidateTimeline,
+  } = useTimeline(intent.tripId, {
+    autoReconcile: false,
+  });
+  const {
+    detail,
+    status: tripStatus,
+    error: tripError,
+    refreshing: tripRefreshing,
+    refresh: refreshTrip,
+  } = useTripDetail(intent.tripId, {
+    autoReconcile: false,
+  });
+  const activeRef = useRef(false);
+  const mountedRef = useRef(true);
+  const generationRef = useRef(0);
+  const hasRequestedInitialRef = useRef(false);
+  const parentHref = `/trips/${intent.tripId}/timeline` as const;
+
+  const refreshAll = useCallback(
+    async (mode: 'initial' | 'refresh' | 'silent') => {
+      await Promise.all([refreshTimeline(mode), refreshTrip(mode)]);
+    },
+    [refreshTimeline, refreshTrip],
+  );
+
+  const requestReconcile = useCallback(
+    (forceInitial = false) => {
+      const mode =
+        forceInitial || !hasRequestedInitialRef.current
+          ? 'initial'
+          : 'silent';
+      hasRequestedInitialRef.current = true;
+      return refreshAll(mode);
+    },
+    [refreshAll],
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      activeRef.current = true;
+      generationRef.current += 1;
+      void requestReconcile();
+
+      return () => {
+        activeRef.current = false;
+        generationRef.current += 1;
+      };
+    }, [requestReconcile]),
+  );
+
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+      activeRef.current = false;
+      generationRef.current += 1;
+    },
+    [],
+  );
+
+  useAppForegroundEffect(
+    useCallback(() => {
+      if (activeRef.current) {
+        void requestReconcile();
+      }
+    }, [requestReconcile]),
+  );
+
+  useEffect(
+    () =>
+      subscribeToTimelineEvents(intent.tripId, () => {
+        if (!activeRef.current) {
+          return;
+        }
+        return requestReconcile();
+      }),
+    [intent.tripId, requestReconcile],
+  );
+
+  useEffect(
+    () =>
+      subscribeToTripEvents((event) => {
+        if (
+          activeRef.current &&
+          isEventForTrip(event, intent.tripId)
+        ) {
+          void requestReconcile();
+        }
+      }),
+    [intent.tripId, requestReconcile],
+  );
+
+  const isActiveGeneration = useCallback((generation: number) => {
+    return (
+      mountedRef.current &&
+      activeRef.current &&
+      generationRef.current === generation
+    );
+  }, []);
+
+  const getGeneration = useCallback(() => generationRef.current, []);
+
+  const cancel = useCallback(() => {
+    router.dismissTo(parentHref);
+  }, [parentHref, router]);
+
+  const retryInitial = useCallback(() => {
+    void requestReconcile(true);
+  }, [requestReconcile]);
+
+  const title = intent.mode === 'create' ? 'Add Activity' : 'Edit Activity';
+  const currentCreateSection =
+    intent.mode === 'create'
+      ? timeline?.sections.find(
+          (section) => section.id === intent.sectionId,
+        )
+      : undefined;
+  const currentEditTarget =
+    intent.mode === 'edit'
+      ? findActivityTarget(timeline?.sections ?? [], intent.activityId)
+      : undefined;
+
+  if (!timeline || !detail) {
+    const loadError = timelineError ?? tripError;
+    const loading =
+      !loadError &&
+      (timelineStatus === 'loading' || tripStatus === 'loading');
+
+    return (
+      <>
+        <Stack.Screen
+          options={{
+            title,
+            gestureEnabled: true,
+            headerLeft: () => (
+              <HeaderCancelAction disabled={false} onPress={cancel} />
+            ),
+          }}
+        />
+        {loading ? (
+          <LoadingScreen />
+        ) : (
+          <ActivityFormLoadError
+            error={loadError}
+            onRetry={retryInitial}
+          />
+        )}
+      </>
+    );
+  }
+
+  return (
+    <HydratedActivityForm
+      intent={intent}
+      timeline={timeline}
+      detail={detail}
+      timelineError={timelineError}
+      tripError={tripError}
+      timelineRefreshing={timelineRefreshing}
+      tripRefreshing={tripRefreshing}
+      currentCreateSection={currentCreateSection}
+      currentEditTarget={currentEditTarget}
+      refreshAll={refreshAll}
+      requestReconcile={requestReconcile}
+      invalidateTimeline={invalidateTimeline}
+      isActiveGeneration={isActiveGeneration}
+      getGeneration={getGeneration}
+      onCancel={cancel}
+    />
+  );
 }
 
 export function ActivityFormScreen() {
-  const { tripId, mode, sectionId, activityId } = useLocalSearchParams();
+  const { tripId, mode, sectionId, activityId } =
+    useLocalSearchParams();
   const intent = parseActivityFormRouteIntent({
     tripId,
     mode,
@@ -25,5 +613,126 @@ export function ActivityFormScreen() {
     );
   }
 
-  return <ValidActivityFormScreen intent={intent} />;
+  return (
+    <ValidActivityFormScreen
+      key={activityFormIdentity(intent)}
+      intent={intent}
+    />
+  );
 }
+
+function buildInitialFormState(
+  intent: ActivityFormRouteIntent,
+  createSection: TimelineSection | undefined,
+  editTarget: ResolvedActivityTarget | undefined,
+): InitialFormState {
+  if (intent.mode === 'create') {
+    if (!createSection) {
+      return { kind: 'missing' };
+    }
+    return {
+      kind: 'ready',
+      initialDraft: createActivityDraft(),
+    };
+  }
+
+  if (!editTarget) {
+    return { kind: 'missing' };
+  }
+  return {
+    kind: 'ready',
+    initialDraft: hydrateActivityDraft(editTarget.activity),
+    initialActivity: editTarget.activity,
+  };
+}
+
+function findActivityTarget(
+  sections: readonly TimelineSection[],
+  activityId: string,
+): ResolvedActivityTarget | undefined {
+  for (const section of sections) {
+    const activity = section.activities.find(
+      (candidate) => candidate.id === activityId,
+    );
+    if (activity) {
+      return { section, activity };
+    }
+  }
+  return undefined;
+}
+
+function activityFormIdentity(intent: ActivityFormRouteIntent): string {
+  return intent.mode === 'create'
+    ? `${intent.tripId}:create:${intent.sectionId}`
+    : `${intent.tripId}:edit:${intent.activityId}`;
+}
+
+function isEventForTrip(event: TripEvent, tripId: string): boolean {
+  return event.type === 'updated'
+    ? event.trip.id === tripId
+    : event.tripId === tripId;
+}
+
+function shouldReconcileAfterFailure(error: ApiError): boolean {
+  return error.status === 403 || error.status === 404 || error.status === 409;
+}
+
+function getAuthorityMessage({
+  activeMembership,
+  terminal,
+  targetStillExists,
+  serverAllowsMutation,
+  mode,
+}: {
+  activeMembership: boolean;
+  terminal: boolean;
+  targetStillExists: boolean;
+  serverAllowsMutation: boolean;
+  mode: 'create' | 'edit';
+}): string | undefined {
+  if (!activeMembership) {
+    return 'You are no longer an active member of this trip.';
+  }
+  if (terminal) {
+    return 'Completed and cancelled trips can no longer be edited.';
+  }
+  if (!targetStillExists) {
+    return mode === 'create'
+      ? 'This timeline day no longer exists.'
+      : 'This activity no longer exists.';
+  }
+  if (!serverAllowsMutation) {
+    return 'You no longer have permission to save this activity.';
+  }
+  return undefined;
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.background },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.md,
+    padding: spacing.lg,
+  },
+  stateTitle: {
+    ...typography.heading,
+    color: colors.text,
+    textAlign: 'center',
+  },
+  stateMessage: {
+    ...typography.body,
+    color: colors.textMuted,
+    textAlign: 'center',
+  },
+  headerAction: {
+    minHeight: 44,
+    justifyContent: 'center',
+    marginLeft: -spacing.sm,
+    paddingHorizontal: spacing.sm,
+  },
+  headerActionText: { ...typography.body, color: colors.primary },
+  disabled: { opacity: 0.55 },
+  pressed: { opacity: 0.55 },
+});

--- a/mobile/src/features/timeline/screens/CustomTypeManagerScreen.tsx
+++ b/mobile/src/features/timeline/screens/CustomTypeManagerScreen.tsx
@@ -1,6 +1,563 @@
-import { useLocalSearchParams } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import {
+  Stack,
+  useFocusEffect,
+  useLocalSearchParams,
+  useRouter,
+} from 'expo-router';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Alert,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { type ApiError, normalizeApiError } from '@/shared/api/errors';
+import { useAppForegroundEffect } from '@/shared/hooks/useAppForegroundEffect';
+import { colors, spacing, typography } from '@/shared/theme/tokens';
+import { Button } from '@/shared/ui/Button';
+import { LoadingScreen } from '@/shared/ui/LoadingScreen';
+import {
+  createCustomType,
+  deleteCustomType,
+  patchCustomType,
+} from '../api';
+import {
+  CustomTypeManager,
+  type CustomTypeMutationError,
+  type CustomTypeMutationScope,
+} from '../components/CustomTypeManager';
+import {
+  buildCreateCustomTypePayload,
+  buildPatchCustomTypePayload,
+  createCustomTypeDraft,
+  hydrateCustomTypeDraft,
+  type CustomTypeDraft,
+  type CustomTypeFieldErrors,
+  validateCustomTypeDraft,
+} from '../customTypeModel';
+import {
+  type TimelineLoadMode,
+  useTimeline,
+} from '../hooks/useTimeline';
 import { parseTimelineRouteIntent } from '../routeIntent';
-import { RouteReadyState, RouteUnavailableState } from './RouteState';
+import {
+  publishTimelineEvent,
+  subscribeToTimelineEvents,
+} from '../timelineEvents';
+import type { TimelineCustomTypeMeta } from '../types';
+import { RouteUnavailableState } from './RouteState';
+
+interface EditState {
+  typeId: string;
+  initial: CustomTypeDraft;
+  draft: CustomTypeDraft;
+}
+
+interface ManagerStateProps {
+  title: string;
+  message: string;
+  actionTitle?: string;
+  onAction?: () => void;
+}
+
+function ManagerState({
+  title,
+  message,
+  actionTitle,
+  onAction,
+}: ManagerStateProps) {
+  return (
+    <SafeAreaView style={styles.safe} edges={['left', 'right', 'bottom']}>
+      <View style={styles.centered}>
+        <Ionicons
+          name="pricetags-outline"
+          size={44}
+          color={colors.textMuted}
+        />
+        <Text accessibilityRole="header" style={styles.stateTitle}>
+          {title}
+        </Text>
+        <Text style={styles.stateBody}>{message}</Text>
+        {actionTitle && onAction ? (
+          <Button title={actionTitle} onPress={onAction} />
+        ) : null}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+function HeaderCloseAction({
+  disabled,
+  onPress,
+}: {
+  disabled: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel="Close custom types"
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      hitSlop={spacing.sm}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.headerAction,
+        (pressed || disabled) ? styles.headerActionMuted : null,
+      ]}
+    >
+      <Text style={styles.headerActionText}>Close</Text>
+    </Pressable>
+  );
+}
+
+function ManagerNavigation({
+  busy,
+  onClose,
+}: {
+  busy: boolean;
+  onClose: () => void;
+}) {
+  return (
+    <Stack.Screen
+      options={{
+        title: 'Custom Types',
+        gestureEnabled: !busy,
+        headerLeft: () => (
+          <HeaderCloseAction disabled={busy} onPress={onClose} />
+        ),
+      }}
+    />
+  );
+}
+
+function shouldReconcileAfterFailure(error: ApiError): boolean {
+  return error.status === 403 || error.status === 404 || error.status === 409;
+}
+
+function mutationKeyForScope(scope: CustomTypeMutationScope): string {
+  return scope.kind === 'create'
+    ? 'create'
+    : `${scope.kind}:${scope.typeId}`;
+}
+
+function hasPayloadFields(payload: object | null): boolean {
+  return payload !== null && Object.keys(payload).length > 0;
+}
+
+function ValidCustomTypeManagerScreen({ tripId }: { tripId: string }) {
+  const router = useRouter();
+  const {
+    timeline,
+    status,
+    error: loadError,
+    refresh,
+    invalidate,
+  } = useTimeline(tripId, { autoReconcile: false });
+  const [createDraft, setCreateDraft] = useState(createCustomTypeDraft);
+  const [createFieldErrors, setCreateFieldErrors] =
+    useState<CustomTypeFieldErrors>({});
+  const [editState, setEditState] = useState<EditState | null>(null);
+  const [editFieldErrors, setEditFieldErrors] =
+    useState<CustomTypeFieldErrors>({});
+  const [mutationKey, setMutationKey] = useState<string | null>(null);
+  const [mutationError, setMutationError] =
+    useState<CustomTypeMutationError | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const mutationLockRef = useRef(false);
+  const confirmationLockRef = useRef(false);
+  const activeRef = useRef(false);
+  const mountedRef = useRef(true);
+  const generationRef = useRef(0);
+  const hasRequestedInitialRef = useRef(false);
+  const parentHref = `/trips/${tripId}/timeline` as const;
+
+  const requestReconcile = useCallback(
+    (forceInitial = false): Promise<void> => {
+      const mode: TimelineLoadMode =
+        forceInitial || !hasRequestedInitialRef.current
+          ? 'initial'
+          : 'silent';
+      hasRequestedInitialRef.current = true;
+      return refresh(mode);
+    },
+    [refresh],
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      activeRef.current = true;
+      generationRef.current += 1;
+      if (!mutationLockRef.current) {
+        setMutationKey(null);
+      }
+      void requestReconcile();
+
+      return () => {
+        activeRef.current = false;
+        generationRef.current += 1;
+      };
+    }, [requestReconcile]),
+  );
+
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+      activeRef.current = false;
+      generationRef.current += 1;
+    },
+    [],
+  );
+
+  useAppForegroundEffect(
+    useCallback(() => {
+      if (activeRef.current && !mutationLockRef.current) {
+        void requestReconcile();
+      }
+    }, [requestReconcile]),
+  );
+
+  useEffect(
+    () =>
+      subscribeToTimelineEvents(tripId, () => {
+        if (activeRef.current) {
+          return requestReconcile();
+        }
+        return undefined;
+      }),
+    [requestReconcile, tripId],
+  );
+
+  const isActiveGeneration = useCallback((generation: number): boolean => {
+    return (
+      mountedRef.current &&
+      activeRef.current &&
+      generationRef.current === generation
+    );
+  }, []);
+
+  const close = useCallback(() => {
+    if (!mutationLockRef.current) {
+      router.dismissTo(parentHref);
+    }
+  }, [parentHref, router]);
+
+  const clearFeedback = useCallback(() => {
+    setMutationError(null);
+    setSuccessMessage(null);
+  }, []);
+
+  const changeCreateDraft = useCallback(
+    (changes: Partial<CustomTypeDraft>) => {
+      setCreateDraft((current) => ({ ...current, ...changes }));
+      setCreateFieldErrors({});
+      clearFeedback();
+    },
+    [clearFeedback],
+  );
+
+  const startEdit = useCallback(
+    (customType: TimelineCustomTypeMeta) => {
+      if (mutationLockRef.current) {
+        return;
+      }
+      const initial = hydrateCustomTypeDraft(customType);
+      setEditState({
+        typeId: customType.id,
+        initial: { ...initial },
+        draft: { ...initial },
+      });
+      setEditFieldErrors({});
+      clearFeedback();
+    },
+    [clearFeedback],
+  );
+
+  const changeEditDraft = useCallback(
+    (changes: Partial<CustomTypeDraft>) => {
+      setEditState((current) =>
+        current
+          ? {
+              ...current,
+              draft: { ...current.draft, ...changes },
+            }
+          : current,
+      );
+      setEditFieldErrors({});
+      clearFeedback();
+    },
+    [clearFeedback],
+  );
+
+  const cancelEdit = useCallback(() => {
+    if (!mutationLockRef.current) {
+      setEditState(null);
+      setEditFieldErrors({});
+      clearFeedback();
+    }
+  }, [clearFeedback]);
+
+  const runMutation = useCallback(
+    async (
+      scope: CustomTypeMutationScope,
+      mutate: () => Promise<unknown>,
+      activeSuccessMessage: string,
+      onActiveSuccess?: () => void,
+    ): Promise<void> => {
+      if (mutationLockRef.current) {
+        return;
+      }
+
+      const generation = generationRef.current;
+      mutationLockRef.current = true;
+      setMutationKey(mutationKeyForScope(scope));
+      setMutationError(null);
+      setSuccessMessage(null);
+      invalidate();
+
+      try {
+        await mutate();
+        await publishTimelineEvent({
+          type: 'timelineChanged',
+          tripId,
+        });
+        if (isActiveGeneration(generation)) {
+          onActiveSuccess?.();
+          setSuccessMessage(activeSuccessMessage);
+        }
+      } catch (caught) {
+        if (!isActiveGeneration(generation)) {
+          return;
+        }
+        const normalized = normalizeApiError(caught);
+        setMutationError({ scope, error: normalized });
+        if (shouldReconcileAfterFailure(normalized)) {
+          await refresh('silent');
+        }
+      } finally {
+        mutationLockRef.current = false;
+        if (isActiveGeneration(generation)) {
+          setMutationKey(null);
+        }
+      }
+    },
+    [invalidate, isActiveGeneration, refresh, tripId],
+  );
+
+  const submitCreate = useCallback(() => {
+    const validation = validateCustomTypeDraft(createDraft);
+    setCreateFieldErrors(validation.fieldErrors);
+    setMutationError(null);
+    setSuccessMessage(null);
+    const payload = buildCreateCustomTypePayload(createDraft);
+    if (!validation.isValid || !payload) {
+      return;
+    }
+
+    void runMutation(
+      { kind: 'create' },
+      () => createCustomType(tripId, payload),
+      'Custom type created.',
+      () => {
+        setCreateDraft(createCustomTypeDraft());
+        setCreateFieldErrors({});
+      },
+    );
+  }, [createDraft, runMutation, tripId]);
+
+  const submitEdit = useCallback(() => {
+    if (!editState) {
+      return;
+    }
+
+    const validation = validateCustomTypeDraft(editState.draft);
+    setEditFieldErrors(validation.fieldErrors);
+    setMutationError(null);
+    setSuccessMessage(null);
+    const payload = buildPatchCustomTypePayload(
+      editState.initial,
+      editState.draft,
+    );
+    if (
+      !validation.isValid ||
+      payload === null ||
+      Object.keys(payload).length === 0
+    ) {
+      return;
+    }
+
+    void runMutation(
+      { kind: 'edit', typeId: editState.typeId },
+      () => patchCustomType(tripId, editState.typeId, payload),
+      'Custom type updated.',
+      () => {
+        setEditState(null);
+        setEditFieldErrors({});
+      },
+    );
+  }, [editState, runMutation, tripId]);
+
+  const toggleActive = useCallback(
+    (customType: TimelineCustomTypeMeta) => {
+      const nextActive = !customType.is_active;
+      void runMutation(
+        { kind: 'toggle', typeId: customType.id },
+        () =>
+          patchCustomType(tripId, customType.id, {
+            is_active: nextActive,
+          }),
+        `Custom type ${nextActive ? 'activated' : 'deactivated'}.`,
+      );
+    },
+    [runMutation, tripId],
+  );
+
+  const requestDelete = useCallback(
+    (customType: TimelineCustomTypeMeta) => {
+      if (mutationLockRef.current || confirmationLockRef.current) {
+        return;
+      }
+
+      confirmationLockRef.current = true;
+      const releaseConfirmation = () => {
+        confirmationLockRef.current = false;
+      };
+      Alert.alert(
+        'Delete custom type?',
+        `Delete "${customType.name}" permanently?`,
+        [
+          {
+            text: 'Cancel',
+            style: 'cancel',
+            onPress: releaseConfirmation,
+          },
+          {
+            text: 'Delete',
+            style: 'destructive',
+            onPress: () => {
+              releaseConfirmation();
+              void runMutation(
+                { kind: 'delete', typeId: customType.id },
+                () => deleteCustomType(tripId, customType.id),
+                'Custom type deleted.',
+                () => {
+                  setEditState((current) =>
+                    current?.typeId === customType.id ? null : current,
+                  );
+                },
+              );
+            },
+          },
+        ],
+        {
+          cancelable: true,
+          onDismiss: releaseConfirmation,
+        },
+      );
+    },
+    [runMutation, tripId],
+  );
+
+  const editPayload = editState
+    ? buildPatchCustomTypePayload(editState.initial, editState.draft)
+    : null;
+  const editDirty = hasPayloadFields(editPayload);
+  const busy = mutationKey !== null;
+
+  if (!timeline && status === 'loading') {
+    return (
+      <>
+        <ManagerNavigation busy={false} onClose={close} />
+        <LoadingScreen />
+      </>
+    );
+  }
+
+  if (!timeline) {
+    const notFound = loadError?.status === 404;
+    return (
+      <>
+        <ManagerNavigation busy={false} onClose={close} />
+        <ManagerState
+          title={
+            notFound
+              ? 'Custom types unavailable'
+              : 'Could not load custom types'
+          }
+          message={
+            notFound
+              ? 'This trip does not exist or you are not a member of it.'
+              : loadError?.message ?? 'Please try again.'
+          }
+          actionTitle={notFound ? 'Back to timeline' : 'Try again'}
+          onAction={
+            notFound ? close : () => void requestReconcile(true)
+          }
+        />
+      </>
+    );
+  }
+
+  if (!timeline.permissions.can_manage_custom_types) {
+    return (
+      <>
+        <ManagerNavigation busy={false} onClose={close} />
+        <ManagerState
+          title="Custom type management unavailable"
+          message="You do not have permission to manage custom activity types."
+          actionTitle="Back to timeline"
+          onAction={close}
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <ManagerNavigation busy={busy} onClose={close} />
+      <SafeAreaView
+        style={styles.safe}
+        edges={['left', 'right', 'bottom']}
+      >
+        {loadError ? (
+          <View accessibilityRole="alert" style={styles.errorBanner}>
+            <Text style={styles.errorBannerText}>{loadError.message}</Text>
+          </View>
+        ) : null}
+        {successMessage ? (
+          <View
+            accessibilityLiveRegion="polite"
+            style={styles.successBanner}
+          >
+            <Text style={styles.successBannerText}>{successMessage}</Text>
+          </View>
+        ) : null}
+        <CustomTypeManager
+          customTypes={timeline.custom_types}
+          createDraft={createDraft}
+          createFieldErrors={createFieldErrors}
+          editTypeId={editState?.typeId ?? null}
+          editDraft={editState?.draft ?? null}
+          editFieldErrors={editFieldErrors}
+          editDirty={editDirty}
+          mutationKey={mutationKey}
+          mutationError={mutationError}
+          onChangeCreate={changeCreateDraft}
+          onCreate={submitCreate}
+          onStartEdit={startEdit}
+          onChangeEdit={changeEditDraft}
+          onSaveEdit={submitEdit}
+          onCancelEdit={cancelEdit}
+          onToggleActive={toggleActive}
+          onDelete={requestDelete}
+        />
+      </SafeAreaView>
+    </>
+  );
+}
 
 export function CustomTypeManagerScreen() {
   const { tripId } = useLocalSearchParams();
@@ -15,5 +572,51 @@ export function CustomTypeManagerScreen() {
     );
   }
 
-  return <RouteReadyState testID="custom-types-route-ready" />;
+  return (
+    <ValidCustomTypeManagerScreen
+      key={intent.tripId}
+      tripId={intent.tripId}
+    />
+  );
 }
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.background },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.md,
+    padding: spacing.lg,
+  },
+  stateTitle: {
+    ...typography.heading,
+    color: colors.text,
+    textAlign: 'center',
+  },
+  stateBody: {
+    ...typography.body,
+    color: colors.textMuted,
+    textAlign: 'center',
+  },
+  headerAction: {
+    minHeight: 44,
+    justifyContent: 'center',
+    marginLeft: -spacing.sm,
+    paddingHorizontal: spacing.sm,
+  },
+  headerActionMuted: { opacity: 0.55 },
+  headerActionText: { ...typography.body, color: colors.primary },
+  errorBanner: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    backgroundColor: colors.dangerSoft,
+  },
+  errorBannerText: { ...typography.caption, color: colors.danger },
+  successBanner: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    backgroundColor: colors.successSoft,
+  },
+  successBannerText: { ...typography.caption, color: colors.success },
+});

--- a/mobile/src/features/timeline/screens/CustomTypeManagerScreen.tsx
+++ b/mobile/src/features/timeline/screens/CustomTypeManagerScreen.tsx
@@ -1,0 +1,19 @@
+import { useLocalSearchParams } from 'expo-router';
+import { parseTimelineRouteIntent } from '../routeIntent';
+import { RouteReadyState, RouteUnavailableState } from './RouteState';
+
+export function CustomTypeManagerScreen() {
+  const { tripId } = useLocalSearchParams();
+  const intent = parseTimelineRouteIntent({ tripId });
+
+  if (!intent) {
+    return (
+      <RouteUnavailableState
+        title="Custom types unavailable"
+        message="This custom types link is invalid or incomplete."
+      />
+    );
+  }
+
+  return <RouteReadyState testID="custom-types-route-ready" />;
+}

--- a/mobile/src/features/timeline/screens/CustomTypeManagerScreen.tsx
+++ b/mobile/src/features/timeline/screens/CustomTypeManagerScreen.tsx
@@ -343,7 +343,7 @@ function ValidCustomTypeManagerScreen({ tripId }: { tripId: string }) {
         }
       } finally {
         mutationLockRef.current = false;
-        if (isActiveGeneration(generation)) {
+        if (mountedRef.current && activeRef.current) {
           setMutationKey(null);
         }
       }

--- a/mobile/src/features/timeline/screens/CustomTypeManagerScreen.tsx
+++ b/mobile/src/features/timeline/screens/CustomTypeManagerScreen.tsx
@@ -241,7 +241,11 @@ function ValidCustomTypeManagerScreen({ tripId }: { tripId: string }) {
 
   const close = useCallback(() => {
     if (!mutationLockRef.current) {
-      router.dismissTo(parentHref);
+      if (router.canGoBack()) {
+        router.back();
+      } else {
+        router.dismissTo(parentHref);
+      }
     }
   }, [parentHref, router]);
 

--- a/mobile/src/features/timeline/screens/CustomTypeManagerScreen.tsx
+++ b/mobile/src/features/timeline/screens/CustomTypeManagerScreen.tsx
@@ -309,7 +309,7 @@ function ValidCustomTypeManagerScreen({ tripId }: { tripId: string }) {
       scope: CustomTypeMutationScope,
       mutate: () => Promise<unknown>,
       activeSuccessMessage: string,
-      onActiveSuccess?: () => void,
+      onCommittedSuccess?: () => void,
     ): Promise<void> => {
       if (mutationLockRef.current) {
         return;
@@ -324,12 +324,14 @@ function ValidCustomTypeManagerScreen({ tripId }: { tripId: string }) {
 
       try {
         await mutate();
+        if (mountedRef.current) {
+          onCommittedSuccess?.();
+        }
         await publishTimelineEvent({
           type: 'timelineChanged',
           tripId,
         });
         if (isActiveGeneration(generation)) {
-          onActiveSuccess?.();
           setSuccessMessage(activeSuccessMessage);
         }
       } catch (caught) {

--- a/mobile/src/features/timeline/screens/RouteState.tsx
+++ b/mobile/src/features/timeline/screens/RouteState.tsx
@@ -1,0 +1,68 @@
+import { Ionicons } from '@expo/vector-icons';
+import type { ComponentProps } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors, spacing, typography } from '@/shared/theme/tokens';
+import { LoadingScreen } from '@/shared/ui/LoadingScreen';
+
+interface RouteUnavailableStateProps {
+  title: string;
+  message: string;
+}
+
+interface RouteReadyStateProps {
+  testID: string;
+}
+
+export function RouteUnavailableState({ title, message }: RouteUnavailableStateProps) {
+  return (
+    <SafeAreaView style={styles.safe} edges={['left', 'right', 'bottom']}>
+      <View style={styles.centered}>
+        <Ionicons
+          name={'help-circle-outline' satisfies ComponentProps<typeof Ionicons>['name']}
+          size={44}
+          color={colors.textMuted}
+        />
+        <Text accessibilityRole="header" style={styles.title}>
+          {title}
+        </Text>
+        <Text style={styles.message}>{message}</Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+export function RouteReadyState({ testID }: RouteReadyStateProps) {
+  return (
+    <View testID={testID} style={styles.ready}>
+      <LoadingScreen />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.sm,
+    padding: spacing.lg,
+  },
+  title: {
+    ...typography.heading,
+    color: colors.text,
+    textAlign: 'center',
+  },
+  message: {
+    ...typography.body,
+    color: colors.textMuted,
+    textAlign: 'center',
+  },
+  ready: {
+    flex: 1,
+  },
+});

--- a/mobile/src/features/timeline/screens/SectionFormScreen.tsx
+++ b/mobile/src/features/timeline/screens/SectionFormScreen.tsx
@@ -1,0 +1,24 @@
+import { useLocalSearchParams } from 'expo-router';
+import type { SectionFormRouteIntent } from '../routeIntent';
+import { parseSectionFormRouteIntent } from '../routeIntent';
+import { RouteReadyState, RouteUnavailableState } from './RouteState';
+
+function ValidSectionFormScreen({ intent }: { intent: SectionFormRouteIntent }) {
+  return <RouteReadyState testID={`section-form-${intent.mode}-route-ready`} />;
+}
+
+export function SectionFormScreen() {
+  const { tripId, mode, sectionId } = useLocalSearchParams();
+  const intent = parseSectionFormRouteIntent({ tripId, mode, sectionId });
+
+  if (!intent) {
+    return (
+      <RouteUnavailableState
+        title="Form unavailable"
+        message="This form link is invalid or incomplete."
+      />
+    );
+  }
+
+  return <ValidSectionFormScreen intent={intent} />;
+}

--- a/mobile/src/features/timeline/screens/SectionFormScreen.tsx
+++ b/mobile/src/features/timeline/screens/SectionFormScreen.tsx
@@ -131,6 +131,7 @@ interface SectionFormEditorProps {
   initialDraft: SectionFormDraft;
   canManage: boolean;
   submitLockRef: { current: boolean };
+  submissionCommittedRef: { current: boolean };
   submitting: boolean;
   setSubmitting: (submitting: boolean) => void;
   invalidate: () => void;
@@ -148,6 +149,7 @@ function SectionFormEditor({
   initialDraft,
   canManage,
   submitLockRef,
+  submissionCommittedRef,
   submitting,
   setSubmitting,
   invalidate,
@@ -242,15 +244,22 @@ function SectionFormEditor({
       } else if (intent.mode === 'edit' && patchPayload) {
         await patchSection(intent.tripId, intent.sectionId, patchPayload);
       }
+      submissionCommittedRef.current = true;
 
       await publishTimelineEvent({
         type: 'timelineChanged',
         tripId: intent.tripId,
       });
-      if (mountedRef.current && isActiveGeneration(generation)) {
+      if (isScreenActive()) {
         onConfirmedSuccess();
       }
     } catch (caught) {
+      if (submissionCommittedRef.current) {
+        if (isScreenActive()) {
+          onConfirmedSuccess();
+        }
+        return;
+      }
       if (!mountedRef.current || !isActiveGeneration(generation)) {
         return;
       }
@@ -260,8 +269,10 @@ function SectionFormEditor({
         await refresh('silent');
       }
     } finally {
-      submitLockRef.current = false;
-      if (isScreenActive()) {
+      if (!submissionCommittedRef.current) {
+        submitLockRef.current = false;
+      }
+      if (!submissionCommittedRef.current && isScreenActive()) {
         setSubmitting(false);
       }
     }
@@ -279,6 +290,7 @@ function SectionFormEditor({
     refresh,
     setSubmitting,
     submitLockRef,
+    submissionCommittedRef,
     timeline.sections,
   ]);
 
@@ -334,6 +346,7 @@ function ValidSectionFormScreen({
   } = useTimeline(intent.tripId, { autoReconcile: false });
   const [submitting, setSubmitting] = useState(false);
   const submitLockRef = useRef(false);
+  const submissionCommittedRef = useRef(false);
   const activeRef = useRef(false);
   const mountedRef = useRef(true);
   const generationRef = useRef(0);
@@ -360,16 +373,20 @@ function ValidSectionFormScreen({
     useCallback(() => {
       activeRef.current = true;
       generationRef.current += 1;
-      if (!submitLockRef.current) {
-        setSubmitting(false);
+      if (submissionCommittedRef.current) {
+        router.dismissTo(parentHref);
+      } else {
+        if (!submitLockRef.current) {
+          setSubmitting(false);
+        }
+        void requestReconcile();
       }
-      void requestReconcile();
 
       return () => {
         activeRef.current = false;
         generationRef.current += 1;
       };
-    }, [requestReconcile]),
+    }, [parentHref, requestReconcile, router]),
   );
 
   useEffect(
@@ -392,7 +409,7 @@ function ValidSectionFormScreen({
   useEffect(
     () =>
       subscribeToTimelineEvents(intent.tripId, () => {
-        if (activeRef.current) {
+        if (activeRef.current && !submissionCommittedRef.current) {
           return requestReconcile();
         }
         return undefined;
@@ -525,6 +542,7 @@ function ValidSectionFormScreen({
         initialDraft={initialDraft}
         canManage={canManage}
         submitLockRef={submitLockRef}
+        submissionCommittedRef={submissionCommittedRef}
         submitting={submitting}
         setSubmitting={setSubmitting}
         invalidate={invalidate}

--- a/mobile/src/features/timeline/screens/SectionFormScreen.tsx
+++ b/mobile/src/features/timeline/screens/SectionFormScreen.tsx
@@ -1,10 +1,517 @@
-import { useLocalSearchParams } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import {
+  Stack,
+  useFocusEffect,
+  useLocalSearchParams,
+  useRouter,
+} from 'expo-router';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { type ApiError, normalizeApiError } from '@/shared/api/errors';
+import { useAppForegroundEffect } from '@/shared/hooks/useAppForegroundEffect';
+import { colors, spacing, typography } from '@/shared/theme/tokens';
+import { Button } from '@/shared/ui/Button';
+import { LoadingScreen } from '@/shared/ui/LoadingScreen';
+import { createSection, patchSection } from '../api';
+import { SectionForm } from '../components/SectionForm';
+import {
+  buildCreateSectionPayload,
+  buildPatchSectionPayload,
+  createSectionDraft,
+  getSectionDirtyFields,
+  hydrateSectionDraft,
+  type SectionFormDraft,
+  type SectionFormFieldErrors,
+  validateSectionDraft,
+} from '../formModel';
+import {
+  type TimelineLoadMode,
+  useTimeline,
+} from '../hooks/useTimeline';
 import type { SectionFormRouteIntent } from '../routeIntent';
 import { parseSectionFormRouteIntent } from '../routeIntent';
-import { RouteReadyState, RouteUnavailableState } from './RouteState';
+import {
+  publishTimelineEvent,
+  subscribeToTimelineEvents,
+} from '../timelineEvents';
+import type { TimelineResponse } from '../types';
+import { getTodayDateInTimeZone } from '../viewModel';
+import { RouteUnavailableState } from './RouteState';
 
-function ValidSectionFormScreen({ intent }: { intent: SectionFormRouteIntent }) {
-  return <RouteReadyState testID={`section-form-${intent.mode}-route-ready`} />;
+interface SectionFormStateProps {
+  title: string;
+  message: string;
+  actionTitle?: string;
+  onAction?: () => void;
+}
+
+function SectionFormState({
+  title,
+  message,
+  actionTitle,
+  onAction,
+}: SectionFormStateProps) {
+  return (
+    <SafeAreaView style={styles.safe} edges={['left', 'right', 'bottom']}>
+      <View style={styles.centered}>
+        <Ionicons
+          name="calendar-outline"
+          size={44}
+          color={colors.textMuted}
+        />
+        <Text accessibilityRole="header" style={styles.stateTitle}>
+          {title}
+        </Text>
+        <Text style={styles.stateBody}>{message}</Text>
+        {actionTitle && onAction ? (
+          <Button title={actionTitle} onPress={onAction} />
+        ) : null}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+function HeaderCancelAction({
+  disabled,
+  onPress,
+}: {
+  disabled: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel="Cancel timeline day form"
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      hitSlop={spacing.sm}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.headerAction,
+        (pressed || disabled) && styles.headerActionMuted,
+      ]}
+    >
+      <Text style={styles.headerActionText}>Cancel</Text>
+    </Pressable>
+  );
+}
+
+function hasDirtyFields(
+  initial: SectionFormDraft,
+  draft: SectionFormDraft,
+): boolean {
+  return Object.values(getSectionDirtyFields(initial, draft)).some(Boolean);
+}
+
+function isUnavailableDate(
+  sections: readonly { id: string; section_date: string }[],
+  sectionDate: string,
+  editedSectionId?: string,
+): boolean {
+  return sections.some(
+    (section) =>
+      section.id !== editedSectionId &&
+      section.section_date === sectionDate,
+  );
+}
+
+function shouldReconcileAfterFailure(error: ApiError): boolean {
+  return error.status === 403 || error.status === 404 || error.status === 409;
+}
+
+interface SectionFormEditorProps {
+  intent: SectionFormRouteIntent;
+  timeline: TimelineResponse;
+  initialDraft: SectionFormDraft;
+  submitLockRef: { current: boolean };
+  invalidate: () => void;
+  refresh: (mode?: TimelineLoadMode) => Promise<void>;
+  getGeneration: () => number;
+  isActiveGeneration: (generation: number) => boolean;
+  onCancel: () => void;
+  onConfirmedSuccess: () => void;
+}
+
+function SectionFormEditor({
+  intent,
+  timeline,
+  initialDraft,
+  submitLockRef,
+  invalidate,
+  refresh,
+  getGeneration,
+  isActiveGeneration,
+  onCancel,
+  onConfirmedSuccess,
+}: SectionFormEditorProps) {
+  const [initial] = useState<SectionFormDraft>(() => ({
+    ...initialDraft,
+  }));
+  const [draft, setDraft] = useState<SectionFormDraft>(() => ({
+    ...initialDraft,
+  }));
+  const [fieldErrors, setFieldErrors] =
+    useState<SectionFormFieldErrors>({});
+  const [submitError, setSubmitError] = useState<ApiError | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const mountedRef = useRef(true);
+  const editedSectionId =
+    intent.mode === 'edit' ? intent.sectionId : undefined;
+  const dateUnavailable = isUnavailableDate(
+    timeline.sections,
+    draft.section_date,
+    editedSectionId,
+  );
+  const dirty = hasDirtyFields(initial, draft);
+
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    [],
+  );
+
+  const changeDraft = useCallback(
+    (changes: Partial<SectionFormDraft>) => {
+      setDraft((current) => ({ ...current, ...changes }));
+      setFieldErrors({});
+      setSubmitError(null);
+    },
+    [],
+  );
+
+  const submit = useCallback(async () => {
+    if (submitLockRef.current) {
+      return;
+    }
+
+    const validation = validateSectionDraft(draft);
+    setFieldErrors(validation.fieldErrors);
+    setSubmitError(null);
+    if (
+      !validation.isValid ||
+      isUnavailableDate(
+        timeline.sections,
+        draft.section_date,
+        editedSectionId,
+      )
+    ) {
+      return;
+    }
+
+    const createPayload =
+      intent.mode === 'create'
+        ? buildCreateSectionPayload(draft)
+        : null;
+    const patchPayload =
+      intent.mode === 'edit'
+        ? buildPatchSectionPayload(initial, draft)
+        : null;
+    if (
+      (intent.mode === 'create' && !createPayload) ||
+      (intent.mode === 'edit' &&
+        (!patchPayload || Object.keys(patchPayload).length === 0))
+    ) {
+      return;
+    }
+
+    const generation = getGeneration();
+    submitLockRef.current = true;
+    setSubmitting(true);
+    invalidate();
+
+    try {
+      if (intent.mode === 'create' && createPayload) {
+        await createSection(intent.tripId, createPayload);
+      } else if (intent.mode === 'edit' && patchPayload) {
+        await patchSection(intent.tripId, intent.sectionId, patchPayload);
+      }
+
+      await publishTimelineEvent({
+        type: 'timelineChanged',
+        tripId: intent.tripId,
+      });
+      if (mountedRef.current && isActiveGeneration(generation)) {
+        onConfirmedSuccess();
+      }
+    } catch (caught) {
+      if (!mountedRef.current || !isActiveGeneration(generation)) {
+        return;
+      }
+      const normalized = normalizeApiError(caught);
+      setSubmitError(normalized);
+      if (shouldReconcileAfterFailure(normalized)) {
+        await refresh('silent');
+      }
+    } finally {
+      submitLockRef.current = false;
+      if (mountedRef.current && isActiveGeneration(generation)) {
+        setSubmitting(false);
+      }
+    }
+  }, [
+    draft,
+    editedSectionId,
+    getGeneration,
+    initial,
+    intent,
+    invalidate,
+    isActiveGeneration,
+    onConfirmedSuccess,
+    refresh,
+    submitLockRef,
+    timeline.sections,
+  ]);
+
+  const title = intent.mode === 'create' ? 'Add Day' : 'Edit Day';
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          title,
+          gestureEnabled: !submitting,
+          headerLeft: () => (
+            <HeaderCancelAction
+              disabled={submitting}
+              onPress={onCancel}
+            />
+          ),
+        }}
+      />
+      <SectionForm
+        mode={intent.mode}
+        draft={draft}
+        fieldErrors={fieldErrors}
+        submitError={submitError}
+        dateUnavailable={dateUnavailable}
+        dirty={dirty}
+        submitting={submitting}
+        onChange={changeDraft}
+        onSubmit={() => void submit()}
+      />
+    </>
+  );
+}
+
+function ValidSectionFormScreen({
+  intent,
+}: {
+  intent: SectionFormRouteIntent;
+}) {
+  const router = useRouter();
+  const {
+    timeline,
+    status,
+    error: loadError,
+    refresh,
+    invalidate,
+  } = useTimeline(intent.tripId, { autoReconcile: false });
+  const submitLockRef = useRef(false);
+  const activeRef = useRef(false);
+  const generationRef = useRef(0);
+  const hasRequestedInitialRef = useRef(false);
+  const parentHref = `/trips/${intent.tripId}/timeline` as const;
+  const currentSection =
+    intent.mode === 'edit'
+      ? timeline?.sections.find((section) => section.id === intent.sectionId)
+      : undefined;
+
+  const requestReconcile = useCallback(
+    (forceInitial = false) => {
+      const mode =
+        forceInitial || !hasRequestedInitialRef.current
+          ? 'initial'
+          : 'silent';
+      hasRequestedInitialRef.current = true;
+      return refresh(mode);
+    },
+    [refresh],
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      activeRef.current = true;
+      generationRef.current += 1;
+      void requestReconcile();
+
+      return () => {
+        activeRef.current = false;
+        generationRef.current += 1;
+      };
+    }, [requestReconcile]),
+  );
+
+  useEffect(
+    () => () => {
+      activeRef.current = false;
+      generationRef.current += 1;
+    },
+    [],
+  );
+
+  useAppForegroundEffect(
+    useCallback(() => {
+      if (activeRef.current && !submitLockRef.current) {
+        void requestReconcile();
+      }
+    }, [requestReconcile]),
+  );
+
+  useEffect(
+    () =>
+      subscribeToTimelineEvents(intent.tripId, () => {
+        if (activeRef.current) {
+          return requestReconcile();
+        }
+        return undefined;
+      }),
+    [intent.tripId, requestReconcile],
+  );
+
+  const canManage =
+    intent.mode === 'create'
+      ? timeline?.permissions.can_create_sections === true
+      : timeline?.permissions.can_edit_timeline === true;
+
+  const isActiveGeneration = useCallback((generation: number) => {
+    return activeRef.current && generationRef.current === generation;
+  }, []);
+
+  const getGeneration = useCallback(() => generationRef.current, []);
+
+  const cancel = useCallback(() => {
+    if (!submitLockRef.current) {
+      router.dismissTo(parentHref);
+    }
+  }, [parentHref, router]);
+
+  const title = intent.mode === 'create' ? 'Add Day' : 'Edit Day';
+
+  if (!timeline && status === 'loading') {
+    return (
+      <>
+        <Stack.Screen
+          options={{
+            title,
+            gestureEnabled: true,
+            headerLeft: () => (
+              <HeaderCancelAction disabled={false} onPress={cancel} />
+            ),
+          }}
+        />
+        <LoadingScreen />
+      </>
+    );
+  }
+
+  if (!timeline) {
+    const notFound = loadError?.status === 404;
+    return (
+      <>
+        <Stack.Screen
+          options={{
+            title,
+            gestureEnabled: true,
+            headerLeft: () => (
+              <HeaderCancelAction disabled={false} onPress={cancel} />
+            ),
+          }}
+        />
+        <SectionFormState
+          title={notFound ? 'Timeline unavailable' : 'Could not load timeline'}
+          message={
+            notFound
+              ? 'This trip does not exist or you are not a member of it.'
+              : loadError?.message ?? 'Please try again.'
+          }
+          actionTitle={notFound ? 'Back to timeline' : 'Try again'}
+          onAction={
+            notFound ? cancel : () => void requestReconcile(true)
+          }
+        />
+      </>
+    );
+  }
+
+  if (intent.mode === 'edit' && !currentSection) {
+    return (
+      <>
+        <Stack.Screen
+          options={{
+            title,
+            gestureEnabled: true,
+            headerLeft: () => (
+              <HeaderCancelAction disabled={false} onPress={cancel} />
+            ),
+          }}
+        />
+        <SectionFormState
+          title="Day unavailable"
+          message="This timeline day no longer exists."
+          actionTitle="Back to timeline"
+          onAction={cancel}
+        />
+      </>
+    );
+  }
+
+  if (!canManage) {
+    return (
+      <>
+        <Stack.Screen
+          options={{
+            title,
+            gestureEnabled: true,
+            headerLeft: () => (
+              <HeaderCancelAction disabled={false} onPress={cancel} />
+            ),
+          }}
+        />
+        <SectionFormState
+          title="Day management unavailable"
+          message="You do not have permission to manage timeline days."
+          actionTitle="Back to timeline"
+          onAction={cancel}
+        />
+      </>
+    );
+  }
+
+  const initialDraft =
+    intent.mode === 'edit'
+      ? hydrateSectionDraft(currentSection!)
+      : createSectionDraft(
+          getTodayDateInTimeZone(timeline.trip_timezone),
+        );
+
+  return (
+    <>
+      {loadError ? (
+        <View accessibilityRole="alert" style={styles.refreshError}>
+          <Text style={styles.refreshErrorText}>{loadError.message}</Text>
+        </View>
+      ) : null}
+      <SectionFormEditor
+        intent={intent}
+        timeline={timeline}
+        initialDraft={initialDraft}
+        submitLockRef={submitLockRef}
+        invalidate={invalidate}
+        refresh={refresh}
+        getGeneration={getGeneration}
+        isActiveGeneration={isActiveGeneration}
+        onCancel={cancel}
+        onConfirmedSuccess={() => router.dismissTo(parentHref)}
+      />
+    </>
+  );
 }
 
 export function SectionFormScreen() {
@@ -20,5 +527,47 @@ export function SectionFormScreen() {
     );
   }
 
-  return <ValidSectionFormScreen intent={intent} />;
+  const identity =
+    intent.mode === 'create'
+      ? `${intent.tripId}:create`
+      : `${intent.tripId}:edit:${intent.sectionId}`;
+  return <ValidSectionFormScreen key={identity} intent={intent} />;
 }
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.background },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.md,
+    padding: spacing.lg,
+  },
+  stateTitle: {
+    ...typography.heading,
+    color: colors.text,
+    textAlign: 'center',
+  },
+  stateBody: {
+    ...typography.body,
+    color: colors.textMuted,
+    textAlign: 'center',
+  },
+  headerAction: {
+    minHeight: 44,
+    justifyContent: 'center',
+    marginLeft: -spacing.sm,
+    paddingHorizontal: spacing.sm,
+  },
+  headerActionMuted: { opacity: 0.55 },
+  headerActionText: { ...typography.body, color: colors.primary },
+  refreshError: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    backgroundColor: colors.dangerSoft,
+  },
+  refreshErrorText: {
+    ...typography.caption,
+    color: colors.danger,
+  },
+});

--- a/mobile/src/features/timeline/screens/SectionFormScreen.tsx
+++ b/mobile/src/features/timeline/screens/SectionFormScreen.tsx
@@ -129,10 +129,14 @@ interface SectionFormEditorProps {
   intent: SectionFormRouteIntent;
   timeline: TimelineResponse;
   initialDraft: SectionFormDraft;
+  canManage: boolean;
   submitLockRef: { current: boolean };
+  submitting: boolean;
+  setSubmitting: (submitting: boolean) => void;
   invalidate: () => void;
   refresh: (mode?: TimelineLoadMode) => Promise<void>;
   getGeneration: () => number;
+  isScreenActive: () => boolean;
   isActiveGeneration: (generation: number) => boolean;
   onCancel: () => void;
   onConfirmedSuccess: () => void;
@@ -142,10 +146,14 @@ function SectionFormEditor({
   intent,
   timeline,
   initialDraft,
+  canManage,
   submitLockRef,
+  submitting,
+  setSubmitting,
   invalidate,
   refresh,
   getGeneration,
+  isScreenActive,
   isActiveGeneration,
   onCancel,
   onConfirmedSuccess,
@@ -159,7 +167,6 @@ function SectionFormEditor({
   const [fieldErrors, setFieldErrors] =
     useState<SectionFormFieldErrors>({});
   const [submitError, setSubmitError] = useState<ApiError | null>(null);
-  const [submitting, setSubmitting] = useState(false);
   const mountedRef = useRef(true);
   const editedSectionId =
     intent.mode === 'edit' ? intent.sectionId : undefined;
@@ -179,15 +186,18 @@ function SectionFormEditor({
 
   const changeDraft = useCallback(
     (changes: Partial<SectionFormDraft>) => {
+      if (submitLockRef.current || !canManage) {
+        return;
+      }
       setDraft((current) => ({ ...current, ...changes }));
       setFieldErrors({});
       setSubmitError(null);
     },
-    [],
+    [canManage, submitLockRef],
   );
 
   const submit = useCallback(async () => {
-    if (submitLockRef.current) {
+    if (submitLockRef.current || !canManage) {
       return;
     }
 
@@ -251,11 +261,12 @@ function SectionFormEditor({
       }
     } finally {
       submitLockRef.current = false;
-      if (mountedRef.current && isActiveGeneration(generation)) {
+      if (isScreenActive()) {
         setSubmitting(false);
       }
     }
   }, [
+    canManage,
     draft,
     editedSectionId,
     getGeneration,
@@ -263,8 +274,10 @@ function SectionFormEditor({
     intent,
     invalidate,
     isActiveGeneration,
+    isScreenActive,
     onConfirmedSuccess,
     refresh,
+    setSubmitting,
     submitLockRef,
     timeline.sections,
   ]);
@@ -293,6 +306,12 @@ function SectionFormEditor({
         dateUnavailable={dateUnavailable}
         dirty={dirty}
         submitting={submitting}
+        disabled={!canManage}
+        authorityMessage={
+          canManage
+            ? undefined
+            : 'You do not have permission to manage timeline days.'
+        }
         onChange={changeDraft}
         onSubmit={() => void submit()}
       />
@@ -313,8 +332,10 @@ function ValidSectionFormScreen({
     refresh,
     invalidate,
   } = useTimeline(intent.tripId, { autoReconcile: false });
+  const [submitting, setSubmitting] = useState(false);
   const submitLockRef = useRef(false);
   const activeRef = useRef(false);
+  const mountedRef = useRef(true);
   const generationRef = useRef(0);
   const hasRequestedInitialRef = useRef(false);
   const parentHref = `/trips/${intent.tripId}/timeline` as const;
@@ -339,6 +360,9 @@ function ValidSectionFormScreen({
     useCallback(() => {
       activeRef.current = true;
       generationRef.current += 1;
+      if (!submitLockRef.current) {
+        setSubmitting(false);
+      }
       void requestReconcile();
 
       return () => {
@@ -350,6 +374,7 @@ function ValidSectionFormScreen({
 
   useEffect(
     () => () => {
+      mountedRef.current = false;
       activeRef.current = false;
       generationRef.current += 1;
     },
@@ -381,8 +406,17 @@ function ValidSectionFormScreen({
       : timeline?.permissions.can_edit_timeline === true;
 
   const isActiveGeneration = useCallback((generation: number) => {
-    return activeRef.current && generationRef.current === generation;
+    return (
+      mountedRef.current &&
+      activeRef.current &&
+      generationRef.current === generation
+    );
   }, []);
+
+  const isScreenActive = useCallback(
+    () => mountedRef.current && activeRef.current,
+    [],
+  );
 
   const getGeneration = useCallback(() => generationRef.current, []);
 
@@ -400,9 +434,12 @@ function ValidSectionFormScreen({
         <Stack.Screen
           options={{
             title,
-            gestureEnabled: true,
+            gestureEnabled: !submitting,
             headerLeft: () => (
-              <HeaderCancelAction disabled={false} onPress={cancel} />
+              <HeaderCancelAction
+                disabled={submitting}
+                onPress={cancel}
+              />
             ),
           }}
         />
@@ -418,9 +455,12 @@ function ValidSectionFormScreen({
         <Stack.Screen
           options={{
             title,
-            gestureEnabled: true,
+            gestureEnabled: !submitting,
             headerLeft: () => (
-              <HeaderCancelAction disabled={false} onPress={cancel} />
+              <HeaderCancelAction
+                disabled={submitting}
+                onPress={cancel}
+              />
             ),
           }}
         />
@@ -446,37 +486,18 @@ function ValidSectionFormScreen({
         <Stack.Screen
           options={{
             title,
-            gestureEnabled: true,
+            gestureEnabled: !submitting,
             headerLeft: () => (
-              <HeaderCancelAction disabled={false} onPress={cancel} />
+              <HeaderCancelAction
+                disabled={submitting}
+                onPress={cancel}
+              />
             ),
           }}
         />
         <SectionFormState
           title="Day unavailable"
           message="This timeline day no longer exists."
-          actionTitle="Back to timeline"
-          onAction={cancel}
-        />
-      </>
-    );
-  }
-
-  if (!canManage) {
-    return (
-      <>
-        <Stack.Screen
-          options={{
-            title,
-            gestureEnabled: true,
-            headerLeft: () => (
-              <HeaderCancelAction disabled={false} onPress={cancel} />
-            ),
-          }}
-        />
-        <SectionFormState
-          title="Day management unavailable"
-          message="You do not have permission to manage timeline days."
           actionTitle="Back to timeline"
           onAction={cancel}
         />
@@ -502,10 +523,14 @@ function ValidSectionFormScreen({
         intent={intent}
         timeline={timeline}
         initialDraft={initialDraft}
+        canManage={canManage}
         submitLockRef={submitLockRef}
+        submitting={submitting}
+        setSubmitting={setSubmitting}
         invalidate={invalidate}
         refresh={refresh}
         getGeneration={getGeneration}
+        isScreenActive={isScreenActive}
         isActiveGeneration={isActiveGeneration}
         onCancel={cancel}
         onConfirmedSuccess={() => router.dismissTo(parentHref)}

--- a/mobile/src/features/timeline/screens/TimelineScreen.tsx
+++ b/mobile/src/features/timeline/screens/TimelineScreen.tsx
@@ -289,7 +289,7 @@ function TimelineContent({ tripId }: TimelineContentProps) {
       };
       Alert.alert(
         'Delete timeline day?',
-        `Delete ${section.label} and all activities in it? This cannot be undone.`,
+        `Delete ${section.label}? Only empty timeline days can be deleted. This cannot be undone.`,
         [
           {
             text: 'Cancel',

--- a/mobile/src/features/timeline/screens/TimelineScreen.tsx
+++ b/mobile/src/features/timeline/screens/TimelineScreen.tsx
@@ -1,7 +1,9 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
+  ActivityIndicator,
+  Alert,
   Pressable,
   RefreshControl,
   SectionList,
@@ -11,13 +13,17 @@ import {
   type SectionListRenderItemInfo,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { normalizeApiError } from '@/shared/api/errors';
 import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
 import { Button } from '@/shared/ui/Button';
 import { LoadingScreen } from '@/shared/ui/LoadingScreen';
+import { deleteSection as deleteTimelineSection } from '../api';
 import { ActivityRow } from '../components/ActivityRow';
 import { SectionGroup } from '../components/SectionGroup';
 import { useTimeline } from '../hooks/useTimeline';
 import { parseTimelineRouteIntent } from '../routeIntent';
+import { publishTimelineEvent } from '../timelineEvents';
+import type { TimelineSection } from '../types';
 import {
   buildTimelineListSections,
   getDefaultFocusedSectionIndex,
@@ -39,9 +45,19 @@ interface ScrollFailureInfo {
 
 function TimelineContent({ tripId }: TimelineContentProps) {
   const router = useRouter();
-  const { timeline, status, error, refreshing, refresh } = useTimeline(tripId);
+  const {
+    timeline,
+    status,
+    error,
+    refreshing,
+    refresh,
+    invalidate,
+  } = useTimeline(tripId);
   const listRef =
     useRef<SectionList<TimelineListRow, TimelineListSection>>(null);
+  const mountedRef = useRef(true);
+  const deleteLockRef = useRef(false);
+  const deleteStartedRef = useRef(false);
   const lastScrollTripIdRef = useRef<string | null>(null);
   const scrollTargetRef = useRef<{
     tripId: string;
@@ -49,6 +65,11 @@ function TimelineContent({ tripId }: TimelineContentProps) {
     retried: boolean;
   } | null>(null);
   const retryFrameRef = useRef<number | null>(null);
+  const [sectionActionsLocked, setSectionActionsLocked] = useState(false);
+  const [deletingSectionId, setDeletingSectionId] = useState<string | null>(
+    null,
+  );
+  const [mutationError, setMutationError] = useState<string | null>(null);
   const sections = useMemo(
     () => buildTimelineListSections(timeline?.sections ?? []),
     [timeline?.sections],
@@ -88,6 +109,7 @@ function TimelineContent({ tripId }: TimelineContentProps) {
 
   useEffect(
     () => () => {
+      mountedRef.current = false;
       if (retryFrameRef.current !== null) {
         cancelAnimationFrame(retryFrameRef.current);
         retryFrameRef.current = null;
@@ -137,8 +159,113 @@ function TimelineContent({ tripId }: TimelineContentProps) {
   );
 
   const openCreateDay = useCallback(() => {
+    setMutationError(null);
     router.push(`/trips/${tripId}/timeline/section-form?mode=create`);
   }, [router, tripId]);
+
+  const openEditSection = useCallback(
+    (section: TimelineSection) => {
+      setMutationError(null);
+      router.push(
+        `/trips/${tripId}/timeline/section-form?mode=edit&sectionId=${section.id}`,
+      );
+    },
+    [router, tripId],
+  );
+
+  const performDeleteSection = useCallback(
+    async (section: TimelineSection) => {
+      if (!mountedRef.current) {
+        deleteStartedRef.current = false;
+        deleteLockRef.current = false;
+        return;
+      }
+
+      setDeletingSectionId(section.id);
+      setMutationError(null);
+      invalidate();
+
+      try {
+        await deleteTimelineSection(tripId, section.id);
+        await publishTimelineEvent({
+          type: 'timelineChanged',
+          tripId,
+        });
+      } catch (caught) {
+        if (!mountedRef.current) {
+          return;
+        }
+
+        const normalized = normalizeApiError(caught);
+        setMutationError(normalized.message);
+        if (
+          normalized.status === 403 ||
+          normalized.status === 404 ||
+          normalized.status === 409
+        ) {
+          await refresh('silent');
+        }
+      } finally {
+        deleteStartedRef.current = false;
+        deleteLockRef.current = false;
+        if (mountedRef.current) {
+          setDeletingSectionId(null);
+          setSectionActionsLocked(false);
+        }
+      }
+    },
+    [invalidate, refresh, tripId],
+  );
+
+  const confirmDeleteSection = useCallback(
+    (section: TimelineSection) => {
+      if (deleteLockRef.current) {
+        return;
+      }
+
+      deleteLockRef.current = true;
+      deleteStartedRef.current = false;
+      setSectionActionsLocked(true);
+      setMutationError(null);
+      const releasePrompt = () => {
+        if (deleteStartedRef.current) {
+          return;
+        }
+        deleteStartedRef.current = false;
+        deleteLockRef.current = false;
+        if (mountedRef.current) {
+          setSectionActionsLocked(false);
+        }
+      };
+      Alert.alert(
+        'Delete timeline day?',
+        `Delete ${section.label} and all activities in it? This cannot be undone.`,
+        [
+          {
+            text: 'Cancel',
+            style: 'cancel',
+            onPress: releasePrompt,
+          },
+          {
+            text: 'Delete',
+            style: 'destructive',
+            onPress: () => {
+              if (deleteStartedRef.current) {
+                return;
+              }
+              deleteStartedRef.current = true;
+              void performDeleteSection(section);
+            },
+          },
+        ],
+        {
+          cancelable: true,
+          onDismiss: releasePrompt,
+        },
+      );
+    },
+    [performDeleteSection],
+  );
 
   const renderItem = useCallback(
     ({
@@ -166,9 +293,21 @@ function TimelineContent({ tripId }: TimelineContentProps) {
 
   const renderSectionHeader = useCallback(
     ({ section }: { section: TimelineListSection }) => (
-      <SectionGroup section={section.section} />
+      <SectionGroup
+        section={section.section}
+        canEdit={timeline?.permissions.can_edit_timeline === true}
+        canDelete={timeline?.permissions.can_edit_timeline === true}
+        actionsDisabled={sectionActionsLocked}
+        onEdit={openEditSection}
+        onDelete={confirmDeleteSection}
+      />
     ),
-    [],
+    [
+      confirmDeleteSection,
+      openEditSection,
+      sectionActionsLocked,
+      timeline?.permissions.can_edit_timeline,
+    ],
   );
 
   if (status === 'loading') {
@@ -231,25 +370,51 @@ function TimelineContent({ tripId }: TimelineContentProps) {
           />
         }
         ListHeaderComponent={
-          error ? (
-            <View accessibilityRole="alert" style={styles.inlineError}>
-              <Ionicons
-                name="alert-circle-outline"
-                size={20}
-                color={colors.danger}
-              />
-              <Text style={styles.inlineErrorText}>{error.message}</Text>
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel="Retry refreshing timeline"
-                onPress={retryBackgroundLoad}
-                style={({ pressed }) => [
-                  styles.retryButton,
-                  pressed ? styles.pressed : null,
-                ]}
-              >
-                <Text style={styles.retryText}>Retry</Text>
-              </Pressable>
+          error || mutationError || deletingSectionId ? (
+            <View>
+              {error ? (
+                <View accessibilityRole="alert" style={styles.inlineError}>
+                  <Ionicons
+                    name="alert-circle-outline"
+                    size={20}
+                    color={colors.danger}
+                  />
+                  <Text style={styles.inlineErrorText}>{error.message}</Text>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Retry refreshing timeline"
+                    onPress={retryBackgroundLoad}
+                    style={({ pressed }) => [
+                      styles.retryButton,
+                      pressed ? styles.pressed : null,
+                    ]}
+                  >
+                    <Text style={styles.retryText}>Retry</Text>
+                  </Pressable>
+                </View>
+              ) : null}
+              {mutationError ? (
+                <View accessibilityRole="alert" style={styles.inlineError}>
+                  <Ionicons
+                    name="alert-circle-outline"
+                    size={20}
+                    color={colors.danger}
+                  />
+                  <Text style={styles.inlineErrorText}>{mutationError}</Text>
+                </View>
+              ) : null}
+              {deletingSectionId ? (
+                <View
+                  accessibilityRole="progressbar"
+                  accessibilityLabel="Deleting timeline day"
+                  style={styles.mutationProgress}
+                >
+                  <ActivityIndicator color={colors.primary} />
+                  <Text style={styles.mutationProgressText}>
+                    Deleting timeline day…
+                  </Text>
+                </View>
+              ) : null}
             </View>
           ) : null
         }
@@ -271,6 +436,17 @@ function TimelineContent({ tripId }: TimelineContentProps) {
             ) : null}
           </View>
         }
+        ListFooterComponent={
+          sections.length > 0 && canCreateSections ? (
+            <View style={styles.footerAction}>
+              <Button
+                title="Add day"
+                disabled={sectionActionsLocked}
+                onPress={openCreateDay}
+              />
+            </View>
+          ) : null
+        }
       />
     </SafeAreaView>
   );
@@ -289,7 +465,7 @@ export function TimelineScreen() {
     );
   }
 
-  return <TimelineContent tripId={intent.tripId} />;
+  return <TimelineContent key={intent.tripId} tripId={intent.tripId} />;
 }
 
 const styles = StyleSheet.create({
@@ -354,6 +530,24 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     gap: spacing.md,
     padding: spacing.lg,
+  },
+  mutationProgress: {
+    minHeight: 56,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    marginHorizontal: spacing.md,
+    marginBottom: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    backgroundColor: colors.background,
+  },
+  mutationProgressText: { ...typography.caption, color: colors.textMuted },
+  footerAction: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.sm,
   },
   pressed: { opacity: 0.55 },
 });

--- a/mobile/src/features/timeline/screens/TimelineScreen.tsx
+++ b/mobile/src/features/timeline/screens/TimelineScreen.tsx
@@ -1,6 +1,280 @@
-import { useLocalSearchParams } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import {
+  Pressable,
+  RefreshControl,
+  SectionList,
+  StyleSheet,
+  Text,
+  View,
+  type SectionListRenderItemInfo,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { Button } from '@/shared/ui/Button';
+import { LoadingScreen } from '@/shared/ui/LoadingScreen';
+import { ActivityRow } from '../components/ActivityRow';
+import { SectionGroup } from '../components/SectionGroup';
+import { useTimeline } from '../hooks/useTimeline';
 import { parseTimelineRouteIntent } from '../routeIntent';
-import { RouteReadyState, RouteUnavailableState } from './RouteState';
+import {
+  buildTimelineListSections,
+  getDefaultFocusedSectionIndex,
+  getTimelineRowKey,
+  type TimelineListRow,
+  type TimelineListSection,
+} from '../viewModel';
+import { RouteUnavailableState } from './RouteState';
+
+interface TimelineContentProps {
+  tripId: string;
+}
+
+interface ScrollFailureInfo {
+  index: number;
+  highestMeasuredFrameIndex: number;
+  averageItemLength: number;
+}
+
+function TimelineContent({ tripId }: TimelineContentProps) {
+  const router = useRouter();
+  const { timeline, status, error, refreshing, refresh } = useTimeline(tripId);
+  const listRef =
+    useRef<SectionList<TimelineListRow, TimelineListSection>>(null);
+  const lastScrollTripIdRef = useRef<string | null>(null);
+  const scrollTargetRef = useRef<{
+    tripId: string;
+    sectionIndex: number;
+    retried: boolean;
+  } | null>(null);
+  const retryFrameRef = useRef<number | null>(null);
+  const sections = useMemo(
+    () => buildTimelineListSections(timeline?.sections ?? []),
+    [timeline?.sections],
+  );
+
+  useEffect(() => {
+    if (
+      status !== 'ready' ||
+      !timeline ||
+      sections.length === 0 ||
+      lastScrollTripIdRef.current === tripId
+    ) {
+      return;
+    }
+
+    const sectionIndex = getDefaultFocusedSectionIndex(
+      sections,
+      timeline.trip_timezone,
+    );
+    if (sectionIndex === null) {
+      return;
+    }
+
+    lastScrollTripIdRef.current = tripId;
+    scrollTargetRef.current = {
+      tripId,
+      sectionIndex,
+      retried: false,
+    };
+    listRef.current?.scrollToLocation({
+      animated: false,
+      sectionIndex,
+      itemIndex: 0,
+      viewPosition: 0,
+    });
+  }, [sections, status, timeline, tripId]);
+
+  useEffect(
+    () => () => {
+      if (retryFrameRef.current !== null) {
+        cancelAnimationFrame(retryFrameRef.current);
+        retryFrameRef.current = null;
+      }
+    },
+    [tripId],
+  );
+
+  const retryInitialLoad = useCallback(() => {
+    void refresh('initial');
+  }, [refresh]);
+
+  const retryBackgroundLoad = useCallback(() => {
+    void refresh('silent');
+  }, [refresh]);
+
+  const pullToRefresh = useCallback(() => {
+    void refresh('refresh');
+  }, [refresh]);
+
+  const recoverFailedInitialScroll = useCallback(
+    ({ averageItemLength, index }: ScrollFailureInfo) => {
+      const target = scrollTargetRef.current;
+      if (!target || target.tripId !== tripId || target.retried) {
+        return;
+      }
+
+      target.retried = true;
+      listRef.current?.getScrollResponder()?.scrollTo({
+        animated: false,
+        y: Math.max(0, averageItemLength * index),
+      });
+      retryFrameRef.current = requestAnimationFrame(() => {
+        retryFrameRef.current = null;
+        if (scrollTargetRef.current !== target) {
+          return;
+        }
+        listRef.current?.scrollToLocation({
+          animated: false,
+          sectionIndex: target.sectionIndex,
+          itemIndex: 0,
+          viewPosition: 0,
+        });
+      });
+    },
+    [tripId],
+  );
+
+  const openCreateDay = useCallback(() => {
+    router.push(`/trips/${tripId}/timeline/section-form?mode=create`);
+  }, [router, tripId]);
+
+  const renderItem = useCallback(
+    ({
+      item,
+    }: SectionListRenderItemInfo<
+      TimelineListRow,
+      TimelineListSection
+    >) => {
+      if (item.type === 'group-header') {
+        return (
+          <Text accessibilityRole="header" style={styles.groupHeader}>
+            {item.label}
+          </Text>
+        );
+      }
+
+      if (item.type === 'empty') {
+        return <Text style={styles.dayEmpty}>No activities yet.</Text>;
+      }
+
+      return <ActivityRow activity={item.activity} />;
+    },
+    [],
+  );
+
+  const renderSectionHeader = useCallback(
+    ({ section }: { section: TimelineListSection }) => (
+      <SectionGroup section={section.section} />
+    ),
+    [],
+  );
+
+  if (status === 'loading') {
+    return <LoadingScreen />;
+  }
+
+  if (status === 'error' || !timeline) {
+    const isNotFound = error?.status === 404;
+    return (
+      <SafeAreaView style={styles.safe} edges={['left', 'right', 'bottom']}>
+        <Stack.Screen options={{ title: 'Timeline' }} />
+        <View style={styles.centered}>
+          <Ionicons
+            name={isNotFound ? 'help-circle-outline' : 'cloud-offline-outline'}
+            size={44}
+            color={colors.textMuted}
+          />
+          <Text accessibilityRole="header" style={styles.errorTitle}>
+            {isNotFound ? 'Timeline not found' : 'Could not load timeline'}
+          </Text>
+          <Text style={styles.centeredMessage}>
+            {isNotFound
+              ? 'This trip does not exist or you no longer have access to it.'
+              : error?.message ?? 'Timeline is unavailable.'}
+          </Text>
+          <Button title="Try again" onPress={retryInitialLoad} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const canCreateSections = timeline.permissions.can_create_sections;
+
+  return (
+    <SafeAreaView
+      testID="timeline-route-ready"
+      style={styles.safe}
+      edges={['left', 'right', 'bottom']}
+    >
+      <Stack.Screen options={{ title: 'Timeline' }} />
+      <SectionList<TimelineListRow, TimelineListSection>
+        ref={listRef}
+        testID="timeline-list"
+        sections={sections}
+        keyExtractor={getTimelineRowKey}
+        renderItem={renderItem}
+        renderSectionHeader={renderSectionHeader}
+        onScrollToIndexFailed={recoverFailedInitialScroll}
+        stickySectionHeadersEnabled
+        contentInsetAdjustmentBehavior="automatic"
+        contentContainerStyle={[
+          styles.listContent,
+          sections.length === 0 ? styles.emptyListContent : null,
+        ]}
+        refreshControl={
+          <RefreshControl
+            testID="timeline-refresh-control"
+            refreshing={refreshing}
+            onRefresh={pullToRefresh}
+          />
+        }
+        ListHeaderComponent={
+          error ? (
+            <View accessibilityRole="alert" style={styles.inlineError}>
+              <Ionicons
+                name="alert-circle-outline"
+                size={20}
+                color={colors.danger}
+              />
+              <Text style={styles.inlineErrorText}>{error.message}</Text>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Retry refreshing timeline"
+                onPress={retryBackgroundLoad}
+                style={({ pressed }) => [
+                  styles.retryButton,
+                  pressed ? styles.pressed : null,
+                ]}
+              >
+                <Text style={styles.retryText}>Retry</Text>
+              </Pressable>
+            </View>
+          ) : null
+        }
+        ListEmptyComponent={
+          <View style={styles.emptyState}>
+            <Ionicons
+              name="calendar-outline"
+              size={44}
+              color={colors.textMuted}
+            />
+            <Text accessibilityRole="header" style={styles.errorTitle}>
+              No days yet
+            </Text>
+            <Text style={styles.centeredMessage}>
+              Add the first day to start planning this trip.
+            </Text>
+            {canCreateSections ? (
+              <Button title="Add day" onPress={openCreateDay} />
+            ) : null}
+          </View>
+        }
+      />
+    </SafeAreaView>
+  );
+}
 
 export function TimelineScreen() {
   const { tripId } = useLocalSearchParams();
@@ -15,5 +289,71 @@ export function TimelineScreen() {
     );
   }
 
-  return <RouteReadyState testID="timeline-route-ready" />;
+  return <TimelineContent tripId={intent.tripId} />;
 }
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.surface },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.md,
+    padding: spacing.lg,
+  },
+  errorTitle: { ...typography.heading, color: colors.text, textAlign: 'center' },
+  centeredMessage: {
+    ...typography.body,
+    color: colors.textMuted,
+    textAlign: 'center',
+  },
+  listContent: { paddingBottom: spacing.xl },
+  emptyListContent: { flexGrow: 1 },
+  inlineError: {
+    minHeight: 56,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    margin: spacing.md,
+    paddingHorizontal: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.dangerBorder,
+    borderRadius: radii.md,
+    backgroundColor: colors.dangerSoft,
+  },
+  inlineErrorText: { ...typography.caption, color: colors.danger, flex: 1 },
+  retryButton: {
+    minHeight: 44,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.xs,
+  },
+  retryText: { ...typography.label, color: colors.danger },
+  groupHeader: {
+    ...typography.label,
+    color: colors.textMuted,
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.sm,
+    paddingBottom: spacing.xs,
+    backgroundColor: colors.surface,
+  },
+  dayEmpty: {
+    ...typography.body,
+    color: colors.textMuted,
+    marginHorizontal: spacing.md,
+    marginBottom: spacing.md,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    textAlign: 'center',
+    backgroundColor: colors.background,
+  },
+  emptyState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.md,
+    padding: spacing.lg,
+  },
+  pressed: { opacity: 0.55 },
+});

--- a/mobile/src/features/timeline/screens/TimelineScreen.tsx
+++ b/mobile/src/features/timeline/screens/TimelineScreen.tsx
@@ -17,13 +17,20 @@ import { normalizeApiError } from '@/shared/api/errors';
 import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
 import { Button } from '@/shared/ui/Button';
 import { LoadingScreen } from '@/shared/ui/LoadingScreen';
-import { deleteSection as deleteTimelineSection } from '../api';
+import {
+  deleteActivity as deleteTimelineActivity,
+  deleteSection as deleteTimelineSection,
+  updateActivityStatus,
+} from '../api';
 import { ActivityRow } from '../components/ActivityRow';
 import { SectionGroup } from '../components/SectionGroup';
 import { useTimeline } from '../hooks/useTimeline';
 import { parseTimelineRouteIntent } from '../routeIntent';
 import { publishTimelineEvent } from '../timelineEvents';
-import type { TimelineSection } from '../types';
+import type {
+  TimelineActivityStatus,
+  TimelineSection,
+} from '../types';
 import {
   buildTimelineListSections,
   getDefaultFocusedSectionIndex,
@@ -43,6 +50,11 @@ interface ScrollFailureInfo {
   averageItemLength: number;
 }
 
+interface PendingActivityMutation {
+  activityId: string;
+  kind: 'delete' | 'status';
+}
+
 function TimelineContent({ tripId }: TimelineContentProps) {
   const router = useRouter();
   const {
@@ -58,6 +70,8 @@ function TimelineContent({ tripId }: TimelineContentProps) {
   const mountedRef = useRef(true);
   const deleteLockRef = useRef(false);
   const deleteStartedRef = useRef(false);
+  const activityLockRef = useRef(false);
+  const activityDeleteStartedRef = useRef(false);
   const lastScrollTripIdRef = useRef<string | null>(null);
   const scrollTargetRef = useRef<{
     tripId: string;
@@ -66,14 +80,18 @@ function TimelineContent({ tripId }: TimelineContentProps) {
   } | null>(null);
   const retryFrameRef = useRef<number | null>(null);
   const [sectionActionsLocked, setSectionActionsLocked] = useState(false);
+  const [activityActionsLocked, setActivityActionsLocked] = useState(false);
   const [deletingSectionId, setDeletingSectionId] = useState<string | null>(
     null,
   );
+  const [pendingActivityMutation, setPendingActivityMutation] =
+    useState<PendingActivityMutation | null>(null);
   const [mutationError, setMutationError] = useState<string | null>(null);
   const sections = useMemo(
     () => buildTimelineListSections(timeline?.sections ?? []),
     [timeline?.sections],
   );
+  const actionsLocked = sectionActionsLocked || activityActionsLocked;
 
   useEffect(() => {
     if (
@@ -159,15 +177,47 @@ function TimelineContent({ tripId }: TimelineContentProps) {
   );
 
   const openCreateDay = useCallback(() => {
+    if (deleteLockRef.current || activityLockRef.current) {
+      return;
+    }
     setMutationError(null);
     router.push(`/trips/${tripId}/timeline/section-form?mode=create`);
   }, [router, tripId]);
 
   const openEditSection = useCallback(
     (section: TimelineSection) => {
+      if (deleteLockRef.current || activityLockRef.current) {
+        return;
+      }
       setMutationError(null);
       router.push(
         `/trips/${tripId}/timeline/section-form?mode=edit&sectionId=${section.id}`,
+      );
+    },
+    [router, tripId],
+  );
+
+  const openCreateActivity = useCallback(
+    (sectionId: string) => {
+      if (deleteLockRef.current || activityLockRef.current) {
+        return;
+      }
+      setMutationError(null);
+      router.push(
+        `/trips/${tripId}/timeline/activity-form?mode=create&sectionId=${sectionId}`,
+      );
+    },
+    [router, tripId],
+  );
+
+  const openEditActivity = useCallback(
+    (activityId: string) => {
+      if (deleteLockRef.current || activityLockRef.current) {
+        return;
+      }
+      setMutationError(null);
+      router.push(
+        `/trips/${tripId}/timeline/activity-form?mode=edit&activityId=${activityId}`,
       );
     },
     [router, tripId],
@@ -219,7 +269,7 @@ function TimelineContent({ tripId }: TimelineContentProps) {
 
   const confirmDeleteSection = useCallback(
     (section: TimelineSection) => {
-      if (deleteLockRef.current) {
+      if (deleteLockRef.current || activityLockRef.current) {
         return;
       }
 
@@ -267,6 +317,156 @@ function TimelineContent({ tripId }: TimelineContentProps) {
     [performDeleteSection],
   );
 
+  const changeActivityStatus = useCallback(
+    async (
+      activityId: string,
+      nextStatus: TimelineActivityStatus,
+    ) => {
+      if (
+        !mountedRef.current ||
+        deleteLockRef.current ||
+        activityLockRef.current
+      ) {
+        return;
+      }
+
+      activityLockRef.current = true;
+      setActivityActionsLocked(true);
+      setPendingActivityMutation({ activityId, kind: 'status' });
+      invalidate();
+
+      try {
+        await updateActivityStatus(tripId, activityId, {
+          status: nextStatus,
+        });
+        await publishTimelineEvent({
+          type: 'timelineChanged',
+          tripId,
+        });
+      } catch (caught) {
+        if (mountedRef.current) {
+          const normalized = normalizeApiError(caught);
+          if (
+            normalized.status === 403 ||
+            normalized.status === 404 ||
+            normalized.status === 409
+          ) {
+            await refresh('silent');
+          }
+        }
+        throw caught;
+      } finally {
+        activityLockRef.current = false;
+        if (mountedRef.current) {
+          setPendingActivityMutation(null);
+          setActivityActionsLocked(false);
+        }
+      }
+    },
+    [invalidate, refresh, tripId],
+  );
+
+  const performDeleteActivity = useCallback(
+    async (activityId: string) => {
+      if (!mountedRef.current) {
+        activityDeleteStartedRef.current = false;
+        activityLockRef.current = false;
+        return;
+      }
+
+      setPendingActivityMutation({ activityId, kind: 'delete' });
+      setMutationError(null);
+      invalidate();
+
+      try {
+        await deleteTimelineActivity(tripId, activityId);
+        await publishTimelineEvent({
+          type: 'timelineChanged',
+          tripId,
+        });
+      } catch (caught) {
+        if (!mountedRef.current) {
+          return;
+        }
+
+        const normalized = normalizeApiError(caught);
+        setMutationError(normalized.message);
+        if (
+          normalized.status === 403 ||
+          normalized.status === 404 ||
+          normalized.status === 409
+        ) {
+          await refresh('silent');
+        }
+      } finally {
+        activityDeleteStartedRef.current = false;
+        activityLockRef.current = false;
+        if (mountedRef.current) {
+          setPendingActivityMutation(null);
+          setActivityActionsLocked(false);
+        }
+      }
+    },
+    [invalidate, refresh, tripId],
+  );
+
+  const confirmDeleteActivity = useCallback(
+    (activityId: string) => {
+      if (deleteLockRef.current || activityLockRef.current) {
+        return;
+      }
+
+      const activity = timeline?.sections
+        .flatMap((section) => section.activities)
+        .find((candidate) => candidate.id === activityId);
+      if (!activity) {
+        return;
+      }
+
+      activityLockRef.current = true;
+      activityDeleteStartedRef.current = false;
+      setActivityActionsLocked(true);
+      setMutationError(null);
+      const releasePrompt = () => {
+        if (activityDeleteStartedRef.current) {
+          return;
+        }
+        activityDeleteStartedRef.current = false;
+        activityLockRef.current = false;
+        if (mountedRef.current) {
+          setActivityActionsLocked(false);
+        }
+      };
+      Alert.alert(
+        'Delete activity?',
+        `Delete ${activity.title}? This cannot be undone.`,
+        [
+          {
+            text: 'Cancel',
+            style: 'cancel',
+            onPress: releasePrompt,
+          },
+          {
+            text: 'Delete',
+            style: 'destructive',
+            onPress: () => {
+              if (activityDeleteStartedRef.current) {
+                return;
+              }
+              activityDeleteStartedRef.current = true;
+              void performDeleteActivity(activity.id);
+            },
+          },
+        ],
+        {
+          cancelable: true,
+          onDismiss: releasePrompt,
+        },
+      );
+    },
+    [performDeleteActivity, timeline?.sections],
+  );
+
   const renderItem = useCallback(
     ({
       item,
@@ -286,9 +486,22 @@ function TimelineContent({ tripId }: TimelineContentProps) {
         return <Text style={styles.dayEmpty}>No activities yet.</Text>;
       }
 
-      return <ActivityRow activity={item.activity} />;
+      return (
+        <ActivityRow
+          activity={item.activity}
+          actionsDisabled={actionsLocked}
+          onEdit={openEditActivity}
+          onDelete={confirmDeleteActivity}
+          onChangeStatus={changeActivityStatus}
+        />
+      );
     },
-    [],
+    [
+      actionsLocked,
+      changeActivityStatus,
+      confirmDeleteActivity,
+      openEditActivity,
+    ],
   );
 
   const renderSectionHeader = useCallback(
@@ -297,15 +510,46 @@ function TimelineContent({ tripId }: TimelineContentProps) {
         section={section.section}
         canEdit={timeline?.permissions.can_edit_timeline === true}
         canDelete={timeline?.permissions.can_edit_timeline === true}
-        actionsDisabled={sectionActionsLocked}
+        actionsDisabled={actionsLocked}
         onEdit={openEditSection}
         onDelete={confirmDeleteSection}
       />
     ),
     [
       confirmDeleteSection,
+      actionsLocked,
       openEditSection,
-      sectionActionsLocked,
+      timeline?.permissions.can_edit_timeline,
+    ],
+  );
+
+  const renderSectionFooter = useCallback(
+    ({ section }: { section: TimelineListSection }) =>
+      timeline?.permissions.can_edit_timeline === true ? (
+        <View style={styles.sectionFooter}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={`Add activity to ${section.section.label}`}
+            accessibilityState={{ disabled: actionsLocked }}
+            disabled={actionsLocked}
+            onPress={() => openCreateActivity(section.section.id)}
+            style={({ pressed }) => [
+              styles.addActivityButton,
+              pressed || actionsLocked ? styles.pressed : null,
+            ]}
+          >
+            <Ionicons
+              name="add-circle-outline"
+              size={18}
+              color={colors.primary}
+            />
+            <Text style={styles.addActivityText}>Add activity</Text>
+          </Pressable>
+        </View>
+      ) : null,
+    [
+      actionsLocked,
+      openCreateActivity,
       timeline?.permissions.can_edit_timeline,
     ],
   );
@@ -355,6 +599,7 @@ function TimelineContent({ tripId }: TimelineContentProps) {
         keyExtractor={getTimelineRowKey}
         renderItem={renderItem}
         renderSectionHeader={renderSectionHeader}
+        renderSectionFooter={renderSectionFooter}
         onScrollToIndexFailed={recoverFailedInitialScroll}
         stickySectionHeadersEnabled
         contentInsetAdjustmentBehavior="automatic"
@@ -370,7 +615,10 @@ function TimelineContent({ tripId }: TimelineContentProps) {
           />
         }
         ListHeaderComponent={
-          error || mutationError || deletingSectionId ? (
+          error ||
+          mutationError ||
+          deletingSectionId ||
+          pendingActivityMutation ? (
             <View>
               {error ? (
                 <View accessibilityRole="alert" style={styles.inlineError}>
@@ -415,6 +663,24 @@ function TimelineContent({ tripId }: TimelineContentProps) {
                   </Text>
                 </View>
               ) : null}
+              {pendingActivityMutation ? (
+                <View
+                  accessibilityRole="progressbar"
+                  accessibilityLabel={
+                    pendingActivityMutation.kind === 'delete'
+                      ? 'Deleting activity'
+                      : 'Updating activity status'
+                  }
+                  style={styles.mutationProgress}
+                >
+                  <ActivityIndicator color={colors.primary} />
+                  <Text style={styles.mutationProgressText}>
+                    {pendingActivityMutation.kind === 'delete'
+                      ? 'Deleting activity…'
+                      : 'Updating activity status…'}
+                  </Text>
+                </View>
+              ) : null}
             </View>
           ) : null
         }
@@ -432,7 +698,11 @@ function TimelineContent({ tripId }: TimelineContentProps) {
               Add the first day to start planning this trip.
             </Text>
             {canCreateSections ? (
-              <Button title="Add day" onPress={openCreateDay} />
+              <Button
+                title="Add day"
+                disabled={actionsLocked}
+                onPress={openCreateDay}
+              />
             ) : null}
           </View>
         }
@@ -441,7 +711,7 @@ function TimelineContent({ tripId }: TimelineContentProps) {
             <View style={styles.footerAction}>
               <Button
                 title="Add day"
-                disabled={sectionActionsLocked}
+                disabled={actionsLocked}
                 onPress={openCreateDay}
               />
             </View>
@@ -524,6 +794,19 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     backgroundColor: colors.background,
   },
+  sectionFooter: {
+    alignItems: 'flex-end',
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.md,
+  },
+  addActivityButton: {
+    minHeight: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.sm,
+  },
+  addActivityText: { ...typography.label, color: colors.primary },
   emptyState: {
     flex: 1,
     alignItems: 'center',

--- a/mobile/src/features/timeline/screens/TimelineScreen.tsx
+++ b/mobile/src/features/timeline/screens/TimelineScreen.tsx
@@ -13,7 +13,7 @@ import {
   type SectionListRenderItemInfo,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { normalizeApiError } from '@/shared/api/errors';
+import { normalizeApiError, type ApiError } from '@/shared/api/errors';
 import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
 import { Button } from '@/shared/ui/Button';
 import { LoadingScreen } from '@/shared/ui/LoadingScreen';
@@ -55,6 +55,11 @@ interface PendingActivityMutation {
   kind: 'delete' | 'status';
 }
 
+interface ActivityStatusMutationError {
+  activityId: string;
+  error: ApiError;
+}
+
 function TimelineContent({ tripId }: TimelineContentProps) {
   const router = useRouter();
   const {
@@ -86,12 +91,26 @@ function TimelineContent({ tripId }: TimelineContentProps) {
   );
   const [pendingActivityMutation, setPendingActivityMutation] =
     useState<PendingActivityMutation | null>(null);
+  const [activityStatusError, setActivityStatusError] =
+    useState<ActivityStatusMutationError | null>(null);
   const [mutationError, setMutationError] = useState<string | null>(null);
   const sections = useMemo(
     () => buildTimelineListSections(timeline?.sections ?? []),
     [timeline?.sections],
   );
   const actionsLocked = sectionActionsLocked || activityActionsLocked;
+  const statusErrorActivityExists =
+    activityStatusError !== null &&
+    timeline?.sections.some((section) =>
+      section.activities.some(
+        (activity) => activity.id === activityStatusError.activityId,
+      ),
+    ) === true;
+  const detachedStatusErrorMessage =
+    activityStatusError && !statusErrorActivityExists
+      ? activityStatusError.error.message
+      : null;
+  const visibleMutationError = mutationError ?? detachedStatusErrorMessage;
 
   useEffect(() => {
     if (
@@ -181,6 +200,7 @@ function TimelineContent({ tripId }: TimelineContentProps) {
       return;
     }
     setMutationError(null);
+    setActivityStatusError(null);
     router.push(`/trips/${tripId}/timeline/section-form?mode=create`);
   }, [router, tripId]);
 
@@ -190,6 +210,7 @@ function TimelineContent({ tripId }: TimelineContentProps) {
         return;
       }
       setMutationError(null);
+      setActivityStatusError(null);
       router.push(
         `/trips/${tripId}/timeline/section-form?mode=edit&sectionId=${section.id}`,
       );
@@ -203,6 +224,7 @@ function TimelineContent({ tripId }: TimelineContentProps) {
         return;
       }
       setMutationError(null);
+      setActivityStatusError(null);
       router.push(
         `/trips/${tripId}/timeline/activity-form?mode=create&sectionId=${sectionId}`,
       );
@@ -216,6 +238,7 @@ function TimelineContent({ tripId }: TimelineContentProps) {
         return;
       }
       setMutationError(null);
+      setActivityStatusError(null);
       router.push(
         `/trips/${tripId}/timeline/activity-form?mode=edit&activityId=${activityId}`,
       );
@@ -233,6 +256,7 @@ function TimelineContent({ tripId }: TimelineContentProps) {
 
       setDeletingSectionId(section.id);
       setMutationError(null);
+      setActivityStatusError(null);
       invalidate();
 
       try {
@@ -277,6 +301,7 @@ function TimelineContent({ tripId }: TimelineContentProps) {
       deleteStartedRef.current = false;
       setSectionActionsLocked(true);
       setMutationError(null);
+      setActivityStatusError(null);
       const releasePrompt = () => {
         if (deleteStartedRef.current) {
           return;
@@ -333,6 +358,8 @@ function TimelineContent({ tripId }: TimelineContentProps) {
       activityLockRef.current = true;
       setActivityActionsLocked(true);
       setPendingActivityMutation({ activityId, kind: 'status' });
+      setActivityStatusError(null);
+      setMutationError(null);
       invalidate();
 
       try {
@@ -346,6 +373,7 @@ function TimelineContent({ tripId }: TimelineContentProps) {
       } catch (caught) {
         if (mountedRef.current) {
           const normalized = normalizeApiError(caught);
+          setActivityStatusError({ activityId, error: normalized });
           if (
             normalized.status === 403 ||
             normalized.status === 404 ||
@@ -376,6 +404,7 @@ function TimelineContent({ tripId }: TimelineContentProps) {
 
       setPendingActivityMutation({ activityId, kind: 'delete' });
       setMutationError(null);
+      setActivityStatusError(null);
       invalidate();
 
       try {
@@ -427,6 +456,7 @@ function TimelineContent({ tripId }: TimelineContentProps) {
       activityDeleteStartedRef.current = false;
       setActivityActionsLocked(true);
       setMutationError(null);
+      setActivityStatusError(null);
       const releasePrompt = () => {
         if (activityDeleteStartedRef.current) {
           return;
@@ -493,11 +523,17 @@ function TimelineContent({ tripId }: TimelineContentProps) {
           onEdit={openEditActivity}
           onDelete={confirmDeleteActivity}
           onChangeStatus={changeActivityStatus}
+          statusError={
+            activityStatusError?.activityId === item.activity.id
+              ? activityStatusError.error
+              : null
+          }
         />
       );
     },
     [
       actionsLocked,
+      activityStatusError,
       changeActivityStatus,
       confirmDeleteActivity,
       openEditActivity,
@@ -616,7 +652,7 @@ function TimelineContent({ tripId }: TimelineContentProps) {
         }
         ListHeaderComponent={
           error ||
-          mutationError ||
+          visibleMutationError ||
           deletingSectionId ||
           pendingActivityMutation ? (
             <View>
@@ -641,14 +677,16 @@ function TimelineContent({ tripId }: TimelineContentProps) {
                   </Pressable>
                 </View>
               ) : null}
-              {mutationError ? (
+              {visibleMutationError ? (
                 <View accessibilityRole="alert" style={styles.inlineError}>
                   <Ionicons
                     name="alert-circle-outline"
                     size={20}
                     color={colors.danger}
                   />
-                  <Text style={styles.inlineErrorText}>{mutationError}</Text>
+                  <Text style={styles.inlineErrorText}>
+                    {visibleMutationError}
+                  </Text>
                 </View>
               ) : null}
               {deletingSectionId ? (

--- a/mobile/src/features/timeline/screens/TimelineScreen.tsx
+++ b/mobile/src/features/timeline/screens/TimelineScreen.tsx
@@ -1,0 +1,19 @@
+import { useLocalSearchParams } from 'expo-router';
+import { parseTimelineRouteIntent } from '../routeIntent';
+import { RouteReadyState, RouteUnavailableState } from './RouteState';
+
+export function TimelineScreen() {
+  const { tripId } = useLocalSearchParams();
+  const intent = parseTimelineRouteIntent({ tripId });
+
+  if (!intent) {
+    return (
+      <RouteUnavailableState
+        title="Timeline unavailable"
+        message="This timeline link is invalid or incomplete."
+      />
+    );
+  }
+
+  return <RouteReadyState testID="timeline-route-ready" />;
+}

--- a/mobile/src/features/timeline/timelineEvents.ts
+++ b/mobile/src/features/timeline/timelineEvents.ts
@@ -3,19 +3,21 @@ export type TimelineEvent = {
   tripId: string;
 };
 
-type TimelineEventListener = (event: TimelineEvent) => void;
+type TimelineEventListener = (
+  event: TimelineEvent,
+) => void | Promise<void>;
 
 const listenersByTripId = new Map<string, Set<TimelineEventListener>>();
 
-export function publishTimelineEvent(event: TimelineEvent): void {
+export async function publishTimelineEvent(event: TimelineEvent): Promise<void> {
   const listeners = listenersByTripId.get(event.tripId);
   if (!listeners) {
     return;
   }
 
-  for (const listener of listeners) {
-    listener(event);
-  }
+  await Promise.all(
+    Array.from(listeners, (listener) => listener(event)),
+  );
 }
 
 export function subscribeToTimelineEvents(

--- a/mobile/src/features/timeline/timelineEvents.ts
+++ b/mobile/src/features/timeline/timelineEvents.ts
@@ -1,0 +1,42 @@
+export type TimelineEvent = {
+  type: 'timelineChanged';
+  tripId: string;
+};
+
+type TimelineEventListener = (event: TimelineEvent) => void;
+
+const listenersByTripId = new Map<string, Set<TimelineEventListener>>();
+
+export function publishTimelineEvent(event: TimelineEvent): void {
+  const listeners = listenersByTripId.get(event.tripId);
+  if (!listeners) {
+    return;
+  }
+
+  for (const listener of listeners) {
+    listener(event);
+  }
+}
+
+export function subscribeToTimelineEvents(
+  tripId: string,
+  listener: TimelineEventListener,
+): () => void {
+  let listeners = listenersByTripId.get(tripId);
+  if (!listeners) {
+    listeners = new Set();
+    listenersByTripId.set(tripId, listeners);
+  }
+  listeners.add(listener);
+
+  return () => {
+    const currentListeners = listenersByTripId.get(tripId);
+    if (!currentListeners) {
+      return;
+    }
+    currentListeners.delete(listener);
+    if (currentListeners.size === 0) {
+      listenersByTripId.delete(tripId);
+    }
+  };
+}

--- a/mobile/src/features/timeline/tokenMaps.ts
+++ b/mobile/src/features/timeline/tokenMaps.ts
@@ -1,0 +1,98 @@
+import { type ComponentProps } from 'react';
+import { Ionicons } from '@expo/vector-icons';
+import { colors } from '@/shared/theme/tokens';
+
+function hasOwn<T extends object>(value: T, key: PropertyKey): key is keyof T {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+export const TIMELINE_COLOR_TOKENS = [
+  'sky',
+  'amber',
+  'rose',
+  'emerald',
+  'violet',
+  'indigo',
+  'teal',
+  'slate',
+] as const;
+
+export type TimelineColorToken = (typeof TIMELINE_COLOR_TOKENS)[number];
+
+export interface TimelineTokenColors {
+  color: string;
+  backgroundColor: string;
+}
+
+const COLOR_MAP: Record<TimelineColorToken, TimelineTokenColors> = {
+  sky: { color: colors.sky, backgroundColor: colors.skySoft },
+  amber: { color: colors.amber, backgroundColor: colors.amberSoft },
+  rose: { color: colors.rose, backgroundColor: colors.roseSoft },
+  emerald: { color: colors.emerald, backgroundColor: colors.emeraldSoft },
+  violet: { color: colors.violet, backgroundColor: colors.violetSoft },
+  indigo: { color: colors.indigo, backgroundColor: colors.indigoSoft },
+  teal: { color: colors.teal, backgroundColor: colors.tealSoft },
+  slate: { color: colors.slate, backgroundColor: colors.slateSoft },
+};
+
+export const TIMELINE_COLOR_OPTIONS = TIMELINE_COLOR_TOKENS.map((value) => ({
+  value,
+  label: value[0].toUpperCase() + value.slice(1),
+  ...COLOR_MAP[value],
+}));
+
+export function getTimelineTokenColors(value: string | null | undefined): TimelineTokenColors {
+  if (value && hasOwn(COLOR_MAP, value)) {
+    return COLOR_MAP[value];
+  }
+  return COLOR_MAP.slate;
+}
+
+export const TIMELINE_ICON_KEYS = [
+  'bus',
+  'bed',
+  'utensils',
+  'camera',
+  'shopping-bag',
+  'key',
+  'smile',
+  'tag',
+] as const;
+
+export type TimelineIconKey = (typeof TIMELINE_ICON_KEYS)[number];
+export type TimelineIconName = ComponentProps<typeof Ionicons>['name'];
+
+const ICON_MAP: Record<TimelineIconKey, TimelineIconName> = {
+  bus: 'bus-outline',
+  bed: 'bed-outline',
+  utensils: 'restaurant-outline',
+  camera: 'camera-outline',
+  'shopping-bag': 'bag-outline',
+  key: 'key-outline',
+  smile: 'happy-outline',
+  tag: 'pricetag-outline',
+};
+
+const ICON_LABELS: Record<TimelineIconKey, string> = {
+  bus: 'Transport',
+  bed: 'Stay',
+  utensils: 'Food',
+  camera: 'Sightseeing',
+  'shopping-bag': 'Shopping',
+  key: 'Booking',
+  smile: 'Leisure',
+  tag: 'Other',
+};
+
+export const TIMELINE_ICON_OPTIONS = TIMELINE_ICON_KEYS.map((value) => ({
+  value,
+  label: ICON_LABELS[value],
+  icon: ICON_MAP[value],
+}));
+
+export function getTimelineIconName(value: string | null | undefined): TimelineIconName {
+  if (value && hasOwn(ICON_MAP, value)) {
+    return ICON_MAP[value];
+  }
+  return ICON_MAP.tag;
+}

--- a/mobile/src/features/timeline/tokenMaps.ts
+++ b/mobile/src/features/timeline/tokenMaps.ts
@@ -18,6 +18,7 @@ export const TIMELINE_COLOR_TOKENS = [
 ] as const;
 
 export type TimelineColorToken = (typeof TIMELINE_COLOR_TOKENS)[number];
+export const DEFAULT_TIMELINE_COLOR_TOKEN: TimelineColorToken = 'slate';
 
 export interface TimelineTokenColors {
   color: string;
@@ -45,7 +46,13 @@ export function getTimelineTokenColors(value: string | null | undefined): Timeli
   if (value && hasOwn(COLOR_MAP, value)) {
     return COLOR_MAP[value];
   }
-  return COLOR_MAP.slate;
+  return COLOR_MAP[DEFAULT_TIMELINE_COLOR_TOKEN];
+}
+
+export function isTimelineColorToken(
+  value: string,
+): value is TimelineColorToken {
+  return hasOwn(COLOR_MAP, value);
 }
 
 export const TIMELINE_ICON_KEYS = [
@@ -61,6 +68,7 @@ export const TIMELINE_ICON_KEYS = [
 
 export type TimelineIconKey = (typeof TIMELINE_ICON_KEYS)[number];
 export type TimelineIconName = ComponentProps<typeof Ionicons>['name'];
+export const DEFAULT_TIMELINE_ICON_KEY: TimelineIconKey = 'tag';
 
 const ICON_MAP: Record<TimelineIconKey, TimelineIconName> = {
   bus: 'bus-outline',
@@ -94,5 +102,11 @@ export function getTimelineIconName(value: string | null | undefined): TimelineI
   if (value && hasOwn(ICON_MAP, value)) {
     return ICON_MAP[value];
   }
-  return ICON_MAP.tag;
+  return ICON_MAP[DEFAULT_TIMELINE_ICON_KEY];
+}
+
+export function isTimelineIconKey(
+  value: string,
+): value is TimelineIconKey {
+  return hasOwn(ICON_MAP, value);
 }

--- a/mobile/src/features/timeline/types.ts
+++ b/mobile/src/features/timeline/types.ts
@@ -1,0 +1,215 @@
+export type TimelineActivityTimeMode =
+  | 'ALL_DAY'
+  | 'FLEXIBLE'
+  | 'AT_TIME'
+  | 'TIME_RANGE';
+
+export type TimelineActivityStatus =
+  | 'UPCOMING'
+  | 'IN_PROGRESS'
+  | 'DONE'
+  | 'CANCELLED';
+
+export type TimelineActivityAssigneeScope = 'NONE' | 'USER' | 'EVERYONE';
+export type TimelineLocationMode = 'MANUAL' | 'STRUCTURED';
+
+export type TimelineSystemTypeCode =
+  | 'TRANSPORTATION'
+  | 'ACCOMMODATION'
+  | 'FOOD'
+  | 'SIGHTSEEING'
+  | 'SHOPPING'
+  | 'CHECKIN_OUT'
+  | 'FREE_TIME'
+  | 'OTHER';
+
+export interface TimelineSystemTypeMeta {
+  code: TimelineSystemTypeCode;
+  label: string;
+  color_token: string;
+  icon_key: string;
+}
+
+export interface TimelineCustomTypeMeta {
+  id: string;
+  name: string;
+  normalized_name: string;
+  color_token: string;
+  icon_key: string;
+  is_active: boolean;
+}
+
+export interface TimelineSystemActivityType {
+  kind: 'SYSTEM';
+  code: TimelineSystemTypeCode;
+  label: string;
+  color_token: string;
+  icon_key: string;
+}
+
+export interface TimelineCustomActivityType {
+  kind: 'CUSTOM';
+  id: string;
+  label: string;
+  color_token: string;
+  icon_key: string;
+}
+
+export type TimelineActivityType =
+  | TimelineSystemActivityType
+  | TimelineCustomActivityType;
+
+export interface TimelineAssignee {
+  id: string;
+  display_name: string;
+  identify_tag: string | null;
+}
+
+export interface TimelinePlace {
+  provider: string;
+  provider_id: string;
+  title: string;
+  address: string;
+  lat: number | null;
+  lng: number | null;
+}
+
+export interface TimelineLocation {
+  location_mode: TimelineLocationMode;
+  location_label: string;
+  location_note: string;
+  place: TimelinePlace | null;
+  open_url: string | null;
+}
+
+export interface TimelineActivityCapabilities {
+  can_edit: boolean;
+  can_delete: boolean;
+  can_update_status: boolean;
+}
+
+export interface TimelineActivity {
+  id: string;
+  title: string;
+  time_mode: TimelineActivityTimeMode;
+  start_time: string | null;
+  end_time: string | null;
+  status: TimelineActivityStatus;
+  position: number;
+  activity_type: TimelineActivityType | null;
+  assignee_scope: TimelineActivityAssigneeScope;
+  assignee: TimelineAssignee | null;
+  location: TimelineLocation;
+  note: string;
+  meeting_point: string;
+  contact_name: string;
+  contact_phone: string;
+  booking_reference: string;
+  external_link: string;
+  reminder_offsets_minutes: number[];
+  capabilities: TimelineActivityCapabilities;
+}
+
+export interface TimelineSection {
+  id: string;
+  section_date: string;
+  label: string;
+  is_label_custom: boolean;
+  is_in_trip_range: boolean;
+  position: number;
+  activities: TimelineActivity[];
+}
+
+export interface TimelinePermissions {
+  can_edit_timeline: boolean;
+  can_manage_custom_types: boolean;
+  can_create_sections: boolean;
+}
+
+export interface TimelineResponse {
+  trip_timezone: string;
+  permissions: TimelinePermissions;
+  system_types: TimelineSystemTypeMeta[];
+  custom_types: TimelineCustomTypeMeta[];
+  sections: TimelineSection[];
+}
+
+export interface CreateSectionPayload {
+  section_date: string;
+  label: string;
+}
+
+export type PatchSectionPayload = Partial<CreateSectionPayload>;
+
+export interface ActivityPlacePayload {
+  provider: string;
+  provider_id: string;
+  title: string;
+  address?: string;
+  lat?: number | null;
+  lng?: number | null;
+}
+
+export interface CreateActivityPayload {
+  title: string;
+  time_mode: TimelineActivityTimeMode;
+  start_time?: string | null;
+  end_time?: string | null;
+  system_type?: TimelineSystemTypeCode | '';
+  custom_type_id?: string | null;
+  assignee_scope?: TimelineActivityAssigneeScope;
+  assignee_user_id?: string | null;
+  location_mode?: TimelineLocationMode;
+  location_label?: string;
+  location_note?: string;
+  place?: ActivityPlacePayload | null;
+  note?: string;
+  meeting_point?: string;
+  contact_name?: string;
+  contact_phone?: string;
+  booking_reference?: string;
+  external_link?: string;
+  reminder_offsets_minutes?: number[];
+}
+
+export type PatchActivityPayload = Partial<CreateActivityPayload>;
+
+export interface UpdateActivityStatusPayload {
+  status: TimelineActivityStatus;
+}
+
+export interface UpdateActivityStatusResult {
+  activity_id: string;
+  status: TimelineActivityStatus;
+}
+
+export interface CreateCustomTypePayload {
+  name: string;
+  color_token?: string;
+  icon_key?: string;
+}
+
+export type PatchCustomTypePayload = Partial<{
+  name: string;
+  color_token: string;
+  icon_key: string;
+  is_active: boolean;
+}>;
+
+export interface LocationSuggestion {
+  provider: 'here';
+  provider_id: string;
+  title: string;
+  subtitle: string;
+}
+
+export interface ResolvedLocationLookup {
+  destination: string;
+  destination_provider: 'here';
+  destination_provider_id: string;
+  destination_lat: number | null;
+  destination_lng: number | null;
+  destination_country_code: string;
+}
+
+export type ResolvedLookup = ResolvedLocationLookup;

--- a/mobile/src/features/timeline/viewModel.ts
+++ b/mobile/src/features/timeline/viewModel.ts
@@ -1,0 +1,430 @@
+import type {
+  ActivityPlacePayload,
+  LocationSuggestion,
+  ResolvedLookup,
+  TimelineActivity,
+  TimelineSection,
+} from './types';
+
+const MINUTES_PER_DAY = 24 * 60;
+const MAX_LOCATION_LABEL_LENGTH = 200;
+const MAX_PLACE_TITLE_LENGTH = 200;
+const MAX_PLACE_ADDRESS_LENGTH = 255;
+const MAX_PROVIDER_ID_LENGTH = 255;
+
+const SECTION_DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  weekday: 'short',
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+  timeZone: 'UTC',
+});
+
+const UTC_TODAY_FORMATTER = createTodayFormatter('UTC');
+const todayFormatterCache = new Map<string, Intl.DateTimeFormat>([
+  ['UTC', UTC_TODAY_FORMATTER],
+]);
+
+export type TimelineActivityGroup = 'all-day' | 'scheduled' | 'flexible';
+
+export interface GroupedTimelineActivities {
+  allDay: TimelineActivity[];
+  scheduled: TimelineActivity[];
+  flexible: TimelineActivity[];
+}
+
+export interface TimelineGroupHeaderRow {
+  type: 'group-header';
+  key: string;
+  group: TimelineActivityGroup;
+  label: string;
+}
+
+export interface TimelineActivityRow {
+  type: 'activity';
+  key: string;
+  group: TimelineActivityGroup;
+  activity: TimelineActivity;
+}
+
+export interface TimelineEmptyRow {
+  type: 'empty';
+  key: string;
+}
+
+export type TimelineListRow =
+  | TimelineGroupHeaderRow
+  | TimelineActivityRow
+  | TimelineEmptyRow;
+
+export interface TimelineListSection {
+  key: string;
+  section: TimelineSection;
+  data: TimelineListRow[];
+}
+
+export interface StructuredLocationValue {
+  location_label: string;
+  place: ActivityPlacePayload;
+}
+
+interface IndexedValue<T> {
+  originalIndex: number;
+  value: T;
+}
+
+const GROUP_LABELS: Record<TimelineActivityGroup, string> = {
+  'all-day': 'All day',
+  scheduled: 'Scheduled',
+  flexible: 'Flexible',
+};
+
+export function sortTimelineSections(
+  sections: readonly TimelineSection[],
+): TimelineSection[] {
+  return stableSort(sections, (left, right) => {
+    const dateComparison = left.section_date.localeCompare(right.section_date);
+    if (dateComparison !== 0) {
+      return dateComparison;
+    }
+    return left.position - right.position;
+  });
+}
+
+export function groupActivitiesForDay(
+  activities: readonly TimelineActivity[],
+): GroupedTimelineActivities {
+  const allDay: TimelineActivity[] = [];
+  const scheduled: TimelineActivity[] = [];
+  const flexible: TimelineActivity[] = [];
+
+  for (const activity of activities) {
+    if (activity.time_mode === 'ALL_DAY') {
+      allDay.push(activity);
+    } else if (activity.time_mode === 'FLEXIBLE') {
+      flexible.push(activity);
+    } else {
+      scheduled.push(activity);
+    }
+  }
+
+  return {
+    allDay: stableSort(allDay, compareByPosition),
+    scheduled: stableSort(scheduled, compareScheduledActivities),
+    flexible: stableSort(flexible, compareByPosition),
+  };
+}
+
+export function buildTimelineListSections(
+  sections: readonly TimelineSection[],
+): TimelineListSection[] {
+  return sortTimelineSections(sections).map((section) => {
+    const groups = groupActivitiesForDay(section.activities);
+    const data: TimelineListRow[] = [];
+
+    appendActivityGroup(data, section.id, 'all-day', groups.allDay);
+    appendActivityGroup(data, section.id, 'scheduled', groups.scheduled);
+    appendActivityGroup(data, section.id, 'flexible', groups.flexible);
+
+    if (data.length === 0) {
+      data.push({
+        type: 'empty',
+        key: `empty:${section.id}`,
+      });
+    }
+
+    return {
+      key: `section:${section.id}`,
+      section,
+      data,
+    };
+  });
+}
+
+export function getTimelineRowKey(row: TimelineListRow): string {
+  return row.key;
+}
+
+export function getTodayDateInTimeZone(
+  timeZone: string,
+  now = new Date(),
+): string {
+  const formatter = getTodayFormatter(timeZone);
+  const parts = formatter.formatToParts(now);
+  const year = getDatePart(parts, 'year', '0000');
+  const month = getDatePart(parts, 'month', '01');
+  const day = getDatePart(parts, 'day', '01');
+  return `${year}-${month}-${day}`;
+}
+
+export function getDefaultFocusedSectionId(
+  sections: readonly TimelineSection[],
+  timeZone: string,
+  now = new Date(),
+): string | null {
+  if (sections.length === 0) {
+    return null;
+  }
+
+  const sortedSections = sortTimelineSections(sections);
+  const today = getTodayDateInTimeZone(timeZone, now);
+  const todaySection = sortedSections.find(
+    (section) => section.section_date === today,
+  );
+  if (todaySection) {
+    return todaySection.id;
+  }
+
+  const inRangeSections = sortedSections.filter(
+    (section) => section.is_in_trip_range,
+  );
+  if (inRangeSections.length > 0) {
+    const firstInRange = inRangeSections[0];
+    const lastInRange = inRangeSections[inRangeSections.length - 1];
+
+    if (today < firstInRange.section_date) {
+      return firstInRange.id;
+    }
+    if (today > lastInRange.section_date) {
+      return lastInRange.id;
+    }
+    return firstInRange.id;
+  }
+
+  const firstSection = sortedSections[0];
+  if (today < firstSection.section_date) {
+    return firstSection.id;
+  }
+
+  const lastSection = sortedSections[sortedSections.length - 1];
+  if (today > lastSection.section_date) {
+    return lastSection.id;
+  }
+
+  return firstSection.id;
+}
+
+export function getDefaultFocusedSectionIndex(
+  sections: readonly TimelineListSection[],
+  timeZone: string,
+  now = new Date(),
+): number | null {
+  const sectionId = getDefaultFocusedSectionId(
+    sections.map((section) => section.section),
+    timeZone,
+    now,
+  );
+  if (sectionId === null) {
+    return null;
+  }
+
+  const index = sections.findIndex((section) => section.section.id === sectionId);
+  return index >= 0 ? index : null;
+}
+
+export function formatSectionDate(sectionDate: string): string {
+  const date = parseIsoDate(sectionDate);
+  return date ? SECTION_DATE_FORMATTER.format(date) : sectionDate;
+}
+
+export function formatTime(time: string | null): string {
+  if (time === null) {
+    return '';
+  }
+  return time.slice(0, 5);
+}
+
+export function formatActivityTime(activity: TimelineActivity): string {
+  if (activity.time_mode === 'ALL_DAY') {
+    return 'All day';
+  }
+  if (activity.time_mode === 'FLEXIBLE') {
+    return 'Flexible';
+  }
+
+  const start = formatTime(activity.start_time);
+  if (activity.time_mode === 'AT_TIME') {
+    return start;
+  }
+
+  const end = formatTime(activity.end_time);
+  if (start && end) {
+    return `${start} – ${end}`;
+  }
+  return start || end;
+}
+
+export function buildStructuredLocation(
+  suggestion: LocationSuggestion,
+  lookup: ResolvedLookup,
+): StructuredLocationValue | null {
+  const canonicalProviderId = lookup.destination_provider_id;
+  if (
+    typeof canonicalProviderId !== 'string' ||
+    canonicalProviderId.trim().length === 0 ||
+    codePointLength(canonicalProviderId) > MAX_PROVIDER_ID_LENGTH
+  ) {
+    return null;
+  }
+
+  const safeTitle = truncateText(
+    suggestion.title,
+    Math.min(MAX_LOCATION_LABEL_LENGTH, MAX_PLACE_TITLE_LENGTH),
+  );
+  const safeAddress = truncateText(
+    lookup.destination ?? suggestion.subtitle,
+    MAX_PLACE_ADDRESS_LENGTH,
+  );
+
+  return {
+    location_label: safeTitle,
+    place: {
+      provider: 'here',
+      provider_id: canonicalProviderId,
+      title: safeTitle,
+      address: safeAddress,
+      lat: lookup.destination_lat ?? null,
+      lng: lookup.destination_lng ?? null,
+    },
+  };
+}
+
+function stableSort<T>(
+  values: readonly T[],
+  compare: (left: T, right: T) => number,
+): T[] {
+  return values
+    .map<IndexedValue<T>>((value, originalIndex) => ({
+      value,
+      originalIndex,
+    }))
+    .sort((left, right) => {
+      const comparison = compare(left.value, right.value);
+      return comparison !== 0 ? comparison : left.originalIndex - right.originalIndex;
+    })
+    .map(({ value }) => value);
+}
+
+function compareByPosition(
+  left: TimelineActivity,
+  right: TimelineActivity,
+): number {
+  return left.position - right.position;
+}
+
+function compareScheduledActivities(
+  left: TimelineActivity,
+  right: TimelineActivity,
+): number {
+  const startComparison =
+    timeToMinutes(left.start_time) - timeToMinutes(right.start_time);
+  if (startComparison !== 0) {
+    return startComparison;
+  }
+  return compareByPosition(left, right);
+}
+
+function timeToMinutes(value: string | null): number {
+  if (value === null) {
+    return MINUTES_PER_DAY;
+  }
+
+  const match = /^(\d{2}):(\d{2})(?::\d{2})?$/.exec(value);
+  if (!match) {
+    return MINUTES_PER_DAY;
+  }
+
+  const hour = Number(match[1]);
+  const minute = Number(match[2]);
+  if (hour > 23 || minute > 59) {
+    return MINUTES_PER_DAY;
+  }
+  return hour * 60 + minute;
+}
+
+function appendActivityGroup(
+  rows: TimelineListRow[],
+  sectionId: string,
+  group: TimelineActivityGroup,
+  activities: readonly TimelineActivity[],
+): void {
+  if (activities.length === 0) {
+    return;
+  }
+
+  rows.push({
+    type: 'group-header',
+    key: `group:${sectionId}:${group}`,
+    group,
+    label: GROUP_LABELS[group],
+  });
+
+  for (const activity of activities) {
+    rows.push({
+      type: 'activity',
+      key: `activity:${sectionId}:${activity.id}`,
+      group,
+      activity,
+    });
+  }
+}
+
+function createTodayFormatter(timeZone: string): Intl.DateTimeFormat {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+}
+
+function getTodayFormatter(timeZone: string): Intl.DateTimeFormat {
+  const cached = todayFormatterCache.get(timeZone);
+  if (cached) {
+    return cached;
+  }
+
+  try {
+    const formatter = createTodayFormatter(timeZone);
+    todayFormatterCache.set(timeZone, formatter);
+    return formatter;
+  } catch {
+    return UTC_TODAY_FORMATTER;
+  }
+}
+
+function getDatePart(
+  parts: Intl.DateTimeFormatPart[],
+  type: Intl.DateTimeFormatPartTypes,
+  fallback: string,
+): string {
+  return parts.find((part) => part.type === type)?.value ?? fallback;
+}
+
+function parseIsoDate(value: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) {
+    return null;
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return null;
+  }
+  return date;
+}
+
+function truncateText(value: string, maxLength: number): string {
+  return Array.from(value).slice(0, maxLength).join('');
+}
+
+function codePointLength(value: string): number {
+  return Array.from(value).length;
+}

--- a/mobile/src/features/trips/__tests__/TripDetailScreen.test.tsx
+++ b/mobile/src/features/trips/__tests__/TripDetailScreen.test.tsx
@@ -158,7 +158,7 @@ describe('TripDetailScreen', () => {
 
     expect(await screen.findByText('Overview')).toBeTruthy();
     expect(mockStackScreen.mock.calls.some(([props]) => props.options.title === 'Da Lat escape')).toBe(true);
-    expect(screen.getByText('Planning')).toBeTruthy();
+    expect(screen.getAllByText('Planning')).toHaveLength(2);
     expect(screen.getByText('Da Lat, Vietnam')).toBeTruthy();
     expect(screen.getByText('Members (1)')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Start trip' })).toBeTruthy();
@@ -169,6 +169,24 @@ describe('TripDetailScreen', () => {
     expect(mockRouter.push).toHaveBeenCalledWith('/trips/trip-123/edit');
     await fireEvent.press(screen.getByRole('button', { name: 'Invite friends' }));
     expect(mockRouter.push).toHaveBeenCalledWith('/trips/trip-123/invite');
+  });
+
+  it('shows only the Timeline Planning entry to every readable trip', async () => {
+    mockUseTripDetail.mockReturnValue(
+      readyHook({
+        ...tripDetail,
+        trip: { ...tripDetail.trip, status: 'COMPLETED' },
+        my_membership: { ...tripDetail.my_membership, role: 'MEMBER' },
+      }),
+    );
+    await render(<TripDetailScreen />);
+
+    expect(screen.getByRole('header', { name: 'Planning' })).toBeTruthy();
+    expect(screen.getByText('Timeline')).toBeTruthy();
+    expect(screen.queryByText('Expenses')).toBeNull();
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Open Timeline' }));
+    expect(mockRouter.push).toHaveBeenCalledWith('/trips/trip-123/timeline');
   });
 
   it('shows only leave for an active member and no actions for a terminal trip', async () => {

--- a/mobile/src/features/trips/__tests__/useTripDetail.test.tsx
+++ b/mobile/src/features/trips/__tests__/useTripDetail.test.tsx
@@ -78,10 +78,12 @@ function axiosErrorWith(status: number, data: unknown): AxiosError {
 
 function deferred<T>() {
   let resolve: (value: T) => void = () => undefined;
-  const promise = new Promise<T>((nextResolve) => {
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
     resolve = nextResolve;
+    reject = nextReject;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 function latestFocusCallback(): () => (() => void) | void {
@@ -106,7 +108,10 @@ describe('useTripDetail', () => {
   });
 
   it('loads on focus then silently refreshes while retaining the detail', async () => {
-    mockGetTripDetail.mockResolvedValue(tripDetail);
+    const silentRefresh = deferred<typeof tripDetail>();
+    mockGetTripDetail
+      .mockResolvedValueOnce(tripDetail)
+      .mockReturnValueOnce(silentRefresh.promise);
     const { result, unmount } = await renderHook(() => useTripDetail('trip-1'));
 
     await act(async () => {
@@ -121,6 +126,166 @@ describe('useTripDetail', () => {
     expect(mockGetTripDetail).toHaveBeenCalledTimes(2);
     expect(result.current.status).toBe('ready');
     expect(result.current.refreshing).toBe(false);
+    await act(async () => {
+      silentRefresh.resolve(tripDetail);
+    });
+    unmount();
+  });
+
+  it('sets refreshing only for an explicit refresh and clears it on completion', async () => {
+    const explicitRefresh = deferred<typeof tripDetail>();
+    mockGetTripDetail
+      .mockResolvedValueOnce(tripDetail)
+      .mockReturnValueOnce(explicitRefresh.promise);
+    const { result, unmount } = await renderHook(() => useTripDetail('trip-1'));
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.detail).toEqual(tripDetail));
+
+    await act(async () => {
+      void result.current.refresh('refresh');
+    });
+    expect(result.current.refreshing).toBe(true);
+    expect(result.current.detail).toEqual(tripDetail);
+
+    await act(async () => {
+      explicitRefresh.resolve(tripDetail);
+    });
+    expect(result.current.refreshing).toBe(false);
+    unmount();
+  });
+
+  it('lets a newer silent request own stale refresh completion and spinner cleanup', async () => {
+    const explicitRefresh = deferred<typeof tripDetail>();
+    const silentRefresh = deferred<typeof tripDetail>();
+    mockGetTripDetail
+      .mockResolvedValueOnce(tripDetail)
+      .mockReturnValueOnce(explicitRefresh.promise)
+      .mockReturnValueOnce(silentRefresh.promise);
+    const { result, unmount } = await renderHook(() => useTripDetail('trip-1'));
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.detail).toEqual(tripDetail));
+
+    await act(async () => {
+      void result.current.refresh('refresh');
+    });
+    expect(result.current.refreshing).toBe(true);
+
+    await act(async () => {
+      void result.current.refresh('silent');
+    });
+    await act(async () => {
+      explicitRefresh.resolve({
+        ...tripDetail,
+        trip: { ...trip, name: 'Stale refresh' },
+      });
+    });
+    expect(result.current.refreshing).toBe(true);
+    expect(result.current.detail?.trip.name).toBe('Da Lat escape');
+
+    await act(async () => {
+      silentRefresh.resolve({
+        ...tripDetail,
+        trip: { ...trip, name: 'Latest silent result' },
+      });
+    });
+    expect(result.current.refreshing).toBe(false);
+    expect(result.current.detail?.trip.name).toBe('Latest silent result');
+    unmount();
+  });
+
+  it('ignores a stale refresh failure across catch and finally', async () => {
+    const staleRefresh = deferred<typeof tripDetail>();
+    const latestRefresh = deferred<typeof tripDetail>();
+    mockGetTripDetail
+      .mockResolvedValueOnce(tripDetail)
+      .mockReturnValueOnce(staleRefresh.promise)
+      .mockReturnValueOnce(latestRefresh.promise);
+    const { result, unmount } = await renderHook(() => useTripDetail('trip-1'));
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.detail).toEqual(tripDetail));
+
+    await act(async () => {
+      void result.current.refresh('refresh');
+      void result.current.refresh('silent');
+    });
+    await act(async () => {
+      staleRefresh.reject(
+        axiosErrorWith(500, { detail: 'Stale refresh failed.' }),
+      );
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.refreshing).toBe(true);
+
+    await act(async () => {
+      latestRefresh.resolve(tripDetail);
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.refreshing).toBe(false);
+    unmount();
+  });
+
+  it('does not own focus, foreground, or trip-event reconciliation when disabled', async () => {
+    mockGetTripDetail.mockResolvedValue(tripDetail);
+    const { result, unmount } = await renderHook(() =>
+      useTripDetail('trip-1', { autoReconcile: false }),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+      latestForegroundCallback()();
+      publishTripEvent({
+        type: 'updated',
+        trip: { ...trip, name: 'Event update' },
+      });
+    });
+
+    expect(mockGetTripDetail).not.toHaveBeenCalled();
+    expect(result.current.detail).toBeNull();
+
+    await act(async () => {
+      await result.current.refresh('initial');
+    });
+    expect(result.current.detail).toEqual(tripDetail);
+
+    await act(async () => {
+      publishTripEvent({
+        type: 'updated',
+        trip: { ...trip, name: 'Ignored event update' },
+      });
+    });
+    expect(result.current.detail?.trip.name).toBe('Da Lat escape');
+    unmount();
+  });
+
+  it('invalidates a coordinator-owned request when a non-reconciling screen blurs', async () => {
+    const pendingRequest = deferred<typeof tripDetail>();
+    mockGetTripDetail.mockReturnValue(pendingRequest.promise);
+    const { result, unmount } = await renderHook(() =>
+      useTripDetail('trip-1', { autoReconcile: false }),
+    );
+
+    let cleanup: (() => void) | void = undefined;
+    await act(async () => {
+      cleanup = latestFocusCallback()();
+      void result.current.refresh('initial');
+    });
+    await act(async () => {
+      cleanup?.();
+      pendingRequest.resolve(tripDetail);
+    });
+
+    expect(result.current.detail).toBeNull();
+    expect(result.current.status).toBe('loading');
     unmount();
   });
 
@@ -207,6 +372,39 @@ describe('useTripDetail', () => {
     });
 
     await waitFor(() => expect(result.current.detail?.trip.name).toBe('Da Lat escape'));
+    unmount();
+  });
+
+  it('hides the previous trip immediately when the resource key changes', async () => {
+    const secondTripDetail = {
+      ...tripDetail,
+      trip: { ...trip, id: 'trip-2', name: 'Second trip' },
+    };
+    const secondRequest = deferred<typeof secondTripDetail>();
+    mockGetTripDetail
+      .mockResolvedValueOnce(tripDetail)
+      .mockReturnValueOnce(secondRequest.promise);
+    const { result, rerender, unmount } = await renderHook(
+      ({ tripId }: { tripId: string }) => useTripDetail(tripId),
+      { initialProps: { tripId: 'trip-1' } },
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.detail).toEqual(tripDetail));
+
+    await rerender({ tripId: 'trip-2' });
+    expect(result.current.detail).toBeNull();
+    expect(result.current.status).toBe('loading');
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await act(async () => {
+      secondRequest.resolve(secondTripDetail);
+    });
+    expect(result.current.detail).toEqual(secondTripDetail);
     unmount();
   });
 

--- a/mobile/src/features/trips/hooks/useTripDetail.ts
+++ b/mobile/src/features/trips/hooks/useTripDetail.ts
@@ -7,7 +7,11 @@ import { subscribeToTripEvents } from '../tripEvents';
 import type { Trip, TripDetailResponse, TripStatus } from '../types';
 
 export type TripDetailLoadStatus = 'loading' | 'ready' | 'error';
-export type TripDetailLoadMode = 'initial' | 'silent';
+export type TripDetailLoadMode = 'initial' | 'refresh' | 'silent';
+
+interface UseTripDetailOptions {
+  autoReconcile?: boolean;
+}
 
 const MISSING_TRIP_ERROR: ApiError = {
   kind: 'message',
@@ -16,7 +20,10 @@ const MISSING_TRIP_ERROR: ApiError = {
   status: 404,
 };
 
-export function useTripDetail(tripId: string | undefined) {
+export function useTripDetail(
+  tripId: string | undefined,
+  { autoReconcile = true }: UseTripDetailOptions = {},
+) {
   const [detail, setDetail] = useState<TripDetailResponse | null>(null);
   const [status, setStatus] = useState<TripDetailLoadStatus>('loading');
   const [error, setError] = useState<ApiError | null>(null);
@@ -44,6 +51,7 @@ export function useTripDetail(tripId: string | undefined) {
         setDetail(null);
         setError(MISSING_TRIP_ERROR);
         setStatus('error');
+        setRefreshing(false);
         return;
       }
 
@@ -53,7 +61,8 @@ export function useTripDetail(tripId: string | undefined) {
         detailRef.current = null;
         setError(null);
         setStatus('loading');
-      } else if (mode === 'silent') {
+        setRefreshing(false);
+      } else if (mode === 'refresh') {
         setRefreshing(true);
       }
 
@@ -126,8 +135,11 @@ export function useTripDetail(tripId: string | undefined) {
   );
 
   useEffect(
-    () =>
-      subscribeToTripEvents((event) => {
+    () => {
+      if (!autoReconcile) {
+        return undefined;
+      }
+      return subscribeToTripEvents((event) => {
         if (event.type === 'updated' && event.trip.id === tripId) {
           applyTrip(event.trip);
         } else if (event.type === 'statusChanged' && event.tripId === tripId) {
@@ -135,23 +147,28 @@ export function useTripDetail(tripId: string | undefined) {
         } else if (event.type === 'memberRemoved' && event.tripId === tripId) {
           applyMemberRemoved(event.userId);
         }
-      }),
-    [applyMemberRemoved, applyStatus, applyTrip, tripId],
+      });
+    },
+    [applyMemberRemoved, applyStatus, applyTrip, autoReconcile, tripId],
   );
 
   const reconcileOnForeground = useCallback(() => {
-    void refresh(detailRef.current?.trip.id === tripId ? 'silent' : 'initial');
-  }, [refresh, tripId]);
+    if (autoReconcile) {
+      void refresh(detailRef.current?.trip.id === tripId ? 'silent' : 'initial');
+    }
+  }, [autoReconcile, refresh, tripId]);
 
   useAppForegroundEffect(reconcileOnForeground);
 
   useFocusEffect(
     useCallback(() => {
-      void refresh(detailRef.current?.trip.id === tripId ? 'silent' : 'initial');
+      if (autoReconcile) {
+        void refresh(detailRef.current?.trip.id === tripId ? 'silent' : 'initial');
+      }
       return () => {
         requestIdRef.current += 1;
       };
-    }, [refresh, tripId]),
+    }, [autoReconcile, refresh, tripId]),
   );
 
   const stateMatchesTrip = stateTripId === tripId;

--- a/mobile/src/features/trips/screens/TripDetailScreen.tsx
+++ b/mobile/src/features/trips/screens/TripDetailScreen.tsx
@@ -162,6 +162,10 @@ export function TripDetailScreen() {
     router.push(`/trips/${tripId}/invite`);
   }, [router, tripId]);
 
+  const openTimeline = useCallback(() => {
+    router.push(`/trips/${tripId}/timeline`);
+  }, [router, tripId]);
+
   if (status === 'loading') {
     return <LoadingScreen />;
   }
@@ -254,6 +258,33 @@ export function TripDetailScreen() {
             <Text style={styles.refreshingText}>Updating trip…</Text>
           </View>
         ) : null}
+        <View style={styles.section}>
+          <Text accessibilityRole="header" style={styles.sectionTitle}>
+            Planning
+          </Text>
+          <View style={styles.card}>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Open Timeline"
+              onPress={openTimeline}
+              style={({ pressed }) => [
+                styles.planningRow,
+                pressed ? styles.planningRowPressed : null,
+              ]}
+            >
+              <View style={styles.infoIcon}>
+                <Ionicons name="calendar-outline" size={18} color={colors.primary} />
+              </View>
+              <View style={styles.planningCopy}>
+                <Text style={styles.infoText}>Timeline</Text>
+                <Text style={styles.planningDescription}>
+                  Plan days, activities, and reminders
+                </Text>
+              </View>
+              <Ionicons name="chevron-forward" size={20} color={colors.textMuted} />
+            </Pressable>
+          </View>
+        </View>
         {trip.description ? (
           <View style={styles.section}>
             <Text accessibilityRole="header" style={styles.sectionTitle}>
@@ -393,6 +424,15 @@ const styles = StyleSheet.create({
   },
   rowDivider: { borderBottomWidth: 1, borderBottomColor: colors.border },
   infoText: { ...typography.body, color: colors.text, flexShrink: 1 },
+  planningRow: {
+    minHeight: 64,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  planningRowPressed: { opacity: 0.55 },
+  planningCopy: { flex: 1, gap: spacing.xs },
+  planningDescription: { ...typography.caption, color: colors.textMuted },
   description: { ...typography.body, color: colors.text, paddingVertical: spacing.md },
   sectionTitle: { ...typography.heading, color: colors.text },
   muted: { ...typography.body, color: colors.textMuted, textAlign: 'center' },

--- a/mobile/src/shared/api/__tests__/errors.test.ts
+++ b/mobile/src/shared/api/__tests__/errors.test.ts
@@ -36,20 +36,89 @@ describe('normalizeApiError', () => {
     });
   });
 
+  it('recursively flattens nested field objects to dotted keys', () => {
+    const result = normalizeApiError(
+      axiosErrorWith(400, {
+        place: {
+          provider_id: ['Select a valid place.'],
+          coordinates: {
+            lat: ['Enter a valid latitude.'],
+          },
+        },
+      }),
+    );
+    expect(result).toEqual({
+      kind: 'field',
+      message: 'Please fix the highlighted fields.',
+      fieldErrors: {
+        'place.provider_id': 'Select a valid place.',
+        'place.coordinates.lat': 'Enter a valid latitude.',
+      },
+      status: 400,
+    });
+  });
+
+  it.each([
+    {
+      place: { provider_id: ['Nested message.'] },
+      'place.provider_id': ['Explicit message.'],
+    },
+    {
+      'place.provider_id': ['Explicit message.'],
+      place: { provider_id: ['Nested message.'] },
+    },
+  ])('lets a top-level pre-dotted leaf win a nested collision regardless of key order', (data) => {
+    const result = normalizeApiError(axiosErrorWith(400, data));
+    expect(result.fieldErrors).toEqual({
+      'place.provider_id': 'Explicit message.',
+    });
+  });
+
+  it('keeps mixed flat, nested, and non-field errors while taking the first string array leaf', () => {
+    const result = normalizeApiError(
+      axiosErrorWith(400, {
+        location_label: [null, 'Enter a location.', 'Later location error.'],
+        place: {
+          title: ['Enter a place title.', 'Later title error.'],
+          non_field_errors: ['The place fields do not match.'],
+        },
+        non_field_errors: ['Review the form.'],
+      }),
+    );
+    expect(result).toEqual({
+      kind: 'field',
+      message: 'Please fix the highlighted fields.',
+      fieldErrors: {
+        location_label: 'Enter a location.',
+        'place.title': 'Enter a place title.',
+        'place.non_field_errors': 'The place fields do not match.',
+        non_field_errors: 'Review the form.',
+      },
+      status: 400,
+    });
+  });
+
   it('maps lone non_field_errors to a message error', () => {
     const result = normalizeApiError(axiosErrorWith(400, { non_field_errors: ['Something failed.'] }));
-    expect(result).toMatchObject({ kind: 'message', message: 'Something failed.' });
+    expect(result).toEqual({ kind: 'message', message: 'Something failed.', status: 400 });
   });
 
   it('maps 429 to throttled', () => {
     const result = normalizeApiError(axiosErrorWith(429, { detail: 'Request was throttled.' }));
-    expect(result.kind).toBe('throttled');
+    expect(result).toEqual({
+      kind: 'throttled',
+      message: 'Too many attempts. Please wait a moment and try again.',
+      status: 429,
+    });
   });
 
   it('maps missing response to network error', () => {
     const config = { headers: new AxiosHeaders() };
     const error = new AxiosError('Network Error', 'ERR_NETWORK', config, {});
-    expect(normalizeApiError(error).kind).toBe('network');
+    expect(normalizeApiError(error)).toEqual({
+      kind: 'network',
+      message: 'Cannot reach the server. Check your connection.',
+    });
   });
 
   it('maps unknown values to a generic message', () => {

--- a/mobile/src/shared/api/errors.ts
+++ b/mobile/src/shared/api/errors.ts
@@ -12,6 +12,55 @@ const GENERIC_MESSAGE = 'Something went wrong. Please try again.';
 const NETWORK_MESSAGE = 'Cannot reach the server. Check your connection.';
 const THROTTLED_MESSAGE = 'Too many attempts. Please wait a moment and try again.';
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function firstString(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.find((item): item is string => typeof item === 'string');
+  }
+  return undefined;
+}
+
+function flattenFieldErrors(body: Record<string, unknown>): Record<string, string> {
+  const fieldErrors: Record<string, string> = {};
+  const explicitTopLevelLeaves = new Set<string>();
+
+  for (const [field, value] of Object.entries(body)) {
+    const message = firstString(value);
+    if (message !== undefined) {
+      explicitTopLevelLeaves.add(field);
+      fieldErrors[field] = message;
+    }
+  }
+
+  function flattenNested(value: Record<string, unknown>, prefix: string): void {
+    for (const [field, nestedValue] of Object.entries(value)) {
+      const path = `${prefix}.${field}`;
+      const message = firstString(nestedValue);
+      if (message !== undefined) {
+        if (!explicitTopLevelLeaves.has(path)) {
+          fieldErrors[path] = message;
+        }
+      } else if (isRecord(nestedValue)) {
+        flattenNested(nestedValue, path);
+      }
+    }
+  }
+
+  for (const [field, value] of Object.entries(body)) {
+    if (isRecord(value)) {
+      flattenNested(value, field);
+    }
+  }
+
+  return fieldErrors;
+}
+
 export function normalizeApiError(error: unknown): ApiError {
   if (!(error instanceof AxiosError)) {
     return { kind: 'message', message: GENERIC_MESSAGE };
@@ -37,13 +86,7 @@ export function normalizeApiError(error: unknown): ApiError {
       };
     }
 
-    const fieldErrors: Record<string, string> = {};
-    for (const [field, value] of Object.entries(body)) {
-      const first = Array.isArray(value) ? value[0] : value;
-      if (typeof first === 'string') {
-        fieldErrors[field] = first;
-      }
-    }
+    const fieldErrors = flattenFieldErrors(body);
     const fields = Object.keys(fieldErrors);
     if (fields.length === 1 && fields[0] === 'non_field_errors') {
       return { kind: 'message', message: fieldErrors.non_field_errors, status };

--- a/mobile/src/shared/theme/tokens.ts
+++ b/mobile/src/shared/theme/tokens.ts
@@ -14,6 +14,22 @@ export const colors = {
   border: '#D8DFE8',
   danger: '#C0392B',
   success: '#1E7A45',
+  sky: '#0369A1',
+  skySoft: '#E0F2FE',
+  amber: '#A16207',
+  amberSoft: '#FEF3C7',
+  rose: '#BE123C',
+  roseSoft: '#FFE4E6',
+  emerald: '#047857',
+  emeraldSoft: '#D1FAE5',
+  violet: '#6D28D9',
+  violetSoft: '#EDE9FE',
+  indigo: '#4338CA',
+  indigoSoft: '#E0E7FF',
+  teal: '#0F766E',
+  tealSoft: '#CCFBF1',
+  slate: '#475569',
+  slateSoft: '#E2E8F0',
 } as const;
 
 export const spacing = { xs: 4, sm: 8, md: 16, lg: 24, xl: 32 } as const;


### PR DESCRIPTION
## Summary

Implements PR 2 of Issue #58: the complete iOS Mobile Timeline surface, based on `main` after merged PR #59.

This PR adds:

- Timeline Planning entry and virtualized read surface
- timeline day create/edit/delete
- activity create/edit/delete/status workflows
- all four time modes using an app-owned iOS `@expo/ui` TimeField wrapper
- custom activity type create/rename/activate/deactivate/delete
- canonical HERE place search/lookup plus explicit manual location mode
- reminder-offset configuration using the existing in-app Notifications delivery path
- route, request-race, form-lifecycle, unknown-token, and reconciliation protections

It also contains two isolated shared changes required by the approved plan:

- Trip Detail `initial | refresh | silent` reconciliation modes
- recursive DRF nested-field error normalization with dotted-key collision precedence

Expenses, Android, native/local notification scheduling, OS push delivery, realtime transport changes, and web redesign remain out of scope.

## Architecture and behavior

- Mobile continues to call Django directly through the shared Axios client.
- Refresh tokens remain SecureStore-only; access tokens remain memory-only.
- Server permissions and per-activity capabilities remain authoritative.
- Timeline uses `SectionList`; server-sized custom-type and choice collections use virtualized lists.
- Explicit `mode=create|edit` route intent is validated before feature requests, including UUID normalization.
- Composed forms own one reconciliation coordinator and use immutable one-time hydration, dirty-field PATCHes, generation guards, terminal success locks, and blocked interactive dismissal.
- Timed create/mode-transition defaults match the native picker display (`00:00`, with `01:00` as the initial range end), so an unchanged visible value is represented in the payload.
- Only a successful canonical lookup persists `STRUCTURED` location data. Coordinates are normalized to the backend's six-decimal contract. Lookup failure retains a bounded typed/provider label in `MANUAL` mode and never persists an unverified provider id.
- Mutation errors remain owned by the Timeline screen so backend 403/404/409 detail survives authoritative reconciliation and disappearing controls/rows.
- Reminders configure backend offsets only. This PR does not add `expo-notifications`, local scheduling, APNs, or Expo push.

## Review follow-up at `7dca2d2`

The PR review findings were fixed and covered by regressions:

- terminal late-success cannot reopen the create lock or replay a committed draft
- HERE coordinates with more than six decimal places no longer cause create/edit 400
- backend status-mutation detail survives status/capability/row reconciliation
- uppercase route UUIDs normalize before strict aggregate lookup
- blurred parent screens no longer duplicate normal Timeline reconciliation
- manual fallback labels are capped to 200 Unicode code points
- authoritative Trip Detail 404 wins over a background Timeline error

The same lifecycle audit also hardened Section late-success and Custom Type authoritative cleanup. The final independent diff review reported no remaining actionable finding.

## Automated evidence

From `mobile/` at head `7dca2d2`:

- focused review regressions — 9 suites / 232 tests passed
- `pnpm lint` — passed
- `pnpm typecheck` — passed
- `pnpm test` — 62 suites / 618 tests passed
- `git diff --check` — clean

Earlier Phase 1 checkpoints also passed the shared-error, Trip Detail, full Timeline, reminder backend, dispatcher, notification payload, and mobile notification suites.

Reminder/backend evidence:

- `trips.tests.test_timeline_reminders` — 16/16 passed
- dispatch subset — 4/4 passed
- notification payload validation — 6/6 passed
- mobile notification parser/row/screen — 28/28 passed
- transactional dispatch probe — exactly one ACTIVE recipient, zero REMOVED recipients, then zero duplicate on the second cycle
- `backend-scheduler-goplan` observed healthy across consecutive 60-second cycles

GitHub currently has no configured status checks for this PR. The recorded local gates and independent review are the verification evidence.

## iOS Simulator evidence

Verified on iPhone 17 Pro Max Simulator.

The main Phase 1 pass covered:

- Planning navigation and back behavior
- captain day create/edit/delete
- activity create/edit and upcoming/in-progress/done/reset transitions
- native DatePicker and TimeField plus all four time modes
- unchanged native `00:00` create default submitted successfully and rendered as `00:00`
- custom type create/rename/deactivate/reactivate
- custom-type manager Close preserving the calling Activity Form draft
- live HERE suggest -> canonical lookup and explicit manual mode
- offline refresh retaining complete Timeline data with a non-destructive error
- Member and terminal-trip read-only surfaces
- foreground/auth persistence and reminder navigation

The 2026-07-28 review-follow-up run additionally proved:

- a database lock held POST for 7.79 seconds while the Activity Form was blurred; late success dismissed safely and created exactly one row
- HERE create returned 201 and edit returned 200; persisted coordinates were six-decimal values (`16.074630 / 108.223610`, then `21.028850 / 105.854630`)
- a stale status control returned 409; controls disappeared after reconciliation while the exact backend detail remained visible
- uppercase trip/activity UUID deep links opened and hydrated the correct edit form
- normal POST/PATCH paths produced one Timeline reconciliation GET
- a failed HERE lookup degraded to a submittable `MANUAL` label and saved successfully
- a missing trip/activity rendered the neutral Activity Form unavailable state without a form retry action

Temporary fixtures were deleted by exact identity. Metro/backend were stopped and the Simulator was shut down without erasing data. No crash or RedBox occurred; only non-blocking development-client/React Native warnings were observed.

## Shared-change blast radius

Nested error normalization has consumers in auth, friends, notifications, and trips. Existing classifications (`detail + error_code`, throttling, network, generic, top-level `non_field_errors`) remain covered, and the full mobile suite passed.

Trip Detail retains complete data through background failures, clears only relevant 404 state, and prevents stale `then`, `catch`, and `finally` branches from mutating the active resource.

## Accepted verification boundaries

The owner explicitly accepted the remaining real-backend manual boundaries on 2026-07-28:

- Trip Detail member-removal reconciliation
- assignee-Member status transition
- provider-disabled/not-configured runtime configuration
- unknown token/icon presentation
- authority/options refresh during an active draft
- exact provider-title-over-200 boundary
- exact simultaneous Timeline-generic-error plus Trip-Detail-404 composition
- 403/row-removal variant of status-error fallback

These exact paths have deterministic automated coverage. Late-completion safety, normal duplicate-load instrumentation, settled lookup fallback, uppercase routing, and capability-removing 409 visibility were manually verified in the follow-up run.

## Merge and post-merge verification

- PR #60 merged into `main` at `f3fdc8aae03e03ae338fffd81185102a5ed5d1ba` on 2026-07-28T02:41:57Z.
- The merge tree exactly matches reviewed branch head `7dca2d286cea5e628535c5b070e5dba3fcb1c289`.
- On updated `main`, `pnpm lint` and `pnpm typecheck` passed.
- On updated `main`, `pnpm test` passed: 62 suites / 618 tests.
- `git diff --check` is clean, and local `main` is synchronized with `origin/main`.

PR 2 is complete and PR 3 Mobile Expenses is unblocked. Issue #58 remains open until PR 3 and the final integration gate complete.

## Dependency and rollback

- Depends on merged PR #59.
- PR 2 can be reverted while PR 1 remains, before PR 3 merges.
- After PR 3 merges, remove Expenses before reverting this Timeline layer.
- The isolated Trip Detail commit can be reverted only after reassessing dependent Timeline composition behavior.

Issue #58 remains open for PR 3 Mobile Expenses and final integration verification.
