### PR TITLE
feat(mobile): add full iOS expenses experience

### DIFF
--- a/mobile/src/app/trips/[tripId]/expenses/[expenseId].tsx
+++ b/mobile/src/app/trips/[tripId]/expenses/[expenseId].tsx
@@ -1,0 +1,1 @@
+export { ExpenseDetailScreen as default } from '@/features/expenses/screens/ExpenseDetailScreen';

--- a/mobile/src/app/trips/[tripId]/expenses/expense-form.tsx
+++ b/mobile/src/app/trips/[tripId]/expenses/expense-form.tsx
@@ -1,0 +1,1 @@
+export { ExpenseFormScreen as default } from '@/features/expenses/screens/ExpenseFormScreen';

--- a/mobile/src/app/trips/[tripId]/expenses/index.tsx
+++ b/mobile/src/app/trips/[tripId]/expenses/index.tsx
@@ -1,0 +1,1 @@
+export { ExpensesScreen as default } from '@/features/expenses/screens/ExpensesScreen';

--- a/mobile/src/app/trips/__tests__/_layout.test.tsx
+++ b/mobile/src/app/trips/__tests__/_layout.test.tsx
@@ -83,6 +83,24 @@ describe('TripsLayout header actions', () => {
     expect(screen.getByLabelText('Close custom types')).toBeTruthy();
   });
 
+  it('registers Expenses dashboard and detail as push routes and its form as a sheet', async () => {
+    await render(<TripsLayout />);
+
+    expect(mockRegisterScreen).toHaveBeenCalledWith(
+      '[tripId]/expenses/index',
+      expect.objectContaining({ title: 'Expenses' }),
+    );
+    expect(mockRegisterScreen).toHaveBeenCalledWith(
+      '[tripId]/expenses/[expenseId]',
+      expect.objectContaining({ title: 'Expense' }),
+    );
+    expect(mockRegisterScreen).toHaveBeenCalledWith(
+      '[tripId]/expenses/expense-form',
+      expect.objectContaining({ title: 'Expense', presentation: 'formSheet' }),
+    );
+    expect(screen.getByLabelText('Cancel expense form')).toBeTruthy();
+  });
+
   it('returns to the previous route from the trip detail header when history exists', async () => {
     mockRouter.canGoBack.mockReturnValue(true);
     await render(<TripsLayout />);
@@ -98,6 +116,7 @@ describe('TripsLayout header actions', () => {
     ['Cancel timeline day form'],
     ['Cancel timeline activity form'],
     ['Close custom types'],
+    ['Cancel expense form'],
   ])('returns to tabs from %s when there is no navigation history', async (label) => {
     mockRouter.canGoBack.mockReturnValue(false);
     await render(<TripsLayout />);

--- a/mobile/src/app/trips/_layout.tsx
+++ b/mobile/src/app/trips/_layout.tsx
@@ -127,6 +127,32 @@ export default function TripsLayout() {
         }}
       />
       <Stack.Screen
+        name="[tripId]/expenses/index"
+        options={{
+          title: 'Expenses',
+        }}
+      />
+      <Stack.Screen
+        name="[tripId]/expenses/[expenseId]"
+        options={{
+          title: 'Expense',
+        }}
+      />
+      <Stack.Screen
+        name="[tripId]/expenses/expense-form"
+        options={{
+          title: 'Expense',
+          presentation: 'formSheet',
+          headerLeft: () => (
+            <HeaderAction
+              label="Cancel"
+              accessibilityLabel="Cancel expense form"
+              onPress={leaveTripsRoute}
+            />
+          ),
+        }}
+      />
+      <Stack.Screen
         name="[tripId]/edit"
         options={{
           title: 'Edit Trip',

--- a/mobile/src/features/expenses/__tests__/ExpenseDashboardComponents.test.tsx
+++ b/mobile/src/features/expenses/__tests__/ExpenseDashboardComponents.test.tsx
@@ -1,0 +1,192 @@
+const mockIonicons = jest.fn((_props: unknown) => null);
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: (props: unknown) => mockIonicons(props),
+}));
+
+// eslint-disable-next-line import/first
+import {
+  fireEvent,
+  render,
+  screen,
+} from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { ExpenseRow } from '../components/ExpenseRow';
+// eslint-disable-next-line import/first
+import { ExpenseSummaryStrip } from '../components/ExpenseSummaryStrip';
+// eslint-disable-next-line import/first
+import { MemberBalanceRow } from '../components/MemberBalanceRow';
+// eslint-disable-next-line import/first
+import type { ExpenseListItem } from '../types';
+
+function buildExpense(
+  overrides: Partial<ExpenseListItem> = {},
+): ExpenseListItem {
+  return {
+    id: 'expense-1',
+    title: 'Beach house',
+    description: 'Three nights by the sea',
+    total_amount: '300.00',
+    paid_amount: '250.00',
+    missing_amount: '50.00',
+    surplus_amount: '0.00',
+    currency_code: 'USD',
+    status: 'UNDERFUNDED',
+    collector: {
+      id: 'collector-1',
+      display_name: 'Minh',
+      identify_tag: 'minh#1234',
+    },
+    locked: false,
+    ...overrides,
+  };
+}
+
+describe('ExpenseSummaryStrip', () => {
+  it('renders only server amounts, the viewer balance, surplus, and progress', async () => {
+    await render(
+      <ExpenseSummaryStrip
+        summary={{
+          total_amount: '100.00',
+          paid_amount: '75.00',
+          missing_amount: '25.00',
+          surplus_amount: '5.00',
+        }}
+        myBalance={{
+          balance: '-10.00',
+          surplus_held: '2.00',
+        }}
+        currencyCode="USD"
+      />,
+    );
+
+    expect(screen.getByText('Total expenses')).toBeTruthy();
+    expect(screen.getByText('$100.00')).toBeTruthy();
+    expect(screen.getByText('$75.00')).toBeTruthy();
+    expect(screen.getByText('$25.00')).toBeTruthy();
+    expect(screen.getByText('$5.00')).toBeTruthy();
+    expect(screen.getByText('You owe $10.00')).toBeTruthy();
+    expect(screen.getByText('$2.00')).toBeTruthy();
+    expect(
+      screen.getByLabelText('Collection progress 75 percent').props
+        .accessibilityValue,
+    ).toEqual({ min: 0, max: 100, now: 75 });
+  });
+
+  it('does not show a surplus note for a canonical zero string', async () => {
+    await render(
+      <ExpenseSummaryStrip
+        summary={{
+          total_amount: '0.00',
+          paid_amount: '0.00',
+          missing_amount: '0.00',
+          surplus_amount: '0.00',
+        }}
+        myBalance={{
+          balance: '-0.00',
+          surplus_held: '0.00',
+        }}
+        currencyCode="USD"
+      />,
+    );
+
+    expect(screen.getByText('Settled')).toBeTruthy();
+    expect(screen.queryByText(/in group surplus/)).toBeNull();
+    expect(
+      screen.getByLabelText('Collection progress 0 percent').props
+        .accessibilityValue,
+    ).toMatchObject({ now: 0 });
+  });
+});
+
+describe('MemberBalanceRow', () => {
+  it('uses the neutral Member fallback and never needs a raw user id', async () => {
+    await render(
+      <MemberBalanceRow
+        memberName={null}
+        balance="-18.50"
+        currencyCode="USD"
+      />,
+    );
+
+    expect(screen.getByText('Member')).toBeTruthy();
+    expect(screen.getByText('Owes $18.50')).toBeTruthy();
+    expect(screen.getByLabelText('Member, Owes $18.50')).toBeTruthy();
+  });
+
+  it('renders positive and settled directions without client-derived shares', async () => {
+    const rendered = await render(
+      <MemberBalanceRow
+        memberName="An"
+        identifyTag="an#1200"
+        balance="12.00"
+        currencyCode="USD"
+      />,
+    );
+
+    expect(screen.getByText('Is owed $12.00')).toBeTruthy();
+    await rendered.rerender(
+      <MemberBalanceRow
+        memberName="An"
+        identifyTag="an#1200"
+        balance="0.00"
+        currencyCode="USD"
+      />,
+    );
+    expect(screen.getByText('Settled')).toBeTruthy();
+  });
+});
+
+describe('ExpenseRow', () => {
+  it('renders status, collector, server amounts, and forwards the stable id', async () => {
+    const onPress = jest.fn();
+    await render(
+      <ExpenseRow expense={buildExpense()} onPress={onPress} />,
+    );
+
+    expect(screen.getByText('Beach house')).toBeTruthy();
+    expect(screen.getByText('Underfunded')).toBeTruthy();
+    expect(screen.getByText('Missing $50.00')).toBeTruthy();
+    expect(screen.getByText('$300.00')).toBeTruthy();
+    expect(screen.getByText('$250.00')).toBeTruthy();
+    expect(screen.getByText('Minh')).toBeTruthy();
+
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: 'Open expense Beach house, Underfunded, total $300.00, collected $250.00, collector Minh',
+      }),
+    );
+    expect(onPress).toHaveBeenCalledWith('expense-1');
+  });
+
+  it('shows locked/overfunded state and blocks disabled presses', async () => {
+    const onPress = jest.fn();
+    await render(
+      <ExpenseRow
+        expense={buildExpense({
+          status: 'OVERFUNDED',
+          surplus_amount: '12.00',
+          locked: true,
+        })}
+        disabled
+        onPress={onPress}
+      />,
+    );
+
+    expect(screen.getByText('Overfunded')).toBeTruthy();
+    expect(screen.getByText('Surplus $12.00')).toBeTruthy();
+    expect(
+      mockIonicons.mock.calls.some(
+        ([props]) =>
+          (props as { name?: string }).name ===
+          'lock-closed-outline',
+      ),
+    ).toBe(true);
+    const row = screen.getByRole('button', {
+      name: 'Open expense Beach house, Overfunded, locked, total $300.00, collected $250.00, collector Minh',
+    });
+    expect(row.props.accessibilityState).toEqual({ disabled: true });
+    await fireEvent.press(row);
+    expect(onPress).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/features/expenses/__tests__/ExpenseDetailScreen.test.tsx
+++ b/mobile/src/features/expenses/__tests__/ExpenseDetailScreen.test.tsx
@@ -1,0 +1,836 @@
+import type { ReactNode } from 'react';
+import { Alert, View } from 'react-native';
+
+let mockParams: Record<string, string | string[] | undefined> = {};
+const mockRouter = {
+  push: jest.fn(),
+  dismissTo: jest.fn(),
+};
+const mockUseExpenseDetail = jest.fn();
+const mockUseTripDetail = jest.fn();
+const mockUseExpenseCompositionCoordinator = jest.fn();
+const mockRefreshDetail = jest.fn();
+const mockInvalidateDetail = jest.fn();
+const mockRefreshTrip = jest.fn();
+const mockRefreshAll = jest.fn();
+const mockRequestReconcile = jest.fn();
+const mockIsScreenActive = jest.fn();
+const mockPublishExpenseEvent = jest.fn();
+
+function mockRenderStackScreen({
+  options,
+}: {
+  options: {
+    headerRight?: () => ReactNode;
+  };
+}) {
+  return <View>{options.headerRight?.()}</View>;
+}
+
+jest.mock('expo-router', () => ({
+  Stack: { Screen: mockRenderStackScreen },
+  useLocalSearchParams: () => mockParams,
+  useRouter: () => mockRouter,
+}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('../hooks/useExpenseDetail', () => ({
+  useExpenseDetail: (...args: unknown[]) => mockUseExpenseDetail(...args),
+}));
+jest.mock('@/features/trips/hooks/useTripDetail', () => ({
+  useTripDetail: (...args: unknown[]) => mockUseTripDetail(...args),
+}));
+jest.mock('../hooks/useExpenseCompositionCoordinator', () => ({
+  useExpenseCompositionCoordinator: (...args: unknown[]) =>
+    mockUseExpenseCompositionCoordinator(...args),
+}));
+jest.mock('../api', () => ({
+  deleteExpense: jest.fn(),
+  setContribution: jest.fn(),
+}));
+jest.mock('../expenseEvents', () => ({
+  publishExpenseEvent: (...args: unknown[]) =>
+    mockPublishExpenseEvent(...args),
+}));
+
+// eslint-disable-next-line import/first
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { AxiosError, AxiosHeaders } from 'axios';
+// eslint-disable-next-line import/first
+import { deleteExpense, setContribution } from '../api';
+// eslint-disable-next-line import/first
+import { ExpenseDetailScreen } from '../screens/ExpenseDetailScreen';
+// eslint-disable-next-line import/first
+import type {
+  ContributionResponse,
+  ExpenseDetailResponse,
+  ExpenseParticipant,
+} from '../types';
+// eslint-disable-next-line import/first
+import type { TripDetailResponse, TripStatus } from '@/features/trips/types';
+// eslint-disable-next-line import/first
+import type { ApiError } from '@/shared/api/errors';
+
+const mockDeleteExpense =
+  deleteExpense as jest.MockedFunction<typeof deleteExpense>;
+const mockSetContribution =
+  setContribution as jest.MockedFunction<typeof setContribution>;
+
+const TRIP_ID = '123e4567-e89b-12d3-a456-426614174000';
+const EXPENSE_ID = '2c1dfd8d-9c7f-43c7-9b99-71f6d1edda55';
+const PAYER_ID = '7191f7c4-16f0-4fc5-996f-3264a46e7761';
+const RECIPIENT_ID = '4f44f738-0f5c-4608-a0b8-fd4ca3ecacde';
+
+function participant(
+  overrides: Partial<ExpenseParticipant> = {},
+): ExpenseParticipant {
+  return {
+    user_id: PAYER_ID,
+    display_name: 'Minh',
+    identify_tag: 'minh#1234',
+    share_amount: '60.00',
+    contributed_amount: '60.00',
+    balance: '0.00',
+    surplus_held: '0.00',
+    ...overrides,
+  };
+}
+
+function expenseDetail(
+  overrides: Partial<ExpenseDetailResponse> = {},
+): ExpenseDetailResponse {
+  return {
+    id: EXPENSE_ID,
+    title: 'Hotel',
+    description: 'Two nights',
+    total_amount: '120.00',
+    paid_amount: '120.00',
+    missing_amount: '0.00',
+    surplus_amount: '0.00',
+    currency_code: 'USD',
+    status: 'FUNDED',
+    collector: {
+      id: PAYER_ID,
+      display_name: 'Minh',
+      identify_tag: 'minh#1234',
+    },
+    locked: false,
+    locked_at: null,
+    created_at: '2026-07-28T00:00:00Z',
+    permissions: {
+      can_manage_expenses: true,
+    },
+    participants: [
+      participant(),
+      participant({
+        user_id: RECIPIENT_ID,
+        display_name: 'Lan',
+        identify_tag: 'lan#5678',
+      }),
+    ],
+    ...overrides,
+  };
+}
+
+function tripDetail({
+  status = 'PLANNING',
+  membershipStatus = 'ACTIVE',
+}: {
+  status?: TripStatus;
+  membershipStatus?: TripDetailResponse['my_membership']['status'];
+} = {}): TripDetailResponse {
+  return {
+    trip: {
+      id: TRIP_ID,
+      name: 'Da Nang weekend',
+      destination: 'Da Nang, Vietnam',
+      destination_provider: '',
+      destination_provider_id: '',
+      destination_lat: null,
+      destination_lng: null,
+      destination_country_code: 'VN',
+      cover_image_url: '',
+      start_date: '2026-08-01',
+      end_date: '2026-08-03',
+      description: '',
+      status,
+      currency_code: 'USD',
+      timezone: 'Asia/Ho_Chi_Minh',
+      budget_estimate: null,
+      cancelled_at: null,
+      created_at: '2026-01-01T00:00:00Z',
+    },
+    my_membership: {
+      role: 'CAPTAIN',
+      status: membershipStatus,
+      joined_at: '2026-01-01T00:00:00Z',
+    },
+    members: [],
+  };
+}
+
+function detailHookState({
+  detail = expenseDetail(),
+  status = 'ready',
+  error = null,
+  refreshing = false,
+}: {
+  detail?: ExpenseDetailResponse | null;
+  status?: 'loading' | 'ready' | 'error';
+  error?: ApiError | null;
+  refreshing?: boolean;
+} = {}) {
+  return {
+    detail,
+    status,
+    error,
+    refreshing,
+    refresh: mockRefreshDetail,
+    invalidate: mockInvalidateDetail,
+  };
+}
+
+function tripHookState({
+  detail = tripDetail(),
+  status = 'ready',
+  error = null,
+  refreshing = false,
+}: {
+  detail?: TripDetailResponse | null;
+  status?: 'loading' | 'ready' | 'error';
+  error?: ApiError | null;
+  refreshing?: boolean;
+} = {}) {
+  return {
+    detail,
+    status,
+    error,
+    refreshing,
+    refresh: mockRefreshTrip,
+  };
+}
+
+function contributionResponse(
+  amount: string,
+  userId = PAYER_ID,
+): ContributionResponse {
+  return {
+    id: 'contribution-1',
+    user: {
+      id: userId,
+      display_name: userId === PAYER_ID ? 'Minh' : 'Lan',
+      identify_tag: userId === PAYER_ID ? 'minh#1234' : 'lan#5678',
+    },
+    amount,
+    updated_at: '2026-07-28T01:00:00Z',
+  };
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, {}, {
+    status,
+    statusText: '',
+    headers: {},
+    config,
+    data,
+  });
+}
+
+type AlertButton = {
+  text?: string;
+  onPress?: () => void;
+};
+
+let alertSpy: jest.SpyInstance;
+
+function alertAction(callIndex: number, text: string): () => void {
+  const buttons = alertSpy.mock.calls[callIndex]?.[2] as
+    | AlertButton[]
+    | undefined;
+  const action = buttons?.find((button) => button.text === text)?.onPress;
+  if (!action) {
+    throw new Error(`Expected alert action "${text}".`);
+  }
+  return action;
+}
+
+async function beginContributionEdit(name = 'Minh'): Promise<void> {
+  await fireEvent.press(
+    screen.getByRole('button', {
+      name: `Edit contribution for ${name}`,
+    }),
+  );
+}
+
+async function changeContribution(
+  value: string,
+  name = 'Minh',
+): Promise<void> {
+  await fireEvent.changeText(
+    screen.getByLabelText(`Contribution amount for ${name}`),
+    value,
+  );
+}
+
+async function saveContribution(name = 'Minh'): Promise<void> {
+  await fireEvent.press(
+    screen.getByRole('button', {
+      name: `Save contribution for ${name}`,
+    }),
+  );
+}
+
+describe('ExpenseDetailScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockParams = { tripId: TRIP_ID, expenseId: EXPENSE_ID };
+    mockRefreshDetail.mockResolvedValue(undefined);
+    mockRefreshTrip.mockResolvedValue(undefined);
+    mockRefreshAll.mockResolvedValue(undefined);
+    mockRequestReconcile.mockResolvedValue(undefined);
+    mockIsScreenActive.mockReturnValue(true);
+    mockUseExpenseDetail.mockReturnValue(detailHookState());
+    mockUseTripDetail.mockReturnValue(tripHookState());
+    mockUseExpenseCompositionCoordinator.mockReturnValue({
+      refreshAll: mockRefreshAll,
+      requestReconcile: mockRequestReconcile,
+      isScreenActive: mockIsScreenActive,
+      isActiveGeneration: jest.fn(() => true),
+      getGeneration: jest.fn(() => 1),
+    });
+    mockDeleteExpense.mockResolvedValue(undefined);
+    mockSetContribution.mockImplementation(
+      async (_tripId, _expenseId, userId, payload) =>
+        contributionResponse(payload.amount, userId),
+    );
+    mockPublishExpenseEvent.mockResolvedValue(undefined);
+    alertSpy = jest
+      .spyOn(Alert, 'alert')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
+  });
+
+  it('rejects invalid UUID route intent before hooks or APIs', async () => {
+    mockParams = { tripId: TRIP_ID, expenseId: ['not-a-uuid'] };
+    await render(<ExpenseDetailScreen />);
+
+    expect(screen.getByText('Expense unavailable')).toBeTruthy();
+    expect(mockUseExpenseDetail).not.toHaveBeenCalled();
+    expect(mockUseTripDetail).not.toHaveBeenCalled();
+    expect(mockUseExpenseCompositionCoordinator).not.toHaveBeenCalled();
+    expect(mockDeleteExpense).not.toHaveBeenCalled();
+    expect(mockSetContribution).not.toHaveBeenCalled();
+  });
+
+  it('canonicalizes uppercase composite UUIDs and mounts one coordinator', async () => {
+    mockParams = {
+      tripId: TRIP_ID.toUpperCase(),
+      expenseId: EXPENSE_ID.toUpperCase(),
+    };
+    await render(<ExpenseDetailScreen />);
+
+    expect(mockUseExpenseDetail).toHaveBeenCalledWith(
+      TRIP_ID,
+      EXPENSE_ID,
+      { autoReconcile: false },
+    );
+    expect(mockUseTripDetail).toHaveBeenCalledWith(TRIP_ID, {
+      autoReconcile: false,
+    });
+    expect(mockUseExpenseCompositionCoordinator).toHaveBeenCalledWith({
+      tripId: TRIP_ID,
+      refreshExpense: mockRefreshDetail,
+      refreshTrip: mockRefreshTrip,
+    });
+  });
+
+  it.each(['expense-first', 'trip-first'] as const)(
+    'waits for both authoritative sources before rendering (%s)',
+    async (order) => {
+      if (order === 'expense-first') {
+        mockUseExpenseDetail.mockReturnValue(detailHookState());
+        mockUseTripDetail.mockReturnValue(
+          tripHookState({ detail: null, status: 'loading' }),
+        );
+      } else {
+        mockUseExpenseDetail.mockReturnValue(
+          detailHookState({ detail: null, status: 'loading' }),
+        );
+        mockUseTripDetail.mockReturnValue(tripHookState());
+      }
+      const view = await render(<ExpenseDetailScreen />);
+
+      expect(screen.queryByText('Participants (2)')).toBeNull();
+
+      mockUseExpenseDetail.mockReturnValue(detailHookState());
+      mockUseTripDetail.mockReturnValue(tripHookState());
+      await view.rerender(<ExpenseDetailScreen />);
+
+      expect(screen.getByText('Participants (2)')).toBeTruthy();
+      expect(
+        screen.getByLabelText('Contribution for Minh'),
+      ).toBeTruthy();
+    },
+  );
+
+  it.each([
+    {
+      name: 'expense permission denial',
+      nextDetail: expenseDetail({
+        permissions: { can_manage_expenses: false },
+      }),
+      nextTrip: tripDetail(),
+    },
+    {
+      name: 'inactive membership',
+      nextDetail: expenseDetail(),
+      nextTrip: tripDetail({ membershipStatus: 'REMOVED' }),
+    },
+    {
+      name: 'terminal trip',
+      nextDetail: expenseDetail(),
+      nextTrip: tripDetail({ status: 'COMPLETED' }),
+    },
+    {
+      name: 'locked expense',
+      nextDetail: expenseDetail({
+        locked: true,
+        locked_at: '2026-07-28T02:00:00Z',
+      }),
+      nextTrip: tripDetail(),
+    },
+  ])('applies deny-wins controls for $name', async ({
+    nextDetail,
+    nextTrip,
+  }) => {
+    mockUseExpenseDetail.mockReturnValue(
+      detailHookState({ detail: nextDetail }),
+    );
+    mockUseTripDetail.mockReturnValue(
+      tripHookState({ detail: nextTrip }),
+    );
+    await render(<ExpenseDetailScreen />);
+
+    expect(screen.queryByRole('button', { name: 'Edit expense' })).toBeNull();
+    expect(
+      screen.queryByRole('button', { name: 'Delete expense' }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole('button', {
+        name: 'Edit contribution for Minh',
+      }),
+    ).toBeNull();
+    expect(screen.getAllByText('View only').length).toBeGreaterThan(0);
+  });
+
+  it('shows the authoritative locked timestamp in the settlement notice', async () => {
+    mockUseExpenseDetail.mockReturnValue(
+      detailHookState({
+        detail: expenseDetail({
+          locked: true,
+          locked_at: '2026-07-28T02:00:00Z',
+        }),
+      }),
+    );
+    await render(<ExpenseDetailScreen />);
+
+    expect(
+      screen.getByText(
+        /Settlement is finalized \(locked on .+\)\. Reopen it before editing expenses or contributions\./,
+      ),
+    ).toBeTruthy();
+  });
+
+  it('renders participants through the virtualized list with stable data', async () => {
+    const participants = Array.from({ length: 30 }, (_, index) =>
+      participant({
+        user_id: `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`,
+        display_name: `Member ${index}`,
+        identify_tag: null,
+      }),
+    );
+    mockUseExpenseDetail.mockReturnValue(
+      detailHookState({
+        detail: expenseDetail({ participants }),
+      }),
+    );
+    const rendered = await render(<ExpenseDetailScreen />);
+
+    expect(screen.getByText('Participants (30)')).toBeTruthy();
+    const virtualizedDataOwner = rendered.container.queryAll(
+      (instance) =>
+        Array.isArray(instance.props.data) &&
+        instance.props.data.length === participants.length,
+    )[0];
+    expect(virtualizedDataOwner?.props.data).toBe(participants);
+    expect(
+      virtualizedDataOwner?.props.keyboardShouldPersistTaps,
+    ).toBe('handled');
+  });
+
+  it('preserves an id-keyed contribution draft across authority refresh', async () => {
+    const rendered = await render(<ExpenseDetailScreen />);
+    await beginContributionEdit();
+    await changeContribution('199.00');
+
+    mockUseExpenseDetail.mockReturnValue(
+      detailHookState({
+        detail: expenseDetail({
+          permissions: { can_manage_expenses: false },
+          participants: [
+            participant({ contributed_amount: '80.00' }),
+            participant({
+              user_id: RECIPIENT_ID,
+              display_name: 'Lan',
+              identify_tag: 'lan#5678',
+            }),
+          ],
+        }),
+      }),
+    );
+    await rendered.rerender(<ExpenseDetailScreen />);
+
+    expect(
+      screen.queryByLabelText('Contribution amount for Minh'),
+    ).toBeNull();
+    mockUseExpenseDetail.mockReturnValue(
+      detailHookState({
+        detail: expenseDetail({
+          participants: [
+            participant({ contributed_amount: '80.00' }),
+            participant({
+              user_id: RECIPIENT_ID,
+              display_name: 'Lan',
+              identify_tag: 'lan#5678',
+            }),
+          ],
+        }),
+      }),
+    );
+    await rendered.rerender(<ExpenseDetailScreen />);
+
+    expect(
+      screen.getByLabelText('Contribution amount for Minh').props.value,
+    ).toBe('199.00');
+    expect(
+      screen.getByRole('button', {
+        name: 'Save contribution for Minh',
+      }),
+    ).toBeTruthy();
+  });
+
+  it('hydrates a row from refreshed authority before editing begins', async () => {
+    const rendered = await render(<ExpenseDetailScreen />);
+
+    mockUseExpenseDetail.mockReturnValue(
+      detailHookState({
+        detail: expenseDetail({
+          participants: [
+            participant({ contributed_amount: '80.00' }),
+            participant({
+              user_id: RECIPIENT_ID,
+              display_name: 'Lan',
+              identify_tag: 'lan#5678',
+            }),
+          ],
+        }),
+      }),
+    );
+    await rendered.rerender(<ExpenseDetailScreen />);
+    await beginContributionEdit();
+
+    expect(
+      screen.getByLabelText('Contribution amount for Minh').props.value,
+    ).toBe('80.00');
+  });
+
+  it('rejects invalid contribution strings locally', async () => {
+    await render(<ExpenseDetailScreen />);
+    await beginContributionEdit();
+    await changeContribution('-1.00');
+    await saveContribution();
+
+    expect(mockSetContribution).not.toHaveBeenCalled();
+    expect(
+      screen.getByText('Enter a valid non-negative amount.'),
+    ).toBeTruthy();
+  });
+
+  it.each(['0.00', '200.00'])(
+    'submits canonical zero/overfunding contribution %s',
+    async (amount) => {
+      await render(<ExpenseDetailScreen />);
+      await beginContributionEdit();
+      await changeContribution(amount);
+      await saveContribution();
+
+      await waitFor(() =>
+        expect(mockSetContribution).toHaveBeenCalledWith(
+          TRIP_ID,
+          EXPENSE_ID,
+          PAYER_ID,
+          { amount },
+        ),
+      );
+      expect(mockInvalidateDetail).toHaveBeenCalledTimes(1);
+      expect(mockPublishExpenseEvent).toHaveBeenCalledWith({
+        type: 'expensesChanged',
+        tripId: TRIP_ID,
+      });
+    },
+  );
+
+  it('locks duplicate contribution submits by participant id', async () => {
+    const pending = deferred<ContributionResponse>();
+    mockSetContribution.mockReturnValue(pending.promise);
+    await render(<ExpenseDetailScreen />);
+    await beginContributionEdit();
+    await changeContribution('80.00');
+
+    const save = screen.getByRole('button', {
+      name: 'Save contribution for Minh',
+    });
+    await fireEvent.press(save);
+    await fireEvent.press(save);
+    expect(mockSetContribution).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      pending.resolve(contributionResponse('80.00'));
+    });
+    await waitFor(() =>
+      expect(mockPublishExpenseEvent).toHaveBeenCalledTimes(1),
+    );
+  });
+
+  it('cleans a completed contribution lock while the mounted screen is blurred', async () => {
+    const pending = deferred<ContributionResponse>();
+    mockSetContribution.mockReturnValueOnce(pending.promise);
+    const rendered = await render(<ExpenseDetailScreen />);
+    await beginContributionEdit();
+    await changeContribution('80.00');
+    await saveContribution();
+
+    mockIsScreenActive.mockReturnValue(false);
+    await act(async () => {
+      pending.resolve(contributionResponse('80.00'));
+      await pending.promise;
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', {
+          name: 'Save contribution for Minh',
+        }),
+      ).toBeNull();
+      expect(
+        screen.getByRole('button', {
+          name: 'Edit contribution for Minh',
+        }).props.accessibilityState,
+      ).toMatchObject({ disabled: false });
+    });
+
+    mockUseExpenseDetail.mockReturnValue(
+      detailHookState({
+        detail: expenseDetail({
+          participants: [
+            participant({ contributed_amount: '80.00' }),
+            participant({
+              user_id: RECIPIENT_ID,
+              display_name: 'Lan',
+              identify_tag: 'lan#5678',
+            }),
+          ],
+        }),
+      }),
+    );
+    mockIsScreenActive.mockReturnValue(true);
+    await rendered.rerender(<ExpenseDetailScreen />);
+    await beginContributionEdit();
+    expect(
+      screen.getByLabelText('Contribution amount for Minh').props.value,
+    ).toBe('80.00');
+  });
+
+  it('surfaces a contribution 409 per row and publishes reconciliation', async () => {
+    mockSetContribution.mockRejectedValueOnce(
+      axiosErrorWith(409, {
+        detail: 'Settlement is finalized.',
+        error_code: 'EXPENSE_LOCKED',
+      }),
+    );
+    await render(<ExpenseDetailScreen />);
+    await beginContributionEdit();
+    await changeContribution('80.00');
+    await saveContribution();
+
+    await waitFor(() =>
+      expect(screen.getByText('Settlement is finalized.')).toBeTruthy(),
+    );
+    expect(mockPublishExpenseEvent).toHaveBeenCalledWith({
+      type: 'expensesChanged',
+      tripId: TRIP_ID,
+    });
+  });
+
+  it('preserves complete detail through background failure and retries silently', async () => {
+    mockUseExpenseDetail.mockReturnValue(
+      detailHookState({
+        error: {
+          kind: 'message',
+          message: 'Expense refresh failed.',
+          status: 500,
+        },
+      }),
+    );
+    await render(<ExpenseDetailScreen />);
+
+    expect(screen.getByText('Hotel')).toBeTruthy();
+    expect(screen.getByText('Expense refresh failed.')).toBeTruthy();
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: 'Retry refreshing expense detail',
+      }),
+    );
+    expect(mockRequestReconcile).toHaveBeenCalledWith();
+  });
+
+  it('uses explicit mode for participant-list pull refresh', async () => {
+    const rendered = await render(<ExpenseDetailScreen />);
+    const refreshControl = rendered.container.queryAll(
+      (instance) => instance.type === 'RCTRefreshControl',
+    )[0];
+    if (!refreshControl) {
+      throw new Error('Expected Expense Detail RefreshControl.');
+    }
+    await fireEvent(refreshControl, 'refresh');
+    expect(mockRefreshAll).toHaveBeenCalledWith('refresh');
+  });
+
+  it('navigates to the exact edit form target', async () => {
+    await render(<ExpenseDetailScreen />);
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Edit expense' }),
+    );
+
+    expect(mockRouter.push).toHaveBeenCalledWith(
+      `/trips/${TRIP_ID}/expenses/expense-form?mode=edit&expenseId=${EXPENSE_ID}`,
+    );
+  });
+
+  it('locks duplicate delete confirmation, publishes, and dismisses to dashboard', async () => {
+    const pending = deferred<void>();
+    mockDeleteExpense.mockReturnValue(pending.promise);
+    await render(<ExpenseDetailScreen />);
+
+    const deleteButton = screen.getByRole('button', {
+      name: 'Delete expense',
+    });
+    await fireEvent.press(deleteButton);
+    await fireEvent.press(deleteButton);
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      alertAction(0, 'Delete')();
+    });
+    expect(mockInvalidateDetail).toHaveBeenCalledTimes(1);
+    expect(mockDeleteExpense).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      pending.resolve();
+    });
+    await waitFor(() =>
+      expect(mockRouter.dismissTo).toHaveBeenCalledWith(
+        `/trips/${TRIP_ID}/expenses`,
+      ),
+    );
+    expect(mockPublishExpenseEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('converges EXPENSE_NOT_FOUND delete as already deleted', async () => {
+    mockDeleteExpense.mockRejectedValueOnce(
+      axiosErrorWith(404, {
+        detail: 'Expense not found.',
+        error_code: 'EXPENSE_NOT_FOUND',
+      }),
+    );
+    await render(<ExpenseDetailScreen />);
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Delete expense' }),
+    );
+    await act(async () => {
+      alertAction(0, 'Delete')();
+    });
+
+    await waitFor(() =>
+      expect(mockRouter.dismissTo).toHaveBeenCalledWith(
+        `/trips/${TRIP_ID}/expenses`,
+      ),
+    );
+    expect(mockPublishExpenseEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces delete conflicts, reconciles, and does not navigate', async () => {
+    mockDeleteExpense.mockRejectedValueOnce(
+      axiosErrorWith(409, {
+        detail: 'Settlement is finalized.',
+        error_code: 'EXPENSE_LOCKED',
+      }),
+    );
+    await render(<ExpenseDetailScreen />);
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Delete expense' }),
+    );
+    await act(async () => {
+      alertAction(0, 'Delete')();
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText('Settlement is finalized.')).toBeTruthy(),
+    );
+    expect(mockPublishExpenseEvent).toHaveBeenCalledTimes(1);
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+  });
+
+  it('publishes late delete success without navigating an inactive screen', async () => {
+    const pending = deferred<void>();
+    mockDeleteExpense.mockReturnValue(pending.promise);
+    await render(<ExpenseDetailScreen />);
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Delete expense' }),
+    );
+    await act(async () => {
+      alertAction(0, 'Delete')();
+    });
+    mockIsScreenActive.mockReturnValue(false);
+
+    await act(async () => {
+      pending.resolve();
+    });
+
+    await waitFor(() =>
+      expect(mockPublishExpenseEvent).toHaveBeenCalledTimes(1),
+    );
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/features/expenses/__tests__/ExpenseFormScreen.test.tsx
+++ b/mobile/src/features/expenses/__tests__/ExpenseFormScreen.test.tsx
@@ -1,0 +1,1079 @@
+import type { ComponentProps, ReactNode } from 'react';
+import { View } from 'react-native';
+import type { ExpenseForm } from '../components/ExpenseForm';
+
+let mockParams: Record<string, string | string[] | undefined> = {};
+const mockRouter = {
+  dismissTo: jest.fn(),
+};
+const mockUseFocusEffect = jest.fn();
+const mockUseAppForegroundEffect = jest.fn();
+const mockUseExpenseDashboard = jest.fn();
+const mockUseExpenseDetail = jest.fn();
+const mockUseTripDetail = jest.fn();
+const mockRefreshDashboard = jest.fn();
+const mockInvalidateDashboard = jest.fn();
+const mockRefreshDetail = jest.fn();
+const mockInvalidateDetail = jest.fn();
+const mockRefreshTrip = jest.fn();
+const mockPublishExpenseEvent = jest.fn();
+const mockSubscribeToExpenseEvents = jest.fn();
+const mockSubscribeToTripEvents = jest.fn();
+let mockExpenseFormProps: unknown;
+let mockExpenseListener:
+  | ((event: {
+      type: 'expensesChanged';
+      tripId: string;
+    }) => void | Promise<void>)
+  | undefined;
+let mockTripListener:
+  | ((event: {
+      type: 'statusChanged';
+      tripId: string;
+      status: 'PLANNING' | 'ONGOING' | 'COMPLETED' | 'CANCELLED';
+    }) => void)
+  | undefined;
+let mockLatestStackOptions:
+  | {
+      gestureEnabled?: boolean;
+      headerLeft?: () => ReactNode;
+    }
+  | undefined;
+
+function mockRenderStackScreen({
+  options,
+}: {
+  options: {
+    gestureEnabled?: boolean;
+    headerLeft?: () => ReactNode;
+  };
+}) {
+  mockLatestStackOptions = options;
+  return <View>{options.headerLeft?.()}</View>;
+}
+
+function mockRenderExpenseForm(props: unknown) {
+  mockExpenseFormProps = props;
+  return <View testID="mock-expense-form" />;
+}
+
+jest.mock('expo-router', () => ({
+  Stack: { Screen: mockRenderStackScreen },
+  useFocusEffect: (effect: () => (() => void) | void) =>
+    mockUseFocusEffect(effect),
+  useLocalSearchParams: () => mockParams,
+  useRouter: () => mockRouter,
+}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('@/shared/hooks/useAppForegroundEffect', () => ({
+  useAppForegroundEffect: (listener: () => void) =>
+    mockUseAppForegroundEffect(listener),
+}));
+jest.mock('../hooks/useExpenseDashboard', () => ({
+  useExpenseDashboard: (...args: unknown[]) =>
+    mockUseExpenseDashboard(...args),
+}));
+jest.mock('../hooks/useExpenseDetail', () => ({
+  useExpenseDetail: (...args: unknown[]) => mockUseExpenseDetail(...args),
+}));
+jest.mock('@/features/trips/hooks/useTripDetail', () => ({
+  useTripDetail: (...args: unknown[]) => mockUseTripDetail(...args),
+}));
+jest.mock('../components/ExpenseForm', () => ({
+  ExpenseForm: mockRenderExpenseForm,
+}));
+jest.mock('../api', () => ({
+  createExpense: jest.fn(),
+  updateExpense: jest.fn(),
+}));
+jest.mock('../expenseEvents', () => ({
+  publishExpenseEvent: (...args: unknown[]) =>
+    mockPublishExpenseEvent(...args),
+  subscribeToExpenseEvents: (...args: unknown[]) =>
+    mockSubscribeToExpenseEvents(...args),
+}));
+jest.mock('@/features/trips/tripEvents', () => ({
+  subscribeToTripEvents: (...args: unknown[]) =>
+    mockSubscribeToTripEvents(...args),
+}));
+
+// eslint-disable-next-line import/first
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { AxiosError, AxiosHeaders } from 'axios';
+// eslint-disable-next-line import/first
+import { createExpense, updateExpense } from '../api';
+// eslint-disable-next-line import/first
+import { ExpenseFormScreen } from '../screens/ExpenseFormScreen';
+// eslint-disable-next-line import/first
+import type {
+  ExpenseDashboardResponse,
+  ExpenseDetailResponse,
+  ExpenseParticipant,
+  ExpenseResponse,
+} from '../types';
+// eslint-disable-next-line import/first
+import type { TripDetailResponse, TripMember, TripStatus } from '@/features/trips/types';
+
+const mockCreateExpense =
+  createExpense as jest.MockedFunction<typeof createExpense>;
+const mockUpdateExpense =
+  updateExpense as jest.MockedFunction<typeof updateExpense>;
+
+const TRIP_ID = '123e4567-e89b-12d3-a456-426614174000';
+const EXPENSE_ID = '2c1dfd8d-9c7f-43c7-9b99-71f6d1edda55';
+const OTHER_EXPENSE_ID = 'a11957b3-3329-4fcf-9c7b-673a51c1d8a7';
+const CAPTAIN_ID = '7191f7c4-16f0-4fc5-996f-3264a46e7761';
+const MEMBER_ID = '4f44f738-0f5c-4608-a0b8-fd4ca3ecacde';
+const LATE_MEMBER_ID = '6a40735b-a4e3-41de-a153-f5ef23c49733';
+const DEPARTED_ID = 'fa65ed4a-f9c1-4601-9e92-c89e10e7eed1';
+
+function member(
+  id: string,
+  displayName: string,
+  role: TripMember['role'] = 'MEMBER',
+): TripMember {
+  return {
+    membership_id: `membership-${id}`,
+    user: {
+      id,
+      display_name: displayName,
+      identify_tag: `${displayName.toLowerCase()}#1234`,
+      avatar_url: null,
+    },
+    role,
+    joined_at: '2026-01-01T00:00:00Z',
+  };
+}
+
+function participant(
+  userId: string,
+  displayName: string,
+): ExpenseParticipant {
+  return {
+    user_id: userId,
+    display_name: displayName,
+    identify_tag: `${displayName.toLowerCase()}#1234`,
+    share_amount: '60.00',
+    contributed_amount: '60.00',
+    balance: '0.00',
+    surplus_held: '0.00',
+  };
+}
+
+function dashboard(
+  overrides: Partial<ExpenseDashboardResponse> = {},
+): ExpenseDashboardResponse {
+  return {
+    currency_code: 'USD',
+    summary: {
+      total_amount: '0.00',
+      paid_amount: '0.00',
+      missing_amount: '0.00',
+      surplus_amount: '0.00',
+    },
+    permissions: {
+      can_manage_expenses: true,
+    },
+    my_balance: {
+      balance: '0.00',
+      surplus_held: '0.00',
+    },
+    member_balances: {},
+    settlement: null,
+    expenses: [],
+    ...overrides,
+  };
+}
+
+function expenseDetail(
+  overrides: Partial<ExpenseDetailResponse> = {},
+): ExpenseDetailResponse {
+  return {
+    id: EXPENSE_ID,
+    title: 'Hotel',
+    description: 'Two nights',
+    total_amount: '120.00',
+    paid_amount: '120.00',
+    missing_amount: '0.00',
+    surplus_amount: '0.00',
+    currency_code: 'USD',
+    status: 'FUNDED',
+    collector: {
+      id: CAPTAIN_ID,
+      display_name: 'Minh',
+      identify_tag: 'minh#1234',
+    },
+    locked: false,
+    locked_at: null,
+    created_at: '2026-07-28T00:00:00Z',
+    permissions: {
+      can_manage_expenses: true,
+    },
+    participants: [
+      participant(CAPTAIN_ID, 'Minh'),
+      participant(MEMBER_ID, 'Lan'),
+    ],
+    ...overrides,
+  };
+}
+
+function tripDetail({
+  status = 'PLANNING',
+  membershipStatus = 'ACTIVE',
+  currencyCode = 'USD',
+  members = [
+    member(CAPTAIN_ID, 'Minh', 'CAPTAIN'),
+    member(MEMBER_ID, 'Lan'),
+    member(LATE_MEMBER_ID, 'New member'),
+  ],
+}: {
+  status?: TripStatus;
+  membershipStatus?: TripDetailResponse['my_membership']['status'];
+  currencyCode?: string;
+  members?: TripMember[];
+} = {}): TripDetailResponse {
+  return {
+    trip: {
+      id: TRIP_ID,
+      name: 'Da Nang weekend',
+      destination: 'Da Nang, Vietnam',
+      destination_provider: '',
+      destination_provider_id: '',
+      destination_lat: null,
+      destination_lng: null,
+      destination_country_code: 'VN',
+      cover_image_url: '',
+      start_date: '2026-08-01',
+      end_date: '2026-08-03',
+      description: '',
+      status,
+      currency_code: currencyCode,
+      timezone: 'Asia/Ho_Chi_Minh',
+      budget_estimate: null,
+      cancelled_at: null,
+      created_at: '2026-01-01T00:00:00Z',
+    },
+    my_membership: {
+      role: 'CAPTAIN',
+      status: membershipStatus,
+      joined_at: '2026-01-01T00:00:00Z',
+    },
+    members,
+  };
+}
+
+function dashboardHookState(
+  nextDashboard: ExpenseDashboardResponse | null = dashboard(),
+) {
+  return {
+    dashboard: nextDashboard,
+    status: nextDashboard ? ('ready' as const) : ('loading' as const),
+    error: null,
+    refreshing: false,
+    refresh: mockRefreshDashboard,
+    invalidate: mockInvalidateDashboard,
+  };
+}
+
+function detailHookState(
+  detail: ExpenseDetailResponse | null = expenseDetail(),
+) {
+  return {
+    detail,
+    status: detail ? ('ready' as const) : ('loading' as const),
+    error: null,
+    refreshing: false,
+    refresh: mockRefreshDetail,
+    invalidate: mockInvalidateDetail,
+  };
+}
+
+function tripHookState(detail: TripDetailResponse | null = tripDetail()) {
+  return {
+    detail,
+    status: detail ? ('ready' as const) : ('loading' as const),
+    error: null,
+    refreshing: false,
+    refresh: mockRefreshTrip,
+  };
+}
+
+function expenseResponse(
+  overrides: Partial<ExpenseResponse> = {},
+): ExpenseResponse {
+  return {
+    id: EXPENSE_ID,
+    title: 'Hotel',
+    description: 'Two nights',
+    total_amount: '120.00',
+    currency_code: 'USD',
+    locked_at: null,
+    created_at: '2026-07-28T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, {}, {
+    status,
+    statusText: '',
+    headers: {},
+    config,
+    data,
+  });
+}
+
+function currentFormProps(): ComponentProps<typeof ExpenseForm> {
+  if (!mockExpenseFormProps) {
+    throw new Error('Expected ExpenseForm to render.');
+  }
+  return mockExpenseFormProps as ComponentProps<typeof ExpenseForm>;
+}
+
+function latestFocusCallback(): () => (() => void) | void {
+  const callback = mockUseFocusEffect.mock.calls.at(-1)?.[0] as
+    | (() => (() => void) | void)
+    | undefined;
+  if (!callback) {
+    throw new Error('Expected useFocusEffect to register a callback.');
+  }
+  return callback;
+}
+
+function latestForegroundCallback(): () => void {
+  const callback = mockUseAppForegroundEffect.mock.calls.at(-1)?.[0] as
+    | (() => void)
+    | undefined;
+  if (!callback) {
+    throw new Error(
+      'Expected useAppForegroundEffect to register a callback.',
+    );
+  }
+  return callback;
+}
+
+async function focusScreen(): Promise<(() => void) | undefined> {
+  let cleanup: (() => void) | undefined;
+  await act(async () => {
+    cleanup = latestFocusCallback()() || undefined;
+  });
+  return cleanup;
+}
+
+async function changeDraft(
+  changes: Parameters<ComponentProps<typeof ExpenseForm>['onChange']>[0],
+): Promise<void> {
+  await act(async () => {
+    currentFormProps().onChange(changes);
+  });
+}
+
+describe('ExpenseFormScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockParams = {
+      tripId: TRIP_ID,
+      mode: 'edit',
+      expenseId: EXPENSE_ID,
+    };
+    mockExpenseFormProps = undefined;
+    mockExpenseListener = undefined;
+    mockTripListener = undefined;
+    mockLatestStackOptions = undefined;
+    mockRefreshDashboard.mockResolvedValue(undefined);
+    mockRefreshDetail.mockResolvedValue(undefined);
+    mockRefreshTrip.mockResolvedValue(undefined);
+    mockUseExpenseDashboard.mockReturnValue(dashboardHookState());
+    mockUseExpenseDetail.mockReturnValue(detailHookState());
+    mockUseTripDetail.mockReturnValue(tripHookState());
+    mockCreateExpense.mockResolvedValue(expenseResponse());
+    mockUpdateExpense.mockResolvedValue(expenseDetail());
+    mockSubscribeToExpenseEvents.mockImplementation(
+      (
+        _tripId: string,
+        listener: (
+          event: {
+            type: 'expensesChanged';
+            tripId: string;
+          },
+        ) => void | Promise<void>,
+      ) => {
+        mockExpenseListener = listener;
+        return () => {
+          if (mockExpenseListener === listener) {
+            mockExpenseListener = undefined;
+          }
+        };
+      },
+    );
+    mockPublishExpenseEvent.mockImplementation(
+      async (event: { type: 'expensesChanged'; tripId: string }) => {
+        await mockExpenseListener?.(event);
+      },
+    );
+    mockSubscribeToTripEvents.mockImplementation(
+      (
+        listener: (event: {
+          type: 'statusChanged';
+          tripId: string;
+          status: 'PLANNING' | 'ONGOING' | 'COMPLETED' | 'CANCELLED';
+        }) => void,
+      ) => {
+        mockTripListener = listener;
+        return () => {
+          if (mockTripListener === listener) {
+            mockTripListener = undefined;
+          }
+        };
+      },
+    );
+  });
+
+  it('rejects contradictory or malformed route intent before mounting hooks', async () => {
+    mockParams = {
+      tripId: TRIP_ID,
+      mode: 'create',
+      expenseId: EXPENSE_ID,
+    };
+    await render(<ExpenseFormScreen />);
+
+    expect(screen.getByText('Form unavailable')).toBeTruthy();
+    expect(mockUseExpenseDashboard).not.toHaveBeenCalled();
+    expect(mockUseExpenseDetail).not.toHaveBeenCalled();
+    expect(mockUseTripDetail).not.toHaveBeenCalled();
+    expect(mockCreateExpense).not.toHaveBeenCalled();
+    expect(mockUpdateExpense).not.toHaveBeenCalled();
+  });
+
+  it.each(['create', 'edit'] as const)(
+    'canonicalizes uppercase UUID keys and disables standalone reconciliation in %s mode',
+    async (mode) => {
+      mockParams =
+        mode === 'create'
+          ? {
+              tripId: TRIP_ID.toUpperCase(),
+              mode,
+            }
+          : {
+              tripId: TRIP_ID.toUpperCase(),
+              mode,
+              expenseId: EXPENSE_ID.toUpperCase(),
+            };
+      await render(<ExpenseFormScreen />);
+
+      expect(mockUseExpenseDashboard).toHaveBeenCalledWith(
+        mode === 'create' ? TRIP_ID : undefined,
+        { autoReconcile: false },
+      );
+      expect(mockUseExpenseDetail).toHaveBeenCalledWith(
+        mode === 'edit' ? TRIP_ID : undefined,
+        mode === 'edit' ? EXPENSE_ID : undefined,
+        { autoReconcile: false },
+      );
+      expect(mockUseTripDetail).toHaveBeenCalledWith(TRIP_ID, {
+        autoReconcile: false,
+      });
+    },
+  );
+
+  it.each([
+    ['create', 'expense-first'],
+    ['create', 'trip-first'],
+    ['edit', 'expense-first'],
+    ['edit', 'trip-first'],
+  ] as const)(
+    'waits for both mandatory sources in %s mode (%s)',
+    async (mode, order) => {
+      mockParams =
+        mode === 'create'
+          ? { tripId: TRIP_ID, mode }
+          : { tripId: TRIP_ID, mode, expenseId: EXPENSE_ID };
+      if (mode === 'create') {
+        mockUseExpenseDashboard.mockReturnValue(
+          dashboardHookState(
+            order === 'expense-first' ? dashboard() : null,
+          ),
+        );
+      } else {
+        mockUseExpenseDetail.mockReturnValue(
+          detailHookState(
+            order === 'expense-first' ? expenseDetail() : null,
+          ),
+        );
+      }
+      mockUseTripDetail.mockReturnValue(
+        tripHookState(order === 'trip-first' ? tripDetail() : null),
+      );
+      const rendered = await render(<ExpenseFormScreen />);
+
+      expect(screen.queryByTestId('mock-expense-form')).toBeNull();
+
+      mockUseExpenseDashboard.mockReturnValue(dashboardHookState());
+      mockUseExpenseDetail.mockReturnValue(detailHookState());
+      mockUseTripDetail.mockReturnValue(tripHookState());
+      await rendered.rerender(<ExpenseFormScreen />);
+
+      expect(screen.getByTestId('mock-expense-form')).toBeTruthy();
+      expect(currentFormProps().mode).toBe(mode);
+    },
+  );
+
+  it('hydrates edit once, preserves touched and untouched values, then rehydrates for a new identity', async () => {
+    const rendered = await render(<ExpenseFormScreen />);
+    expect(currentFormProps().draft).toMatchObject({
+      title: 'Hotel',
+      description: 'Two nights',
+      total_amount: '120.00',
+      collector_id: CAPTAIN_ID,
+    });
+    await changeDraft({ title: 'My draft' });
+
+    mockUseExpenseDetail.mockReturnValue(
+      detailHookState(
+        expenseDetail({
+          title: 'Server title',
+          description: 'Server changed description',
+        }),
+      ),
+    );
+    mockUseTripDetail.mockReturnValue(
+      tripHookState(tripDetail({ status: 'ONGOING' })),
+    );
+    await rendered.rerender(<ExpenseFormScreen />);
+
+    expect(currentFormProps().draft).toMatchObject({
+      title: 'My draft',
+      description: 'Two nights',
+      total_amount: '120.00',
+      collector_id: CAPTAIN_ID,
+    });
+
+    mockParams = {
+      tripId: TRIP_ID,
+      mode: 'edit',
+      expenseId: OTHER_EXPENSE_ID,
+    };
+    mockUseExpenseDetail.mockReturnValue(
+      detailHookState(
+        expenseDetail({
+          id: OTHER_EXPENSE_ID,
+          title: 'Dinner',
+          description: 'New identity',
+        }),
+      ),
+    );
+    await rendered.rerender(<ExpenseFormScreen />);
+
+    expect(currentFormProps().draft).toMatchObject({
+      title: 'Dinner',
+      description: 'New identity',
+    });
+  });
+
+  it('preserves the draft while deny-wins authority disables submission', async () => {
+    const rendered = await render(<ExpenseFormScreen />);
+    await changeDraft({ title: 'Preserved title' });
+    mockUseTripDetail.mockReturnValue(
+      tripHookState(tripDetail({ membershipStatus: 'REMOVED' })),
+    );
+    await rendered.rerender(<ExpenseFormScreen />);
+
+    expect(currentFormProps().draft.title).toBe('Preserved title');
+    expect(currentFormProps().canSubmit).toBe(false);
+    expect(currentFormProps().authorityMessage).toBe(
+      'You are no longer an active member of this trip.',
+    );
+
+    mockUseTripDetail.mockReturnValue(tripHookState());
+    await rendered.rerender(<ExpenseFormScreen />);
+    expect(currentFormProps().draft.title).toBe('Preserved title');
+    expect(currentFormProps().canSubmit).toBe(true);
+  });
+
+  it.each([
+    {
+      name: 'create permission revoked',
+      mode: 'create' as const,
+      nextDashboard: dashboard({
+        permissions: { can_manage_expenses: false },
+      }),
+      nextDetail: expenseDetail(),
+      nextTrip: tripDetail(),
+      message: 'Only the trip captain can add expenses.',
+    },
+    {
+      name: 'create currency mismatch',
+      mode: 'create' as const,
+      nextDashboard: dashboard(),
+      nextDetail: expenseDetail(),
+      nextTrip: tripDetail({ currencyCode: 'VND' }),
+      message: 'Expense currency changed. Refresh before continuing.',
+    },
+    {
+      name: 'edit locked remotely',
+      mode: 'edit' as const,
+      nextDashboard: dashboard(),
+      nextDetail: expenseDetail({
+        locked: true,
+        locked_at: '2026-07-28T02:00:00Z',
+      }),
+      nextTrip: tripDetail(),
+      message:
+        'Settlement is finalized. Reopen it before editing expenses.',
+    },
+    {
+      name: 'terminal lifecycle',
+      mode: 'edit' as const,
+      nextDashboard: dashboard(),
+      nextDetail: expenseDetail(),
+      nextTrip: tripDetail({ status: 'CANCELLED' }),
+      message: 'Completed or cancelled trips cannot change expenses.',
+    },
+  ])('applies form deny-wins for $name', async ({
+    mode,
+    nextDashboard,
+    nextDetail,
+    nextTrip,
+    message,
+  }) => {
+    mockParams =
+      mode === 'create'
+        ? { tripId: TRIP_ID, mode }
+        : {
+            tripId: TRIP_ID,
+            mode,
+            expenseId: EXPENSE_ID,
+          };
+    mockUseExpenseDashboard.mockReturnValue(
+      dashboardHookState(nextDashboard),
+    );
+    mockUseExpenseDetail.mockReturnValue(detailHookState(nextDetail));
+    mockUseTripDetail.mockReturnValue(tripHookState(nextTrip));
+    await render(<ExpenseFormScreen />);
+
+    expect(currentFormProps().canSubmit).toBe(false);
+    expect(currentFormProps().authorityMessage).toBe(message);
+  });
+
+  it('uses all active trip members for create collectors', async () => {
+    mockParams = { tripId: TRIP_ID, mode: 'create' };
+    await render(<ExpenseFormScreen />);
+
+    expect(
+      currentFormProps().collectors.map((candidate) => candidate.user.id),
+    ).toEqual([CAPTAIN_ID, MEMBER_ID, LATE_MEMBER_ID]);
+    expect(currentFormProps().currentCollector).toBeNull();
+  });
+
+  it('intersects edit collectors with immutable participants and keeps a departed collector display-only', async () => {
+    mockUseExpenseDetail.mockReturnValue(
+      detailHookState(
+        expenseDetail({
+          collector: {
+            id: DEPARTED_ID,
+            display_name: 'Former member',
+            identify_tag: 'former#1234',
+          },
+          participants: [
+            participant(DEPARTED_ID, 'Former member'),
+            participant(CAPTAIN_ID, 'Minh'),
+          ],
+        }),
+      ),
+    );
+    await render(<ExpenseFormScreen />);
+
+    expect(
+      currentFormProps().collectors.map((candidate) => candidate.user.id),
+    ).toEqual([CAPTAIN_ID]);
+    expect(currentFormProps().collectors).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          user: expect.objectContaining({ id: LATE_MEMBER_ID }),
+        }),
+      ]),
+    );
+    expect(currentFormProps().currentCollector).toMatchObject({
+      id: DEPARTED_ID,
+      display_name: 'Former member',
+    });
+    expect(currentFormProps().draft.collector_id).toBe(DEPARTED_ID);
+  });
+
+  it('omits an unchanged departed collector from a dirty edit PATCH', async () => {
+    mockUseExpenseDetail.mockReturnValue(
+      detailHookState(
+        expenseDetail({
+          collector: {
+            id: DEPARTED_ID,
+            display_name: 'Former member',
+            identify_tag: 'former#1234',
+          },
+          participants: [
+            participant(DEPARTED_ID, 'Former member'),
+            participant(CAPTAIN_ID, 'Minh'),
+          ],
+        }),
+      ),
+    );
+    await render(<ExpenseFormScreen />);
+    await focusScreen();
+    await changeDraft({ title: 'Updated hotel' });
+    await act(async () => {
+      currentFormProps().onSubmit();
+    });
+
+    await waitFor(() =>
+      expect(mockUpdateExpense).toHaveBeenCalledWith(
+        TRIP_ID,
+        EXPENSE_ID,
+        { title: 'Updated hotel' },
+      ),
+    );
+  });
+
+  it('includes an explicitly selected eligible collector in PATCH', async () => {
+    await render(<ExpenseFormScreen />);
+    await focusScreen();
+    await changeDraft({ collector_id: MEMBER_ID });
+
+    await act(async () => {
+      currentFormProps().onSubmit();
+    });
+
+    await waitFor(() =>
+      expect(mockUpdateExpense).toHaveBeenCalledWith(
+        TRIP_ID,
+        EXPENSE_ID,
+        { collector_id: MEMBER_ID },
+      ),
+    );
+  });
+
+  it('rejects a late active member outside the immutable participant snapshot', async () => {
+    await render(<ExpenseFormScreen />);
+    await focusScreen();
+    await changeDraft({ collector_id: LATE_MEMBER_ID });
+
+    await act(async () => {
+      currentFormProps().onSubmit();
+    });
+
+    expect(mockUpdateExpense).not.toHaveBeenCalled();
+    expect(currentFormProps().fieldErrors.collector_id).toBe(
+      'Choose an eligible active trip member.',
+    );
+  });
+
+  it('sends only dirty normalized edit fields', async () => {
+    await render(<ExpenseFormScreen />);
+    await focusScreen();
+    await changeDraft({ title: '  Updated hotel  ' });
+
+    await act(async () => {
+      currentFormProps().onSubmit();
+    });
+
+    await waitFor(() =>
+      expect(mockUpdateExpense).toHaveBeenCalledWith(
+        TRIP_ID,
+        EXPENSE_ID,
+        { title: 'Updated hotel' },
+      ),
+    );
+    expect(mockCreateExpense).not.toHaveBeenCalled();
+  });
+
+  it('creates with canonical strings and omits creator-default collector', async () => {
+    mockParams = { tripId: TRIP_ID, mode: 'create' };
+    await render(<ExpenseFormScreen />);
+    await focusScreen();
+    await changeDraft({
+      title: '  Taxi  ',
+      description: '  Airport ride  ',
+      total_amount: '00120.50',
+    });
+
+    await act(async () => {
+      currentFormProps().onSubmit();
+    });
+
+    await waitFor(() =>
+      expect(mockCreateExpense).toHaveBeenCalledWith(TRIP_ID, {
+        title: 'Taxi',
+        description: 'Airport ride',
+        total_amount: '120.50',
+      }),
+    );
+  });
+
+  it('locks duplicate submit and Cancel, then publishes and dismisses without self-refresh', async () => {
+    const pending = deferred<ExpenseResponse>();
+    mockCreateExpense.mockReturnValue(pending.promise);
+    mockParams = { tripId: TRIP_ID, mode: 'create' };
+    await render(<ExpenseFormScreen />);
+    await focusScreen();
+    mockRefreshDashboard.mockClear();
+    mockRefreshTrip.mockClear();
+    await changeDraft({
+      title: 'Taxi',
+      total_amount: '120.00',
+    });
+
+    await act(async () => {
+      currentFormProps().onSubmit();
+      currentFormProps().onSubmit();
+    });
+    await waitFor(() =>
+      expect(mockCreateExpense).toHaveBeenCalledTimes(1),
+    );
+    expect(mockInvalidateDashboard).toHaveBeenCalledTimes(1);
+    expect(currentFormProps().submitting).toBe(true);
+    expect(mockLatestStackOptions?.gestureEnabled).toBe(false);
+    await fireEvent.press(
+      screen.getByLabelText('Cancel expense form'),
+    );
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+
+    await act(async () => {
+      pending.resolve(expenseResponse({ title: 'Taxi' }));
+    });
+
+    await waitFor(() =>
+      expect(mockRouter.dismissTo).toHaveBeenCalledWith(
+        `/trips/${TRIP_ID}/expenses`,
+      ),
+    );
+    expect(mockPublishExpenseEvent).toHaveBeenCalledTimes(1);
+    expect(mockRefreshDashboard).not.toHaveBeenCalled();
+    expect(mockRefreshTrip).not.toHaveBeenCalled();
+  });
+
+  it('refreshes both sources after active 409 without event or navigation', async () => {
+    mockUpdateExpense.mockRejectedValueOnce(
+      axiosErrorWith(409, {
+        detail: 'Settlement is finalized.',
+        error_code: 'EXPENSE_LOCKED',
+      }),
+    );
+    await render(<ExpenseFormScreen />);
+    await focusScreen();
+    mockRefreshDetail.mockClear();
+    mockRefreshTrip.mockClear();
+    await changeDraft({ title: 'Conflict' });
+
+    await act(async () => {
+      currentFormProps().onSubmit();
+    });
+
+    await waitFor(() =>
+      expect(currentFormProps().submitError?.message).toBe(
+        'Settlement is finalized.',
+      ),
+    );
+    expect(mockRefreshDetail).toHaveBeenCalledWith('silent');
+    expect(mockRefreshTrip).toHaveBeenCalledWith('silent');
+    expect(mockPublishExpenseEvent).not.toHaveBeenCalled();
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+  });
+
+  it('publishes one late success after unmount without navigation', async () => {
+    const pending = deferred<ExpenseResponse>();
+    mockCreateExpense.mockReturnValue(pending.promise);
+    mockParams = { tripId: TRIP_ID, mode: 'create' };
+    const rendered = await render(<ExpenseFormScreen />);
+    const blur = await focusScreen();
+    await changeDraft({
+      title: 'Late success',
+      total_amount: '120.00',
+    });
+    await act(async () => {
+      currentFormProps().onSubmit();
+    });
+    await waitFor(() =>
+      expect(mockCreateExpense).toHaveBeenCalledTimes(1),
+    );
+
+    await act(async () => {
+      blur?.();
+    });
+    await rendered.unmount();
+    await act(async () => {
+      pending.resolve(expenseResponse({ title: 'Late success' }));
+    });
+
+    await waitFor(() =>
+      expect(mockPublishExpenseEvent).toHaveBeenCalledTimes(1),
+    );
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+  });
+
+  it('ignores a late failure after unmount without refresh, event, or navigation', async () => {
+    const pending = deferred<ExpenseResponse>();
+    mockCreateExpense.mockReturnValue(pending.promise);
+    mockParams = { tripId: TRIP_ID, mode: 'create' };
+    const rendered = await render(<ExpenseFormScreen />);
+    const blur = await focusScreen();
+    await changeDraft({
+      title: 'Late failure',
+      total_amount: '120.00',
+    });
+    await act(async () => {
+      currentFormProps().onSubmit();
+    });
+    await waitFor(() =>
+      expect(mockCreateExpense).toHaveBeenCalledTimes(1),
+    );
+    mockRefreshDashboard.mockClear();
+    mockRefreshTrip.mockClear();
+
+    await act(async () => {
+      blur?.();
+    });
+    await rendered.unmount();
+    await act(async () => {
+      pending.reject(
+        axiosErrorWith(409, {
+          detail: 'Invisible conflict.',
+          error_code: 'SETTLEMENT_ALREADY_FINALIZED',
+        }),
+      );
+    });
+
+    expect(mockRefreshDashboard).not.toHaveBeenCalled();
+    expect(mockRefreshTrip).not.toHaveBeenCalled();
+    expect(mockPublishExpenseEvent).not.toHaveBeenCalled();
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+  });
+
+  it('keeps a blurred committed create terminal and dismisses on refocus without replay', async () => {
+    const pending = deferred<ExpenseResponse>();
+    mockCreateExpense.mockReturnValue(pending.promise);
+    mockParams = { tripId: TRIP_ID, mode: 'create' };
+    await render(<ExpenseFormScreen />);
+    const blur = await focusScreen();
+    await changeDraft({
+      title: 'Committed while blurred',
+      total_amount: '120.00',
+    });
+    await act(async () => {
+      currentFormProps().onSubmit();
+    });
+    await waitFor(() =>
+      expect(mockCreateExpense).toHaveBeenCalledTimes(1),
+    );
+
+    await act(async () => {
+      blur?.();
+      pending.resolve(
+        expenseResponse({ title: 'Committed while blurred' }),
+      );
+    });
+    await waitFor(() =>
+      expect(mockPublishExpenseEvent).toHaveBeenCalledTimes(1),
+    );
+    expect(mockRouter.dismissTo).not.toHaveBeenCalled();
+    await act(async () => {
+      currentFormProps().onSubmit();
+    });
+    expect(mockCreateExpense).toHaveBeenCalledTimes(1);
+
+    await focusScreen();
+    await waitFor(() =>
+      expect(mockRouter.dismissTo).toHaveBeenCalledWith(
+        `/trips/${TRIP_ID}/expenses`,
+      ),
+    );
+    expect(mockCreateExpense).toHaveBeenCalledTimes(1);
+  });
+
+  it('reconciles paired sources for focus, foreground, events, retry, and pull refresh', async () => {
+    await render(<ExpenseFormScreen />);
+    const blur = await focusScreen();
+    expect(mockRefreshDetail).toHaveBeenCalledWith('initial');
+    expect(mockRefreshTrip).toHaveBeenCalledWith('initial');
+    mockRefreshDetail.mockClear();
+    mockRefreshTrip.mockClear();
+
+    await act(async () => {
+      latestForegroundCallback()();
+    });
+    expect(mockRefreshDetail).toHaveBeenCalledWith('silent');
+    expect(mockRefreshTrip).toHaveBeenCalledWith('silent');
+    mockRefreshDetail.mockClear();
+    mockRefreshTrip.mockClear();
+
+    await act(async () => {
+      await mockExpenseListener?.({
+        type: 'expensesChanged',
+        tripId: TRIP_ID,
+      });
+    });
+    expect(mockRefreshDetail).toHaveBeenCalledWith('silent');
+    expect(mockRefreshTrip).toHaveBeenCalledWith('silent');
+    mockRefreshDetail.mockClear();
+    mockRefreshTrip.mockClear();
+
+    await act(async () => {
+      mockTripListener?.({
+        type: 'statusChanged',
+        tripId: 'another-trip',
+        status: 'COMPLETED',
+      });
+    });
+    expect(mockRefreshDetail).not.toHaveBeenCalled();
+    expect(mockRefreshTrip).not.toHaveBeenCalled();
+
+    await act(async () => {
+      mockTripListener?.({
+        type: 'statusChanged',
+        tripId: TRIP_ID,
+        status: 'COMPLETED',
+      });
+    });
+    expect(mockRefreshDetail).toHaveBeenCalledWith('silent');
+    expect(mockRefreshTrip).toHaveBeenCalledWith('silent');
+    mockRefreshDetail.mockClear();
+    mockRefreshTrip.mockClear();
+
+    await act(async () => {
+      currentFormProps().onRetryBackground?.();
+    });
+    expect(mockRefreshDetail).toHaveBeenCalledWith('silent');
+    expect(mockRefreshTrip).toHaveBeenCalledWith('silent');
+    mockRefreshDetail.mockClear();
+    mockRefreshTrip.mockClear();
+
+    await act(async () => {
+      currentFormProps().onRefresh?.();
+    });
+    expect(mockRefreshDetail).toHaveBeenCalledWith('refresh');
+    expect(mockRefreshTrip).toHaveBeenCalledWith('refresh');
+    mockRefreshDetail.mockClear();
+    mockRefreshTrip.mockClear();
+
+    await act(async () => {
+      blur?.();
+      latestForegroundCallback()();
+      await mockExpenseListener?.({
+        type: 'expensesChanged',
+        tripId: TRIP_ID,
+      });
+    });
+    expect(mockRefreshDetail).not.toHaveBeenCalled();
+    expect(mockRefreshTrip).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/features/expenses/__tests__/ExpenseManagementComponents.test.tsx
+++ b/mobile/src/features/expenses/__tests__/ExpenseManagementComponents.test.tsx
@@ -1,0 +1,412 @@
+const mockIonicons = jest.fn((_props: unknown) => null);
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: (props: unknown) => mockIonicons(props),
+}));
+
+// eslint-disable-next-line import/first
+import {
+  fireEvent,
+  render,
+  screen,
+} from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { ContributionEditor } from '../components/ContributionEditor';
+// eslint-disable-next-line import/first
+import { ExpenseForm } from '../components/ExpenseForm';
+// eslint-disable-next-line import/first
+import type {
+  ExpenseFormDraft,
+  ExpenseFormFieldErrors,
+} from '../formModel';
+// eslint-disable-next-line import/first
+import type { ExpenseParticipant } from '../types';
+// eslint-disable-next-line import/first
+import type { TripMember } from '@/features/trips/types';
+
+function buildParticipant(
+  overrides: Partial<ExpenseParticipant> = {},
+): ExpenseParticipant {
+  return {
+    user_id: 'user-1',
+    display_name: 'An Nguyen',
+    identify_tag: 'an#1200',
+    share_amount: '25.00',
+    contributed_amount: '40.00',
+    balance: '15.00',
+    surplus_held: '3.00',
+    ...overrides,
+  };
+}
+
+function buildMember(
+  id: string,
+  displayName: string,
+): TripMember {
+  return {
+    membership_id: `membership-${id}`,
+    user: {
+      id,
+      display_name: displayName,
+      identify_tag: `${displayName.toLowerCase()}#1000`,
+      avatar_url: null,
+    },
+    role: 'MEMBER',
+    joined_at: '2026-07-28T00:00:00Z',
+  };
+}
+
+function buildDraft(
+  overrides: Partial<ExpenseFormDraft> = {},
+): ExpenseFormDraft {
+  return {
+    title: '',
+    description: '',
+    total_amount: '',
+    collector_id: null,
+    ...overrides,
+  };
+}
+
+function renderExpenseForm(
+  overrides: Partial<React.ComponentProps<typeof ExpenseForm>> = {},
+) {
+  const props: React.ComponentProps<typeof ExpenseForm> = {
+    mode: 'create',
+    draft: buildDraft(),
+    fieldErrors: {} as ExpenseFormFieldErrors,
+    submitError: null,
+    collectors: [
+      buildMember('user-1', 'An'),
+      buildMember('user-2', 'Binh'),
+    ],
+    currencyCode: 'USD',
+    canSubmit: true,
+    dirty: true,
+    submitting: false,
+    onChange: jest.fn(),
+    onSubmit: jest.fn(),
+    ...overrides,
+  };
+  return { props, view: render(<ExpenseForm {...props} />) };
+}
+
+describe('ContributionEditor', () => {
+  it('is one virtualizable participant row and gates editing from server-owned actions', async () => {
+    const onStartEditing = jest.fn();
+    const rendered = await render(
+      <ContributionEditor
+        participant={buildParticipant()}
+        currencyCode="USD"
+        canEdit={false}
+        isEditing={false}
+        draftAmount=""
+        onStartEditing={onStartEditing}
+        onDraftChange={jest.fn()}
+        onSubmit={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('An Nguyen')).toBeTruthy();
+    expect(screen.getByText('$25.00')).toBeTruthy();
+    expect(screen.getByText('$40.00')).toBeTruthy();
+    expect(screen.getByText('Overpaid')).toBeTruthy();
+    expect(screen.getByText('+$15.00')).toBeTruthy();
+    expect(screen.getByText('$3.00')).toBeTruthy();
+    expect(screen.getByText('View only')).toBeTruthy();
+    expect(screen.queryByRole('button')).toBeNull();
+
+    await rendered.rerender(
+      <ContributionEditor
+        participant={buildParticipant()}
+        currencyCode="USD"
+        canEdit
+        isEditing={false}
+        draftAmount=""
+        onStartEditing={onStartEditing}
+        onDraftChange={jest.fn()}
+        onSubmit={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: 'Edit contribution for An Nguyen',
+      }),
+    );
+    expect(onStartEditing).toHaveBeenCalledWith('user-1');
+  });
+
+  it('forwards canonical text and stable ids to screen-owned draft/actions', async () => {
+    const onDraftChange = jest.fn();
+    const onSubmit = jest.fn();
+    const onCancel = jest.fn();
+    await render(
+      <ContributionEditor
+        participant={buildParticipant()}
+        currencyCode="USD"
+        canEdit
+        isEditing
+        draftAmount="40.00"
+        amountError="Amount has too many digits."
+        error="Contribution changed in another session."
+        onStartEditing={jest.fn()}
+        onDraftChange={onDraftChange}
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+      />,
+    );
+
+    await fireEvent.changeText(
+      screen.getByLabelText('Contribution amount for An Nguyen'),
+      '1,234.50',
+    );
+    expect(onDraftChange).toHaveBeenCalledWith(
+      'user-1',
+      '1,234.50',
+    );
+    expect(
+      screen.getByText('Amount has too many digits.'),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        'Contribution changed in another session.',
+      ),
+    ).toBeTruthy();
+
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: 'Save contribution for An Nguyen',
+      }),
+    );
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: 'Cancel contribution edit for An Nguyen',
+      }),
+    );
+    expect(onSubmit).toHaveBeenCalledWith('user-1');
+    expect(onCancel).toHaveBeenCalledWith('user-1');
+  });
+
+  it('matches the contribution keyboard to the currency scale', async () => {
+    const props = {
+      participant: buildParticipant(),
+      canEdit: true,
+      isEditing: true,
+      draftAmount: '40',
+      onStartEditing: jest.fn(),
+      onDraftChange: jest.fn(),
+      onSubmit: jest.fn(),
+      onCancel: jest.fn(),
+    };
+    const rendered = await render(
+      <ContributionEditor {...props} currencyCode="USD" />,
+    );
+
+    expect(
+      screen.getByLabelText(
+        'Contribution amount for An Nguyen',
+      ).props.keyboardType,
+    ).toBe('decimal-pad');
+
+    await rendered.rerender(
+      <ContributionEditor {...props} currencyCode="VND" />,
+    );
+    expect(
+      screen.getByLabelText(
+        'Contribution amount for An Nguyen',
+      ).props.keyboardType,
+    ).toBe('number-pad');
+  });
+
+  it('uses a per-row loading lock for both editor actions', async () => {
+    const onSubmit = jest.fn();
+    const onCancel = jest.fn();
+    await render(
+      <ContributionEditor
+        participant={buildParticipant()}
+        currencyCode="USD"
+        canEdit
+        isEditing
+        draftAmount="40.00"
+        loading
+        onStartEditing={jest.fn()}
+        onDraftChange={jest.fn()}
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+      />,
+    );
+
+    const save = screen.getByRole('button', {
+      name: 'Save contribution for An Nguyen',
+    });
+    const cancel = screen.getByRole('button', {
+      name: 'Cancel contribution edit for An Nguyen',
+    });
+    expect(save.props.accessibilityState).toMatchObject({
+      busy: true,
+      disabled: true,
+    });
+    expect(cancel.props.accessibilityState).toMatchObject({
+      disabled: true,
+    });
+    await fireEvent.press(save);
+    await fireEvent.press(cancel);
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+});
+
+describe('ExpenseForm', () => {
+  it('keeps raw canonical input controlled and virtualizes collector options horizontally', async () => {
+    const onChange = jest.fn();
+    await renderExpenseForm({ onChange }).view;
+
+    const collectorList = screen.getByTestId(
+      'expense-collector-list',
+    );
+    expect(collectorList.props.horizontal).toBe(true);
+    expect(collectorList.props.data).toHaveLength(2);
+    expect(
+      screen.getByRole('button', {
+        name: 'Use expense creator as collector',
+      }).props.accessibilityState,
+    ).toMatchObject({ selected: true });
+
+    await fireEvent.changeText(
+      screen.getByLabelText('Expense total amount'),
+      '1,234.50',
+    );
+    expect(onChange).toHaveBeenCalledWith({
+      total_amount: '1,234.50',
+    });
+
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: 'Choose Binh as collector',
+      }),
+    );
+    expect(onChange).toHaveBeenCalledWith({
+      collector_id: 'user-2',
+    });
+  });
+
+  it('uses a zero-decimal keyboard for VND without changing the draft string', async () => {
+    await renderExpenseForm({
+      currencyCode: 'vnd',
+      draft: buildDraft({ total_amount: '50000' }),
+    }).view;
+
+    expect(
+      screen.getByLabelText('Expense total amount').props.keyboardType,
+    ).toBe('number-pad');
+    expect(screen.getByText('VND')).toBeTruthy();
+  });
+
+  it('shows a departed current collector as display-only and keeps eligible options virtualized', async () => {
+    const onChange = jest.fn();
+    await renderExpenseForm({
+      mode: 'edit',
+      draft: buildDraft({
+        title: 'Beach house',
+        total_amount: '300.00',
+        collector_id: 'departed-1',
+      }),
+      currentCollector: {
+        id: 'departed-1',
+        display_name: 'Former Member',
+        identify_tag: 'former#9090',
+      },
+      collectors: [buildMember('user-2', 'Binh')],
+      dirty: true,
+      onChange,
+    }).view;
+
+    expect(
+      screen.getByLabelText(
+        'Former Member, current collector, left trip',
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText('former#9090 · left trip')).toBeTruthy();
+    expect(
+      screen.getByTestId('expense-collector-list').props.data,
+    ).toHaveLength(1);
+
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: 'Choose Binh as collector',
+      }),
+    );
+    expect(onChange).toHaveBeenCalledWith({
+      collector_id: 'user-2',
+    });
+  });
+
+  it('merges field errors, exposes pull-refresh, and retries background failure', async () => {
+    const onRefresh = jest.fn();
+    const onRetryBackground = jest.fn();
+    await renderExpenseForm({
+      fieldErrors: {
+        title: 'Enter an expense name.',
+      } as ExpenseFormFieldErrors,
+      submitError: {
+        kind: 'field',
+        message: 'Fix the highlighted fields.',
+        fieldErrors: {
+          total_amount: 'Enter a positive amount.',
+          collector_id: 'Collector is no longer eligible.',
+        },
+      },
+      backgroundError: {
+        kind: 'message',
+        message: 'Could not refresh expense authority.',
+      },
+      refreshing: true,
+      onRefresh,
+      onRetryBackground,
+    }).view;
+
+    expect(screen.getByText('Enter an expense name.')).toBeTruthy();
+    expect(screen.getByText('Enter a positive amount.')).toBeTruthy();
+    expect(
+      screen.getByText('Collector is no longer eligible.'),
+    ).toBeTruthy();
+    expect(
+      screen.getByText('Could not refresh expense authority.'),
+    ).toBeTruthy();
+    const refreshControl =
+      screen.getByTestId('expense-form-scroll').props.refreshControl;
+    expect(refreshControl.props.refreshing).toBe(true);
+    refreshControl.props.onRefresh();
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: 'Retry refreshing expense form',
+      }),
+    );
+    expect(onRetryBackground).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables editing on authority loss and unchanged edit submit', async () => {
+    const rendered = renderExpenseForm({
+      mode: 'edit',
+      canSubmit: false,
+      dirty: false,
+      authorityMessage: 'You can no longer edit this expense.',
+    });
+    await rendered.view;
+
+    expect(screen.getByLabelText('Expense name').props.editable).toBe(
+      false,
+    );
+    expect(
+      screen.getByRole('button', { name: 'Save expense' }).props
+        .accessibilityState,
+    ).toMatchObject({ disabled: true });
+    expect(
+      screen.getByText('You can no longer edit this expense.'),
+    ).toBeTruthy();
+  });
+});

--- a/mobile/src/features/expenses/__tests__/ExpenseSettlementComponents.test.tsx
+++ b/mobile/src/features/expenses/__tests__/ExpenseSettlementComponents.test.tsx
@@ -1,0 +1,288 @@
+const mockIonicons = jest.fn((_props: unknown) => null);
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: (props: unknown) => mockIonicons(props),
+}));
+
+// eslint-disable-next-line import/first
+import { Alert } from 'react-native';
+// eslint-disable-next-line import/first
+import {
+  fireEvent,
+  render,
+  screen,
+} from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { SettlementPanel } from '../components/SettlementPanel';
+// eslint-disable-next-line import/first
+import { TransferRow } from '../components/TransferRow';
+// eslint-disable-next-line import/first
+import type {
+  SettlementTransfer,
+  TripSettlement,
+} from '../types';
+
+function buildTransfer(
+  overrides: Partial<SettlementTransfer> = {},
+): SettlementTransfer {
+  return {
+    id: 'transfer-1',
+    payer: {
+      id: 'payer-1',
+      display_name: 'Payer User',
+      identify_tag: 'payer#1000',
+    },
+    recipient: {
+      id: 'recipient-1',
+      display_name: 'Recipient User',
+      identify_tag: 'recipient#2000',
+    },
+    amount: '40.00',
+    payer_marked_sent_at: null,
+    recipient_confirmed_at: null,
+    ...overrides,
+  };
+}
+
+function buildSettlement(
+  overrides: Partial<TripSettlement> = {},
+): TripSettlement {
+  return {
+    id: 'settlement-1',
+    status: 'FINALIZED',
+    finalized_at: '2026-07-28T03:00:00Z',
+    transfers: [],
+    ...overrides,
+  };
+}
+
+function confirmLastAlert(): void {
+  const [, , buttons] = jest.mocked(Alert.alert).mock.calls.at(-1) ?? [];
+  const confirm = buttons?.find((button) => button.text !== 'Cancel');
+  confirm?.onPress?.();
+}
+
+describe('SettlementPanel', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('keeps the finalized notice and Reopen for a valid solo settlement', async () => {
+    const onReopen = jest.fn();
+    jest.spyOn(Alert, 'alert');
+    await render(
+      <SettlementPanel
+        settlement={buildSettlement()}
+        canReopen
+        onReopen={onReopen}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        'Settlement finalized. Expenses are locked.',
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        'No transfers are needed for this settlement.',
+      ),
+    ).toBeTruthy();
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Reopen settlement' }),
+    );
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Reopen settlement?',
+      'Expenses and contributions will be unlocked for editing.',
+      expect.any(Array),
+    );
+    confirmLastAlert();
+    expect(onReopen).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render a reopened settlement or unauthorized Reopen action', async () => {
+    const rendered = await render(
+      <SettlementPanel
+        settlement={buildSettlement()}
+        canReopen={false}
+        onReopen={jest.fn()}
+      />,
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Reopen settlement' }),
+    ).toBeNull();
+
+    await rendered.rerender(
+      <SettlementPanel
+        settlement={buildSettlement({ status: 'REOPENED' })}
+        canReopen
+        onReopen={jest.fn()}
+      />,
+    );
+    expect(screen.queryByText('Settlement finalized')).toBeNull();
+  });
+
+  it('renders a normalized per-action error passed by the owner', async () => {
+    await render(
+      <SettlementPanel
+        settlement={buildSettlement()}
+        canReopen
+        error={{
+          kind: 'message',
+          message: 'Settlement is no longer finalized.',
+          status: 409,
+        }}
+        onReopen={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole('alert', {
+        name: 'Settlement is no longer finalized.',
+      }),
+    ).toBeTruthy();
+  });
+});
+
+describe('TransferRow', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('lets only the payer confirm an unsent transfer with exact wording', async () => {
+    const onMarkSent = jest.fn();
+    jest.spyOn(Alert, 'alert');
+    await render(
+      <TransferRow
+        transfer={buildTransfer()}
+        currencyCode="USD"
+        viewerId="payer-1"
+        onMarkSent={onMarkSent}
+        onConfirmReceived={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Not sent')).toBeTruthy();
+    expect(screen.getByText('Not received')).toBeTruthy();
+    expect(
+      screen.queryByRole('button', { name: 'I received it' }),
+    ).toBeNull();
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'I sent it' }),
+    );
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Confirm transfer sent?',
+      'You are confirming that you sent money to Recipient User.',
+      expect.any(Array),
+    );
+    confirmLastAlert();
+    expect(onMarkSent).toHaveBeenCalledWith('transfer-1');
+  });
+
+  it('lets the recipient confirm only after sent and renders guidance', async () => {
+    const onConfirmReceived = jest.fn();
+    jest.spyOn(Alert, 'alert');
+    await render(
+      <TransferRow
+        transfer={buildTransfer({
+          payer_marked_sent_at: '2026-07-28T03:10:00Z',
+        })}
+        currencyCode="USD"
+        viewerId="recipient-1"
+        onMarkSent={jest.fn()}
+        onConfirmReceived={onConfirmReceived}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        'Payer User marked this as sent. Confirm only after the money arrives.',
+      ),
+    ).toBeTruthy();
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'I received it' }),
+    );
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Confirm transfer received?',
+      'You are confirming that you received money from Payer User.',
+      expect.any(Array),
+    );
+    confirmLastAlert();
+    expect(onConfirmReceived).toHaveBeenCalledWith('transfer-1');
+  });
+
+  it.each([
+    ['recipient before sent', 'recipient-1'],
+    ['unrelated viewer', 'viewer-9'],
+    ['nullable unresolved viewer', null],
+  ])(
+    'renders tracking-only UI for %s',
+    async (_label, viewerId) => {
+      await render(
+        <TransferRow
+          transfer={buildTransfer()}
+          currencyCode="USD"
+          viewerId={viewerId}
+          onMarkSent={jest.fn()}
+          onConfirmReceived={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByText('Tracking')).toBeTruthy();
+      expect(
+        screen.queryByRole('button', { name: 'I sent it' }),
+      ).toBeNull();
+      expect(
+        screen.queryByRole('button', { name: 'I received it' }),
+      ).toBeNull();
+    },
+  );
+
+  it('renders sent/received completion without any action', async () => {
+    await render(
+      <TransferRow
+        transfer={buildTransfer({
+          payer_marked_sent_at: '2026-07-28T03:10:00Z',
+          recipient_confirmed_at: '2026-07-28T03:15:00Z',
+        })}
+        currencyCode="USD"
+        viewerId="payer-1"
+        onMarkSent={jest.fn()}
+        onConfirmReceived={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Sent')).toBeTruthy();
+    expect(screen.getByText('Received')).toBeTruthy();
+    expect(screen.getByText('Tracking')).toBeTruthy();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('uses owner-provided per-row loading and error without a terminal gate', async () => {
+    await render(
+      <TransferRow
+        transfer={buildTransfer()}
+        currencyCode="USD"
+        viewerId="payer-1"
+        loading
+        error={{
+          kind: 'message',
+          message: 'Transfer changed in another session.',
+          status: 409,
+        }}
+        onMarkSent={jest.fn()}
+        onConfirmReceived={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'I sent it' }).props
+        .accessibilityState,
+    ).toMatchObject({ busy: true, disabled: true });
+    expect(
+      screen.getByText('Transfer changed in another session.'),
+    ).toBeTruthy();
+  });
+});

--- a/mobile/src/features/expenses/__tests__/ExpensesScreen.test.tsx
+++ b/mobile/src/features/expenses/__tests__/ExpensesScreen.test.tsx
@@ -1,0 +1,837 @@
+import type { ReactNode } from 'react';
+import { Alert, View } from 'react-native';
+
+let mockParams: Record<string, string | string[] | undefined> = {};
+const mockRouter = { push: jest.fn() };
+const mockUseSession = jest.fn();
+const mockUseExpenseDashboard = jest.fn();
+const mockUseTripDetail = jest.fn();
+const mockUseExpenseCompositionCoordinator = jest.fn();
+const mockRefreshDashboard = jest.fn();
+const mockInvalidateDashboard = jest.fn();
+const mockRefreshTrip = jest.fn();
+const mockRefreshAll = jest.fn();
+const mockRequestReconcile = jest.fn();
+const mockPublishExpenseEvent = jest.fn();
+
+function mockRenderStackScreen({
+  options,
+}: {
+  options: {
+    headerRight?: () => ReactNode;
+  };
+}) {
+  return <View>{options.headerRight?.()}</View>;
+}
+
+jest.mock('expo-router', () => ({
+  Stack: { Screen: mockRenderStackScreen },
+  useLocalSearchParams: () => mockParams,
+  useRouter: () => mockRouter,
+}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('@/features/auth/session', () => ({
+  useSession: () => mockUseSession(),
+}));
+jest.mock('../hooks/useExpenseDashboard', () => ({
+  useExpenseDashboard: (...args: unknown[]) =>
+    mockUseExpenseDashboard(...args),
+}));
+jest.mock('@/features/trips/hooks/useTripDetail', () => ({
+  useTripDetail: (...args: unknown[]) => mockUseTripDetail(...args),
+}));
+jest.mock('../hooks/useExpenseCompositionCoordinator', () => ({
+  useExpenseCompositionCoordinator: (...args: unknown[]) =>
+    mockUseExpenseCompositionCoordinator(...args),
+}));
+jest.mock('../api', () => ({
+  finalizeSettlement: jest.fn(),
+  reopenSettlement: jest.fn(),
+  markTransferSent: jest.fn(),
+  confirmTransferReceived: jest.fn(),
+}));
+jest.mock('../expenseEvents', () => ({
+  publishExpenseEvent: (...args: unknown[]) =>
+    mockPublishExpenseEvent(...args),
+}));
+
+// eslint-disable-next-line import/first
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { AxiosError, AxiosHeaders } from 'axios';
+// eslint-disable-next-line import/first
+import {
+  confirmTransferReceived,
+  finalizeSettlement,
+  markTransferSent,
+  reopenSettlement,
+} from '../api';
+// eslint-disable-next-line import/first
+import { ExpensesScreen } from '../screens/ExpensesScreen';
+// eslint-disable-next-line import/first
+import type {
+  ExpenseDashboardResponse,
+  ExpenseListItem,
+  SettlementTransfer,
+  TripSettlement,
+} from '../types';
+// eslint-disable-next-line import/first
+import type { TripDetailResponse, TripStatus } from '@/features/trips/types';
+// eslint-disable-next-line import/first
+import type { ApiError } from '@/shared/api/errors';
+
+const mockFinalizeSettlement =
+  finalizeSettlement as jest.MockedFunction<typeof finalizeSettlement>;
+const mockReopenSettlement =
+  reopenSettlement as jest.MockedFunction<typeof reopenSettlement>;
+const mockMarkTransferSent =
+  markTransferSent as jest.MockedFunction<typeof markTransferSent>;
+const mockConfirmTransferReceived =
+  confirmTransferReceived as jest.MockedFunction<
+    typeof confirmTransferReceived
+  >;
+let alertSpy: jest.SpyInstance;
+
+const TRIP_ID = '123e4567-e89b-12d3-a456-426614174000';
+const EXPENSE_ID = '2c1dfd8d-9c7f-43c7-9b99-71f6d1edda55';
+const TRANSFER_ID = 'a11957b3-3329-4fcf-9c7b-673a51c1d8a7';
+const PAYER_ID = '7191f7c4-16f0-4fc5-996f-3264a46e7761';
+const RECIPIENT_ID = '4f44f738-0f5c-4608-a0b8-fd4ca3ecacde';
+const OTHER_USER_ID = '6a40735b-a4e3-41de-a153-f5ef23c49733';
+
+function expense(
+  overrides: Partial<ExpenseListItem> = {},
+): ExpenseListItem {
+  return {
+    id: EXPENSE_ID,
+    title: 'Hotel',
+    description: 'Two nights',
+    total_amount: '120.00',
+    paid_amount: '120.00',
+    missing_amount: '0.00',
+    surplus_amount: '0.00',
+    currency_code: 'USD',
+    status: 'FUNDED',
+    collector: {
+      id: PAYER_ID,
+      display_name: 'Minh',
+      identify_tag: 'minh#1234',
+    },
+    locked: false,
+    ...overrides,
+  };
+}
+
+function transfer(
+  overrides: Partial<SettlementTransfer> = {},
+): SettlementTransfer {
+  return {
+    id: TRANSFER_ID,
+    payer: {
+      id: PAYER_ID,
+      display_name: 'Minh',
+      identify_tag: 'minh#1234',
+    },
+    recipient: {
+      id: RECIPIENT_ID,
+      display_name: 'Lan',
+      identify_tag: 'lan#5678',
+    },
+    amount: '60.00',
+    payer_marked_sent_at: null,
+    recipient_confirmed_at: null,
+    ...overrides,
+  };
+}
+
+function settlement(
+  overrides: Partial<TripSettlement> = {},
+): TripSettlement {
+  return {
+    id: 'settlement-1',
+    status: 'FINALIZED',
+    finalized_at: '2026-07-28T00:00:00Z',
+    transfers: [transfer()],
+    ...overrides,
+  };
+}
+
+function dashboard(
+  overrides: Partial<ExpenseDashboardResponse> = {},
+): ExpenseDashboardResponse {
+  return {
+    currency_code: 'USD',
+    summary: {
+      total_amount: '120.00',
+      paid_amount: '120.00',
+      missing_amount: '0.00',
+      surplus_amount: '0.00',
+    },
+    permissions: {
+      can_manage_expenses: true,
+    },
+    my_balance: {
+      balance: '0.00',
+      surplus_held: '0.00',
+    },
+    member_balances: {
+      [PAYER_ID]: { balance: '60.00' },
+      [RECIPIENT_ID]: { balance: '-60.00' },
+    },
+    settlement: null,
+    expenses: [expense()],
+    ...overrides,
+  };
+}
+
+function tripDetail({
+  status = 'PLANNING',
+  membershipStatus = 'ACTIVE',
+}: {
+  status?: TripStatus;
+  membershipStatus?: TripDetailResponse['my_membership']['status'];
+} = {}): TripDetailResponse {
+  return {
+    trip: {
+      id: TRIP_ID,
+      name: 'Da Nang weekend',
+      destination: 'Da Nang, Vietnam',
+      destination_provider: '',
+      destination_provider_id: '',
+      destination_lat: null,
+      destination_lng: null,
+      destination_country_code: 'VN',
+      cover_image_url: '',
+      start_date: '2026-08-01',
+      end_date: '2026-08-03',
+      description: '',
+      status,
+      currency_code: 'USD',
+      timezone: 'Asia/Ho_Chi_Minh',
+      budget_estimate: null,
+      cancelled_at: null,
+      created_at: '2026-01-01T00:00:00Z',
+    },
+    my_membership: {
+      role: 'CAPTAIN',
+      status: membershipStatus,
+      joined_at: '2026-01-01T00:00:00Z',
+    },
+    members: [
+      {
+        membership_id: 'membership-1',
+        user: {
+          id: PAYER_ID,
+          display_name: 'Minh',
+          identify_tag: 'minh#1234',
+          avatar_url: null,
+        },
+        role: 'CAPTAIN',
+        joined_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        membership_id: 'membership-2',
+        user: {
+          id: RECIPIENT_ID,
+          display_name: 'Lan',
+          identify_tag: 'lan#5678',
+          avatar_url: null,
+        },
+        role: 'MEMBER',
+        joined_at: '2026-01-02T00:00:00Z',
+      },
+    ],
+  };
+}
+
+function dashboardHookState({
+  nextDashboard = dashboard(),
+  status = 'ready',
+  error = null,
+  refreshing = false,
+}: {
+  nextDashboard?: ExpenseDashboardResponse | null;
+  status?: 'loading' | 'ready' | 'error';
+  error?: ApiError | null;
+  refreshing?: boolean;
+} = {}) {
+  return {
+    dashboard: nextDashboard,
+    status,
+    error,
+    refreshing,
+    refresh: mockRefreshDashboard,
+    invalidate: mockInvalidateDashboard,
+  };
+}
+
+function tripHookState({
+  detail = tripDetail(),
+  status = 'ready',
+  error = null,
+  refreshing = false,
+}: {
+  detail?: TripDetailResponse | null;
+  status?: 'loading' | 'ready' | 'error';
+  error?: ApiError | null;
+  refreshing?: boolean;
+} = {}) {
+  return {
+    detail,
+    status,
+    error,
+    refreshing,
+    refresh: mockRefreshTrip,
+  };
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, {}, {
+    status,
+    statusText: '',
+    headers: {},
+    config,
+    data,
+  });
+}
+
+type AlertButton = {
+  text?: string;
+  onPress?: () => void;
+};
+
+function alertAction(callIndex: number, text: string): () => void {
+  const buttons = alertSpy.mock.calls[callIndex]?.[2] as
+    | AlertButton[]
+    | undefined;
+  const action = buttons?.find((button) => button.text === text)?.onPress;
+  if (!action) {
+    throw new Error(`Expected alert action "${text}".`);
+  }
+  return action;
+}
+
+describe('ExpensesScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockParams = { tripId: TRIP_ID };
+    mockUseSession.mockReturnValue({ user: { id: PAYER_ID } });
+    mockRefreshDashboard.mockResolvedValue(undefined);
+    mockRefreshTrip.mockResolvedValue(undefined);
+    mockRefreshAll.mockResolvedValue(undefined);
+    mockRequestReconcile.mockResolvedValue(undefined);
+    mockUseExpenseDashboard.mockReturnValue(dashboardHookState());
+    mockUseTripDetail.mockReturnValue(tripHookState());
+    mockUseExpenseCompositionCoordinator.mockReturnValue({
+      refreshAll: mockRefreshAll,
+      requestReconcile: mockRequestReconcile,
+      isScreenActive: jest.fn(() => true),
+      isActiveGeneration: jest.fn(() => true),
+      getGeneration: jest.fn(() => 1),
+    });
+    mockFinalizeSettlement.mockResolvedValue(settlement());
+    mockReopenSettlement.mockResolvedValue(
+      settlement({ status: 'REOPENED', transfers: [] }),
+    );
+    mockMarkTransferSent.mockResolvedValue(
+      transfer({ payer_marked_sent_at: '2026-07-28T01:00:00Z' }),
+    );
+    mockConfirmTransferReceived.mockResolvedValue(
+      transfer({
+        payer_marked_sent_at: '2026-07-28T01:00:00Z',
+        recipient_confirmed_at: '2026-07-28T02:00:00Z',
+      }),
+    );
+    mockPublishExpenseEvent.mockResolvedValue(undefined);
+    alertSpy = jest
+      .spyOn(Alert, 'alert')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
+  });
+
+  it('rejects invalid trip UUIDs before mounting hooks or APIs', async () => {
+    mockParams = { tripId: 'not-a-uuid' };
+    await render(<ExpensesScreen />);
+
+    expect(screen.getByText('Expenses unavailable')).toBeTruthy();
+    expect(mockUseExpenseDashboard).not.toHaveBeenCalled();
+    expect(mockUseTripDetail).not.toHaveBeenCalled();
+    expect(mockUseExpenseCompositionCoordinator).not.toHaveBeenCalled();
+    expect(mockFinalizeSettlement).not.toHaveBeenCalled();
+  });
+
+  it('canonicalizes an uppercase trip UUID and composes both hooks with one coordinator', async () => {
+    mockParams = { tripId: TRIP_ID.toUpperCase() };
+    await render(<ExpensesScreen />);
+
+    expect(mockUseExpenseDashboard).toHaveBeenCalledWith(TRIP_ID, {
+      autoReconcile: false,
+    });
+    expect(mockUseTripDetail).toHaveBeenCalledWith(TRIP_ID, {
+      autoReconcile: false,
+    });
+    expect(mockUseExpenseCompositionCoordinator).toHaveBeenCalledWith({
+      tripId: TRIP_ID,
+      refreshExpense: mockRefreshDashboard,
+      refreshTrip: mockRefreshTrip,
+    });
+  });
+
+  it.each(['dashboard-first', 'trip-first'] as const)(
+    'waits for both authoritative sources before rendering (%s)',
+    async (order) => {
+      if (order === 'dashboard-first') {
+        mockUseExpenseDashboard.mockReturnValue(dashboardHookState());
+        mockUseTripDetail.mockReturnValue(
+          tripHookState({ detail: null, status: 'loading' }),
+        );
+      } else {
+        mockUseExpenseDashboard.mockReturnValue(
+          dashboardHookState({
+            nextDashboard: null,
+            status: 'loading',
+          }),
+        );
+        mockUseTripDetail.mockReturnValue(tripHookState());
+      }
+      const view = await render(<ExpensesScreen />);
+
+      expect(screen.queryByLabelText('Expense summary')).toBeNull();
+
+      mockUseExpenseDashboard.mockReturnValue(dashboardHookState());
+      mockUseTripDetail.mockReturnValue(tripHookState());
+      await view.rerender(<ExpensesScreen />);
+
+      expect(screen.getByLabelText('Expense summary')).toBeTruthy();
+      expect(screen.getByText('Hotel')).toBeTruthy();
+    },
+  );
+
+  it.each([
+    {
+      name: 'dashboard permission denial',
+      nextDashboard: dashboard({
+        permissions: { can_manage_expenses: false },
+      }),
+      nextTripDetail: tripDetail(),
+    },
+    {
+      name: 'inactive current membership',
+      nextDashboard: dashboard(),
+      nextTripDetail: tripDetail({ membershipStatus: 'REMOVED' }),
+    },
+    {
+      name: 'terminal trip lifecycle',
+      nextDashboard: dashboard(),
+      nextTripDetail: tripDetail({ status: 'COMPLETED' }),
+    },
+  ])('applies deny-wins controls for $name', async ({
+    nextDashboard,
+    nextTripDetail,
+  }) => {
+    mockUseExpenseDashboard.mockReturnValue(
+      dashboardHookState({ nextDashboard }),
+    );
+    mockUseTripDetail.mockReturnValue(
+      tripHookState({ detail: nextTripDetail }),
+    );
+    await render(<ExpensesScreen />);
+
+    expect(screen.queryByRole('button', { name: 'Add expense' })).toBeNull();
+    expect(
+      screen.queryByRole('button', { name: 'Finalize settlement' }),
+    ).toBeNull();
+    expect(screen.getByText('Hotel')).toBeTruthy();
+  });
+
+  it('preserves complete content through background errors and retries silently', async () => {
+    mockUseExpenseDashboard.mockReturnValue(
+      dashboardHookState({
+        error: {
+          kind: 'message',
+          message: 'Dashboard refresh failed.',
+          status: 500,
+        },
+      }),
+    );
+    mockUseTripDetail.mockReturnValue(
+      tripHookState({
+        error: {
+          kind: 'network',
+          message: 'Trip refresh failed.',
+        },
+      }),
+    );
+    await render(<ExpensesScreen />);
+
+    expect(screen.getByText('Hotel')).toBeTruthy();
+    expect(screen.getByText('Dashboard refresh failed.')).toBeTruthy();
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: 'Retry refreshing expenses',
+      }),
+    );
+    expect(mockRequestReconcile).toHaveBeenCalledWith();
+  });
+
+  it('uses coordinator-owned retry and pull refresh modes', async () => {
+    mockUseExpenseDashboard.mockReturnValue(
+      dashboardHookState({
+        nextDashboard: null,
+        status: 'error',
+        error: {
+          kind: 'message',
+          message: 'Expense service failed.',
+          status: 500,
+        },
+      }),
+    );
+    const view = await render(<ExpensesScreen />);
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Try again' }),
+    );
+    expect(mockRequestReconcile).toHaveBeenCalledWith(true);
+
+    mockUseExpenseDashboard.mockReturnValue(dashboardHookState());
+    await view.rerender(<ExpensesScreen />);
+    const refreshControl = view.container.queryAll(
+      (instance) => instance.type === 'RCTRefreshControl',
+    )[0];
+    if (!refreshControl) {
+      throw new Error('Expected Expenses RefreshControl.');
+    }
+    await fireEvent(refreshControl, 'refresh');
+    expect(mockRefreshAll).toHaveBeenCalledWith('refresh');
+  });
+
+  it('navigates to create and detail using the canonical trip key', async () => {
+    await render(<ExpensesScreen />);
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Add expense' }),
+    );
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: 'Open expense Hotel, Funded, total $120.00, collected $120.00, collector Minh',
+      }),
+    );
+
+    expect(mockRouter.push).toHaveBeenNthCalledWith(
+      1,
+      `/trips/${TRIP_ID}/expenses/expense-form?mode=create`,
+    );
+    expect(mockRouter.push).toHaveBeenNthCalledWith(
+      2,
+      `/trips/${TRIP_ID}/expenses/${EXPENSE_ID}`,
+    );
+  });
+
+  it('locks duplicate finalize confirmation and publishes after success', async () => {
+    const pending = deferred<TripSettlement>();
+    mockFinalizeSettlement.mockReturnValue(pending.promise);
+    await render(<ExpensesScreen />);
+
+    const finalizeButton = screen.getByRole('button', {
+      name: 'Finalize settlement',
+    });
+    await fireEvent.press(finalizeButton);
+    await fireEvent.press(finalizeButton);
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      alertAction(0, 'Finalize')();
+    });
+    expect(mockInvalidateDashboard).toHaveBeenCalledTimes(1);
+    expect(mockFinalizeSettlement).toHaveBeenCalledTimes(1);
+    expect(mockFinalizeSettlement).toHaveBeenCalledWith(TRIP_ID);
+
+    await act(async () => {
+      pending.resolve(settlement());
+    });
+    await waitFor(() =>
+      expect(mockPublishExpenseEvent).toHaveBeenCalledWith({
+        type: 'expensesChanged',
+        tripId: TRIP_ID,
+      }),
+    );
+  });
+
+  it('surfaces a finalize 409 verbatim and publishes reconciliation', async () => {
+    mockFinalizeSettlement.mockRejectedValueOnce(
+      axiosErrorWith(409, {
+        detail: 'All expenses must be fully funded before settlement.',
+        error_code: 'SETTLEMENT_UNDERFUNDED',
+      }),
+    );
+    await render(<ExpensesScreen />);
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Finalize settlement' }),
+    );
+    await act(async () => {
+      alertAction(0, 'Finalize')();
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          'All expenses must be fully funded before settlement.',
+        ),
+      ).toBeTruthy(),
+    );
+    expect(mockPublishExpenseEvent).toHaveBeenCalledWith({
+      type: 'expensesChanged',
+      tripId: TRIP_ID,
+    });
+  });
+
+  it('keeps finalized solo settlement and Reopen visible without transfer rows', async () => {
+    mockUseExpenseDashboard.mockReturnValue(
+      dashboardHookState({
+        nextDashboard: dashboard({
+          settlement: settlement({ transfers: [] }),
+        }),
+      }),
+    );
+    await render(<ExpensesScreen />);
+
+    expect(screen.getByText('Settlement finalized')).toBeTruthy();
+    expect(
+      screen.getByText('No transfers are needed for this settlement.'),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: 'Reopen settlement' }),
+    ).toBeTruthy();
+    expect(screen.queryByText('Transfers')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'I sent it' })).toBeNull();
+  });
+
+  it('locks duplicate reopen callbacks and publishes after success', async () => {
+    const pending = deferred<TripSettlement>();
+    mockReopenSettlement.mockReturnValue(pending.promise);
+    mockUseExpenseDashboard.mockReturnValue(
+      dashboardHookState({
+        nextDashboard: dashboard({ settlement: settlement() }),
+      }),
+    );
+    await render(<ExpensesScreen />);
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Reopen settlement' }),
+    );
+    const reopen = alertAction(0, 'Reopen');
+    await act(async () => {
+      reopen();
+      reopen();
+    });
+
+    expect(mockReopenSettlement).toHaveBeenCalledTimes(1);
+    expect(mockReopenSettlement).toHaveBeenCalledWith(TRIP_ID);
+    await act(async () => {
+      pending.resolve(settlement({ status: 'REOPENED' }));
+    });
+    await waitFor(() =>
+      expect(mockPublishExpenseEvent).toHaveBeenCalledTimes(1),
+    );
+  });
+
+  it('surfaces a reopen 409 verbatim and publishes reconciliation', async () => {
+    mockReopenSettlement.mockRejectedValueOnce(
+      axiosErrorWith(409, {
+        detail: 'Settlement is no longer finalized.',
+        error_code: 'SETTLEMENT_NOT_FINALIZED',
+      }),
+    );
+    mockUseExpenseDashboard.mockReturnValue(
+      dashboardHookState({
+        nextDashboard: dashboard({ settlement: settlement() }),
+      }),
+    );
+    await render(<ExpensesScreen />);
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Reopen settlement' }),
+    );
+    await act(async () => {
+      alertAction(0, 'Reopen')();
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Settlement is no longer finalized.'),
+      ).toBeTruthy(),
+    );
+    expect(mockPublishExpenseEvent).toHaveBeenCalledWith({
+      type: 'expensesChanged',
+      tripId: TRIP_ID,
+    });
+  });
+
+  it.each([
+    {
+      name: 'payer on a completed trip',
+      viewerId: PAYER_ID,
+      nextTransfer: transfer(),
+      button: 'I sent it',
+    },
+    {
+      name: 'recipient on a cancelled trip after payer sent',
+      viewerId: RECIPIENT_ID,
+      nextTransfer: transfer({
+        payer_marked_sent_at: '2026-07-28T01:00:00Z',
+      }),
+      button: 'I received it',
+    },
+  ])(
+    'keeps transfer role action independent of terminal gate: $name',
+    async ({ viewerId, nextTransfer, button }) => {
+      mockUseSession.mockReturnValue({ user: { id: viewerId } });
+      mockUseTripDetail.mockReturnValue(
+        tripHookState({
+          detail: tripDetail({
+            status: button === 'I sent it' ? 'COMPLETED' : 'CANCELLED',
+          }),
+        }),
+      );
+      mockUseExpenseDashboard.mockReturnValue(
+        dashboardHookState({
+          nextDashboard: dashboard({
+            settlement: settlement({ transfers: [nextTransfer] }),
+          }),
+        }),
+      );
+      await render(<ExpensesScreen />);
+
+      expect(screen.getByRole('button', { name: button })).toBeTruthy();
+      expect(
+        screen.queryByRole('button', { name: 'Reopen settlement' }),
+      ).toBeNull();
+      expect(
+        screen.queryByRole('button', { name: 'Add expense' }),
+      ).toBeNull();
+    },
+  );
+
+  it.each([
+    ['unrelated viewer', OTHER_USER_ID],
+    ['unresolved viewer', null],
+  ])('shows tracking only for %s', async (_name, viewerId) => {
+    mockUseSession.mockReturnValue({
+      user: viewerId ? { id: viewerId } : null,
+    });
+    mockUseExpenseDashboard.mockReturnValue(
+      dashboardHookState({
+        nextDashboard: dashboard({ settlement: settlement() }),
+      }),
+    );
+    await render(<ExpensesScreen />);
+
+    expect(screen.getByText('Tracking')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'I sent it' })).toBeNull();
+    expect(
+      screen.queryByRole('button', { name: 'I received it' }),
+    ).toBeNull();
+  });
+
+  it('locks duplicate transfer confirmations per transfer id', async () => {
+    const pending = deferred<SettlementTransfer>();
+    mockMarkTransferSent.mockReturnValue(pending.promise);
+    mockUseExpenseDashboard.mockReturnValue(
+      dashboardHookState({
+        nextDashboard: dashboard({ settlement: settlement() }),
+      }),
+    );
+    await render(<ExpensesScreen />);
+
+    const sentButton = screen.getByRole('button', { name: 'I sent it' });
+    await fireEvent.press(sentButton);
+    await fireEvent.press(sentButton);
+    expect(alertSpy).toHaveBeenCalledTimes(2);
+
+    const firstConfirm = alertAction(0, 'Confirm');
+    const secondConfirm = alertAction(1, 'Confirm');
+    await act(async () => {
+      firstConfirm();
+      secondConfirm();
+    });
+    expect(mockMarkTransferSent).toHaveBeenCalledTimes(1);
+    expect(mockMarkTransferSent).toHaveBeenCalledWith(
+      TRIP_ID,
+      TRANSFER_ID,
+    );
+
+    await act(async () => {
+      pending.resolve(
+        transfer({ payer_marked_sent_at: '2026-07-28T01:00:00Z' }),
+      );
+    });
+    await waitFor(() =>
+      expect(mockPublishExpenseEvent).toHaveBeenCalledTimes(1),
+    );
+  });
+
+  it('surfaces transfer 409 per row and publishes reconciliation', async () => {
+    mockConfirmTransferReceived.mockRejectedValueOnce(
+      axiosErrorWith(409, {
+        detail: 'The payer has not marked this transfer as sent.',
+        error_code: 'TRANSFER_NOT_SENT',
+      }),
+    );
+    mockUseSession.mockReturnValue({ user: { id: RECIPIENT_ID } });
+    mockUseExpenseDashboard.mockReturnValue(
+      dashboardHookState({
+        nextDashboard: dashboard({
+          settlement: settlement({
+            transfers: [
+              transfer({
+                payer_marked_sent_at: '2026-07-28T01:00:00Z',
+              }),
+            ],
+          }),
+        }),
+      }),
+    );
+    await render(<ExpensesScreen />);
+
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'I received it' }),
+    );
+    await act(async () => {
+      alertAction(0, 'Confirm')();
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          'The payer has not marked this transfer as sent.',
+        ),
+      ).toBeTruthy(),
+    );
+    expect(mockPublishExpenseEvent).toHaveBeenCalledWith({
+      type: 'expensesChanged',
+      tripId: TRIP_ID,
+    });
+  });
+});

--- a/mobile/src/features/expenses/__tests__/RouteScreens.test.tsx
+++ b/mobile/src/features/expenses/__tests__/RouteScreens.test.tsx
@@ -1,0 +1,118 @@
+let mockParams: Record<string, string | string[] | undefined> = {};
+const mockUseExpenseDashboard = jest.fn();
+const mockUseExpenseDetail = jest.fn();
+const mockUseTripDetail = jest.fn();
+const mockUseExpenseCompositionCoordinator = jest.fn();
+
+jest.mock('expo-router', () => ({
+  Stack: { Screen: () => null },
+  useFocusEffect: jest.fn(),
+  useLocalSearchParams: () => mockParams,
+  useRouter: () => ({
+    push: jest.fn(),
+    dismissTo: jest.fn(),
+  }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('../hooks/useExpenseDashboard', () => ({
+  useExpenseDashboard: (...args: unknown[]) =>
+    mockUseExpenseDashboard(...args),
+}));
+jest.mock('../hooks/useExpenseDetail', () => ({
+  useExpenseDetail: (...args: unknown[]) => mockUseExpenseDetail(...args),
+}));
+jest.mock('@/features/trips/hooks/useTripDetail', () => ({
+  useTripDetail: (...args: unknown[]) => mockUseTripDetail(...args),
+}));
+jest.mock('../hooks/useExpenseCompositionCoordinator', () => ({
+  useExpenseCompositionCoordinator: (...args: unknown[]) =>
+    mockUseExpenseCompositionCoordinator(...args),
+}));
+
+// eslint-disable-next-line import/first
+import { render, screen } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import ExpensesRoute from '@/app/trips/[tripId]/expenses/index';
+// eslint-disable-next-line import/first
+import ExpenseDetailRoute from '@/app/trips/[tripId]/expenses/[expenseId]';
+// eslint-disable-next-line import/first
+import ExpenseFormRoute from '@/app/trips/[tripId]/expenses/expense-form';
+// eslint-disable-next-line import/first
+import { ExpensesScreen } from '../screens/ExpensesScreen';
+// eslint-disable-next-line import/first
+import { ExpenseDetailScreen } from '../screens/ExpenseDetailScreen';
+// eslint-disable-next-line import/first
+import { ExpenseFormScreen } from '../screens/ExpenseFormScreen';
+
+const TRIP_ID = '123e4567-e89b-12d3-a456-426614174000';
+const EXPENSE_ID = '2c1dfd8d-9c7f-43c7-9b99-71f6d1edda55';
+
+describe('Expenses route screens', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockParams = {};
+  });
+
+  it('keeps every Expo Router file a thin default re-export', () => {
+    expect(ExpensesRoute).toBe(ExpensesScreen);
+    expect(ExpenseDetailRoute).toBe(ExpenseDetailScreen);
+    expect(ExpenseFormRoute).toBe(ExpenseFormScreen);
+  });
+
+  it('guards invalid dashboard intent before any aggregate hook', async () => {
+    mockParams = { tripId: [TRIP_ID] };
+    await render(<ExpensesRoute />);
+
+    expect(screen.getByText('Expenses unavailable')).toBeTruthy();
+    expect(mockUseExpenseDashboard).not.toHaveBeenCalled();
+    expect(mockUseTripDetail).not.toHaveBeenCalled();
+    expect(mockUseExpenseCompositionCoordinator).not.toHaveBeenCalled();
+  });
+
+  it('guards invalid detail intent before any aggregate hook', async () => {
+    mockParams = {
+      tripId: TRIP_ID,
+      expenseId: [EXPENSE_ID],
+    };
+    await render(<ExpenseDetailRoute />);
+
+    expect(screen.getByText('Expense unavailable')).toBeTruthy();
+    expect(mockUseExpenseDetail).not.toHaveBeenCalled();
+    expect(mockUseTripDetail).not.toHaveBeenCalled();
+    expect(mockUseExpenseCompositionCoordinator).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: 'create with an expense id',
+      params: {
+        tripId: TRIP_ID,
+        mode: 'create',
+        expenseId: EXPENSE_ID,
+      },
+    },
+    {
+      name: 'edit without an expense id',
+      params: {
+        tripId: TRIP_ID,
+        mode: 'edit',
+      },
+    },
+    {
+      name: 'unknown mode',
+      params: {
+        tripId: TRIP_ID,
+        mode: 'duplicate',
+      },
+    },
+  ])('guards contradictory form intent: $name', async ({ params }) => {
+    mockParams = params;
+    await render(<ExpenseFormRoute />);
+
+    expect(screen.getByText('Form unavailable')).toBeTruthy();
+    expect(mockUseExpenseDashboard).not.toHaveBeenCalled();
+    expect(mockUseExpenseDetail).not.toHaveBeenCalled();
+    expect(mockUseTripDetail).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/features/expenses/__tests__/actions.test.ts
+++ b/mobile/src/features/expenses/__tests__/actions.test.ts
@@ -1,0 +1,147 @@
+import type { TripStatus } from '@/features/trips/types';
+import {
+  getExpenseDashboardActions,
+  getExpenseItemActions,
+} from '../actions';
+import type { TripSettlement } from '../types';
+
+const TRIP_STATUSES: readonly TripStatus[] = [
+  'PLANNING',
+  'ONGOING',
+  'COMPLETED',
+  'CANCELLED',
+];
+
+const FINALIZED_SETTLEMENT: TripSettlement = {
+  id: 'settlement-1',
+  status: 'FINALIZED',
+  finalized_at: '2026-07-28T00:00:00Z',
+  transfers: [],
+};
+
+const DASHBOARD_CASES = [false, true].flatMap((canManageExpenses) =>
+  TRIP_STATUSES.flatMap((tripStatus) =>
+    [null, FINALIZED_SETTLEMENT].flatMap((settlement) =>
+      [0, 1].map((expenseCount) => ({
+        canManageExpenses,
+        tripStatus,
+        settlement,
+        expenseCount,
+      })),
+    ),
+  ),
+);
+
+const ITEM_CASES = [false, true].flatMap((canManageExpenses) =>
+  TRIP_STATUSES.flatMap((tripStatus) =>
+    [false, true].map((locked) => ({
+      canManageExpenses,
+      tripStatus,
+      locked,
+    })),
+  ),
+);
+
+describe('getExpenseDashboardActions', () => {
+  it.each(DASHBOARD_CASES)(
+    'covers canManage=$canManageExpenses status=$tripStatus finalized=$settlement expenseCount=$expenseCount',
+    ({ canManageExpenses, tripStatus, settlement, expenseCount }) => {
+      const isTerminal =
+        tripStatus === 'COMPLETED' || tripStatus === 'CANCELLED';
+      const isFinalized = settlement !== null;
+      const canMutate = canManageExpenses && !isTerminal;
+
+      expect(
+        getExpenseDashboardActions({
+          canManageExpenses,
+          tripStatus,
+          settlement,
+          expenseCount,
+        }),
+      ).toEqual({
+        canAddExpense: canMutate && !isFinalized,
+        canFinalize:
+          canMutate && !isFinalized && expenseCount > 0,
+        canReopen: canMutate && isFinalized,
+      });
+    },
+  );
+
+  it('executes all 32 required dashboard combinations', () => {
+    expect(DASHBOARD_CASES).toHaveLength(32);
+  });
+
+  it('ignores an inconsistent client-derived captain guess', () => {
+    const staleClientRole = {
+      canManageExpenses: false,
+      tripStatus: 'PLANNING' as const,
+      settlement: null,
+      expenseCount: 1,
+      isCaptain: true,
+    };
+
+    expect(getExpenseDashboardActions(staleClientRole)).toEqual({
+      canAddExpense: false,
+      canFinalize: false,
+      canReopen: false,
+    });
+  });
+
+  it('does not treat an impossible reopened dashboard object as finalized', () => {
+    expect(
+      getExpenseDashboardActions({
+        canManageExpenses: true,
+        tripStatus: 'PLANNING',
+        settlement: {
+          ...FINALIZED_SETTLEMENT,
+          status: 'REOPENED',
+        },
+        expenseCount: 1,
+      }),
+    ).toEqual({
+      canAddExpense: true,
+      canFinalize: true,
+      canReopen: false,
+    });
+  });
+});
+
+describe('getExpenseItemActions', () => {
+  it.each(ITEM_CASES)(
+    'covers canManage=$canManageExpenses status=$tripStatus locked=$locked',
+    ({ canManageExpenses, tripStatus, locked }) => {
+      const isTerminal =
+        tripStatus === 'COMPLETED' || tripStatus === 'CANCELLED';
+      const expected = canManageExpenses && !isTerminal && !locked;
+
+      expect(
+        getExpenseItemActions({
+          canManageExpenses,
+          tripStatus,
+          locked,
+        }),
+      ).toEqual({
+        canEditExpense: expected,
+        canEditContributions: expected,
+      });
+    },
+  );
+
+  it('executes all 16 required item combinations', () => {
+    expect(ITEM_CASES).toHaveLength(16);
+  });
+
+  it('ignores an inconsistent client-derived captain guess', () => {
+    const staleClientRole = {
+      canManageExpenses: false,
+      tripStatus: 'PLANNING' as const,
+      locked: false,
+      isCaptain: true,
+    };
+
+    expect(getExpenseItemActions(staleClientRole)).toEqual({
+      canEditExpense: false,
+      canEditContributions: false,
+    });
+  });
+});

--- a/mobile/src/features/expenses/__tests__/api.test.ts
+++ b/mobile/src/features/expenses/__tests__/api.test.ts
@@ -1,0 +1,217 @@
+jest.mock('@/shared/api/client', () => ({
+  apiClient: {
+    delete: jest.fn(),
+    get: jest.fn(),
+    patch: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { apiClient } from '@/shared/api/client';
+// eslint-disable-next-line import/first
+import {
+  confirmTransferReceived,
+  createExpense,
+  deleteExpense,
+  finalizeSettlement,
+  getExpenseDashboard,
+  getExpenseDetail,
+  markTransferSent,
+  reopenSettlement,
+  setContribution,
+  updateExpense,
+} from '../api';
+
+const mockDelete = apiClient.delete as jest.MockedFunction<
+  typeof apiClient.delete
+>;
+const mockGet = apiClient.get as jest.MockedFunction<typeof apiClient.get>;
+const mockPatch = apiClient.patch as jest.MockedFunction<
+  typeof apiClient.patch
+>;
+const mockPost = apiClient.post as jest.MockedFunction<typeof apiClient.post>;
+
+describe('expense api', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('gets the raw dashboard with cancellation support', async () => {
+    const controller = new AbortController();
+    const dashboard = {
+      currency_code: 'VND',
+      summary: {
+        total_amount: '100000',
+        paid_amount: '0',
+        missing_amount: '100000',
+        surplus_amount: '0',
+      },
+      permissions: { can_manage_expenses: true },
+      my_balance: { balance: '-50000', surplus_held: '0' },
+      member_balances: {},
+      settlement: null,
+      expenses: [],
+    };
+    mockGet.mockResolvedValue({ data: dashboard } as never);
+
+    await expect(
+      getExpenseDashboard('trip-1', controller.signal),
+    ).resolves.toBe(dashboard);
+    expect(mockGet).toHaveBeenCalledWith('/trips/trip-1/expenses', {
+      signal: controller.signal,
+    });
+  });
+
+  it('gets the raw expense detail with cancellation support', async () => {
+    const controller = new AbortController();
+    const detail = { id: 'expense-1', participants: [] };
+    mockGet.mockResolvedValue({ data: detail } as never);
+
+    await expect(
+      getExpenseDetail('trip-1', 'expense-1', controller.signal),
+    ).resolves.toBe(detail);
+    expect(mockGet).toHaveBeenCalledWith(
+      '/trips/trip-1/expenses/expense-1',
+      { signal: controller.signal },
+    );
+  });
+
+  it('creates an expense and returns the raw create response', async () => {
+    const payload = {
+      title: 'Hotel',
+      description: 'Deposit',
+      total_amount: '120.00',
+      collector_id: 'user-1',
+    };
+    const created = {
+      id: 'expense-1',
+      ...payload,
+      currency_code: 'USD',
+      locked_at: null,
+      created_at: '2026-07-28T00:00:00Z',
+    };
+    mockPost.mockResolvedValue({ data: created } as never);
+
+    await expect(createExpense('trip-1', payload)).resolves.toBe(created);
+    expect(mockPost).toHaveBeenCalledWith(
+      '/trips/trip-1/expenses',
+      payload,
+    );
+  });
+
+  it('updates an expense and returns the full raw detail response', async () => {
+    const payload = { title: 'New hotel', total_amount: '200.00' };
+    const detail = {
+      id: 'expense-1',
+      title: 'New hotel',
+      participants: [],
+    };
+    mockPatch.mockResolvedValue({ data: detail } as never);
+
+    await expect(
+      updateExpense('trip-1', 'expense-1', payload),
+    ).resolves.toBe(detail);
+    expect(mockPatch).toHaveBeenCalledWith(
+      '/trips/trip-1/expenses/expense-1',
+      payload,
+    );
+  });
+
+  it('deletes an expense and returns void for HTTP 204', async () => {
+    mockDelete.mockResolvedValue({ data: undefined } as never);
+
+    await expect(
+      deleteExpense('trip-1', 'expense-1'),
+    ).resolves.toBeUndefined();
+    expect(mockDelete).toHaveBeenCalledWith(
+      '/trips/trip-1/expenses/expense-1',
+    );
+  });
+
+  it('sets a participant contribution and returns the raw response', async () => {
+    const payload = { amount: '0' };
+    const contribution = {
+      id: 'contribution-1',
+      user: {
+        id: 'user-1',
+        display_name: 'Minh',
+        identify_tag: '@minh',
+      },
+      amount: '0',
+      updated_at: '2026-07-28T00:00:00Z',
+    };
+    mockPatch.mockResolvedValue({ data: contribution } as never);
+
+    await expect(
+      setContribution(
+        'trip-1',
+        'expense-1',
+        'user-1',
+        payload,
+      ),
+    ).resolves.toBe(contribution);
+    expect(mockPatch).toHaveBeenCalledWith(
+      '/trips/trip-1/expenses/expense-1/contributions/user-1',
+      payload,
+    );
+  });
+
+  it('finalizes settlement with no request body and returns the raw settlement', async () => {
+    const settlement = {
+      id: 'settlement-1',
+      status: 'FINALIZED',
+      finalized_at: '2026-07-28T00:00:00Z',
+      transfers: [],
+    };
+    mockPost.mockResolvedValue({ data: settlement } as never);
+
+    await expect(finalizeSettlement('trip-1')).resolves.toBe(settlement);
+    expect(mockPost).toHaveBeenCalledWith(
+      '/trips/trip-1/settlement/finalize',
+    );
+  });
+
+  it('reopens settlement with no request body and returns the raw settlement', async () => {
+    const settlement = {
+      id: 'settlement-1',
+      status: 'REOPENED',
+      finalized_at: '2026-07-28T00:00:00Z',
+      transfers: [],
+    };
+    mockPost.mockResolvedValue({ data: settlement } as never);
+
+    await expect(reopenSettlement('trip-1')).resolves.toBe(settlement);
+    expect(mockPost).toHaveBeenCalledWith(
+      '/trips/trip-1/settlement/reopen',
+    );
+  });
+
+  it('marks a transfer sent with no request body and returns the raw transfer', async () => {
+    const transfer = {
+      id: 'transfer-1',
+      payer_marked_sent_at: '2026-07-28T00:00:00Z',
+    };
+    mockPost.mockResolvedValue({ data: transfer } as never);
+
+    await expect(
+      markTransferSent('trip-1', 'transfer-1'),
+    ).resolves.toBe(transfer);
+    expect(mockPost).toHaveBeenCalledWith(
+      '/trips/trip-1/settlement/transfers/transfer-1/sent',
+    );
+  });
+
+  it('confirms a transfer received with no request body and returns the raw transfer', async () => {
+    const transfer = {
+      id: 'transfer-1',
+      recipient_confirmed_at: '2026-07-28T00:00:00Z',
+    };
+    mockPost.mockResolvedValue({ data: transfer } as never);
+
+    await expect(
+      confirmTransferReceived('trip-1', 'transfer-1'),
+    ).resolves.toBe(transfer);
+    expect(mockPost).toHaveBeenCalledWith(
+      '/trips/trip-1/settlement/transfers/transfer-1/received',
+    );
+  });
+});

--- a/mobile/src/features/expenses/__tests__/expenseEvents.test.ts
+++ b/mobile/src/features/expenses/__tests__/expenseEvents.test.ts
@@ -1,0 +1,86 @@
+import {
+  publishExpenseEvent,
+  subscribeToExpenseEvents,
+  type ExpenseEvent,
+} from '../expenseEvents';
+
+describe('expense events', () => {
+  it('publishes only to listeners keyed to the changed trip', async () => {
+    const tripOneListener = jest.fn();
+    const tripTwoListener = jest.fn();
+    const unsubscribeTripOne = subscribeToExpenseEvents(
+      'trip-1',
+      tripOneListener,
+    );
+    const unsubscribeTripTwo = subscribeToExpenseEvents(
+      'trip-2',
+      tripTwoListener,
+    );
+    const event: ExpenseEvent = {
+      type: 'expensesChanged',
+      tripId: 'trip-1',
+    };
+
+    await publishExpenseEvent(event);
+
+    expect(tripOneListener).toHaveBeenCalledTimes(1);
+    expect(tripOneListener).toHaveBeenCalledWith(event);
+    expect(tripTwoListener).not.toHaveBeenCalled();
+
+    unsubscribeTripOne();
+    unsubscribeTripTwo();
+  });
+
+  it('notifies every listener and stops after unsubscribe', async () => {
+    const firstListener = jest.fn();
+    const secondListener = jest.fn();
+    const unsubscribeFirst = subscribeToExpenseEvents(
+      'trip-1',
+      firstListener,
+    );
+    const unsubscribeSecond = subscribeToExpenseEvents(
+      'trip-1',
+      secondListener,
+    );
+    const event: ExpenseEvent = {
+      type: 'expensesChanged',
+      tripId: 'trip-1',
+    };
+
+    await publishExpenseEvent(event);
+    unsubscribeFirst();
+    await publishExpenseEvent(event);
+    unsubscribeFirst();
+    unsubscribeSecond();
+    await publishExpenseEvent(event);
+
+    expect(firstListener).toHaveBeenCalledTimes(1);
+    expect(secondListener).toHaveBeenCalledTimes(2);
+  });
+
+  it('waits for asynchronous listeners before resolving', async () => {
+    let resolveListener: () => void = () => undefined;
+    const listener = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveListener = resolve;
+        }),
+    );
+    const unsubscribe = subscribeToExpenseEvents('trip-1', listener);
+    let settled = false;
+
+    const published = publishExpenseEvent({
+      type: 'expensesChanged',
+      tripId: 'trip-1',
+    }).then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    resolveListener();
+    await published;
+    expect(settled).toBe(true);
+    unsubscribe();
+  });
+});

--- a/mobile/src/features/expenses/__tests__/formModel.test.ts
+++ b/mobile/src/features/expenses/__tests__/formModel.test.ts
@@ -1,0 +1,346 @@
+import type { TripMember } from '@/features/trips/types';
+import {
+  buildContributionPayload,
+  buildCreateExpensePayload,
+  buildPatchExpensePayload,
+  createExpenseDraft,
+  getDepartedCurrentCollector,
+  getEligibleCollectors,
+  getExpenseDirtyFields,
+  hydrateExpenseDraft,
+  validateContributionAmount,
+  validateExpenseDraft,
+} from '../formModel';
+import type {
+  ExpenseDetailResponse,
+  ExpenseParticipant,
+} from '../types';
+
+function buildMember(
+  id: string,
+  displayName = id,
+): TripMember {
+  return {
+    membership_id: `membership-${id}`,
+    user: {
+      id,
+      display_name: displayName,
+      identify_tag: `@${id}`,
+      avatar_url: null,
+    },
+    role: 'MEMBER',
+    joined_at: '2026-07-28T00:00:00Z',
+  };
+}
+
+function buildParticipant(
+  userId: string,
+): ExpenseParticipant {
+  return {
+    user_id: userId,
+    display_name: userId,
+    identify_tag: `@${userId}`,
+    share_amount: '50.00',
+    contributed_amount: '0.00',
+    balance: '-50.00',
+    surplus_held: '0.00',
+  };
+}
+
+function buildDetail(
+  overrides: Partial<ExpenseDetailResponse> = {},
+): ExpenseDetailResponse {
+  return {
+    id: 'expense-1',
+    title: 'Hotel',
+    description: 'Deposit',
+    total_amount: '100.00',
+    paid_amount: '0.00',
+    missing_amount: '100.00',
+    surplus_amount: '0.00',
+    currency_code: 'USD',
+    status: 'UNDERFUNDED',
+    collector: {
+      id: 'collector-1',
+      display_name: 'Collector',
+      identify_tag: '@collector',
+    },
+    locked: false,
+    locked_at: null,
+    created_at: '2026-07-28T00:00:00Z',
+    permissions: { can_manage_expenses: true },
+    participants: [
+      buildParticipant('collector-1'),
+      buildParticipant('member-1'),
+    ],
+    ...overrides,
+  };
+}
+
+describe('expense form drafts and validation', () => {
+  it('creates a fresh draft and hydrates one immutable snapshot', () => {
+    expect(createExpenseDraft('collector-1')).toEqual({
+      title: '',
+      description: '',
+      total_amount: '',
+      collector_id: 'collector-1',
+    });
+
+    const detail = buildDetail();
+    const draft = hydrateExpenseDraft(detail);
+    expect(draft).toEqual({
+      title: 'Hotel',
+      description: 'Deposit',
+      total_amount: '100.00',
+      collector_id: 'collector-1',
+    });
+
+    detail.title = 'Refreshed server title';
+    detail.collector.id = 'other-collector';
+    expect(draft.title).toBe('Hotel');
+    expect(draft.collector_id).toBe('collector-1');
+  });
+
+  it('validates title, positive total, scale, and collector eligibility', () => {
+    const invalid = validateExpenseDraft(
+      {
+        title: ' ',
+        description: '',
+        total_amount: '0',
+        collector_id: 'outsider-1',
+      },
+      'USD',
+      {
+        mode: 'create',
+        eligibleCollectorIds: ['member-1'],
+      },
+    );
+
+    expect(invalid).toEqual({
+      isValid: false,
+      fieldErrors: {
+        title: 'Title is required.',
+        total_amount: 'Amount must be greater than zero.',
+        collector_id: 'Choose an eligible active trip member.',
+      },
+    });
+
+    expect(
+      validateExpenseDraft(
+        {
+          title: '😀'.repeat(121),
+          description: '',
+          total_amount: '10.555',
+          collector_id: null,
+        },
+        'USD',
+      ).fieldErrors,
+    ).toMatchObject({
+      title: 'Title must be 120 characters or fewer.',
+      total_amount: 'Invalid amount.',
+    });
+  });
+
+  it('builds a canonical create payload without numeric money conversion', () => {
+    expect(
+      buildCreateExpensePayload(
+        {
+          title: '  Hotel deposit  ',
+          description: '  First night  ',
+          total_amount: '001,200.50',
+          collector_id: 'member-1',
+        },
+        'USD',
+        ['member-1'],
+      ),
+    ).toEqual({
+      title: 'Hotel deposit',
+      description: 'First night',
+      total_amount: '1200.50',
+      collector_id: 'member-1',
+    });
+  });
+
+  it('omits an empty collector so the server can default it', () => {
+    expect(
+      buildCreateExpensePayload(
+        {
+          title: 'Dinner',
+          description: '',
+          total_amount: '600000',
+          collector_id: null,
+        },
+        'VND',
+      ),
+    ).toEqual({
+      title: 'Dinner',
+      description: '',
+      total_amount: '600000',
+    });
+  });
+});
+
+describe('minimal expense PATCH', () => {
+  it('emits only canonical fields that are both dirty and changed', () => {
+    const initial = hydrateExpenseDraft(buildDetail());
+    const draft = {
+      ...initial,
+      title: '  New hotel  ',
+      description: ' Deposit ',
+      total_amount: '0100.00',
+    };
+    const dirtyFields = getExpenseDirtyFields(initial, draft);
+
+    expect(dirtyFields).toEqual({
+      title: true,
+      description: true,
+      total_amount: true,
+    });
+    expect(
+      buildPatchExpensePayload(
+        initial,
+        draft,
+        'USD',
+        dirtyFields,
+        ['collector-1', 'member-1'],
+      ),
+    ).toEqual({
+      title: 'New hotel',
+    });
+  });
+
+  it('omits an unchanged departed collector from PATCH', () => {
+    const initial = hydrateExpenseDraft(
+      buildDetail({
+        collector: {
+          id: 'departed-1',
+          display_name: 'Departed collector',
+          identify_tag: '@departed',
+        },
+      }),
+    );
+    const draft = { ...initial, title: 'Updated hotel' };
+
+    expect(
+      buildPatchExpensePayload(
+        initial,
+        draft,
+        'USD',
+        undefined,
+        ['member-1'],
+      ),
+    ).toEqual({ title: 'Updated hotel' });
+  });
+
+  it('includes an explicitly selected eligible replacement collector', () => {
+    const initial = hydrateExpenseDraft(
+      buildDetail({
+        collector: {
+          id: 'departed-1',
+          display_name: 'Departed collector',
+          identify_tag: '@departed',
+        },
+      }),
+    );
+
+    expect(
+      buildPatchExpensePayload(
+        initial,
+        { ...initial, collector_id: 'member-1' },
+        'USD',
+        undefined,
+        ['member-1'],
+      ),
+    ).toEqual({ collector_id: 'member-1' });
+  });
+
+  it('rejects an ineligible replacement and an empty edit collector', () => {
+    const initial = hydrateExpenseDraft(buildDetail());
+
+    expect(
+      buildPatchExpensePayload(
+        initial,
+        { ...initial, collector_id: 'late-member' },
+        'USD',
+        undefined,
+        ['member-1'],
+      ),
+    ).toBeNull();
+    expect(
+      buildPatchExpensePayload(
+        initial,
+        { ...initial, collector_id: null },
+        'USD',
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('collector eligibility', () => {
+  const activeMembers = [
+    buildMember('collector-1', 'Collector'),
+    buildMember('member-1', 'Member'),
+    buildMember('late-member', 'Late member'),
+  ];
+
+  it('uses every active member for create', () => {
+    expect(
+      getEligibleCollectors(activeMembers).map((member) => member.user.id),
+    ).toEqual(['collector-1', 'member-1', 'late-member']);
+  });
+
+  it('intersects active members with the immutable participant snapshot for edit', () => {
+    expect(
+      getEligibleCollectors(activeMembers, [
+        buildParticipant('collector-1'),
+        buildParticipant('member-1'),
+        buildParticipant('departed-1'),
+      ]).map((member) => member.user.id),
+    ).toEqual(['collector-1', 'member-1']);
+  });
+
+  it('returns a departed current collector only for display, never as an option', () => {
+    const departed = {
+      id: 'departed-1',
+      display_name: 'Departed collector',
+      identify_tag: '@departed',
+    };
+    const eligible = getEligibleCollectors(activeMembers, [
+      buildParticipant('departed-1'),
+      buildParticipant('member-1'),
+    ]);
+
+    expect(eligible.map((member) => member.user.id)).toEqual(['member-1']);
+    expect(getDepartedCurrentCollector(departed, eligible)).toBe(departed);
+    expect(
+      getDepartedCurrentCollector(
+        {
+          id: 'member-1',
+          display_name: 'Member',
+          identify_tag: '@member',
+        },
+        eligible,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('contribution payload', () => {
+  it('accepts zero and overfunding as canonical strings', () => {
+    expect(buildContributionPayload('0', 'VND')).toEqual({ amount: '0' });
+    expect(
+      buildContributionPayload('999999999999.99', 'USD'),
+    ).toEqual({
+      amount: '999999999999.99',
+    });
+  });
+
+  it('rejects negative, excess-scale, and max-digit violations', () => {
+    expect(buildContributionPayload('-1', 'USD')).toBeNull();
+    expect(buildContributionPayload('10.555', 'USD')).toBeNull();
+    expect(buildContributionPayload('9999999999999', 'VND')).toBeNull();
+    expect(validateContributionAmount('', 'USD').error).toBe(
+      'Amount is required.',
+    );
+  });
+});

--- a/mobile/src/features/expenses/__tests__/money.test.ts
+++ b/mobile/src/features/expenses/__tests__/money.test.ts
@@ -1,0 +1,268 @@
+import {
+  formatExpenseMoney,
+  getExpenseCurrencyScale,
+  getExpenseFundingPercent,
+  getExpenseStatusLabel,
+  getExpenseStatusTone,
+  getSettlementTransferRoleState,
+  getUserBalanceDirection,
+  getUserBalanceLabel,
+  normalizeExpenseMoneyInput,
+  parseMoneyAmount,
+  ZERO_DECIMAL_CURRENCIES,
+} from '../money';
+import type { SettlementTransfer } from '../types';
+
+function buildTransfer(
+  overrides: Partial<SettlementTransfer> = {},
+): SettlementTransfer {
+  return {
+    id: 'transfer-1',
+    payer: {
+      id: 'payer-1',
+      display_name: 'Payer',
+      identify_tag: '@payer',
+    },
+    recipient: {
+      id: 'recipient-1',
+      display_name: 'Recipient',
+      identify_tag: '@recipient',
+    },
+    amount: '100.00',
+    payer_marked_sent_at: null,
+    recipient_confirmed_at: null,
+    ...overrides,
+  };
+}
+
+describe('expense money formatting', () => {
+  it('uses the backend zero-decimal currency set', () => {
+    expect([...ZERO_DECIMAL_CURRENCIES]).toEqual(['VND', 'JPY', 'KRW']);
+    expect(getExpenseCurrencyScale('vnd')).toBe(0);
+    expect(getExpenseCurrencyScale('JPY')).toBe(0);
+    expect(getExpenseCurrencyScale('krw')).toBe(0);
+    expect(getExpenseCurrencyScale('USD')).toBe(2);
+  });
+
+  it('formats zero-decimal and two-decimal amounts for display only', () => {
+    const vnd = formatExpenseMoney('50000', 'VND');
+    const usd = formatExpenseMoney('10.50', 'USD');
+
+    expect(vnd).toContain('50');
+    expect(vnd).not.toMatch(/[.,]00(?:\D|$)/);
+    expect(usd).toContain('10.50');
+  });
+
+  it('falls back safely for an unknown or malformed currency code', () => {
+    expect(formatExpenseMoney('10', 'NOT-A-CURRENCY')).toBe(
+      '10 NOT-A-CURRENCY',
+    );
+  });
+
+  it('parses only for display helpers and degrades invalid values to zero', () => {
+    expect(parseMoneyAmount('12.50')).toBe(12.5);
+    expect(parseMoneyAmount(12.5)).toBe(12.5);
+    expect(parseMoneyAmount('not-money')).toBe(0);
+  });
+});
+
+describe('canonical expense input', () => {
+  it.each([
+    ['1500000', '1500000'],
+    ['1.500.000', '1500000'],
+    ['1,500,000', '1500000'],
+    ['1 500 000', '1500000'],
+    ['0001500', '1500'],
+  ])('normalizes VND %s without Number conversion', (input, expected) => {
+    expect(normalizeExpenseMoneyInput(input, 'VND')).toEqual({
+      value: expected,
+      error: null,
+    });
+  });
+
+  it.each(['1500.50', '1,50', '1..500', '-1', '1e3'])(
+    'rejects invalid zero-decimal input %s',
+    (input) => {
+      expect(normalizeExpenseMoneyInput(input, 'VND').value).toBeNull();
+    },
+  );
+
+  it.each([
+    ['1500', '1500'],
+    ['1,500.50', '1500.50'],
+    ['001500.50', '1500.50'],
+    ['0.01', '0.01'],
+  ])('normalizes USD %s as a canonical decimal string', (input, expected) => {
+    expect(normalizeExpenseMoneyInput(input, 'USD')).toEqual({
+      value: expected,
+      error: null,
+    });
+  });
+
+  it.each(['10.555', '1.500,50', '.50', '-1.00', '1e3'])(
+    'rejects invalid two-decimal input %s',
+    (input) => {
+      expect(normalizeExpenseMoneyInput(input, 'USD').value).toBeNull();
+    },
+  );
+
+  it('mirrors DRF max_digits=14 and decimal_places=2 boundaries', () => {
+    expect(
+      normalizeExpenseMoneyInput('999999999999', 'VND'),
+    ).toEqual({
+      value: '999999999999',
+      error: null,
+    });
+    expect(
+      normalizeExpenseMoneyInput('9999999999999', 'VND').value,
+    ).toBeNull();
+
+    expect(
+      normalizeExpenseMoneyInput('999999999999.99', 'USD'),
+    ).toEqual({
+      value: '999999999999.99',
+      error: null,
+    });
+    expect(
+      normalizeExpenseMoneyInput('9999999999999.9', 'USD').value,
+    ).toBeNull();
+  });
+
+  it('requires positive totals while retaining zero as a valid contribution', () => {
+    expect(
+      normalizeExpenseMoneyInput('0', 'VND', {
+        minimum: 'positive',
+      }),
+    ).toEqual({
+      value: null,
+      error: 'Amount must be greater than zero.',
+    });
+    expect(
+      normalizeExpenseMoneyInput('0', 'VND', {
+        minimum: 'non-negative',
+      }),
+    ).toEqual({ value: '0', error: null });
+  });
+
+  it('does not impose a client-side overfunding ceiling', () => {
+    expect(
+      normalizeExpenseMoneyInput('999999999999.99', 'USD', {
+        minimum: 'non-negative',
+      }).value,
+    ).toBe('999999999999.99');
+  });
+});
+
+describe('expense display state helpers', () => {
+  it('clamps funding percentages and handles invalid totals', () => {
+    expect(
+      getExpenseFundingPercent({
+        total_amount: '100.00',
+        paid_amount: '25.00',
+      }),
+    ).toBe(25);
+    expect(
+      getExpenseFundingPercent({
+        total_amount: '100.00',
+        paid_amount: '150.00',
+      }),
+    ).toBe(100);
+    expect(
+      getExpenseFundingPercent({
+        total_amount: '0',
+        paid_amount: '50.00',
+      }),
+    ).toBe(0);
+  });
+
+  it('labels balance direction without deriving business money', () => {
+    expect(getUserBalanceDirection('-10.00')).toBe('owe');
+    expect(getUserBalanceDirection('10.00')).toBe('receive');
+    expect(getUserBalanceDirection('0.00')).toBe('balanced');
+    expect(getUserBalanceLabel('-10.00', 'USD')).toContain('You owe');
+    expect(getUserBalanceLabel('10.00', 'USD')).toContain('You are owed');
+    expect(getUserBalanceLabel('0.00', 'USD')).toBe('Settled');
+  });
+
+  it.each([
+    ['UNDERFUNDED', 'Underfunded', 'warning'],
+    ['FUNDED', 'Funded', 'success'],
+    ['OVERFUNDED', 'Overfunded', 'danger'],
+  ] as const)('maps %s to its label and tone', (status, label, tone) => {
+    expect(getExpenseStatusLabel(status)).toBe(label);
+    expect(getExpenseStatusTone(status)).toBe(tone);
+  });
+});
+
+describe('settlement transfer role state', () => {
+  it('allows only the payer to mark an unsent transfer', () => {
+    expect(
+      getSettlementTransferRoleState(buildTransfer(), 'payer-1'),
+    ).toEqual({
+      isPayer: true,
+      isRecipient: false,
+      isSent: false,
+      isReceived: false,
+      canMarkSent: true,
+      canConfirmReceived: false,
+      actionLabel: 'I sent it',
+    });
+  });
+
+  it('allows only the recipient to confirm after sent and before received', () => {
+    const transfer = buildTransfer({
+      payer_marked_sent_at: '2026-07-28T00:00:00Z',
+    });
+
+    expect(
+      getSettlementTransferRoleState(transfer, 'recipient-1'),
+    ).toMatchObject({
+      isRecipient: true,
+      isSent: true,
+      isReceived: false,
+      canMarkSent: false,
+      canConfirmReceived: true,
+      actionLabel: 'I received it',
+    });
+    expect(
+      getSettlementTransferRoleState(transfer, 'payer-1'),
+    ).toMatchObject({
+      canMarkSent: false,
+      canConfirmReceived: false,
+      actionLabel: null,
+    });
+  });
+
+  it('makes received transfers tracking-only and idempotent in the UI', () => {
+    const transfer = buildTransfer({
+      payer_marked_sent_at: '2026-07-28T00:00:00Z',
+      recipient_confirmed_at: '2026-07-28T01:00:00Z',
+    });
+
+    expect(
+      getSettlementTransferRoleState(transfer, 'recipient-1'),
+    ).toMatchObject({
+      isReceived: true,
+      canMarkSent: false,
+      canConfirmReceived: false,
+      actionLabel: null,
+    });
+  });
+
+  it.each([null, 'unrelated-1'])(
+    'returns tracking-only state for nullable or unrelated viewer %s',
+    (viewerId) => {
+      expect(
+        getSettlementTransferRoleState(buildTransfer(), viewerId),
+      ).toEqual({
+        isPayer: false,
+        isRecipient: false,
+        isSent: false,
+        isReceived: false,
+        canMarkSent: false,
+        canConfirmReceived: false,
+        actionLabel: null,
+      });
+    },
+  );
+});

--- a/mobile/src/features/expenses/__tests__/routeIntent.test.ts
+++ b/mobile/src/features/expenses/__tests__/routeIntent.test.ts
@@ -1,0 +1,150 @@
+import {
+  parseExpenseDetailRouteIntent,
+  parseExpenseFormRouteIntent,
+  parseExpensesRouteIntent,
+  type ExpenseFormRouteParams,
+  type ExpenseRouteParam,
+} from '../routeIntent';
+
+const TRIP_ID = '123e4567-e89b-12d3-a456-426614174000';
+const EXPENSE_ID = '2c1dfd8d-9c7f-43c7-9b99-71f6d1edda55';
+
+const INVALID_UUID_PARAMS: ExpenseRouteParam[] = [
+  undefined,
+  '',
+  '   ',
+  ` ${TRIP_ID}`,
+  `${TRIP_ID} `,
+  'not-a-uuid',
+  '123e4567e89b12d3a456426614174000',
+  [TRIP_ID],
+];
+
+describe('parseExpensesRouteIntent', () => {
+  it('accepts one UUID string and canonicalizes uppercase values', () => {
+    expect(parseExpensesRouteIntent({ tripId: TRIP_ID })).toEqual({
+      tripId: TRIP_ID,
+    });
+    expect(
+      parseExpensesRouteIntent({ tripId: TRIP_ID.toUpperCase() }),
+    ).toEqual({ tripId: TRIP_ID });
+  });
+
+  it.each(INVALID_UUID_PARAMS)('rejects invalid tripId %#', (tripId) => {
+    expect(parseExpensesRouteIntent({ tripId })).toBeNull();
+  });
+});
+
+describe('parseExpenseDetailRouteIntent', () => {
+  it('requires exactly one valid trip and expense id', () => {
+    expect(
+      parseExpenseDetailRouteIntent({
+        tripId: TRIP_ID.toUpperCase(),
+        expenseId: EXPENSE_ID.toUpperCase(),
+      }),
+    ).toEqual({
+      tripId: TRIP_ID,
+      expenseId: EXPENSE_ID,
+    });
+  });
+
+  it.each(INVALID_UUID_PARAMS)(
+    'rejects invalid detail tripId %#',
+    (tripId) => {
+      expect(
+        parseExpenseDetailRouteIntent({
+          tripId,
+          expenseId: EXPENSE_ID,
+        }),
+      ).toBeNull();
+    },
+  );
+
+  it.each(INVALID_UUID_PARAMS)(
+    'rejects invalid detail expenseId %#',
+    (expenseId) => {
+      expect(
+        parseExpenseDetailRouteIntent({
+          tripId: TRIP_ID,
+          expenseId,
+        }),
+      ).toBeNull();
+    },
+  );
+});
+
+describe('parseExpenseFormRouteIntent', () => {
+  const createParams: ExpenseFormRouteParams = {
+    tripId: TRIP_ID,
+    mode: 'create',
+    expenseId: undefined,
+  };
+  const editParams: ExpenseFormRouteParams = {
+    tripId: TRIP_ID,
+    mode: 'edit',
+    expenseId: EXPENSE_ID,
+  };
+
+  it('returns strict explicit create and edit discriminants', () => {
+    expect(parseExpenseFormRouteIntent(createParams)).toEqual({
+      mode: 'create',
+      tripId: TRIP_ID,
+    });
+    expect(
+      parseExpenseFormRouteIntent({
+        ...editParams,
+        tripId: TRIP_ID.toUpperCase(),
+        expenseId: EXPENSE_ID.toUpperCase(),
+      }),
+    ).toEqual({
+      mode: 'edit',
+      tripId: TRIP_ID,
+      expenseId: EXPENSE_ID,
+    });
+  });
+
+  it.each(INVALID_UUID_PARAMS)('rejects invalid tripId %#', (tripId) => {
+    expect(
+      parseExpenseFormRouteIntent({ ...createParams, tripId }),
+    ).toBeNull();
+  });
+
+  it.each([
+    undefined,
+    '',
+    'CREATE',
+    'unknown',
+    ['create'],
+  ] as ExpenseRouteParam[])(
+    'rejects missing, blank, unknown, or array mode %#',
+    (mode) => {
+      expect(
+        parseExpenseFormRouteIntent({ ...createParams, mode }),
+      ).toBeNull();
+    },
+  );
+
+  it.each(['', 'not-a-uuid', EXPENSE_ID, [EXPENSE_ID]] as ExpenseRouteParam[])(
+    'rejects create with any expenseId %#',
+    (expenseId) => {
+      expect(
+        parseExpenseFormRouteIntent({
+          ...createParams,
+          expenseId,
+        }),
+      ).toBeNull();
+    },
+  );
+
+  it.each(INVALID_UUID_PARAMS)(
+    'rejects edit without exactly one valid expenseId %#',
+    (expenseId) => {
+      expect(
+        parseExpenseFormRouteIntent({
+          ...editParams,
+          expenseId,
+        }),
+      ).toBeNull();
+    },
+  );
+});

--- a/mobile/src/features/expenses/__tests__/useExpenseCompositionCoordinator.test.tsx
+++ b/mobile/src/features/expenses/__tests__/useExpenseCompositionCoordinator.test.tsx
@@ -1,0 +1,361 @@
+const mockUseFocusEffect = jest.fn();
+const mockUseAppForegroundEffect = jest.fn();
+const mockSubscribeToExpenseEvents = jest.fn();
+const mockSubscribeToTripEvents = jest.fn();
+let mockExpenseListener:
+  | ((event: {
+      type: 'expensesChanged';
+      tripId: string;
+    }) => void | Promise<void>)
+  | undefined;
+let mockTripListener:
+  | ((event:
+      | {
+          type: 'statusChanged';
+          tripId: string;
+          status: 'PLANNING' | 'ONGOING' | 'COMPLETED' | 'CANCELLED';
+        }
+      | {
+          type: 'removed';
+          tripId: string;
+        }) => void)
+  | undefined;
+
+jest.mock('expo-router', () => ({
+  useFocusEffect: (effect: () => (() => void) | void) =>
+    mockUseFocusEffect(effect),
+}));
+
+jest.mock('@/shared/hooks/useAppForegroundEffect', () => ({
+  useAppForegroundEffect: (listener: () => void) =>
+    mockUseAppForegroundEffect(listener),
+}));
+
+jest.mock('../expenseEvents', () => ({
+  subscribeToExpenseEvents: (...args: unknown[]) =>
+    mockSubscribeToExpenseEvents(...args),
+}));
+
+jest.mock('@/features/trips/tripEvents', () => ({
+  subscribeToTripEvents: (...args: unknown[]) =>
+    mockSubscribeToTripEvents(...args),
+}));
+
+// eslint-disable-next-line import/first
+import { act, renderHook } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { useExpenseCompositionCoordinator } from '../hooks/useExpenseCompositionCoordinator';
+
+const TRIP_ID = '123e4567-e89b-12d3-a456-426614174000';
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function latestFocusCallback(): () => (() => void) | void {
+  const callback = mockUseFocusEffect.mock.calls.at(-1)?.[0] as
+    | (() => (() => void) | void)
+    | undefined;
+  if (!callback) {
+    throw new Error('Expected useFocusEffect to register a callback.');
+  }
+  return callback;
+}
+
+function latestForegroundCallback(): () => void {
+  const callback = mockUseAppForegroundEffect.mock.calls.at(-1)?.[0] as
+    | (() => void)
+    | undefined;
+  if (!callback) {
+    throw new Error(
+      'Expected useAppForegroundEffect to register a callback.',
+    );
+  }
+  return callback;
+}
+
+describe('useExpenseCompositionCoordinator', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockExpenseListener = undefined;
+    mockTripListener = undefined;
+    mockSubscribeToExpenseEvents.mockImplementation(
+      (
+        _tripId: string,
+        listener: (
+          event: {
+            type: 'expensesChanged';
+            tripId: string;
+          },
+        ) => void | Promise<void>,
+      ) => {
+        mockExpenseListener = listener;
+        return () => {
+          if (mockExpenseListener === listener) {
+            mockExpenseListener = undefined;
+          }
+        };
+      },
+    );
+    mockSubscribeToTripEvents.mockImplementation(
+      (
+        listener: (
+          event:
+            | {
+                type: 'statusChanged';
+                tripId: string;
+                status:
+                  | 'PLANNING'
+                  | 'ONGOING'
+                  | 'COMPLETED'
+                  | 'CANCELLED';
+              }
+            | {
+                type: 'removed';
+                tripId: string;
+              },
+        ) => void,
+      ) => {
+        mockTripListener = listener;
+        return () => {
+          if (mockTripListener === listener) {
+            mockTripListener = undefined;
+          }
+        };
+      },
+    );
+  });
+
+  it('owns one paired load for initial focus, refocus, foreground, and matching events', async () => {
+    const refreshExpense = jest.fn().mockResolvedValue(undefined);
+    const refreshTrip = jest.fn().mockResolvedValue(undefined);
+    const { result, unmount } = await renderHook(() =>
+      useExpenseCompositionCoordinator({
+        tripId: TRIP_ID,
+        refreshExpense,
+        refreshTrip,
+      }),
+    );
+
+    let blur: (() => void) | void;
+    await act(async () => {
+      blur = latestFocusCallback()();
+    });
+    expect(refreshExpense).toHaveBeenLastCalledWith('initial');
+    expect(refreshTrip).toHaveBeenLastCalledWith('initial');
+    expect(refreshExpense).toHaveBeenCalledTimes(1);
+    expect(refreshTrip).toHaveBeenCalledTimes(1);
+
+    refreshExpense.mockClear();
+    refreshTrip.mockClear();
+    await act(async () => {
+      blur?.();
+      blur = latestFocusCallback()();
+    });
+    expect(refreshExpense).toHaveBeenCalledTimes(1);
+    expect(refreshTrip).toHaveBeenCalledTimes(1);
+    expect(refreshExpense).toHaveBeenLastCalledWith('silent');
+    expect(refreshTrip).toHaveBeenLastCalledWith('silent');
+
+    refreshExpense.mockClear();
+    refreshTrip.mockClear();
+    await act(async () => {
+      latestForegroundCallback()();
+    });
+    expect(refreshExpense).toHaveBeenCalledTimes(1);
+    expect(refreshTrip).toHaveBeenCalledTimes(1);
+    expect(refreshExpense).toHaveBeenLastCalledWith('silent');
+
+    refreshExpense.mockClear();
+    refreshTrip.mockClear();
+    await act(async () => {
+      await mockExpenseListener?.({
+        type: 'expensesChanged',
+        tripId: TRIP_ID,
+      });
+    });
+    expect(refreshExpense).toHaveBeenCalledTimes(1);
+    expect(refreshTrip).toHaveBeenCalledTimes(1);
+    expect(refreshTrip).toHaveBeenLastCalledWith('silent');
+
+    refreshExpense.mockClear();
+    refreshTrip.mockClear();
+    await act(async () => {
+      mockTripListener?.({
+        type: 'statusChanged',
+        tripId: 'another-trip',
+        status: 'COMPLETED',
+      });
+    });
+    expect(refreshExpense).not.toHaveBeenCalled();
+    expect(refreshTrip).not.toHaveBeenCalled();
+
+    await act(async () => {
+      mockTripListener?.({
+        type: 'statusChanged',
+        tripId: TRIP_ID,
+        status: 'COMPLETED',
+      });
+    });
+    expect(refreshExpense).toHaveBeenCalledTimes(1);
+    expect(refreshTrip).toHaveBeenCalledTimes(1);
+    expect(refreshExpense).toHaveBeenLastCalledWith('silent');
+
+    refreshExpense.mockClear();
+    refreshTrip.mockClear();
+    await act(async () => {
+      blur?.();
+      latestForegroundCallback()();
+      await mockExpenseListener?.({
+        type: 'expensesChanged',
+        tripId: TRIP_ID,
+      });
+      mockTripListener?.({
+        type: 'removed',
+        tripId: TRIP_ID,
+      });
+    });
+    expect(refreshExpense).not.toHaveBeenCalled();
+    expect(refreshTrip).not.toHaveBeenCalled();
+    expect(result.current.isScreenActive()).toBe(false);
+    unmount();
+  });
+
+  it('waits for both mandatory sources during retry and pull refresh', async () => {
+    const expenseRefresh = deferred<void>();
+    const tripRefresh = deferred<void>();
+    const refreshExpense = jest
+      .fn()
+      .mockReturnValue(expenseRefresh.promise);
+    const refreshTrip = jest.fn().mockReturnValue(tripRefresh.promise);
+    const { result, unmount } = await renderHook(() =>
+      useExpenseCompositionCoordinator({
+        tripId: TRIP_ID,
+        refreshExpense,
+        refreshTrip,
+      }),
+    );
+
+    let settled = false;
+    let pullPromise: Promise<void> | undefined;
+    await act(async () => {
+      pullPromise = result.current
+        .refreshAll('refresh')
+        .then(() => {
+          settled = true;
+        });
+    });
+    expect(refreshExpense).toHaveBeenCalledWith('refresh');
+    expect(refreshTrip).toHaveBeenCalledWith('refresh');
+
+    await act(async () => {
+      expenseRefresh.resolve();
+      await Promise.resolve();
+    });
+    expect(settled).toBe(false);
+
+    await act(async () => {
+      tripRefresh.resolve();
+      await pullPromise;
+    });
+    expect(settled).toBe(true);
+
+    refreshExpense.mockResolvedValue(undefined);
+    refreshTrip.mockResolvedValue(undefined);
+    refreshExpense.mockClear();
+    refreshTrip.mockClear();
+    await act(async () => {
+      await result.current.requestReconcile(true);
+    });
+    expect(refreshExpense).toHaveBeenCalledWith('initial');
+    expect(refreshTrip).toHaveBeenCalledWith('initial');
+    unmount();
+  });
+
+  it('does not reconcile automatically when disabled but retains explicit coordinator methods', async () => {
+    const refreshExpense = jest.fn().mockResolvedValue(undefined);
+    const refreshTrip = jest.fn().mockResolvedValue(undefined);
+    const { result, unmount } = await renderHook(() =>
+      useExpenseCompositionCoordinator({
+        tripId: TRIP_ID,
+        refreshExpense,
+        refreshTrip,
+        enabled: false,
+      }),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+      latestForegroundCallback()();
+      await mockExpenseListener?.({
+        type: 'expensesChanged',
+        tripId: TRIP_ID,
+      });
+      mockTripListener?.({
+        type: 'statusChanged',
+        tripId: TRIP_ID,
+        status: 'ONGOING',
+      });
+    });
+    expect(refreshExpense).not.toHaveBeenCalled();
+    expect(refreshTrip).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.refreshAll('refresh');
+    });
+    expect(refreshExpense).toHaveBeenCalledWith('refresh');
+    expect(refreshTrip).toHaveBeenCalledWith('refresh');
+    unmount();
+  });
+
+  it('tracks active generations across blur, refocus, and unmount', async () => {
+    const refreshExpense = jest.fn().mockResolvedValue(undefined);
+    const refreshTrip = jest.fn().mockResolvedValue(undefined);
+    const rendered = await renderHook(() =>
+      useExpenseCompositionCoordinator({
+        tripId: TRIP_ID,
+        refreshExpense,
+        refreshTrip,
+      }),
+    );
+
+    let blur: (() => void) | void;
+    await act(async () => {
+      blur = latestFocusCallback()();
+    });
+    const firstGeneration = rendered.result.current.getGeneration();
+    expect(rendered.result.current.isScreenActive()).toBe(true);
+    expect(
+      rendered.result.current.isActiveGeneration(firstGeneration),
+    ).toBe(true);
+
+    await act(async () => {
+      blur?.();
+    });
+    expect(rendered.result.current.isScreenActive()).toBe(false);
+    expect(
+      rendered.result.current.isActiveGeneration(firstGeneration),
+    ).toBe(false);
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    const secondGeneration = rendered.result.current.getGeneration();
+    expect(secondGeneration).toBeGreaterThan(firstGeneration);
+    expect(
+      rendered.result.current.isActiveGeneration(secondGeneration),
+    ).toBe(true);
+
+    await rendered.unmount();
+    expect(rendered.result.current.isScreenActive()).toBe(false);
+    expect(
+      rendered.result.current.isActiveGeneration(secondGeneration),
+    ).toBe(false);
+  });
+});

--- a/mobile/src/features/expenses/__tests__/useExpenseDashboard.test.tsx
+++ b/mobile/src/features/expenses/__tests__/useExpenseDashboard.test.tsx
@@ -1,0 +1,627 @@
+const mockUseFocusEffect = jest.fn();
+const mockUseAppForegroundEffect = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useFocusEffect: (effect: () => (() => void) | void) =>
+    mockUseFocusEffect(effect),
+}));
+
+jest.mock('@/shared/hooks/useAppForegroundEffect', () => ({
+  useAppForegroundEffect: (listener: () => void) =>
+    mockUseAppForegroundEffect(listener),
+}));
+
+jest.mock('../api', () => ({
+  getExpenseDashboard: jest.fn(),
+}));
+
+// eslint-disable-next-line import/first
+import { AxiosError, AxiosHeaders } from 'axios';
+// eslint-disable-next-line import/first
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { getExpenseDashboard } from '../api';
+// eslint-disable-next-line import/first
+import { publishExpenseEvent } from '../expenseEvents';
+// eslint-disable-next-line import/first
+import { useExpenseDashboard } from '../hooks/useExpenseDashboard';
+// eslint-disable-next-line import/first
+import type { ExpenseDashboardResponse } from '../types';
+
+const mockGetExpenseDashboard =
+  getExpenseDashboard as jest.MockedFunction<typeof getExpenseDashboard>;
+
+function expenseDashboard(title: string): ExpenseDashboardResponse {
+  return {
+    currency_code: 'USD',
+    summary: {
+      total_amount: '120.00',
+      paid_amount: '90.00',
+      missing_amount: '30.00',
+      surplus_amount: '0.00',
+    },
+    permissions: {
+      can_manage_expenses: true,
+    },
+    my_balance: {
+      balance: '-30.00',
+      surplus_held: '0.00',
+    },
+    member_balances: {
+      'user-1': {
+        balance: '-30.00',
+      },
+      'user-2': {
+        balance: '30.00',
+      },
+    },
+    settlement: null,
+    expenses: [
+      {
+        id: 'expense-1',
+        title,
+        description: '',
+        total_amount: '120.00',
+        paid_amount: '90.00',
+        missing_amount: '30.00',
+        surplus_amount: '0.00',
+        currency_code: 'USD',
+        status: 'UNDERFUNDED',
+        collector: {
+          id: 'user-1',
+          display_name: 'Minh',
+          identify_tag: 'minh#1234',
+        },
+        locked: false,
+      },
+    ],
+  };
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, {}, {
+    status,
+    statusText: '',
+    headers: {},
+    config,
+    data,
+  });
+}
+
+function latestFocusCallback(): () => (() => void) | void {
+  const callback = mockUseFocusEffect.mock.calls.at(-1)?.[0] as
+    | (() => (() => void) | void)
+    | undefined;
+  if (!callback) {
+    throw new Error('Expected useFocusEffect to register a callback.');
+  }
+  return callback;
+}
+
+function latestForegroundCallback(): () => void {
+  const callback = mockUseAppForegroundEffect.mock.calls.at(-1)?.[0] as
+    | (() => void)
+    | undefined;
+  if (!callback) {
+    throw new Error('Expected useAppForegroundEffect to register a callback.');
+  }
+  return callback;
+}
+
+describe('useExpenseDashboard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads initially on focus and silently reconciles complete data', async () => {
+    const silent = deferred<ExpenseDashboardResponse>();
+    mockGetExpenseDashboard
+      .mockResolvedValueOnce(expenseDashboard('Hotel'))
+      .mockReturnValueOnce(silent.promise);
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDashboard('trip-1'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() =>
+      expect(result.current.dashboard?.expenses[0]?.title).toBe('Hotel'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    expect(result.current.status).toBe('ready');
+    expect(result.current.refreshing).toBe(false);
+    expect(result.current.dashboard?.expenses[0]?.title).toBe('Hotel');
+
+    await act(async () => {
+      silent.resolve(expenseDashboard('Updated hotel'));
+    });
+    expect(result.current.dashboard?.expenses[0]?.title).toBe(
+      'Updated hotel',
+    );
+    unmount();
+  });
+
+  it('sets refreshing only for explicit refresh and keeps data visible', async () => {
+    const explicit = deferred<ExpenseDashboardResponse>();
+    mockGetExpenseDashboard
+      .mockResolvedValueOnce(expenseDashboard('Hotel'))
+      .mockReturnValueOnce(explicit.promise);
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDashboard('trip-1'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      void result.current.refresh('refresh');
+    });
+    expect(result.current.refreshing).toBe(true);
+    expect(result.current.dashboard?.expenses[0]?.title).toBe('Hotel');
+
+    await act(async () => {
+      explicit.resolve(expenseDashboard('Refreshed hotel'));
+    });
+    expect(result.current.refreshing).toBe(false);
+    expect(result.current.dashboard?.expenses[0]?.title).toBe(
+      'Refreshed hotel',
+    );
+    unmount();
+  });
+
+  it('lets a newer silent request own an older explicit refresh completion', async () => {
+    const explicit = deferred<ExpenseDashboardResponse>();
+    const silent = deferred<ExpenseDashboardResponse>();
+    mockGetExpenseDashboard
+      .mockResolvedValueOnce(expenseDashboard('Hotel'))
+      .mockReturnValueOnce(explicit.promise)
+      .mockReturnValueOnce(silent.promise);
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDashboard('trip-1'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      void result.current.refresh('refresh');
+      void result.current.refresh('silent');
+    });
+    await act(async () => {
+      explicit.resolve(expenseDashboard('Stale explicit'));
+    });
+    expect(result.current.refreshing).toBe(true);
+    expect(result.current.dashboard?.expenses[0]?.title).toBe('Hotel');
+
+    await act(async () => {
+      silent.resolve(expenseDashboard('Latest silent'));
+    });
+    expect(result.current.refreshing).toBe(false);
+    expect(result.current.dashboard?.expenses[0]?.title).toBe(
+      'Latest silent',
+    );
+    unmount();
+  });
+
+  it('lets a newer explicit refresh own an older silent completion', async () => {
+    const silent = deferred<ExpenseDashboardResponse>();
+    const explicit = deferred<ExpenseDashboardResponse>();
+    mockGetExpenseDashboard
+      .mockResolvedValueOnce(expenseDashboard('Hotel'))
+      .mockReturnValueOnce(silent.promise)
+      .mockReturnValueOnce(explicit.promise);
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDashboard('trip-1'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      void result.current.refresh('silent');
+      void result.current.refresh('refresh');
+    });
+    await act(async () => {
+      silent.resolve(expenseDashboard('Stale silent'));
+    });
+    expect(result.current.refreshing).toBe(true);
+    expect(result.current.dashboard?.expenses[0]?.title).toBe('Hotel');
+
+    await act(async () => {
+      explicit.resolve(expenseDashboard('Latest explicit'));
+    });
+    expect(result.current.refreshing).toBe(false);
+    expect(result.current.dashboard?.expenses[0]?.title).toBe(
+      'Latest explicit',
+    );
+    unmount();
+  });
+
+  it('ignores stale catch and finally branches after a newer request starts', async () => {
+    const stale = deferred<ExpenseDashboardResponse>();
+    const latest = deferred<ExpenseDashboardResponse>();
+    mockGetExpenseDashboard
+      .mockResolvedValueOnce(expenseDashboard('Hotel'))
+      .mockReturnValueOnce(stale.promise)
+      .mockReturnValueOnce(latest.promise);
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDashboard('trip-1'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      void result.current.refresh('refresh');
+      void result.current.refresh('silent');
+    });
+    await act(async () => {
+      stale.reject(axiosErrorWith(500, { detail: 'Stale failure.' }));
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.refreshing).toBe(true);
+
+    await act(async () => {
+      latest.resolve(expenseDashboard('Latest'));
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.refreshing).toBe(false);
+    unmount();
+  });
+
+  it('retains complete data after a non-404 background failure', async () => {
+    mockGetExpenseDashboard
+      .mockResolvedValueOnce(expenseDashboard('Hotel'))
+      .mockRejectedValueOnce(
+        axiosErrorWith(500, {
+          detail: 'Expenses are temporarily unavailable.',
+        }),
+      );
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDashboard('trip-1'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    await act(async () => {
+      latestForegroundCallback()();
+    });
+
+    await waitFor(() =>
+      expect(result.current.error?.message).toBe(
+        'Expenses are temporarily unavailable.',
+      ),
+    );
+    expect(result.current.status).toBe('ready');
+    expect(result.current.dashboard?.expenses[0]?.title).toBe('Hotel');
+    unmount();
+  });
+
+  it('retains complete data for an unrelated generic 404', async () => {
+    mockGetExpenseDashboard
+      .mockResolvedValueOnce(expenseDashboard('Hotel'))
+      .mockRejectedValueOnce(
+        axiosErrorWith(404, {
+          detail: 'An unrelated resource was not found.',
+          error_code: 'UNRELATED_NOT_FOUND',
+        }),
+      );
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDashboard('trip-1'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    await act(async () => {
+      latestForegroundCallback()();
+    });
+
+    await waitFor(() => expect(result.current.error?.status).toBe(404));
+    expect(result.current.status).toBe('ready');
+    expect(result.current.dashboard?.expenses[0]?.title).toBe('Hotel');
+    unmount();
+  });
+
+  it('clears complete data for a relevant TRIP_NOT_FOUND response', async () => {
+    mockGetExpenseDashboard
+      .mockResolvedValueOnce(expenseDashboard('Hotel'))
+      .mockRejectedValueOnce(
+        axiosErrorWith(404, {
+          detail: 'Trip not found.',
+          error_code: 'TRIP_NOT_FOUND',
+        }),
+      );
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDashboard('trip-1'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    await act(async () => {
+      latestForegroundCallback()();
+    });
+
+    await waitFor(() => expect(result.current.status).toBe('error'));
+    expect(result.current.dashboard).toBeNull();
+    expect(result.current.error).toMatchObject({
+      message: 'Trip not found.',
+      errorCode: 'TRIP_NOT_FOUND',
+      status: 404,
+    });
+    unmount();
+  });
+
+  it('reconciles only same-trip expense events while focused', async () => {
+    mockGetExpenseDashboard
+      .mockResolvedValueOnce(expenseDashboard('Hotel'))
+      .mockResolvedValueOnce(expenseDashboard('Event update'));
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDashboard('trip-1'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      await publishExpenseEvent({
+        type: 'expensesChanged',
+        tripId: 'trip-2',
+      });
+    });
+    expect(mockGetExpenseDashboard).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await publishExpenseEvent({
+        type: 'expensesChanged',
+        tripId: 'trip-1',
+      });
+    });
+    await waitFor(() =>
+      expect(result.current.dashboard?.expenses[0]?.title).toBe(
+        'Event update',
+      ),
+    );
+    expect(mockGetExpenseDashboard).toHaveBeenCalledTimes(2);
+    unmount();
+  });
+
+  it('ignores event and foreground reconciliation while blurred then loads once on refocus', async () => {
+    mockGetExpenseDashboard
+      .mockResolvedValueOnce(expenseDashboard('Hotel'))
+      .mockResolvedValueOnce(expenseDashboard('Refocused'));
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDashboard('trip-1'),
+    );
+
+    let blur: (() => void) | void;
+    await act(async () => {
+      blur = latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      blur?.();
+      latestForegroundCallback()();
+      await publishExpenseEvent({
+        type: 'expensesChanged',
+        tripId: 'trip-1',
+      });
+    });
+    expect(mockGetExpenseDashboard).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() =>
+      expect(result.current.dashboard?.expenses[0]?.title).toBe('Refocused'),
+    );
+    expect(mockGetExpenseDashboard).toHaveBeenCalledTimes(2);
+    unmount();
+  });
+
+  it('does not own focus, foreground, or events when auto reconciliation is disabled', async () => {
+    mockGetExpenseDashboard.mockResolvedValue(
+      expenseDashboard('Manual load'),
+    );
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDashboard('trip-1', { autoReconcile: false }),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+      latestForegroundCallback()();
+      await publishExpenseEvent({
+        type: 'expensesChanged',
+        tripId: 'trip-1',
+      });
+    });
+    expect(mockGetExpenseDashboard).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.refresh('initial');
+    });
+    expect(result.current.dashboard?.expenses[0]?.title).toBe(
+      'Manual load',
+    );
+    unmount();
+  });
+
+  it('invalidates a coordinator request when a non-reconciling screen blurs', async () => {
+    const pending = deferred<ExpenseDashboardResponse>();
+    mockGetExpenseDashboard.mockReturnValue(pending.promise);
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDashboard('trip-1', { autoReconcile: false }),
+    );
+
+    let cleanup: (() => void) | void;
+    await act(async () => {
+      cleanup = latestFocusCallback()();
+      void result.current.refresh('initial');
+    });
+    await act(async () => {
+      cleanup?.();
+      pending.resolve(expenseDashboard('Stale'));
+    });
+
+    expect(result.current.dashboard).toBeNull();
+    expect(result.current.status).toBe('loading');
+    unmount();
+  });
+
+  it('hides the old trip immediately and ignores its late completion after a key change', async () => {
+    const first = deferred<ExpenseDashboardResponse>();
+    const second = deferred<ExpenseDashboardResponse>();
+    mockGetExpenseDashboard
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const { result, rerender, unmount } = await renderHook(
+      ({ tripId }: { tripId: string }) => useExpenseDashboard(tripId),
+      { initialProps: { tripId: 'trip-1' } },
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await rerender({ tripId: 'trip-2' });
+    expect(result.current.dashboard).toBeNull();
+    expect(result.current.status).toBe('loading');
+
+    await act(async () => {
+      latestFocusCallback()();
+      first.resolve(expenseDashboard('Wrong trip'));
+    });
+    expect(result.current.dashboard).toBeNull();
+
+    await act(async () => {
+      second.resolve(expenseDashboard('Right trip'));
+    });
+    expect(result.current.dashboard?.expenses[0]?.title).toBe('Right trip');
+    expect(mockGetExpenseDashboard).toHaveBeenNthCalledWith(1, 'trip-1');
+    expect(mockGetExpenseDashboard).toHaveBeenNthCalledWith(2, 'trip-2');
+    unmount();
+  });
+
+  it('makes no feature request when the trip id is missing', async () => {
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDashboard(undefined),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+
+    expect(mockGetExpenseDashboard).not.toHaveBeenCalled();
+    expect(result.current.dashboard).toBeNull();
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toMatchObject({
+      errorCode: 'TRIP_NOT_FOUND',
+      status: 404,
+    });
+    unmount();
+  });
+
+  it('mutation invalidation prevents a pre-mutation success from overwriting reconciliation', async () => {
+    const preMutation = deferred<ExpenseDashboardResponse>();
+    const postMutation = deferred<ExpenseDashboardResponse>();
+    mockGetExpenseDashboard
+      .mockResolvedValueOnce(expenseDashboard('Before mutation'))
+      .mockReturnValueOnce(preMutation.promise)
+      .mockReturnValueOnce(postMutation.promise);
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDashboard('trip-1'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      void result.current.refresh('silent');
+      result.current.invalidate();
+      void result.current.refresh('silent');
+    });
+    await act(async () => {
+      preMutation.resolve(expenseDashboard('Stale before mutation'));
+    });
+    expect(result.current.dashboard?.expenses[0]?.title).toBe(
+      'Before mutation',
+    );
+
+    await act(async () => {
+      postMutation.resolve(expenseDashboard('After mutation'));
+    });
+    expect(result.current.dashboard?.expenses[0]?.title).toBe(
+      'After mutation',
+    );
+    unmount();
+  });
+
+  it('mutation invalidation suppresses stale catch and finally without a reload', async () => {
+    const preMutation = deferred<ExpenseDashboardResponse>();
+    mockGetExpenseDashboard
+      .mockResolvedValueOnce(expenseDashboard('Before mutation'))
+      .mockReturnValueOnce(preMutation.promise);
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDashboard('trip-1'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      void result.current.refresh('refresh');
+    });
+    expect(result.current.refreshing).toBe(true);
+
+    await act(async () => {
+      result.current.invalidate();
+      preMutation.reject(
+        axiosErrorWith(404, {
+          detail: 'Trip not found.',
+          error_code: 'TRIP_NOT_FOUND',
+        }),
+      );
+    });
+
+    expect(result.current.refreshing).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.dashboard?.expenses[0]?.title).toBe(
+      'Before mutation',
+    );
+    unmount();
+  });
+});

--- a/mobile/src/features/expenses/__tests__/useExpenseDetail.test.tsx
+++ b/mobile/src/features/expenses/__tests__/useExpenseDetail.test.tsx
@@ -1,0 +1,697 @@
+const mockUseFocusEffect = jest.fn();
+const mockUseAppForegroundEffect = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useFocusEffect: (effect: () => (() => void) | void) =>
+    mockUseFocusEffect(effect),
+}));
+
+jest.mock('@/shared/hooks/useAppForegroundEffect', () => ({
+  useAppForegroundEffect: (listener: () => void) =>
+    mockUseAppForegroundEffect(listener),
+}));
+
+jest.mock('../api', () => ({
+  getExpenseDetail: jest.fn(),
+}));
+
+// eslint-disable-next-line import/first
+import { AxiosError, AxiosHeaders } from 'axios';
+// eslint-disable-next-line import/first
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { getExpenseDetail } from '../api';
+// eslint-disable-next-line import/first
+import { publishExpenseEvent } from '../expenseEvents';
+// eslint-disable-next-line import/first
+import { useExpenseDetail } from '../hooks/useExpenseDetail';
+// eslint-disable-next-line import/first
+import type { ExpenseDetailResponse } from '../types';
+
+const mockGetExpenseDetail =
+  getExpenseDetail as jest.MockedFunction<typeof getExpenseDetail>;
+
+function expenseDetail(
+  title: string,
+  id = 'expense-1',
+): ExpenseDetailResponse {
+  return {
+    id,
+    title,
+    description: '',
+    total_amount: '120.00',
+    paid_amount: '90.00',
+    missing_amount: '30.00',
+    surplus_amount: '0.00',
+    currency_code: 'USD',
+    status: 'UNDERFUNDED',
+    collector: {
+      id: 'user-1',
+      display_name: 'Minh',
+      identify_tag: 'minh#1234',
+    },
+    locked: false,
+    locked_at: null,
+    created_at: '2026-07-28T00:00:00Z',
+    permissions: {
+      can_manage_expenses: true,
+    },
+    participants: [
+      {
+        user_id: 'user-1',
+        display_name: 'Minh',
+        identify_tag: 'minh#1234',
+        share_amount: '60.00',
+        contributed_amount: '90.00',
+        balance: '30.00',
+        surplus_held: '0.00',
+      },
+      {
+        user_id: 'user-2',
+        display_name: 'Lan',
+        identify_tag: 'lan#5678',
+        share_amount: '60.00',
+        contributed_amount: '0.00',
+        balance: '-60.00',
+        surplus_held: '0.00',
+      },
+    ],
+  };
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', config, {}, {
+    status,
+    statusText: '',
+    headers: {},
+    config,
+    data,
+  });
+}
+
+function latestFocusCallback(): () => (() => void) | void {
+  const callback = mockUseFocusEffect.mock.calls.at(-1)?.[0] as
+    | (() => (() => void) | void)
+    | undefined;
+  if (!callback) {
+    throw new Error('Expected useFocusEffect to register a callback.');
+  }
+  return callback;
+}
+
+function latestForegroundCallback(): () => void {
+  const callback = mockUseAppForegroundEffect.mock.calls.at(-1)?.[0] as
+    | (() => void)
+    | undefined;
+  if (!callback) {
+    throw new Error('Expected useAppForegroundEffect to register a callback.');
+  }
+  return callback;
+}
+
+describe('useExpenseDetail', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads initially on focus and silently reconciles complete data', async () => {
+    const silent = deferred<ExpenseDetailResponse>();
+    mockGetExpenseDetail
+      .mockResolvedValueOnce(expenseDetail('Hotel'))
+      .mockReturnValueOnce(silent.promise);
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDetail('trip-1', 'expense-1'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.detail?.title).toBe('Hotel'));
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    expect(result.current.status).toBe('ready');
+    expect(result.current.refreshing).toBe(false);
+    expect(result.current.detail?.title).toBe('Hotel');
+
+    await act(async () => {
+      silent.resolve(expenseDetail('Updated hotel'));
+    });
+    expect(result.current.detail?.title).toBe('Updated hotel');
+    unmount();
+  });
+
+  it('sets refreshing only for explicit refresh and keeps data visible', async () => {
+    const explicit = deferred<ExpenseDetailResponse>();
+    mockGetExpenseDetail
+      .mockResolvedValueOnce(expenseDetail('Hotel'))
+      .mockReturnValueOnce(explicit.promise);
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDetail('trip-1', 'expense-1'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      void result.current.refresh('refresh');
+    });
+    expect(result.current.refreshing).toBe(true);
+    expect(result.current.detail?.title).toBe('Hotel');
+
+    await act(async () => {
+      explicit.resolve(expenseDetail('Refreshed hotel'));
+    });
+    expect(result.current.refreshing).toBe(false);
+    expect(result.current.detail?.title).toBe('Refreshed hotel');
+    unmount();
+  });
+
+  it('lets a newer silent request own an older explicit refresh completion', async () => {
+    const explicit = deferred<ExpenseDetailResponse>();
+    const silent = deferred<ExpenseDetailResponse>();
+    mockGetExpenseDetail
+      .mockResolvedValueOnce(expenseDetail('Hotel'))
+      .mockReturnValueOnce(explicit.promise)
+      .mockReturnValueOnce(silent.promise);
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDetail('trip-1', 'expense-1'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      void result.current.refresh('refresh');
+      void result.current.refresh('silent');
+    });
+    await act(async () => {
+      explicit.resolve(expenseDetail('Stale explicit'));
+    });
+    expect(result.current.refreshing).toBe(true);
+    expect(result.current.detail?.title).toBe('Hotel');
+
+    await act(async () => {
+      silent.resolve(expenseDetail('Latest silent'));
+    });
+    expect(result.current.refreshing).toBe(false);
+    expect(result.current.detail?.title).toBe('Latest silent');
+    unmount();
+  });
+
+  it('lets a newer explicit refresh own an older silent completion', async () => {
+    const silent = deferred<ExpenseDetailResponse>();
+    const explicit = deferred<ExpenseDetailResponse>();
+    mockGetExpenseDetail
+      .mockResolvedValueOnce(expenseDetail('Hotel'))
+      .mockReturnValueOnce(silent.promise)
+      .mockReturnValueOnce(explicit.promise);
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDetail('trip-1', 'expense-1'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      void result.current.refresh('silent');
+      void result.current.refresh('refresh');
+    });
+    await act(async () => {
+      silent.resolve(expenseDetail('Stale silent'));
+    });
+    expect(result.current.refreshing).toBe(true);
+    expect(result.current.detail?.title).toBe('Hotel');
+
+    await act(async () => {
+      explicit.resolve(expenseDetail('Latest explicit'));
+    });
+    expect(result.current.refreshing).toBe(false);
+    expect(result.current.detail?.title).toBe('Latest explicit');
+    unmount();
+  });
+
+  it('ignores stale catch and finally branches after a newer request starts', async () => {
+    const stale = deferred<ExpenseDetailResponse>();
+    const latest = deferred<ExpenseDetailResponse>();
+    mockGetExpenseDetail
+      .mockResolvedValueOnce(expenseDetail('Hotel'))
+      .mockReturnValueOnce(stale.promise)
+      .mockReturnValueOnce(latest.promise);
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDetail('trip-1', 'expense-1'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      void result.current.refresh('refresh');
+      void result.current.refresh('silent');
+    });
+    await act(async () => {
+      stale.reject(axiosErrorWith(500, { detail: 'Stale failure.' }));
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.refreshing).toBe(true);
+
+    await act(async () => {
+      latest.resolve(expenseDetail('Latest'));
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.refreshing).toBe(false);
+    unmount();
+  });
+
+  it('retains complete data after a non-404 background failure', async () => {
+    mockGetExpenseDetail
+      .mockResolvedValueOnce(expenseDetail('Hotel'))
+      .mockRejectedValueOnce(
+        axiosErrorWith(500, {
+          detail: 'Expense is temporarily unavailable.',
+        }),
+      );
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDetail('trip-1', 'expense-1'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    await act(async () => {
+      latestForegroundCallback()();
+    });
+
+    await waitFor(() =>
+      expect(result.current.error?.message).toBe(
+        'Expense is temporarily unavailable.',
+      ),
+    );
+    expect(result.current.status).toBe('ready');
+    expect(result.current.detail?.title).toBe('Hotel');
+    unmount();
+  });
+
+  it('retains complete data for an unrelated generic 404', async () => {
+    mockGetExpenseDetail
+      .mockResolvedValueOnce(expenseDetail('Hotel'))
+      .mockRejectedValueOnce(
+        axiosErrorWith(404, {
+          detail: 'An unrelated resource was not found.',
+          error_code: 'UNRELATED_NOT_FOUND',
+        }),
+      );
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDetail('trip-1', 'expense-1'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    await act(async () => {
+      latestForegroundCallback()();
+    });
+
+    await waitFor(() => expect(result.current.error?.status).toBe(404));
+    expect(result.current.status).toBe('ready');
+    expect(result.current.detail?.title).toBe('Hotel');
+    unmount();
+  });
+
+  it.each([
+    ['TRIP_NOT_FOUND', 'Trip not found.'],
+    ['EXPENSE_NOT_FOUND', 'Expense not found.'],
+  ])(
+    'clears complete data for relevant %s responses',
+    async (errorCode, message) => {
+      mockGetExpenseDetail
+        .mockResolvedValueOnce(expenseDetail('Hotel'))
+        .mockRejectedValueOnce(
+          axiosErrorWith(404, {
+            detail: message,
+            error_code: errorCode,
+          }),
+        );
+      const { result, unmount } = await renderHook(() =>
+        useExpenseDetail('trip-1', 'expense-1'),
+      );
+
+      await act(async () => {
+        latestFocusCallback()();
+      });
+      await waitFor(() => expect(result.current.status).toBe('ready'));
+      await act(async () => {
+        latestForegroundCallback()();
+      });
+
+      await waitFor(() => expect(result.current.status).toBe('error'));
+      expect(result.current.detail).toBeNull();
+      expect(result.current.error).toMatchObject({
+        message,
+        errorCode,
+        status: 404,
+      });
+      unmount();
+    },
+  );
+
+  it('reconciles for every same-trip expense event and ignores other trips', async () => {
+    mockGetExpenseDetail
+      .mockResolvedValueOnce(expenseDetail('Hotel'))
+      .mockResolvedValueOnce(expenseDetail('Event update'));
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDetail('trip-1', 'expense-1'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      await publishExpenseEvent({
+        type: 'expensesChanged',
+        tripId: 'trip-2',
+      });
+    });
+    expect(mockGetExpenseDetail).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await publishExpenseEvent({
+        type: 'expensesChanged',
+        tripId: 'trip-1',
+      });
+    });
+    await waitFor(() =>
+      expect(result.current.detail?.title).toBe('Event update'),
+    );
+    expect(mockGetExpenseDetail).toHaveBeenCalledTimes(2);
+    unmount();
+  });
+
+  it('ignores event and foreground reconciliation while blurred then loads once on refocus', async () => {
+    mockGetExpenseDetail
+      .mockResolvedValueOnce(expenseDetail('Hotel'))
+      .mockResolvedValueOnce(expenseDetail('Refocused'));
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDetail('trip-1', 'expense-1'),
+    );
+
+    let blur: (() => void) | void;
+    await act(async () => {
+      blur = latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      blur?.();
+      latestForegroundCallback()();
+      await publishExpenseEvent({
+        type: 'expensesChanged',
+        tripId: 'trip-1',
+      });
+    });
+    expect(mockGetExpenseDetail).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() =>
+      expect(result.current.detail?.title).toBe('Refocused'),
+    );
+    expect(mockGetExpenseDetail).toHaveBeenCalledTimes(2);
+    unmount();
+  });
+
+  it('does not own focus, foreground, or events when auto reconciliation is disabled', async () => {
+    mockGetExpenseDetail.mockResolvedValue(expenseDetail('Manual load'));
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDetail('trip-1', 'expense-1', {
+        autoReconcile: false,
+      }),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+      latestForegroundCallback()();
+      await publishExpenseEvent({
+        type: 'expensesChanged',
+        tripId: 'trip-1',
+      });
+    });
+    expect(mockGetExpenseDetail).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.refresh('initial');
+    });
+    expect(result.current.detail?.title).toBe('Manual load');
+    unmount();
+  });
+
+  it('invalidates a coordinator request when a non-reconciling screen blurs', async () => {
+    const pending = deferred<ExpenseDetailResponse>();
+    mockGetExpenseDetail.mockReturnValue(pending.promise);
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDetail('trip-1', 'expense-1', {
+        autoReconcile: false,
+      }),
+    );
+
+    let cleanup: (() => void) | void;
+    await act(async () => {
+      cleanup = latestFocusCallback()();
+      void result.current.refresh('initial');
+    });
+    await act(async () => {
+      cleanup?.();
+      pending.resolve(expenseDetail('Stale'));
+    });
+
+    expect(result.current.detail).toBeNull();
+    expect(result.current.status).toBe('loading');
+    unmount();
+  });
+
+  it('isolates the composite key when only the expense id changes', async () => {
+    const first = deferred<ExpenseDetailResponse>();
+    const second = deferred<ExpenseDetailResponse>();
+    mockGetExpenseDetail
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const { result, rerender, unmount } = await renderHook(
+      ({
+        tripId,
+        expenseId,
+      }: {
+        tripId: string;
+        expenseId: string;
+      }) => useExpenseDetail(tripId, expenseId),
+      {
+        initialProps: {
+          tripId: 'trip-1',
+          expenseId: 'expense-1',
+        },
+      },
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await rerender({ tripId: 'trip-1', expenseId: 'expense-2' });
+    expect(result.current.detail).toBeNull();
+    expect(result.current.status).toBe('loading');
+
+    await act(async () => {
+      latestFocusCallback()();
+      first.resolve(expenseDetail('Wrong expense', 'expense-1'));
+    });
+    expect(result.current.detail).toBeNull();
+
+    await act(async () => {
+      second.resolve(expenseDetail('Right expense', 'expense-2'));
+    });
+    expect(result.current.detail).toMatchObject({
+      id: 'expense-2',
+      title: 'Right expense',
+    });
+    expect(mockGetExpenseDetail).toHaveBeenNthCalledWith(
+      1,
+      'trip-1',
+      'expense-1',
+    );
+    expect(mockGetExpenseDetail).toHaveBeenNthCalledWith(
+      2,
+      'trip-1',
+      'expense-2',
+    );
+    unmount();
+  });
+
+  it('isolates the composite key when only the trip id changes', async () => {
+    const first = deferred<ExpenseDetailResponse>();
+    const second = deferred<ExpenseDetailResponse>();
+    mockGetExpenseDetail
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const { result, rerender, unmount } = await renderHook(
+      ({
+        tripId,
+        expenseId,
+      }: {
+        tripId: string;
+        expenseId: string;
+      }) => useExpenseDetail(tripId, expenseId),
+      {
+        initialProps: {
+          tripId: 'trip-1',
+          expenseId: 'expense-1',
+        },
+      },
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await rerender({ tripId: 'trip-2', expenseId: 'expense-1' });
+    expect(result.current.detail).toBeNull();
+
+    await act(async () => {
+      latestFocusCallback()();
+      first.reject(
+        axiosErrorWith(404, {
+          detail: 'Expense not found.',
+          error_code: 'EXPENSE_NOT_FOUND',
+        }),
+      );
+    });
+    expect(result.current.detail).toBeNull();
+    expect(result.current.error).toBeNull();
+
+    await act(async () => {
+      second.resolve(expenseDetail('Right trip'));
+    });
+    expect(result.current.detail?.title).toBe('Right trip');
+    expect(mockGetExpenseDetail).toHaveBeenNthCalledWith(
+      2,
+      'trip-2',
+      'expense-1',
+    );
+    unmount();
+  });
+
+  it.each([
+    [undefined, 'expense-1'],
+    ['trip-1', undefined],
+    [undefined, undefined],
+  ])(
+    'makes no feature request for incomplete key (%s, %s)',
+    async (tripId, expenseId) => {
+      const { result, unmount } = await renderHook(() =>
+        useExpenseDetail(tripId, expenseId),
+      );
+
+      await act(async () => {
+        latestFocusCallback()();
+      });
+
+      expect(mockGetExpenseDetail).not.toHaveBeenCalled();
+      expect(result.current.detail).toBeNull();
+      expect(result.current.status).toBe('error');
+      expect(result.current.error).toMatchObject({
+        errorCode: 'EXPENSE_NOT_FOUND',
+        status: 404,
+      });
+      unmount();
+    },
+  );
+
+  it('mutation invalidation prevents a pre-mutation success from overwriting reconciliation', async () => {
+    const preMutation = deferred<ExpenseDetailResponse>();
+    const postMutation = deferred<ExpenseDetailResponse>();
+    mockGetExpenseDetail
+      .mockResolvedValueOnce(expenseDetail('Before mutation'))
+      .mockReturnValueOnce(preMutation.promise)
+      .mockReturnValueOnce(postMutation.promise);
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDetail('trip-1', 'expense-1'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      void result.current.refresh('silent');
+      result.current.invalidate();
+      void result.current.refresh('silent');
+    });
+    await act(async () => {
+      preMutation.resolve(expenseDetail('Stale before mutation'));
+    });
+    expect(result.current.detail?.title).toBe('Before mutation');
+
+    await act(async () => {
+      postMutation.resolve(expenseDetail('After mutation'));
+    });
+    expect(result.current.detail?.title).toBe('After mutation');
+    unmount();
+  });
+
+  it('mutation invalidation suppresses stale catch and finally without a reload', async () => {
+    const preMutation = deferred<ExpenseDetailResponse>();
+    mockGetExpenseDetail
+      .mockResolvedValueOnce(expenseDetail('Before mutation'))
+      .mockReturnValueOnce(preMutation.promise);
+    const { result, unmount } = await renderHook(() =>
+      useExpenseDetail('trip-1', 'expense-1'),
+    );
+
+    await act(async () => {
+      latestFocusCallback()();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      void result.current.refresh('refresh');
+    });
+    expect(result.current.refreshing).toBe(true);
+
+    await act(async () => {
+      result.current.invalidate();
+      preMutation.reject(
+        axiosErrorWith(404, {
+          detail: 'Expense not found.',
+          error_code: 'EXPENSE_NOT_FOUND',
+        }),
+      );
+    });
+
+    expect(result.current.refreshing).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.detail?.title).toBe('Before mutation');
+    unmount();
+  });
+});

--- a/mobile/src/features/expenses/__tests__/viewModel.test.ts
+++ b/mobile/src/features/expenses/__tests__/viewModel.test.ts
@@ -1,0 +1,269 @@
+import type { TripMember } from '@/features/trips/types';
+import {
+  buildExpenseDashboardRows,
+  getExpenseDashboardRowKey,
+} from '../viewModel';
+import type {
+  ExpenseDashboardResponse,
+  ExpenseListItem,
+  SettlementTransfer,
+} from '../types';
+
+function buildMember(
+  id: string,
+  displayName: string,
+  identifyTag = `@${id}`,
+): TripMember {
+  return {
+    membership_id: `membership-${id}`,
+    user: {
+      id,
+      display_name: displayName,
+      identify_tag: identifyTag,
+      avatar_url: null,
+    },
+    role: 'MEMBER',
+    joined_at: '2026-07-28T00:00:00Z',
+  };
+}
+
+function buildExpense(
+  id: string,
+  title: string,
+): ExpenseListItem {
+  return {
+    id,
+    title,
+    description: '',
+    total_amount: '100.00',
+    paid_amount: '0.00',
+    missing_amount: '100.00',
+    surplus_amount: '0.00',
+    currency_code: 'USD',
+    status: 'UNDERFUNDED',
+    collector: {
+      id: 'member-1',
+      display_name: 'Member one',
+      identify_tag: '@member-1',
+    },
+    locked: false,
+  };
+}
+
+function buildTransfer(
+  id: string,
+  payerId: string,
+  recipientId: string,
+): SettlementTransfer {
+  return {
+    id,
+    payer: {
+      id: payerId,
+      display_name: `Transfer ${payerId}`,
+      identify_tag: `@transfer-${payerId}`,
+    },
+    recipient: {
+      id: recipientId,
+      display_name: `Transfer ${recipientId}`,
+      identify_tag: `@transfer-${recipientId}`,
+    },
+    amount: '50.00',
+    payer_marked_sent_at: null,
+    recipient_confirmed_at: null,
+  };
+}
+
+function buildDashboard(
+  overrides: Partial<ExpenseDashboardResponse> = {},
+): ExpenseDashboardResponse {
+  return {
+    currency_code: 'USD',
+    summary: {
+      total_amount: '200.00',
+      paid_amount: '0.00',
+      missing_amount: '200.00',
+      surplus_amount: '0.00',
+    },
+    permissions: { can_manage_expenses: true },
+    my_balance: { balance: '-100.00', surplus_held: '0.00' },
+    member_balances: {},
+    settlement: null,
+    expenses: [],
+    ...overrides,
+  };
+}
+
+describe('buildExpenseDashboardRows', () => {
+  it('builds one stable heterogeneous list in required row order', () => {
+    const transferOne = buildTransfer(
+      'transfer-1',
+      'member-1',
+      'departed-1',
+    );
+    const transferTwo = buildTransfer(
+      'transfer-2',
+      'departed-1',
+      'member-2',
+    );
+    const expenseOne = buildExpense('expense-1', 'First');
+    const expenseTwo = buildExpense('expense-2', 'Second');
+    const dashboard = buildDashboard({
+      settlement: {
+        id: 'settlement-1',
+        status: 'FINALIZED',
+        finalized_at: '2026-07-28T00:00:00Z',
+        transfers: [transferOne, transferTwo],
+      },
+      member_balances: {
+        'member-1': { balance: '-50.00' },
+        'departed-1': { balance: '50.00' },
+      },
+      expenses: [expenseOne, expenseTwo],
+    });
+
+    const rows = buildExpenseDashboardRows(dashboard, [
+      buildMember('member-1', 'Active member'),
+      buildMember('member-2', 'Second member'),
+    ]);
+
+    expect(rows).toEqual([
+      {
+        type: 'transfer',
+        key: 'transfer:transfer-1',
+        transfer: transferOne,
+      },
+      {
+        type: 'transfer',
+        key: 'transfer:transfer-2',
+        transfer: transferTwo,
+      },
+      {
+        type: 'member-balance',
+        key: 'member-balance:member-1',
+        userId: 'member-1',
+        displayName: 'Active member',
+        identifyTag: '@member-1',
+        balance: '-50.00',
+      },
+      {
+        type: 'member-balance',
+        key: 'member-balance:departed-1',
+        userId: 'departed-1',
+        displayName: 'Transfer departed-1',
+        identifyTag: '@transfer-departed-1',
+        balance: '50.00',
+      },
+      {
+        type: 'expense',
+        key: 'expense:expense-1',
+        expense: expenseOne,
+      },
+      {
+        type: 'expense',
+        key: 'expense:expense-2',
+        expense: expenseTwo,
+      },
+    ]);
+  });
+
+  it('preserves backend expense order instead of sorting client-side', () => {
+    const dashboard = buildDashboard({
+      expenses: [
+        buildExpense('expense-new', 'Z newest'),
+        buildExpense('expense-old', 'A oldest'),
+      ],
+    });
+
+    expect(
+      buildExpenseDashboardRows(dashboard)
+        .filter((row) => row.type === 'expense')
+        .map((row) => row.expense.id),
+    ).toEqual(['expense-new', 'expense-old']);
+  });
+
+  it('falls back to Member and never exposes a raw user id as a name', () => {
+    const rawId = '7ca6454d-c94d-4db7-a4ca-e7c6dca8fdab';
+    const rows = buildExpenseDashboardRows(
+      buildDashboard({
+        member_balances: {
+          [rawId]: { balance: '0.00' },
+        },
+      }),
+    );
+    const balanceRow = rows.find(
+      (row) => row.type === 'member-balance',
+    );
+
+    expect(balanceRow).toMatchObject({
+      type: 'member-balance',
+      displayName: 'Member',
+      identifyTag: null,
+    });
+    expect(
+      balanceRow?.type === 'member-balance'
+        ? balanceRow.displayName
+        : null,
+    ).not.toBe(rawId);
+  });
+
+  it('keeps the active-member name ahead of a conflicting transfer snapshot', () => {
+    const rows = buildExpenseDashboardRows(
+      buildDashboard({
+        member_balances: {
+          'member-1': { balance: '0.00' },
+        },
+        settlement: {
+          id: 'settlement-1',
+          status: 'FINALIZED',
+          finalized_at: '2026-07-28T00:00:00Z',
+          transfers: [
+            buildTransfer('transfer-1', 'member-1', 'member-2'),
+          ],
+        },
+      }),
+      [buildMember('member-1', 'Authoritative active name')],
+    );
+
+    expect(rows[1]).toMatchObject({
+      type: 'member-balance',
+      displayName: 'Authoritative active name',
+    });
+  });
+
+  it('adds one empty-expense row even for a finalized solo settlement', () => {
+    const rows = buildExpenseDashboardRows(
+      buildDashboard({
+        settlement: {
+          id: 'settlement-solo',
+          status: 'FINALIZED',
+          finalized_at: '2026-07-28T00:00:00Z',
+          transfers: [],
+        },
+      }),
+    );
+
+    expect(rows).toEqual([
+      {
+        type: 'empty',
+        key: 'expense:empty',
+      },
+    ]);
+  });
+
+  it('returns stable prefixed keys across rebuilds', () => {
+    const dashboard = buildDashboard({
+      member_balances: { 'member-1': { balance: '0.00' } },
+      expenses: [buildExpense('expense-1', 'Dinner')],
+    });
+    const first = buildExpenseDashboardRows(dashboard);
+    const second = buildExpenseDashboardRows(dashboard);
+
+    expect(first.map(getExpenseDashboardRowKey)).toEqual(
+      second.map(getExpenseDashboardRowKey),
+    );
+    expect(first.map(getExpenseDashboardRowKey)).toEqual([
+      'member-balance:member-1',
+      'expense:expense-1',
+    ]);
+  });
+});

--- a/mobile/src/features/expenses/actions.ts
+++ b/mobile/src/features/expenses/actions.ts
@@ -1,0 +1,60 @@
+import type { TripStatus } from '@/features/trips/types';
+import type { TripSettlement } from './types';
+
+export interface ExpenseDashboardActionInput {
+  canManageExpenses: boolean;
+  tripStatus: TripStatus;
+  settlement: TripSettlement | null;
+  expenseCount: number;
+}
+
+export interface ExpenseDashboardActions {
+  canAddExpense: boolean;
+  canFinalize: boolean;
+  canReopen: boolean;
+}
+
+export interface ExpenseItemActionInput {
+  canManageExpenses: boolean;
+  tripStatus: TripStatus;
+  locked: boolean;
+}
+
+export interface ExpenseItemActions {
+  canEditExpense: boolean;
+  canEditContributions: boolean;
+}
+
+export function isTerminalTripStatus(tripStatus: TripStatus): boolean {
+  return tripStatus === 'COMPLETED' || tripStatus === 'CANCELLED';
+}
+
+export function getExpenseDashboardActions({
+  canManageExpenses,
+  tripStatus,
+  settlement,
+  expenseCount,
+}: ExpenseDashboardActionInput): ExpenseDashboardActions {
+  const canMutate = canManageExpenses && !isTerminalTripStatus(tripStatus);
+  const isFinalized = settlement?.status === 'FINALIZED';
+
+  return {
+    canAddExpense: canMutate && !isFinalized,
+    canFinalize: canMutate && !isFinalized && expenseCount > 0,
+    canReopen: canMutate && isFinalized,
+  };
+}
+
+export function getExpenseItemActions({
+  canManageExpenses,
+  tripStatus,
+  locked,
+}: ExpenseItemActionInput): ExpenseItemActions {
+  const canMutate =
+    canManageExpenses && !isTerminalTripStatus(tripStatus) && !locked;
+
+  return {
+    canEditExpense: canMutate,
+    canEditContributions: canMutate,
+  };
+}

--- a/mobile/src/features/expenses/api.ts
+++ b/mobile/src/features/expenses/api.ts
@@ -1,0 +1,116 @@
+import { apiClient } from '@/shared/api/client';
+import type {
+  ContributionResponse,
+  CreateExpensePayload,
+  ExpenseDashboardResponse,
+  ExpenseDetailResponse,
+  ExpenseResponse,
+  SetContributionPayload,
+  SettlementTransfer,
+  TripSettlement,
+  UpdateExpensePayload,
+} from './types';
+
+export async function getExpenseDashboard(
+  tripId: string,
+  signal?: AbortSignal,
+): Promise<ExpenseDashboardResponse> {
+  const { data } = await apiClient.get<ExpenseDashboardResponse>(
+    `/trips/${tripId}/expenses`,
+    { signal },
+  );
+  return data;
+}
+
+export async function getExpenseDetail(
+  tripId: string,
+  expenseId: string,
+  signal?: AbortSignal,
+): Promise<ExpenseDetailResponse> {
+  const { data } = await apiClient.get<ExpenseDetailResponse>(
+    `/trips/${tripId}/expenses/${expenseId}`,
+    { signal },
+  );
+  return data;
+}
+
+export async function createExpense(
+  tripId: string,
+  payload: CreateExpensePayload,
+): Promise<ExpenseResponse> {
+  const { data } = await apiClient.post<ExpenseResponse>(
+    `/trips/${tripId}/expenses`,
+    payload,
+  );
+  return data;
+}
+
+export async function updateExpense(
+  tripId: string,
+  expenseId: string,
+  payload: UpdateExpensePayload,
+): Promise<ExpenseDetailResponse> {
+  const { data } = await apiClient.patch<ExpenseDetailResponse>(
+    `/trips/${tripId}/expenses/${expenseId}`,
+    payload,
+  );
+  return data;
+}
+
+export async function deleteExpense(
+  tripId: string,
+  expenseId: string,
+): Promise<void> {
+  await apiClient.delete(`/trips/${tripId}/expenses/${expenseId}`);
+}
+
+export async function setContribution(
+  tripId: string,
+  expenseId: string,
+  userId: string,
+  payload: SetContributionPayload,
+): Promise<ContributionResponse> {
+  const { data } = await apiClient.patch<ContributionResponse>(
+    `/trips/${tripId}/expenses/${expenseId}/contributions/${userId}`,
+    payload,
+  );
+  return data;
+}
+
+export async function finalizeSettlement(
+  tripId: string,
+): Promise<TripSettlement> {
+  const { data } = await apiClient.post<TripSettlement>(
+    `/trips/${tripId}/settlement/finalize`,
+  );
+  return data;
+}
+
+export async function reopenSettlement(
+  tripId: string,
+): Promise<TripSettlement> {
+  const { data } = await apiClient.post<TripSettlement>(
+    `/trips/${tripId}/settlement/reopen`,
+  );
+  return data;
+}
+
+export async function markTransferSent(
+  tripId: string,
+  transferId: string,
+): Promise<SettlementTransfer> {
+  const { data } = await apiClient.post<SettlementTransfer>(
+    `/trips/${tripId}/settlement/transfers/${transferId}/sent`,
+  );
+  return data;
+}
+
+export async function confirmTransferReceived(
+  tripId: string,
+  transferId: string,
+): Promise<SettlementTransfer> {
+  const { data } = await apiClient.post<SettlementTransfer>(
+    `/trips/${tripId}/settlement/transfers/${transferId}/received`,
+  );
+  return data;
+}

--- a/mobile/src/features/expenses/components/ContributionEditor.tsx
+++ b/mobile/src/features/expenses/components/ContributionEditor.tsx
@@ -1,0 +1,384 @@
+import { Ionicons } from '@expo/vector-icons';
+import { memo, useCallback } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { TextField } from '@/shared/ui/TextField';
+import {
+  formatExpenseMoney,
+  getExpenseCurrencyScale,
+} from '../money';
+import type { ExpenseParticipant } from '../types';
+
+interface ContributionEditorProps {
+  participant: ExpenseParticipant;
+  currencyCode: string;
+  canEdit: boolean;
+  isEditing: boolean;
+  draftAmount: string;
+  loading?: boolean;
+  error?: string | null;
+  amountError?: string;
+  onStartEditing: (userId: string) => void;
+  onDraftChange: (userId: string, value: string) => void;
+  onSubmit: (userId: string) => void;
+  onCancel: (userId: string) => void;
+}
+
+type ParticipantBalanceDirection = 'owes' | 'overpaid' | 'settled';
+
+function getParticipantBalanceDirection(
+  balance: string,
+): ParticipantBalanceDirection {
+  const trimmed = balance.trim();
+  const hasValue =
+    trimmed
+      .replace(/^[+-]/, '')
+      .replace(/[.,]/g, '')
+      .replace(/0/g, '').length > 0;
+
+  if (!hasValue) {
+    return 'settled';
+  }
+  return trimmed.startsWith('-') ? 'owes' : 'overpaid';
+}
+
+function absoluteCanonicalAmount(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.startsWith('-') || trimmed.startsWith('+')
+    ? trimmed.slice(1)
+    : trimmed;
+}
+
+function ActionButton({
+  title,
+  label,
+  icon,
+  disabled,
+  loading = false,
+  primary = false,
+  onPress,
+}: {
+  title: string;
+  label: string;
+  icon: React.ComponentProps<typeof Ionicons>['name'];
+  disabled: boolean;
+  loading?: boolean;
+  primary?: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ disabled: disabled || loading, busy: loading }}
+      disabled={disabled || loading}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.action,
+        primary ? styles.primaryAction : styles.secondaryAction,
+        pressed && !disabled && !loading ? styles.pressed : null,
+        disabled && !loading ? styles.disabled : null,
+      ]}
+    >
+      {loading ? (
+        <ActivityIndicator
+          color={primary ? colors.background : colors.primary}
+        />
+      ) : (
+        <>
+          <Ionicons
+            name={icon}
+            size={16}
+            color={primary ? colors.background : colors.primary}
+          />
+          <Text
+            style={[
+              styles.actionText,
+              primary ? styles.primaryActionText : null,
+            ]}
+          >
+            {title}
+          </Text>
+        </>
+      )}
+    </Pressable>
+  );
+}
+
+function ContributionEditorComponent({
+  participant,
+  currencyCode,
+  canEdit,
+  isEditing,
+  draftAmount,
+  loading = false,
+  error,
+  amountError,
+  onStartEditing,
+  onDraftChange,
+  onSubmit,
+  onCancel,
+}: ContributionEditorProps) {
+  const direction = getParticipantBalanceDirection(participant.balance);
+  const balanceAmount = formatExpenseMoney(
+    absoluteCanonicalAmount(participant.balance),
+    currencyCode,
+  );
+  const surplusHeld = participant.surplus_held ?? '0';
+  const hasSurplus =
+    surplusHeld
+      .replace(/^[+-]/, '')
+      .replace(/[.,]/g, '')
+      .replace(/0/g, '').length > 0;
+
+  const startEditing = useCallback(
+    () => onStartEditing(participant.user_id),
+    [onStartEditing, participant.user_id],
+  );
+  const changeDraft = useCallback(
+    (value: string) => onDraftChange(participant.user_id, value),
+    [onDraftChange, participant.user_id],
+  );
+  const submit = useCallback(
+    () => onSubmit(participant.user_id),
+    [onSubmit, participant.user_id],
+  );
+  const cancel = useCallback(
+    () => onCancel(participant.user_id),
+    [onCancel, participant.user_id],
+  );
+
+  return (
+    <View
+      accessibilityLabel={`Contribution for ${participant.display_name}`}
+      style={styles.card}
+    >
+      <View style={styles.heading}>
+        <View style={styles.identity}>
+          <Text numberOfLines={1} style={styles.name}>
+            {participant.display_name}
+          </Text>
+          {participant.identify_tag ? (
+            <Text numberOfLines={1} style={styles.tag}>
+              {participant.identify_tag}
+            </Text>
+          ) : null}
+        </View>
+        {canEdit && !isEditing ? (
+          <ActionButton
+            title="Edit"
+            label={`Edit contribution for ${participant.display_name}`}
+            icon="create-outline"
+            disabled={loading}
+            onPress={startEditing}
+          />
+        ) : !canEdit ? (
+          <Text style={styles.viewOnly}>View only</Text>
+        ) : null}
+      </View>
+
+      <View style={styles.metrics}>
+        <View style={styles.metric}>
+          <Text style={styles.metricLabel}>Share</Text>
+          <Text style={styles.metricValue}>
+            {formatExpenseMoney(
+              participant.share_amount,
+              currencyCode,
+            )}
+          </Text>
+        </View>
+        <View style={styles.metric}>
+          <Text style={styles.metricLabel}>Contributed</Text>
+          <Text style={styles.metricValue}>
+            {formatExpenseMoney(
+              participant.contributed_amount,
+              currencyCode,
+            )}
+          </Text>
+        </View>
+        <View style={styles.metric}>
+          <Text
+            style={[
+              styles.metricLabel,
+              direction === 'overpaid' ? styles.receive : null,
+              direction === 'owes' ? styles.owe : null,
+            ]}
+          >
+            {direction === 'overpaid'
+              ? 'Overpaid'
+              : direction === 'owes'
+                ? 'Still owes'
+                : 'Settled'}
+          </Text>
+          <Text
+            style={[
+              styles.metricValue,
+              direction === 'overpaid' ? styles.receive : null,
+              direction === 'owes' ? styles.owe : null,
+            ]}
+          >
+            {direction === 'overpaid' ? '+' : ''}
+            {balanceAmount}
+          </Text>
+        </View>
+      </View>
+
+      {hasSurplus ? (
+        <Text style={styles.surplus}>
+          Holding{' '}
+          <Text style={styles.surplusAmount}>
+            {formatExpenseMoney(surplusHeld, currencyCode)}
+          </Text>{' '}
+          surplus
+        </Text>
+      ) : null}
+
+      {canEdit && isEditing ? (
+        <View style={styles.editor}>
+          <TextField
+            label={`Amount ${participant.display_name} contributed`}
+            accessibilityLabel={`Contribution amount for ${participant.display_name}`}
+            value={draftAmount}
+            onChangeText={changeDraft}
+            keyboardType={
+              getExpenseCurrencyScale(currencyCode) === 0
+                ? 'number-pad'
+                : 'decimal-pad'
+            }
+            autoCorrect={false}
+            editable={!loading}
+            error={amountError}
+          />
+          <View style={styles.actions}>
+            <View style={styles.actionSlot}>
+              <ActionButton
+                title="Save"
+                label={`Save contribution for ${participant.display_name}`}
+                icon="checkmark-outline"
+                disabled={loading}
+                loading={loading}
+                primary
+                onPress={submit}
+              />
+            </View>
+            <View style={styles.actionSlot}>
+              <ActionButton
+                title="Cancel"
+                label={`Cancel contribution edit for ${participant.display_name}`}
+                icon="close-outline"
+                disabled={loading}
+                onPress={cancel}
+              />
+            </View>
+          </View>
+        </View>
+      ) : null}
+
+      {error ? (
+        <Text accessibilityRole="alert" style={styles.error}>
+          {error}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+export const ContributionEditor = memo(ContributionEditorComponent);
+
+const styles = StyleSheet.create({
+  card: {
+    gap: spacing.md,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    backgroundColor: colors.background,
+  },
+  heading: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
+  },
+  identity: {
+    minWidth: 0,
+    flex: 1,
+  },
+  name: {
+    ...typography.body,
+    color: colors.text,
+    fontWeight: '600',
+  },
+  tag: {
+    ...typography.caption,
+    color: colors.textMuted,
+  },
+  viewOnly: {
+    ...typography.label,
+    color: colors.textMuted,
+  },
+  metrics: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+  metric: {
+    minWidth: 0,
+    flex: 1,
+    gap: spacing.xs,
+  },
+  metricLabel: {
+    ...typography.caption,
+    color: colors.textMuted,
+  },
+  metricValue: {
+    ...typography.label,
+    color: colors.text,
+  },
+  receive: { color: colors.success },
+  owe: { color: colors.danger },
+  surplus: {
+    ...typography.caption,
+    color: colors.amber,
+  },
+  surplusAmount: { fontWeight: '600' },
+  editor: { gap: spacing.sm },
+  actions: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+  actionSlot: { flex: 1 },
+  action: {
+    minHeight: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    borderRadius: radii.md,
+  },
+  primaryAction: {
+    backgroundColor: colors.primary,
+  },
+  secondaryAction: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+  },
+  actionText: {
+    ...typography.label,
+    color: colors.primary,
+  },
+  primaryActionText: { color: colors.background },
+  pressed: { opacity: 0.58 },
+  disabled: { opacity: 0.55 },
+  error: {
+    ...typography.caption,
+    color: colors.danger,
+  },
+});

--- a/mobile/src/features/expenses/components/ExpenseForm.tsx
+++ b/mobile/src/features/expenses/components/ExpenseForm.tsx
@@ -1,0 +1,580 @@
+import { Ionicons } from '@expo/vector-icons';
+import {
+  useCallback,
+  useMemo,
+  type ReactElement,
+} from 'react';
+import {
+  FlatList,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  type ListRenderItemInfo,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import type { ApiError } from '@/shared/api/errors';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { Button } from '@/shared/ui/Button';
+import { FormError } from '@/shared/ui/FormError';
+import { TextField } from '@/shared/ui/TextField';
+import type { TripMember } from '@/features/trips/types';
+import type {
+  ExpenseFormDraft,
+  ExpenseFormFieldErrors,
+} from '../formModel';
+import { ZERO_DECIMAL_CURRENCIES } from '../money';
+import type { ExpensePerson } from '../types';
+
+interface ExpenseFormProps {
+  mode: 'create' | 'edit';
+  draft: ExpenseFormDraft;
+  fieldErrors: ExpenseFormFieldErrors;
+  submitError: ApiError | null;
+  collectors: readonly TripMember[];
+  currentCollector?: ExpensePerson | null;
+  currencyCode: string;
+  canSubmit: boolean;
+  dirty: boolean;
+  submitting: boolean;
+  refreshing?: boolean;
+  authorityMessage?: string;
+  backgroundError?: ApiError | null;
+  onChange: (changes: Partial<ExpenseFormDraft>) => void;
+  onSubmit: () => void;
+  onRefresh?: () => void;
+  onRetryBackground?: () => void;
+}
+
+interface CollectorChoiceProps {
+  member: TripMember;
+  selected: boolean;
+  disabled: boolean;
+  onSelect: (userId: string) => void;
+}
+
+function CollectorChoice({
+  member,
+  selected,
+  disabled,
+  onSelect,
+}: CollectorChoiceProps) {
+  const select = useCallback(
+    () => onSelect(member.user.id),
+    [member.user.id, onSelect],
+  );
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`Choose ${member.user.display_name} as collector`}
+      accessibilityState={{ disabled, selected }}
+      disabled={disabled}
+      onPress={select}
+      style={({ pressed }) => [
+        styles.collectorChoice,
+        selected ? styles.collectorChoiceSelected : null,
+        disabled ? styles.disabled : null,
+        pressed && !disabled ? styles.pressed : null,
+      ]}
+    >
+      <Ionicons
+        name={selected ? 'checkmark-circle' : 'person-circle-outline'}
+        size={18}
+        color={selected ? colors.primary : colors.textMuted}
+      />
+      <View style={styles.collectorText}>
+        <Text
+          numberOfLines={1}
+          style={[
+            styles.collectorName,
+            selected ? styles.collectorNameSelected : null,
+          ]}
+        >
+          {member.user.display_name}
+        </Text>
+        <Text numberOfLines={1} style={styles.collectorTag}>
+          {member.user.identify_tag}
+        </Text>
+      </View>
+    </Pressable>
+  );
+}
+
+function collectorKey(member: TripMember): string {
+  return member.user.id;
+}
+
+function EmptyCollectors() {
+  return (
+    <Text style={styles.emptyCollectors}>
+      No eligible active members are available.
+    </Text>
+  );
+}
+
+export function ExpenseForm({
+  mode,
+  draft,
+  fieldErrors,
+  submitError,
+  collectors,
+  currentCollector,
+  currencyCode,
+  canSubmit,
+  dirty,
+  submitting,
+  refreshing = false,
+  authorityMessage,
+  backgroundError,
+  onChange,
+  onSubmit,
+  onRefresh,
+  onRetryBackground,
+}: ExpenseFormProps) {
+  const disabled = submitting || !canSubmit;
+  const mergedFieldErrors = useMemo<ExpenseFormFieldErrors>(
+    () => ({
+      ...(submitError?.fieldErrors ?? {}),
+      ...fieldErrors,
+    }),
+    [fieldErrors, submitError?.fieldErrors],
+  );
+  const selectedCollectorIsEligible = collectors.some(
+    (member) => member.user.id === draft.collector_id,
+  );
+  const showDepartedCurrentCollector =
+    mode === 'edit' &&
+    currentCollector !== null &&
+    currentCollector !== undefined &&
+    draft.collector_id === currentCollector.id &&
+    !selectedCollectorIsEligible;
+  const unchanged = mode === 'edit' && !dirty;
+  const normalizedCurrency = currencyCode.trim().toUpperCase();
+  const amountKeyboardType = ZERO_DECIMAL_CURRENCIES.has(
+    normalizedCurrency,
+  )
+    ? 'number-pad'
+    : 'decimal-pad';
+
+  const selectCollector = useCallback(
+    (collectorId: string) => {
+      onChange({ collector_id: collectorId });
+    },
+    [onChange],
+  );
+
+  const selectCreator = useCallback(() => {
+    onChange({ collector_id: null });
+  }, [onChange]);
+
+  const renderCollector = useCallback(
+    ({ item }: ListRenderItemInfo<TripMember>): ReactElement => (
+      <CollectorChoice
+        member={item}
+        selected={draft.collector_id === item.user.id}
+        disabled={disabled}
+        onSelect={selectCollector}
+      />
+    ),
+    [disabled, draft.collector_id, selectCollector],
+  );
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['left', 'right', 'bottom']}>
+      <KeyboardAvoidingView
+        style={styles.fill}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ScrollView
+          testID="expense-form-scroll"
+          contentContainerStyle={styles.content}
+          contentInsetAdjustmentBehavior="automatic"
+          keyboardShouldPersistTaps="handled"
+          refreshControl={
+            onRefresh ? (
+              <RefreshControl
+                testID="expense-form-refresh-control"
+                refreshing={refreshing}
+                onRefresh={onRefresh}
+              />
+            ) : undefined
+          }
+        >
+          {backgroundError ? (
+            <View accessibilityRole="alert" style={styles.errorBanner}>
+              <Text style={styles.errorBannerText}>
+                {backgroundError.message}
+              </Text>
+              {onRetryBackground ? (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Retry refreshing expense form"
+                  onPress={onRetryBackground}
+                  style={({ pressed }) => [
+                    styles.retry,
+                    pressed ? styles.pressed : null,
+                  ]}
+                >
+                  <Text style={styles.retryText}>Retry</Text>
+                </Pressable>
+              ) : null}
+            </View>
+          ) : null}
+
+          <View style={styles.intro}>
+            <Text accessibilityRole="header" style={styles.title}>
+              {mode === 'create' ? 'Add expense' : 'Edit expense'}
+            </Text>
+            <Text style={styles.body}>
+              {mode === 'create'
+                ? 'Create a new expense for all active trip members.'
+                : 'Update the expense details and eligible collector.'}
+            </Text>
+          </View>
+
+          <View style={styles.section}>
+            <TextField
+              label="Expense name *"
+              accessibilityLabel="Expense name"
+              value={draft.title}
+              onChangeText={(title) => onChange({ title })}
+              maxLength={120}
+              editable={!disabled}
+              error={mergedFieldErrors.title}
+            />
+            <TextField
+              label="Description"
+              accessibilityLabel="Expense description"
+              value={draft.description}
+              onChangeText={(description) => onChange({ description })}
+              multiline
+              numberOfLines={4}
+              editable={!disabled}
+              error={mergedFieldErrors.description}
+            />
+            <View style={styles.amountField}>
+              <View style={styles.amountInput}>
+                <TextField
+                  label="Total amount *"
+                  accessibilityLabel="Expense total amount"
+                  value={draft.total_amount}
+                  onChangeText={(totalAmount) =>
+                    onChange({ total_amount: totalAmount })
+                  }
+                  keyboardType={amountKeyboardType}
+                  autoCorrect={false}
+                  editable={!disabled}
+                  error={mergedFieldErrors.total_amount}
+                />
+              </View>
+              <View
+                accessible
+                accessibilityLabel={`Currency ${normalizedCurrency}`}
+                style={styles.currency}
+              >
+                <Text style={styles.currencyText}>
+                  {normalizedCurrency}
+                </Text>
+              </View>
+            </View>
+          </View>
+
+          <View style={styles.section}>
+            <View style={styles.collectorHeading}>
+              <Text accessibilityRole="header" style={styles.sectionTitle}>
+                Collector
+              </Text>
+              <Text style={styles.collectorHint}>
+                Active participants only
+              </Text>
+            </View>
+
+            {mode === 'create' ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Use expense creator as collector"
+                accessibilityState={{
+                  disabled,
+                  selected:
+                    draft.collector_id === null ||
+                    draft.collector_id === '',
+                }}
+                disabled={disabled}
+                onPress={selectCreator}
+                style={({ pressed }) => [
+                  styles.creatorChoice,
+                  draft.collector_id === null ||
+                  draft.collector_id === ''
+                    ? styles.collectorChoiceSelected
+                    : null,
+                  disabled ? styles.disabled : null,
+                  pressed && !disabled ? styles.pressed : null,
+                ]}
+              >
+                <Ionicons
+                  name="person-add-outline"
+                  size={18}
+                  color={
+                    draft.collector_id === null ||
+                    draft.collector_id === ''
+                      ? colors.primary
+                      : colors.textMuted
+                  }
+                />
+                <Text
+                  style={[
+                    styles.collectorName,
+                    draft.collector_id === null ||
+                    draft.collector_id === ''
+                      ? styles.collectorNameSelected
+                      : null,
+                  ]}
+                >
+                  Expense creator
+                </Text>
+              </Pressable>
+            ) : null}
+
+            {showDepartedCurrentCollector ? (
+              <View
+                accessible
+                accessibilityLabel={`${currentCollector.display_name}, current collector, left trip`}
+                style={[
+                  styles.departedCollector,
+                  styles.collectorChoiceSelected,
+                ]}
+              >
+                <Ionicons
+                  name="person-remove-outline"
+                  size={18}
+                  color={colors.textMuted}
+                />
+                <View style={styles.collectorText}>
+                  <Text numberOfLines={1} style={styles.collectorName}>
+                    {currentCollector.display_name}
+                  </Text>
+                  <Text numberOfLines={1} style={styles.collectorTag}>
+                    {currentCollector.identify_tag
+                      ? `${currentCollector.identify_tag} · left trip`
+                      : 'Current collector · left trip'}
+                  </Text>
+                </View>
+              </View>
+            ) : null}
+
+            <FlatList
+              testID="expense-collector-list"
+              horizontal
+              data={collectors}
+              keyExtractor={collectorKey}
+              renderItem={renderCollector}
+              ListEmptyComponent={EmptyCollectors}
+              contentContainerStyle={styles.collectorList}
+              showsHorizontalScrollIndicator={false}
+              keyboardShouldPersistTaps="handled"
+            />
+
+            {mergedFieldErrors.collector_id ? (
+              <Text accessibilityRole="alert" style={styles.inlineError}>
+                {mergedFieldErrors.collector_id}
+              </Text>
+            ) : null}
+          </View>
+        </ScrollView>
+
+        <View style={styles.footer}>
+          <FormError error={submitError} />
+          {authorityMessage ? (
+            <Text accessibilityRole="alert" style={styles.authorityMessage}>
+              {authorityMessage}
+            </Text>
+          ) : null}
+          {unchanged ? (
+            <Text style={styles.submitHint}>
+              Change at least one field to save.
+            </Text>
+          ) : null}
+          <Button
+            title={mode === 'create' ? 'Create expense' : 'Save expense'}
+            onPress={onSubmit}
+            loading={submitting}
+            disabled={!canSubmit || unchanged}
+          />
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  fill: { flex: 1 },
+  content: {
+    gap: spacing.lg,
+    padding: spacing.md,
+    paddingBottom: spacing.xl,
+  },
+  intro: { gap: spacing.xs },
+  title: {
+    ...typography.heading,
+    color: colors.text,
+  },
+  body: {
+    ...typography.body,
+    color: colors.textMuted,
+  },
+  section: {
+    gap: spacing.md,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.lg,
+    backgroundColor: colors.background,
+  },
+  amountField: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: spacing.sm,
+  },
+  amountInput: { flex: 1 },
+  currency: {
+    minHeight: 48,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    backgroundColor: colors.surface,
+  },
+  currencyText: {
+    ...typography.label,
+    color: colors.textMuted,
+  },
+  collectorHeading: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
+  },
+  sectionTitle: {
+    ...typography.heading,
+    color: colors.text,
+  },
+  collectorHint: {
+    ...typography.caption,
+    color: colors.textMuted,
+    textAlign: 'right',
+  },
+  collectorList: {
+    gap: spacing.sm,
+  },
+  collectorChoice: {
+    minHeight: 52,
+    maxWidth: 220,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    backgroundColor: colors.background,
+  },
+  creatorChoice: {
+    minHeight: 48,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    backgroundColor: colors.background,
+  },
+  departedCollector: {
+    minHeight: 52,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    backgroundColor: colors.surface,
+  },
+  collectorChoiceSelected: {
+    borderColor: colors.primary,
+    backgroundColor: colors.primarySoft,
+  },
+  collectorText: {
+    minWidth: 0,
+    flexShrink: 1,
+  },
+  collectorName: {
+    ...typography.label,
+    color: colors.text,
+  },
+  collectorNameSelected: { color: colors.primary },
+  collectorTag: {
+    ...typography.caption,
+    color: colors.textMuted,
+  },
+  emptyCollectors: {
+    ...typography.caption,
+    color: colors.textMuted,
+  },
+  inlineError: {
+    ...typography.caption,
+    color: colors.danger,
+  },
+  footer: {
+    gap: spacing.sm,
+    padding: spacing.md,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    backgroundColor: colors.background,
+  },
+  authorityMessage: {
+    ...typography.body,
+    color: colors.danger,
+    textAlign: 'center',
+  },
+  submitHint: {
+    ...typography.caption,
+    color: colors.textMuted,
+    textAlign: 'center',
+  },
+  errorBanner: {
+    gap: spacing.sm,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.dangerBorder,
+    borderRadius: radii.md,
+    backgroundColor: colors.dangerSoft,
+  },
+  errorBannerText: {
+    ...typography.body,
+    color: colors.danger,
+  },
+  retry: {
+    alignSelf: 'flex-start',
+    minHeight: 44,
+    justifyContent: 'center',
+  },
+  retryText: {
+    ...typography.label,
+    color: colors.primary,
+  },
+  pressed: { opacity: 0.58 },
+  disabled: { opacity: 0.55 },
+});

--- a/mobile/src/features/expenses/components/ExpenseRow.tsx
+++ b/mobile/src/features/expenses/components/ExpenseRow.tsx
@@ -1,0 +1,261 @@
+import { Ionicons } from '@expo/vector-icons';
+import { memo, useCallback } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import {
+  formatExpenseMoney,
+  getExpenseStatusLabel,
+  getExpenseStatusTone,
+} from '../money';
+import type { ExpenseListItem } from '../types';
+
+interface ExpenseRowProps {
+  expense: ExpenseListItem;
+  disabled?: boolean;
+  onPress: (expenseId: string) => void;
+}
+
+const STATUS_TOKENS = {
+  warning: {
+    color: colors.warning,
+    backgroundColor: colors.warningSoft,
+  },
+  success: {
+    color: colors.success,
+    backgroundColor: colors.successSoft,
+  },
+  danger: {
+    color: colors.danger,
+    backgroundColor: colors.dangerSoft,
+  },
+} as const;
+
+function getStatusMessage(expense: ExpenseListItem): string {
+  if (expense.status === 'UNDERFUNDED') {
+    return `Missing ${formatExpenseMoney(
+      expense.missing_amount,
+      expense.currency_code,
+    )}`;
+  }
+  if (expense.status === 'OVERFUNDED') {
+    return `Surplus ${formatExpenseMoney(
+      expense.surplus_amount,
+      expense.currency_code,
+    )}`;
+  }
+  return expense.description || 'Fully funded';
+}
+
+function ExpenseRowComponent({
+  expense,
+  disabled = false,
+  onPress,
+}: ExpenseRowProps) {
+  const tone = getExpenseStatusTone(expense.status);
+  const statusTokens = STATUS_TOKENS[tone];
+  const openExpense = useCallback(
+    () => onPress(expense.id),
+    [expense.id, onPress],
+  );
+  const totalLabel = formatExpenseMoney(
+    expense.total_amount,
+    expense.currency_code,
+  );
+  const collectedLabel = formatExpenseMoney(
+    expense.paid_amount,
+    expense.currency_code,
+  );
+  const accessibilitySummary = [
+    `Open expense ${expense.title}`,
+    getExpenseStatusLabel(expense.status),
+    expense.locked ? 'locked' : null,
+    `total ${totalLabel}`,
+    `collected ${collectedLabel}`,
+    `collector ${expense.collector.display_name}`,
+  ]
+    .filter(Boolean)
+    .join(', ');
+
+  return (
+    <Pressable
+      testID={`expense-row-${expense.id}`}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilitySummary}
+      accessibilityHint="Shows expense details and participant contributions"
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      onPress={openExpense}
+      style={({ pressed }) => [
+        styles.card,
+        pressed && !disabled ? styles.pressed : null,
+        disabled ? styles.disabled : null,
+      ]}
+    >
+      <View style={styles.heading}>
+        <View style={styles.titleBlock}>
+          <View style={styles.titleLine}>
+            <Text numberOfLines={1} style={styles.title}>
+              {expense.title}
+            </Text>
+            {expense.locked ? (
+              <Ionicons
+                accessibilityLabel="Locked"
+                name="lock-closed-outline"
+                size={16}
+                color={colors.textMuted}
+              />
+            ) : null}
+          </View>
+          <Text
+            numberOfLines={2}
+            style={[
+              styles.statusMessage,
+              tone === 'success' ? null : { color: statusTokens.color },
+            ]}
+          >
+            {getStatusMessage(expense)}
+          </Text>
+        </View>
+        <Ionicons
+          name="chevron-forward"
+          size={18}
+          color={colors.textMuted}
+        />
+      </View>
+
+      <View style={styles.amounts}>
+        <View style={styles.metric}>
+          <Text style={styles.metricLabel}>Total</Text>
+          <Text style={styles.metricValue}>
+            {totalLabel}
+          </Text>
+        </View>
+        <View style={styles.metric}>
+          <Text style={styles.metricLabel}>Collected</Text>
+          <Text style={styles.metricValue}>
+            {collectedLabel}
+          </Text>
+        </View>
+      </View>
+
+      <View style={styles.footer}>
+        <View
+          style={[
+            styles.badge,
+            { backgroundColor: statusTokens.backgroundColor },
+          ]}
+        >
+          <Text style={[styles.badgeText, { color: statusTokens.color }]}>
+            {getExpenseStatusLabel(expense.status)}
+          </Text>
+        </View>
+        <View style={styles.collector}>
+          <Text style={styles.collectorLabel}>Collector</Text>
+          <Text numberOfLines={1} style={styles.collectorName}>
+            {expense.collector.display_name}
+          </Text>
+          {expense.collector.identify_tag ? (
+            <Text numberOfLines={1} style={styles.collectorTag}>
+              {expense.collector.identify_tag}
+            </Text>
+          ) : null}
+        </View>
+      </View>
+    </Pressable>
+  );
+}
+
+export const ExpenseRow = memo(ExpenseRowComponent);
+
+const styles = StyleSheet.create({
+  card: {
+    gap: spacing.md,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.lg,
+    backgroundColor: colors.background,
+  },
+  pressed: { opacity: 0.58 },
+  disabled: { opacity: 0.55 },
+  heading: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.sm,
+  },
+  titleBlock: {
+    minWidth: 0,
+    flex: 1,
+    gap: spacing.xs,
+  },
+  titleLine: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  title: {
+    ...typography.heading,
+    minWidth: 0,
+    flexShrink: 1,
+    color: colors.text,
+  },
+  statusMessage: {
+    ...typography.caption,
+    color: colors.textMuted,
+  },
+  amounts: {
+    flexDirection: 'row',
+    gap: spacing.md,
+  },
+  metric: {
+    minWidth: 0,
+    flex: 1,
+    gap: spacing.xs,
+  },
+  metricLabel: {
+    ...typography.caption,
+    color: colors.textMuted,
+  },
+  metricValue: {
+    ...typography.body,
+    color: colors.text,
+    fontWeight: '600',
+  },
+  footer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.md,
+    paddingTop: spacing.md,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+  },
+  badge: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radii.full,
+  },
+  badgeText: {
+    ...typography.label,
+  },
+  collector: {
+    minWidth: 0,
+    flex: 1,
+    alignItems: 'flex-end',
+  },
+  collectorLabel: {
+    ...typography.caption,
+    color: colors.textMuted,
+  },
+  collectorName: {
+    ...typography.label,
+    maxWidth: '100%',
+    color: colors.text,
+  },
+  collectorTag: {
+    ...typography.caption,
+    maxWidth: '100%',
+    color: colors.textMuted,
+  },
+});

--- a/mobile/src/features/expenses/components/ExpenseSummaryStrip.tsx
+++ b/mobile/src/features/expenses/components/ExpenseSummaryStrip.tsx
@@ -1,0 +1,203 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import {
+  formatExpenseMoney,
+  getExpenseFundingPercent,
+  getUserBalanceLabel,
+} from '../money';
+import type { ExpenseMoneySummary } from '../types';
+
+interface ExpenseSummaryStripProps {
+  summary: ExpenseMoneySummary;
+  myBalance: {
+    balance: string;
+    surplus_held?: string;
+  };
+  currencyCode: string;
+}
+
+type BalanceDirection = 'owe' | 'receive' | 'settled';
+
+function isCanonicalZero(value: string): boolean {
+  const unsigned = value.trim().replace(/^[+-]/, '');
+  return unsigned.replace(/[.,]/g, '').replace(/0/g, '').length === 0;
+}
+
+function getBalanceDirection(balance: string): BalanceDirection {
+  if (isCanonicalZero(balance)) {
+    return 'settled';
+  }
+  return balance.trim().startsWith('-') ? 'owe' : 'receive';
+}
+
+export function ExpenseSummaryStrip({
+  summary,
+  myBalance,
+  currencyCode,
+}: ExpenseSummaryStripProps) {
+  const fundingPercent = getExpenseFundingPercent(summary);
+  const balanceDirection = getBalanceDirection(myBalance.balance);
+  const hasSurplusHeld = !isCanonicalZero(myBalance.surplus_held ?? '0');
+  const stats = [
+    {
+      label: 'Total expenses',
+      value: formatExpenseMoney(summary.total_amount, currencyCode),
+    },
+    {
+      label: 'Collected',
+      value: formatExpenseMoney(summary.paid_amount, currencyCode),
+    },
+    {
+      label: 'Missing',
+      value: formatExpenseMoney(summary.missing_amount, currencyCode),
+    },
+    {
+      label: 'Surplus',
+      value: formatExpenseMoney(summary.surplus_amount, currencyCode),
+    },
+  ] as const;
+
+  return (
+    <View accessibilityLabel="Expense summary" style={styles.card}>
+      <View style={styles.stats}>
+        {stats.map((stat) => (
+          <View key={stat.label} style={styles.stat}>
+            <Text style={styles.label}>{stat.label}</Text>
+            <Text style={styles.value}>
+              {stat.value}
+            </Text>
+          </View>
+        ))}
+      </View>
+
+      <View style={styles.balance}>
+        <Text style={styles.label}>My balance</Text>
+        <Text
+          style={[
+            styles.balanceValue,
+            balanceDirection === 'receive' ? styles.receive : null,
+            balanceDirection === 'owe' ? styles.owe : null,
+          ]}
+        >
+          {getUserBalanceLabel(myBalance.balance, currencyCode)}
+        </Text>
+        {hasSurplusHeld ? (
+          <Text style={styles.surplus}>
+            Holding{' '}
+            <Text style={styles.emphasis}>
+              {formatExpenseMoney(
+                myBalance.surplus_held ?? '0',
+                currencyCode,
+              )}
+            </Text>{' '}
+            in group surplus
+          </Text>
+        ) : null}
+      </View>
+
+      <View style={styles.progressSection}>
+        <View style={styles.progressHeading}>
+          <Text style={styles.label}>Collection progress</Text>
+          <Text style={styles.progressValue}>
+            {Math.round(fundingPercent)}%
+          </Text>
+        </View>
+        <View
+          accessible
+          accessibilityLabel={`Collection progress ${Math.round(fundingPercent)} percent`}
+          accessibilityRole="progressbar"
+          accessibilityValue={{
+            min: 0,
+            max: 100,
+            now: Math.round(fundingPercent),
+          }}
+          style={styles.progressTrack}
+        >
+          <View
+            style={[
+              styles.progressFill,
+              {
+                width: `${fundingPercent}%`,
+                minWidth: fundingPercent > 0 ? spacing.xs : 0,
+              },
+            ]}
+          />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    gap: spacing.md,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.lg,
+    backgroundColor: colors.background,
+  },
+  stats: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.md,
+  },
+  stat: {
+    minWidth: '40%',
+    flexGrow: 1,
+    gap: spacing.xs,
+  },
+  label: {
+    ...typography.label,
+    color: colors.textMuted,
+  },
+  value: {
+    ...typography.body,
+    color: colors.text,
+    fontWeight: '600',
+  },
+  balance: {
+    gap: spacing.xs,
+    paddingTop: spacing.md,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+  },
+  balanceValue: {
+    ...typography.heading,
+    color: colors.text,
+  },
+  receive: { color: colors.success },
+  owe: { color: colors.danger },
+  surplus: {
+    ...typography.caption,
+    color: colors.amber,
+  },
+  emphasis: { fontWeight: '600' },
+  progressSection: {
+    gap: spacing.sm,
+    paddingTop: spacing.md,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+  },
+  progressHeading: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
+  },
+  progressValue: {
+    ...typography.label,
+    color: colors.text,
+  },
+  progressTrack: {
+    height: spacing.xs,
+    overflow: 'hidden',
+    borderRadius: radii.full,
+    backgroundColor: colors.surface,
+  },
+  progressFill: {
+    height: '100%',
+    borderRadius: radii.full,
+    backgroundColor: colors.primary,
+  },
+});

--- a/mobile/src/features/expenses/components/MemberBalanceRow.tsx
+++ b/mobile/src/features/expenses/components/MemberBalanceRow.tsx
@@ -1,0 +1,140 @@
+import { Ionicons } from '@expo/vector-icons';
+import { memo } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { formatExpenseMoney } from '../money';
+
+interface MemberBalanceRowProps {
+  memberName?: string | null;
+  identifyTag?: string | null;
+  balance: string;
+  currencyCode: string;
+}
+
+type BalanceDirection = 'owe' | 'receive' | 'settled';
+
+function getBalanceDirection(balance: string): BalanceDirection {
+  const trimmed = balance.trim();
+  const hasValue =
+    trimmed
+      .replace(/^[+-]/, '')
+      .replace(/[.,]/g, '')
+      .replace(/0/g, '').length > 0;
+
+  if (!hasValue) {
+    return 'settled';
+  }
+  return trimmed.startsWith('-') ? 'owe' : 'receive';
+}
+
+function getAbsoluteCanonicalAmount(balance: string): string {
+  const trimmed = balance.trim();
+  return trimmed.startsWith('-') || trimmed.startsWith('+')
+    ? trimmed.slice(1)
+    : trimmed;
+}
+
+function MemberBalanceRowComponent({
+  memberName,
+  identifyTag,
+  balance,
+  currencyCode,
+}: MemberBalanceRowProps) {
+  const safeName = memberName?.trim() || 'Member';
+  const direction = getBalanceDirection(balance);
+  const amount =
+    direction === 'settled'
+      ? 'Settled'
+      : formatExpenseMoney(
+          getAbsoluteCanonicalAmount(balance),
+          currencyCode,
+        );
+  const directionLabel =
+    direction === 'owe'
+      ? `Owes ${amount}`
+      : direction === 'receive'
+        ? `Is owed ${amount}`
+        : amount;
+
+  return (
+    <View
+      accessible
+      accessibilityLabel={`${safeName}, ${directionLabel}`}
+      style={styles.row}
+    >
+      <View style={styles.avatar}>
+        <Ionicons
+          name="person-outline"
+          size={18}
+          color={colors.textMuted}
+        />
+      </View>
+      <View style={styles.identity}>
+        <Text numberOfLines={1} style={styles.name}>
+          {safeName}
+        </Text>
+        {identifyTag ? (
+          <Text numberOfLines={1} style={styles.tag}>
+            {identifyTag}
+          </Text>
+        ) : null}
+      </View>
+      <Text
+        style={[
+          styles.balance,
+          direction === 'receive' ? styles.receive : null,
+          direction === 'owe' ? styles.owe : null,
+        ]}
+      >
+        {directionLabel}
+      </Text>
+    </View>
+  );
+}
+
+export const MemberBalanceRow = memo(MemberBalanceRowComponent);
+
+const styles = StyleSheet.create({
+  row: {
+    minHeight: 64,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    backgroundColor: colors.background,
+  },
+  avatar: {
+    width: 36,
+    height: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.full,
+    backgroundColor: colors.surface,
+  },
+  identity: {
+    minWidth: 0,
+    flex: 1,
+  },
+  name: {
+    ...typography.body,
+    color: colors.text,
+    fontWeight: '600',
+  },
+  tag: {
+    ...typography.caption,
+    color: colors.textMuted,
+  },
+  balance: {
+    ...typography.label,
+    maxWidth: '42%',
+    flexShrink: 1,
+    color: colors.text,
+    textAlign: 'right',
+  },
+  receive: { color: colors.success },
+  owe: { color: colors.danger },
+});

--- a/mobile/src/features/expenses/components/SettlementPanel.tsx
+++ b/mobile/src/features/expenses/components/SettlementPanel.tsx
@@ -1,0 +1,126 @@
+import { Ionicons } from '@expo/vector-icons';
+import { Alert, StyleSheet, Text, View } from 'react-native';
+import type { ApiError } from '@/shared/api/errors';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { Button } from '@/shared/ui/Button';
+import type { TripSettlement } from '../types';
+
+interface SettlementPanelProps {
+  settlement: TripSettlement;
+  canReopen: boolean;
+  reopening?: boolean;
+  error?: ApiError | null;
+  onReopen: () => void;
+}
+
+export function SettlementPanel({
+  settlement,
+  canReopen,
+  reopening = false,
+  error,
+  onReopen,
+}: SettlementPanelProps) {
+  if (settlement.status !== 'FINALIZED') {
+    return null;
+  }
+
+  const transferCount = settlement.transfers.length;
+  const confirmReopen = () => {
+    Alert.alert(
+      'Reopen settlement?',
+      'Expenses and contributions will be unlocked for editing.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        { text: 'Reopen', onPress: onReopen },
+      ],
+    );
+  };
+
+  return (
+    <View accessibilityLabel="Finalized settlement" style={styles.panel}>
+      <View style={styles.heading}>
+        <View style={styles.icon}>
+          <Ionicons
+            name="checkmark-circle-outline"
+            size={22}
+            color={colors.success}
+          />
+        </View>
+        <View style={styles.titleBlock}>
+          <Text accessibilityRole="header" style={styles.title}>
+            Settlement finalized
+          </Text>
+          <Text style={styles.body}>
+            Settlement finalized. Expenses are locked.
+          </Text>
+        </View>
+      </View>
+
+      <Text style={styles.transferCount}>
+        {transferCount === 0
+          ? 'No transfers are needed for this settlement.'
+          : `${transferCount} ${transferCount === 1 ? 'transfer' : 'transfers'} to track below.`}
+      </Text>
+
+      {canReopen ? (
+        <Button
+          title="Reopen settlement"
+          variant="secondary"
+          loading={reopening}
+          onPress={confirmReopen}
+        />
+      ) : null}
+
+      {error ? (
+        <Text accessibilityRole="alert" style={styles.error}>
+          {error.message}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  panel: {
+    gap: spacing.md,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.lg,
+    backgroundColor: colors.successSoft,
+  },
+  heading: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.sm,
+  },
+  icon: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.md,
+    backgroundColor: colors.background,
+  },
+  titleBlock: {
+    minWidth: 0,
+    flex: 1,
+    gap: spacing.xs,
+  },
+  title: {
+    ...typography.heading,
+    color: colors.text,
+  },
+  body: {
+    ...typography.body,
+    color: colors.textMuted,
+  },
+  transferCount: {
+    ...typography.caption,
+    color: colors.textMuted,
+  },
+  error: {
+    ...typography.caption,
+    color: colors.danger,
+  },
+});

--- a/mobile/src/features/expenses/components/TransferRow.tsx
+++ b/mobile/src/features/expenses/components/TransferRow.tsx
@@ -1,0 +1,292 @@
+import { Ionicons } from '@expo/vector-icons';
+import { memo, useCallback } from 'react';
+import { Alert, StyleSheet, Text, View } from 'react-native';
+import type { ApiError } from '@/shared/api/errors';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { Button } from '@/shared/ui/Button';
+import {
+  formatExpenseMoney,
+  getSettlementTransferRoleState,
+} from '../money';
+import type { SettlementTransfer } from '../types';
+
+interface TransferRowProps {
+  transfer: SettlementTransfer;
+  currencyCode: string;
+  viewerId: string | null;
+  loading?: boolean;
+  error?: ApiError | null;
+  onMarkSent: (transferId: string) => void;
+  onConfirmReceived: (transferId: string) => void;
+}
+
+interface TransferStatusProps {
+  completed: boolean;
+  doneLabel: string;
+  pendingLabel: string;
+}
+
+function TransferStatus({
+  completed,
+  doneLabel,
+  pendingLabel,
+}: TransferStatusProps) {
+  return (
+    <View
+      accessible
+      accessibilityLabel={completed ? doneLabel : pendingLabel}
+      style={[
+        styles.status,
+        completed ? styles.statusComplete : styles.statusPending,
+      ]}
+    >
+      <Ionicons
+        name={
+          completed
+            ? 'checkmark-circle-outline'
+            : 'time-outline'
+        }
+        size={15}
+        color={completed ? colors.success : colors.amber}
+      />
+      <Text
+        style={[
+          styles.statusText,
+          completed ? styles.statusTextComplete : styles.statusTextPending,
+        ]}
+      >
+        {completed ? doneLabel : pendingLabel}
+      </Text>
+    </View>
+  );
+}
+
+function TransferPerson({
+  label,
+  name,
+  tag,
+}: {
+  label: 'Payer' | 'Recipient';
+  name: string;
+  tag: string | null;
+}) {
+  return (
+    <View style={styles.person}>
+      <Text style={styles.personLabel}>{label}</Text>
+      <Text numberOfLines={1} style={styles.personName}>
+        {name}
+      </Text>
+      {tag ? (
+        <Text numberOfLines={1} style={styles.personTag}>
+          {tag}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+function TransferRowComponent({
+  transfer,
+  currencyCode,
+  viewerId,
+  loading = false,
+  error,
+  onMarkSent,
+  onConfirmReceived,
+}: TransferRowProps) {
+  const roleState = getSettlementTransferRoleState(transfer, viewerId);
+  const guidance =
+    roleState.isSent && !roleState.isReceived
+      ? roleState.isRecipient
+        ? `${transfer.payer.display_name} marked this as sent. Confirm only after the money arrives.`
+        : `Waiting for ${transfer.recipient.display_name} to confirm receipt.`
+      : null;
+
+  const confirmSent = useCallback(() => {
+    Alert.alert(
+      'Confirm transfer sent?',
+      `You are confirming that you sent money to ${transfer.recipient.display_name}.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Confirm',
+          onPress: () => onMarkSent(transfer.id),
+        },
+      ],
+    );
+  }, [
+    onMarkSent,
+    transfer.id,
+    transfer.recipient.display_name,
+  ]);
+
+  const confirmReceived = useCallback(() => {
+    Alert.alert(
+      'Confirm transfer received?',
+      `You are confirming that you received money from ${transfer.payer.display_name}.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Confirm',
+          onPress: () => onConfirmReceived(transfer.id),
+        },
+      ],
+    );
+  }, [
+    onConfirmReceived,
+    transfer.id,
+    transfer.payer.display_name,
+  ]);
+
+  return (
+    <View
+      accessibilityLabel={`${transfer.payer.display_name} pays ${transfer.recipient.display_name} ${formatExpenseMoney(
+        transfer.amount,
+        currencyCode,
+      )}`}
+      style={[
+        styles.card,
+        roleState.isReceived ? styles.cardComplete : null,
+      ]}
+    >
+      <View style={styles.people}>
+        <TransferPerson
+          label="Payer"
+          name={transfer.payer.display_name}
+          tag={transfer.payer.identify_tag}
+        />
+        <Ionicons
+          name="arrow-forward"
+          size={18}
+          color={colors.textMuted}
+        />
+        <TransferPerson
+          label="Recipient"
+          name={transfer.recipient.display_name}
+          tag={transfer.recipient.identify_tag}
+        />
+      </View>
+
+      <Text style={styles.amount}>
+        {formatExpenseMoney(transfer.amount, currencyCode)}
+      </Text>
+
+      {guidance ? (
+        <Text style={styles.guidance}>{guidance}</Text>
+      ) : null}
+
+      <View style={styles.statuses}>
+        <TransferStatus
+          completed={roleState.isSent}
+          doneLabel="Sent"
+          pendingLabel="Not sent"
+        />
+        <TransferStatus
+          completed={roleState.isReceived}
+          doneLabel="Received"
+          pendingLabel="Not received"
+        />
+      </View>
+
+      {roleState.canMarkSent ? (
+        <Button
+          title="I sent it"
+          loading={loading}
+          onPress={confirmSent}
+        />
+      ) : roleState.canConfirmReceived ? (
+        <Button
+          title="I received it"
+          variant="secondary"
+          loading={loading}
+          onPress={confirmReceived}
+        />
+      ) : (
+        <Text style={styles.tracking}>Tracking</Text>
+      )}
+
+      {error ? (
+        <Text accessibilityRole="alert" style={styles.error}>
+          {error.message}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+export const TransferRow = memo(TransferRowComponent);
+
+const styles = StyleSheet.create({
+  card: {
+    gap: spacing.md,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.lg,
+    backgroundColor: colors.background,
+  },
+  cardComplete: {
+    borderColor: colors.success,
+    backgroundColor: colors.successSoft,
+  },
+  people: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  person: {
+    minWidth: 0,
+    flex: 1,
+  },
+  personLabel: {
+    ...typography.caption,
+    color: colors.textMuted,
+  },
+  personName: {
+    ...typography.label,
+    color: colors.text,
+  },
+  personTag: {
+    ...typography.caption,
+    color: colors.textMuted,
+  },
+  amount: {
+    ...typography.heading,
+    color: colors.text,
+    textAlign: 'right',
+  },
+  guidance: {
+    ...typography.caption,
+    padding: spacing.sm,
+    borderRadius: radii.sm,
+    color: colors.textMuted,
+    backgroundColor: colors.surface,
+  },
+  statuses: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  status: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radii.full,
+  },
+  statusComplete: { backgroundColor: colors.successSoft },
+  statusPending: { backgroundColor: colors.amberSoft },
+  statusText: { ...typography.label },
+  statusTextComplete: { color: colors.success },
+  statusTextPending: { color: colors.amber },
+  tracking: {
+    ...typography.label,
+    color: colors.textMuted,
+    textAlign: 'right',
+  },
+  error: {
+    ...typography.caption,
+    color: colors.danger,
+  },
+});

--- a/mobile/src/features/expenses/expenseEvents.ts
+++ b/mobile/src/features/expenses/expenseEvents.ts
@@ -1,0 +1,45 @@
+export type ExpenseEvent = {
+  type: 'expensesChanged';
+  tripId: string;
+};
+
+export type ExpenseEventListener = (
+  event: ExpenseEvent,
+) => void | Promise<void>;
+
+const listenersByTripId = new Map<string, Set<ExpenseEventListener>>();
+
+export async function publishExpenseEvent(event: ExpenseEvent): Promise<void> {
+  const listeners = listenersByTripId.get(event.tripId);
+  if (!listeners) {
+    return;
+  }
+
+  await Promise.all(
+    Array.from(listeners, (listener) => listener(event)),
+  );
+}
+
+export function subscribeToExpenseEvents(
+  tripId: string,
+  listener: ExpenseEventListener,
+): () => void {
+  let listeners = listenersByTripId.get(tripId);
+  if (!listeners) {
+    listeners = new Set();
+    listenersByTripId.set(tripId, listeners);
+  }
+  listeners.add(listener);
+
+  return () => {
+    const currentListeners = listenersByTripId.get(tripId);
+    if (!currentListeners) {
+      return;
+    }
+
+    currentListeners.delete(listener);
+    if (currentListeners.size === 0) {
+      listenersByTripId.delete(tripId);
+    }
+  };
+}

--- a/mobile/src/features/expenses/formModel.ts
+++ b/mobile/src/features/expenses/formModel.ts
@@ -1,0 +1,303 @@
+import type { TripMember } from '@/features/trips/types';
+import {
+  normalizeExpenseMoneyInput,
+  type NormalizedExpenseMoneyInput,
+} from './money';
+import type {
+  CreateExpensePayload,
+  ExpenseDetailResponse,
+  ExpenseParticipant,
+  ExpensePerson,
+  SetContributionPayload,
+  UpdateExpensePayload,
+} from './types';
+
+export const EXPENSE_FIELD_LIMITS = {
+  title: 120,
+} as const;
+
+const EXPENSE_DRAFT_FIELDS = [
+  'title',
+  'description',
+  'total_amount',
+  'collector_id',
+] as const;
+
+export interface ExpenseFormDraft {
+  title: string;
+  description: string;
+  total_amount: string;
+  collector_id: string | null;
+}
+
+export type ExpenseDraftField = (typeof EXPENSE_DRAFT_FIELDS)[number];
+
+export type ExpenseFormDirtyFields = Readonly<
+  Partial<Record<ExpenseDraftField, boolean>>
+>;
+
+export type ExpenseFormFieldErrors = Partial<
+  Record<ExpenseDraftField, string>
+>;
+
+export interface ExpenseFormValidationOptions {
+  mode?: 'create' | 'edit';
+  eligibleCollectorIds?: ReadonlySet<string> | readonly string[];
+  initialCollectorId?: string | null;
+}
+
+export interface ExpenseFormValidationResult {
+  isValid: boolean;
+  fieldErrors: ExpenseFormFieldErrors;
+}
+
+export function createExpenseDraft(
+  collectorId: string | null = null,
+): ExpenseFormDraft {
+  return {
+    title: '',
+    description: '',
+    total_amount: '',
+    collector_id: collectorId,
+  };
+}
+
+export function hydrateExpenseDraft(
+  expense: ExpenseDetailResponse,
+): ExpenseFormDraft {
+  return {
+    title: expense.title,
+    description: expense.description,
+    total_amount: expense.total_amount,
+    collector_id: expense.collector.id,
+  };
+}
+
+export function cloneExpenseDraft(
+  draft: ExpenseFormDraft,
+): ExpenseFormDraft {
+  return { ...draft };
+}
+
+export function validateExpenseDraft(
+  draft: ExpenseFormDraft,
+  currencyCode: string,
+  {
+    mode = 'create',
+    eligibleCollectorIds,
+    initialCollectorId = null,
+  }: ExpenseFormValidationOptions = {},
+): ExpenseFormValidationResult {
+  const fieldErrors: ExpenseFormFieldErrors = {};
+  const normalizedTitle = draft.title.trim();
+
+  if (!normalizedTitle) {
+    fieldErrors.title = 'Title is required.';
+  } else if (
+    codePointLength(normalizedTitle) > EXPENSE_FIELD_LIMITS.title
+  ) {
+    fieldErrors.title =
+      `Title must be ${EXPENSE_FIELD_LIMITS.title} characters or fewer.`;
+  }
+
+  const normalizedAmount = normalizeExpenseMoneyInput(
+    draft.total_amount,
+    currencyCode,
+    { minimum: 'positive' },
+  );
+  if (normalizedAmount.error) {
+    fieldErrors.total_amount = normalizedAmount.error;
+  }
+
+  const collectorId = normalizeCollectorId(draft.collector_id);
+  if (mode === 'edit' && !collectorId) {
+    fieldErrors.collector_id = 'Choose a collector.';
+  } else if (
+    collectorId &&
+    eligibleCollectorIds &&
+    collectorId !== initialCollectorId &&
+    !containsId(eligibleCollectorIds, collectorId)
+  ) {
+    fieldErrors.collector_id =
+      'Choose an eligible active trip member.';
+  }
+
+  return {
+    isValid: Object.keys(fieldErrors).length === 0,
+    fieldErrors,
+  };
+}
+
+export function buildCreateExpensePayload(
+  draft: ExpenseFormDraft,
+  currencyCode: string,
+  eligibleCollectorIds?: ReadonlySet<string> | readonly string[],
+): CreateExpensePayload | null {
+  const validation = validateExpenseDraft(draft, currencyCode, {
+    mode: 'create',
+    eligibleCollectorIds,
+  });
+  const totalAmount = normalizeExpenseMoneyInput(
+    draft.total_amount,
+    currencyCode,
+    { minimum: 'positive' },
+  ).value;
+
+  if (!validation.isValid || totalAmount === null) {
+    return null;
+  }
+
+  const collectorId = normalizeCollectorId(draft.collector_id);
+  return {
+    title: draft.title.trim(),
+    description: draft.description.trim(),
+    total_amount: totalAmount,
+    ...(collectorId ? { collector_id: collectorId } : {}),
+  };
+}
+
+export function getExpenseDirtyFields(
+  initialDraft: ExpenseFormDraft,
+  draft: ExpenseFormDraft,
+): ExpenseFormDirtyFields {
+  const dirtyFields: Partial<Record<ExpenseDraftField, boolean>> = {};
+  for (const field of EXPENSE_DRAFT_FIELDS) {
+    if (initialDraft[field] !== draft[field]) {
+      dirtyFields[field] = true;
+    }
+  }
+  return dirtyFields;
+}
+
+export function buildPatchExpensePayload(
+  initialDraft: ExpenseFormDraft,
+  draft: ExpenseFormDraft,
+  currencyCode: string,
+  dirtyFields: ExpenseFormDirtyFields = getExpenseDirtyFields(
+    initialDraft,
+    draft,
+  ),
+  eligibleCollectorIds?: ReadonlySet<string> | readonly string[],
+): UpdateExpensePayload | null {
+  const initialCollectorId = normalizeCollectorId(
+    initialDraft.collector_id,
+  );
+  const validation = validateExpenseDraft(draft, currencyCode, {
+    mode: 'edit',
+    eligibleCollectorIds,
+    initialCollectorId,
+  });
+  const totalAmount = normalizeExpenseMoneyInput(
+    draft.total_amount,
+    currencyCode,
+    { minimum: 'positive' },
+  ).value;
+
+  if (!validation.isValid || totalAmount === null) {
+    return null;
+  }
+
+  const patch: UpdateExpensePayload = {};
+  const initialTitle = initialDraft.title.trim();
+  const nextTitle = draft.title.trim();
+  if (dirtyFields.title && initialTitle !== nextTitle) {
+    patch.title = nextTitle;
+  }
+
+  const initialDescription = initialDraft.description.trim();
+  const nextDescription = draft.description.trim();
+  if (
+    dirtyFields.description &&
+    initialDescription !== nextDescription
+  ) {
+    patch.description = nextDescription;
+  }
+
+  const initialTotalAmount = normalizeExpenseMoneyInput(
+    initialDraft.total_amount,
+    currencyCode,
+    { minimum: 'positive' },
+  ).value;
+  if (
+    dirtyFields.total_amount &&
+    initialTotalAmount !== totalAmount
+  ) {
+    patch.total_amount = totalAmount;
+  }
+
+  const collectorId = normalizeCollectorId(draft.collector_id);
+  if (
+    dirtyFields.collector_id &&
+    collectorId &&
+    collectorId !== initialCollectorId
+  ) {
+    patch.collector_id = collectorId;
+  }
+
+  return patch;
+}
+
+export function getEligibleCollectors(
+  activeMembers: readonly TripMember[],
+  participants?: readonly ExpenseParticipant[],
+): TripMember[] {
+  if (participants === undefined) {
+    return [...activeMembers];
+  }
+
+  const participantIds = new Set(
+    participants.map((participant) => participant.user_id),
+  );
+  return activeMembers.filter((member) =>
+    participantIds.has(member.user.id),
+  );
+}
+
+export function getDepartedCurrentCollector(
+  collector: ExpensePerson,
+  eligibleCollectors: readonly TripMember[],
+): ExpensePerson | null {
+  return eligibleCollectors.some(
+    (member) => member.user.id === collector.id,
+  )
+    ? null
+    : collector;
+}
+
+export function validateContributionAmount(
+  value: string,
+  currencyCode: string,
+): NormalizedExpenseMoneyInput {
+  return normalizeExpenseMoneyInput(value, currencyCode, {
+    minimum: 'non-negative',
+  });
+}
+
+export function buildContributionPayload(
+  value: string,
+  currencyCode: string,
+): SetContributionPayload | null {
+  const normalized = validateContributionAmount(value, currencyCode);
+  return normalized.value === null ? null : { amount: normalized.value };
+}
+
+function normalizeCollectorId(collectorId: string | null): string | null {
+  const normalized = collectorId?.trim() ?? '';
+  return normalized || null;
+}
+
+function containsId(
+  ids: ReadonlySet<string> | readonly string[],
+  id: string,
+): boolean {
+  for (const candidate of ids) {
+    if (candidate === id) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function codePointLength(value: string): number {
+  return Array.from(value).length;
+}

--- a/mobile/src/features/expenses/hooks/useExpenseCompositionCoordinator.ts
+++ b/mobile/src/features/expenses/hooks/useExpenseCompositionCoordinator.ts
@@ -1,0 +1,131 @@
+import { useFocusEffect } from 'expo-router';
+import { useCallback, useEffect, useRef } from 'react';
+import { subscribeToTripEvents, type TripEvent } from '@/features/trips/tripEvents';
+import { useAppForegroundEffect } from '@/shared/hooks/useAppForegroundEffect';
+import { subscribeToExpenseEvents } from '../expenseEvents';
+
+export type ExpenseCompositionLoadMode = 'initial' | 'refresh' | 'silent';
+
+interface UseExpenseCompositionCoordinatorOptions {
+  tripId: string;
+  refreshExpense: (mode: ExpenseCompositionLoadMode) => Promise<void>;
+  refreshTrip: (mode: ExpenseCompositionLoadMode) => Promise<void>;
+  enabled?: boolean;
+}
+
+function isTripEventForTrip(event: TripEvent, tripId: string): boolean {
+  return event.type === 'updated'
+    ? event.trip.id === tripId
+    : event.tripId === tripId;
+}
+
+export function useExpenseCompositionCoordinator({
+  tripId,
+  refreshExpense,
+  refreshTrip,
+  enabled = true,
+}: UseExpenseCompositionCoordinatorOptions) {
+  const activeRef = useRef(false);
+  const mountedRef = useRef(true);
+  const generationRef = useRef(0);
+  const hasRequestedInitialRef = useRef(false);
+
+  const refreshAll = useCallback(
+    async (mode: ExpenseCompositionLoadMode) => {
+      await Promise.all([refreshExpense(mode), refreshTrip(mode)]);
+    },
+    [refreshExpense, refreshTrip],
+  );
+
+  const requestReconcile = useCallback(
+    (forceInitial = false) => {
+      const mode =
+        forceInitial || !hasRequestedInitialRef.current
+          ? 'initial'
+          : 'silent';
+      hasRequestedInitialRef.current = true;
+      return refreshAll(mode);
+    },
+    [refreshAll],
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      activeRef.current = true;
+      generationRef.current += 1;
+      if (enabled) {
+        void requestReconcile();
+      }
+
+      return () => {
+        activeRef.current = false;
+        generationRef.current += 1;
+      };
+    }, [enabled, requestReconcile]),
+  );
+
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+      activeRef.current = false;
+      generationRef.current += 1;
+    },
+    [],
+  );
+
+  useAppForegroundEffect(
+    useCallback(() => {
+      if (enabled && activeRef.current) {
+        void requestReconcile();
+      }
+    }, [enabled, requestReconcile]),
+  );
+
+  useEffect(
+    () =>
+      subscribeToExpenseEvents(tripId, () => {
+        if (enabled && activeRef.current) {
+          return requestReconcile();
+        }
+        return undefined;
+      }),
+    [enabled, requestReconcile, tripId],
+  );
+
+  useEffect(
+    () =>
+      subscribeToTripEvents((event) => {
+        if (
+          enabled &&
+          activeRef.current &&
+          isTripEventForTrip(event, tripId)
+        ) {
+          void requestReconcile();
+        }
+      }),
+    [enabled, requestReconcile, tripId],
+  );
+
+  const isScreenActive = useCallback(
+    () => mountedRef.current && activeRef.current,
+    [],
+  );
+
+  const isActiveGeneration = useCallback((generation: number) => {
+    return (
+      mountedRef.current &&
+      activeRef.current &&
+      generationRef.current === generation
+    );
+  }, []);
+
+  const getGeneration = useCallback(() => generationRef.current, []);
+
+  return {
+    refreshAll,
+    requestReconcile,
+    isScreenActive,
+    isActiveGeneration,
+    getGeneration,
+  };
+}

--- a/mobile/src/features/expenses/hooks/useExpenseDashboard.ts
+++ b/mobile/src/features/expenses/hooks/useExpenseDashboard.ts
@@ -1,0 +1,205 @@
+import { useFocusEffect } from 'expo-router';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { type ApiError, normalizeApiError } from '@/shared/api/errors';
+import { useAppForegroundEffect } from '@/shared/hooks/useAppForegroundEffect';
+import { getExpenseDashboard } from '../api';
+import { subscribeToExpenseEvents } from '../expenseEvents';
+import type { ExpenseDashboardResponse } from '../types';
+
+export type ExpenseDashboardLoadStatus = 'loading' | 'ready' | 'error';
+export type ExpenseDashboardLoadMode = 'initial' | 'refresh' | 'silent';
+
+interface UseExpenseDashboardOptions {
+  autoReconcile?: boolean;
+}
+
+interface ExpenseDashboardSnapshot {
+  tripId: string;
+  dashboard: ExpenseDashboardResponse;
+}
+
+const MISSING_EXPENSE_DASHBOARD_ERROR: ApiError = {
+  kind: 'message',
+  message: 'Trip not found.',
+  errorCode: 'TRIP_NOT_FOUND',
+  status: 404,
+};
+
+function shouldClearExpenseDashboard(error: ApiError): boolean {
+  return error.status === 404 && error.errorCode === 'TRIP_NOT_FOUND';
+}
+
+export function useExpenseDashboard(
+  tripId: string | undefined,
+  { autoReconcile = true }: UseExpenseDashboardOptions = {},
+) {
+  const [dashboard, setDashboard] =
+    useState<ExpenseDashboardResponse | null>(null);
+  const [status, setStatus] =
+    useState<ExpenseDashboardLoadStatus>('loading');
+  const [error, setError] = useState<ApiError | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [stateTripId, setStateTripId] = useState<string | undefined>(tripId);
+  const [dashboardTripId, setDashboardTripId] = useState<
+    string | undefined
+  >();
+  const snapshotRef = useRef<ExpenseDashboardSnapshot | null>(null);
+  const requestIdRef = useRef(0);
+  const activeTripIdRef = useRef(tripId);
+  const focusedRef = useRef(false);
+
+  useEffect(() => {
+    activeTripIdRef.current = tripId;
+    requestIdRef.current += 1;
+  }, [tripId]);
+
+  const isCurrentRequest = useCallback(
+    (requestId: number, resourceKey: string) => {
+      return (
+        requestId === requestIdRef.current &&
+        resourceKey === activeTripIdRef.current
+      );
+    },
+    [],
+  );
+
+  const commitDashboard = useCallback(
+    (resourceKey: string, nextDashboard: ExpenseDashboardResponse) => {
+      snapshotRef.current = {
+        tripId: resourceKey,
+        dashboard: nextDashboard,
+      };
+      setStateTripId(resourceKey);
+      setDashboardTripId(resourceKey);
+      setDashboard(nextDashboard);
+      setError(null);
+      setStatus('ready');
+    },
+    [],
+  );
+
+  const refresh = useCallback(
+    async (mode: ExpenseDashboardLoadMode = 'silent') => {
+      const requestId = requestIdRef.current + 1;
+      requestIdRef.current = requestId;
+
+      if (!tripId) {
+        snapshotRef.current = null;
+        setStateTripId(tripId);
+        setDashboardTripId(undefined);
+        setDashboard(null);
+        setError(MISSING_EXPENSE_DASHBOARD_ERROR);
+        setStatus('error');
+        setRefreshing(false);
+        return;
+      }
+
+      const resourceKey = tripId;
+      const hasDashboard = snapshotRef.current?.tripId === resourceKey;
+      setStateTripId(resourceKey);
+
+      if (!hasDashboard) {
+        snapshotRef.current = null;
+        setDashboardTripId(undefined);
+        setDashboard(null);
+        setError(null);
+        setStatus('loading');
+        setRefreshing(false);
+      } else if (mode === 'refresh') {
+        setRefreshing(true);
+      }
+
+      try {
+        const nextDashboard = await getExpenseDashboard(resourceKey);
+        if (!isCurrentRequest(requestId, resourceKey)) {
+          return;
+        }
+        commitDashboard(resourceKey, nextDashboard);
+      } catch (caught) {
+        if (!isCurrentRequest(requestId, resourceKey)) {
+          return;
+        }
+
+        const nextError = normalizeApiError(caught);
+        const hasCurrentDashboard =
+          snapshotRef.current?.tripId === resourceKey;
+        setStateTripId(resourceKey);
+
+        if (
+          !hasCurrentDashboard ||
+          shouldClearExpenseDashboard(nextError)
+        ) {
+          snapshotRef.current = null;
+          setDashboardTripId(undefined);
+          setDashboard(null);
+          setStatus('error');
+        } else {
+          setStatus('ready');
+        }
+        setError(nextError);
+      } finally {
+        if (isCurrentRequest(requestId, resourceKey)) {
+          setRefreshing(false);
+        }
+      }
+    },
+    [commitDashboard, isCurrentRequest, tripId],
+  );
+
+  const invalidate = useCallback(() => {
+    requestIdRef.current += 1;
+    setRefreshing(false);
+  }, []);
+
+  useEffect(() => {
+    if (!autoReconcile || !tripId) {
+      return undefined;
+    }
+
+    return subscribeToExpenseEvents(tripId, () => {
+      if (focusedRef.current) {
+        return refresh('silent');
+      }
+      return undefined;
+    });
+  }, [autoReconcile, refresh, tripId]);
+
+  const reconcileOnForeground = useCallback(() => {
+    if (autoReconcile && focusedRef.current) {
+      void refresh(
+        snapshotRef.current?.tripId === tripId ? 'silent' : 'initial',
+      );
+    }
+  }, [autoReconcile, refresh, tripId]);
+
+  useAppForegroundEffect(reconcileOnForeground);
+
+  useFocusEffect(
+    useCallback(() => {
+      focusedRef.current = true;
+      if (autoReconcile) {
+        void refresh(
+          snapshotRef.current?.tripId === tripId ? 'silent' : 'initial',
+        );
+      }
+
+      return () => {
+        focusedRef.current = false;
+        requestIdRef.current += 1;
+      };
+    }, [autoReconcile, refresh, tripId]),
+  );
+
+  const stateMatchesTrip = stateTripId === tripId;
+  const visibleDashboard =
+    stateMatchesTrip && dashboardTripId === tripId ? dashboard : null;
+
+  return {
+    dashboard: visibleDashboard,
+    status: stateMatchesTrip ? status : 'loading',
+    error: stateMatchesTrip ? error : null,
+    refreshing: stateMatchesTrip ? refreshing : false,
+    refresh,
+    invalidate,
+  };
+}

--- a/mobile/src/features/expenses/hooks/useExpenseDetail.ts
+++ b/mobile/src/features/expenses/hooks/useExpenseDetail.ts
@@ -1,0 +1,234 @@
+import { useFocusEffect } from 'expo-router';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { type ApiError, normalizeApiError } from '@/shared/api/errors';
+import { useAppForegroundEffect } from '@/shared/hooks/useAppForegroundEffect';
+import { getExpenseDetail } from '../api';
+import { subscribeToExpenseEvents } from '../expenseEvents';
+import type { ExpenseDetailResponse } from '../types';
+
+export type ExpenseDetailLoadStatus = 'loading' | 'ready' | 'error';
+export type ExpenseDetailLoadMode = 'initial' | 'refresh' | 'silent';
+
+interface UseExpenseDetailOptions {
+  autoReconcile?: boolean;
+}
+
+interface ExpenseDetailSnapshot {
+  resourceKey: string;
+  detail: ExpenseDetailResponse;
+}
+
+const MISSING_EXPENSE_DETAIL_ERROR: ApiError = {
+  kind: 'message',
+  message: 'Expense not found.',
+  errorCode: 'EXPENSE_NOT_FOUND',
+  status: 404,
+};
+
+function getExpenseDetailResourceKey(
+  tripId: string | undefined,
+  expenseId: string | undefined,
+): string | undefined {
+  if (!tripId || !expenseId) {
+    return undefined;
+  }
+  return JSON.stringify([tripId, expenseId]);
+}
+
+function shouldClearExpenseDetail(error: ApiError): boolean {
+  return (
+    error.status === 404 &&
+    (error.errorCode === 'TRIP_NOT_FOUND' ||
+      error.errorCode === 'EXPENSE_NOT_FOUND')
+  );
+}
+
+export function useExpenseDetail(
+  tripId: string | undefined,
+  expenseId: string | undefined,
+  { autoReconcile = true }: UseExpenseDetailOptions = {},
+) {
+  const resourceKey = getExpenseDetailResourceKey(tripId, expenseId);
+  const [detail, setDetail] = useState<ExpenseDetailResponse | null>(null);
+  const [status, setStatus] = useState<ExpenseDetailLoadStatus>('loading');
+  const [error, setError] = useState<ApiError | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [stateResourceKey, setStateResourceKey] = useState<
+    string | undefined
+  >(resourceKey);
+  const [detailResourceKey, setDetailResourceKey] = useState<
+    string | undefined
+  >();
+  const snapshotRef = useRef<ExpenseDetailSnapshot | null>(null);
+  const requestIdRef = useRef(0);
+  const activeResourceKeyRef = useRef(resourceKey);
+  const focusedRef = useRef(false);
+
+  useEffect(() => {
+    activeResourceKeyRef.current = resourceKey;
+    requestIdRef.current += 1;
+  }, [resourceKey]);
+
+  const isCurrentRequest = useCallback(
+    (requestId: number, requestResourceKey: string) => {
+      return (
+        requestId === requestIdRef.current &&
+        requestResourceKey === activeResourceKeyRef.current
+      );
+    },
+    [],
+  );
+
+  const commitDetail = useCallback(
+    (
+      requestResourceKey: string,
+      nextDetail: ExpenseDetailResponse,
+    ) => {
+      snapshotRef.current = {
+        resourceKey: requestResourceKey,
+        detail: nextDetail,
+      };
+      setStateResourceKey(requestResourceKey);
+      setDetailResourceKey(requestResourceKey);
+      setDetail(nextDetail);
+      setError(null);
+      setStatus('ready');
+    },
+    [],
+  );
+
+  const refresh = useCallback(
+    async (mode: ExpenseDetailLoadMode = 'silent') => {
+      const requestId = requestIdRef.current + 1;
+      requestIdRef.current = requestId;
+
+      if (!tripId || !expenseId || !resourceKey) {
+        snapshotRef.current = null;
+        setStateResourceKey(resourceKey);
+        setDetailResourceKey(undefined);
+        setDetail(null);
+        setError(MISSING_EXPENSE_DETAIL_ERROR);
+        setStatus('error');
+        setRefreshing(false);
+        return;
+      }
+
+      const requestResourceKey = resourceKey;
+      const hasDetail =
+        snapshotRef.current?.resourceKey === requestResourceKey;
+      setStateResourceKey(requestResourceKey);
+
+      if (!hasDetail) {
+        snapshotRef.current = null;
+        setDetailResourceKey(undefined);
+        setDetail(null);
+        setError(null);
+        setStatus('loading');
+        setRefreshing(false);
+      } else if (mode === 'refresh') {
+        setRefreshing(true);
+      }
+
+      try {
+        const nextDetail = await getExpenseDetail(tripId, expenseId);
+        if (!isCurrentRequest(requestId, requestResourceKey)) {
+          return;
+        }
+        commitDetail(requestResourceKey, nextDetail);
+      } catch (caught) {
+        if (!isCurrentRequest(requestId, requestResourceKey)) {
+          return;
+        }
+
+        const nextError = normalizeApiError(caught);
+        const hasCurrentDetail =
+          snapshotRef.current?.resourceKey === requestResourceKey;
+        setStateResourceKey(requestResourceKey);
+
+        if (!hasCurrentDetail || shouldClearExpenseDetail(nextError)) {
+          snapshotRef.current = null;
+          setDetailResourceKey(undefined);
+          setDetail(null);
+          setStatus('error');
+        } else {
+          setStatus('ready');
+        }
+        setError(nextError);
+      } finally {
+        if (isCurrentRequest(requestId, requestResourceKey)) {
+          setRefreshing(false);
+        }
+      }
+    },
+    [
+      commitDetail,
+      expenseId,
+      isCurrentRequest,
+      resourceKey,
+      tripId,
+    ],
+  );
+
+  const invalidate = useCallback(() => {
+    requestIdRef.current += 1;
+    setRefreshing(false);
+  }, []);
+
+  useEffect(() => {
+    if (!autoReconcile || !tripId || !resourceKey) {
+      return undefined;
+    }
+
+    return subscribeToExpenseEvents(tripId, () => {
+      if (focusedRef.current) {
+        return refresh('silent');
+      }
+      return undefined;
+    });
+  }, [autoReconcile, refresh, resourceKey, tripId]);
+
+  const reconcileOnForeground = useCallback(() => {
+    if (autoReconcile && focusedRef.current) {
+      void refresh(
+        snapshotRef.current?.resourceKey === resourceKey
+          ? 'silent'
+          : 'initial',
+      );
+    }
+  }, [autoReconcile, refresh, resourceKey]);
+
+  useAppForegroundEffect(reconcileOnForeground);
+
+  useFocusEffect(
+    useCallback(() => {
+      focusedRef.current = true;
+      if (autoReconcile) {
+        void refresh(
+          snapshotRef.current?.resourceKey === resourceKey
+            ? 'silent'
+            : 'initial',
+        );
+      }
+
+      return () => {
+        focusedRef.current = false;
+        requestIdRef.current += 1;
+      };
+    }, [autoReconcile, refresh, resourceKey]),
+  );
+
+  const stateMatchesResource = stateResourceKey === resourceKey;
+  const visibleDetail =
+    stateMatchesResource && detailResourceKey === resourceKey
+      ? detail
+      : null;
+
+  return {
+    detail: visibleDetail,
+    status: stateMatchesResource ? status : 'loading',
+    error: stateMatchesResource ? error : null,
+    refreshing: stateMatchesResource ? refreshing : false,
+    refresh,
+    invalidate,
+  };
+}

--- a/mobile/src/features/expenses/money.ts
+++ b/mobile/src/features/expenses/money.ts
@@ -1,0 +1,289 @@
+import type {
+  ExpenseMoneySummary,
+  ExpenseStatus,
+  SettlementTransfer,
+} from './types';
+
+export const ZERO_DECIMAL_CURRENCIES: ReadonlySet<string> = new Set([
+  'VND',
+  'JPY',
+  'KRW',
+]);
+
+export const EXPENSE_MAX_DIGITS = 14;
+export const EXPENSE_DECIMAL_PLACES = 2;
+export const EXPENSE_MAX_WHOLE_DIGITS =
+  EXPENSE_MAX_DIGITS - EXPENSE_DECIMAL_PLACES;
+
+const DEFAULT_CURRENCY_CODE = 'VND';
+
+const CURRENCY_LOCALES: Readonly<Record<string, string>> = {
+  AUD: 'en-AU',
+  CAD: 'en-CA',
+  EUR: 'de-DE',
+  GBP: 'en-GB',
+  JPY: 'ja-JP',
+  KRW: 'ko-KR',
+  SGD: 'en-SG',
+  USD: 'en-US',
+  VND: 'vi-VN',
+};
+
+export type ExpenseStatusTone = 'warning' | 'success' | 'danger';
+export type UserBalanceDirection = 'owe' | 'receive' | 'balanced';
+export type ExpenseMoneyMinimum = 'positive' | 'non-negative';
+
+export interface NormalizeExpenseMoneyOptions {
+  minimum?: ExpenseMoneyMinimum;
+}
+
+export interface NormalizedExpenseMoneyInput {
+  value: string | null;
+  error: string | null;
+}
+
+export interface SettlementTransferRoleState {
+  isPayer: boolean;
+  isRecipient: boolean;
+  isSent: boolean;
+  isReceived: boolean;
+  canMarkSent: boolean;
+  canConfirmReceived: boolean;
+  actionLabel: 'I sent it' | 'I received it' | null;
+}
+
+type ExpenseFundingAmounts = Pick<
+  ExpenseMoneySummary,
+  'paid_amount' | 'total_amount'
+>;
+
+const EXPENSE_STATUS_LABELS: Readonly<Record<ExpenseStatus, string>> = {
+  UNDERFUNDED: 'Underfunded',
+  FUNDED: 'Funded',
+  OVERFUNDED: 'Overfunded',
+};
+
+const EXPENSE_STATUS_TONES: Readonly<
+  Record<ExpenseStatus, ExpenseStatusTone>
+> = {
+  UNDERFUNDED: 'warning',
+  FUNDED: 'success',
+  OVERFUNDED: 'danger',
+};
+
+export function normalizeExpenseCurrencyCode(currencyCode: string): string {
+  return currencyCode.trim().toUpperCase() || DEFAULT_CURRENCY_CODE;
+}
+
+export function getExpenseCurrencyScale(currencyCode: string): 0 | 2 {
+  return ZERO_DECIMAL_CURRENCIES.has(
+    normalizeExpenseCurrencyCode(currencyCode),
+  )
+    ? 0
+    : 2;
+}
+
+export function parseMoneyAmount(amount: string | number): number {
+  const parsed =
+    typeof amount === 'number' ? amount : Number.parseFloat(amount);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function formatExpenseMoney(
+  amount: string | number,
+  currencyCode: string,
+): string {
+  const numericAmount = parseMoneyAmount(amount);
+  const normalizedCurrencyCode =
+    normalizeExpenseCurrencyCode(currencyCode);
+  const fractionDigits = getExpenseCurrencyScale(normalizedCurrencyCode);
+  const locale = CURRENCY_LOCALES[normalizedCurrencyCode] ?? 'en-US';
+
+  try {
+    return new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency: normalizedCurrencyCode,
+      minimumFractionDigits: fractionDigits,
+      maximumFractionDigits: fractionDigits,
+    }).format(numericAmount);
+  } catch {
+    const grouped = new Intl.NumberFormat('en-US', {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: fractionDigits,
+    }).format(numericAmount);
+    return `${grouped} ${normalizedCurrencyCode}`;
+  }
+}
+
+export function normalizeExpenseMoneyInput(
+  value: string,
+  currencyCode: string,
+  { minimum = 'non-negative' }: NormalizeExpenseMoneyOptions = {},
+): NormalizedExpenseMoneyInput {
+  const trimmedValue = value.trim();
+  if (!trimmedValue) {
+    return { value: null, error: 'Amount is required.' };
+  }
+
+  const scale = getExpenseCurrencyScale(currencyCode);
+  const canonicalValue =
+    scale === 0
+      ? normalizeZeroDecimalInput(trimmedValue)
+      : normalizeDecimalInput(trimmedValue);
+
+  if (canonicalValue === null) {
+    return { value: null, error: 'Invalid amount.' };
+  }
+
+  if (!hasValidDecimalPrecision(canonicalValue, scale)) {
+    return {
+      value: null,
+      error: `Amount must use at most ${EXPENSE_MAX_DIGITS} digits with no more than ${EXPENSE_MAX_WHOLE_DIGITS} before the decimal point.`,
+    };
+  }
+
+  if (minimum === 'positive' && !hasNonZeroDigit(canonicalValue)) {
+    return {
+      value: null,
+      error: 'Amount must be greater than zero.',
+    };
+  }
+
+  return { value: canonicalValue, error: null };
+}
+
+export function getExpenseFundingPercent(
+  amounts: ExpenseFundingAmounts,
+): number {
+  const paidAmount = parseMoneyAmount(amounts.paid_amount);
+  const totalAmount = parseMoneyAmount(amounts.total_amount);
+  if (totalAmount <= 0) {
+    return 0;
+  }
+  return clampPercent((paidAmount / totalAmount) * 100);
+}
+
+export function getUserBalanceDirection(
+  balance: string,
+): UserBalanceDirection {
+  const numericBalance = parseMoneyAmount(balance);
+  if (numericBalance < 0) {
+    return 'owe';
+  }
+  if (numericBalance > 0) {
+    return 'receive';
+  }
+  return 'balanced';
+}
+
+export function getUserBalanceLabel(
+  balance: string,
+  currencyCode: string,
+): string {
+  const numericBalance = parseMoneyAmount(balance);
+  if (numericBalance < 0) {
+    return `You owe ${formatExpenseMoney(
+      Math.abs(numericBalance),
+      currencyCode,
+    )}`;
+  }
+  if (numericBalance > 0) {
+    return `You are owed ${formatExpenseMoney(
+      numericBalance,
+      currencyCode,
+    )}`;
+  }
+  return 'Settled';
+}
+
+export function getExpenseStatusLabel(status: ExpenseStatus): string {
+  return EXPENSE_STATUS_LABELS[status];
+}
+
+export function getExpenseStatusTone(
+  status: ExpenseStatus,
+): ExpenseStatusTone {
+  return EXPENSE_STATUS_TONES[status];
+}
+
+export function getSettlementTransferRoleState(
+  transfer: SettlementTransfer,
+  viewerId: string | null,
+): SettlementTransferRoleState {
+  const isPayer = viewerId !== null && transfer.payer.id === viewerId;
+  const isRecipient =
+    viewerId !== null && transfer.recipient.id === viewerId;
+  const isSent = transfer.payer_marked_sent_at !== null;
+  const isReceived = transfer.recipient_confirmed_at !== null;
+  const canMarkSent = isPayer && !isSent;
+  const canConfirmReceived = isRecipient && isSent && !isReceived;
+
+  return {
+    isPayer,
+    isRecipient,
+    isSent,
+    isReceived,
+    canMarkSent,
+    canConfirmReceived,
+    actionLabel: canMarkSent
+      ? 'I sent it'
+      : canConfirmReceived
+        ? 'I received it'
+        : null,
+  };
+}
+
+function normalizeZeroDecimalInput(value: string): string | null {
+  if (/^\d+$/.test(value)) {
+    return normalizeInteger(value);
+  }
+
+  if (!/^\d{1,3}(?:[.,\s]\d{3})+$/.test(value)) {
+    return null;
+  }
+
+  return normalizeInteger(value.replace(/[.,\s]/g, ''));
+}
+
+function normalizeDecimalInput(value: string): string | null {
+  const match =
+    /^(?:(\d+)|(\d{1,3}(?:,\d{3})+))(?:\.(\d{1,2}))?$/.exec(value);
+  if (!match) {
+    return null;
+  }
+
+  const integer = normalizeInteger((match[1] ?? match[2]).replace(/,/g, ''));
+  const fraction = match[3];
+  return fraction === undefined ? integer : `${integer}.${fraction}`;
+}
+
+function normalizeInteger(value: string): string {
+  const withoutLeadingZeros = value.replace(/^0+(?=\d)/, '');
+  return withoutLeadingZeros || '0';
+}
+
+function hasValidDecimalPrecision(
+  value: string,
+  currencyScale: 0 | 2,
+): boolean {
+  const [integer, fraction = ''] = value.split('.');
+  const wholeDigits = integer === '0' ? 0 : integer.length;
+  const totalDigits = wholeDigits + fraction.length;
+
+  return (
+    fraction.length <= currencyScale &&
+    wholeDigits <= EXPENSE_MAX_WHOLE_DIGITS &&
+    totalDigits <= EXPENSE_MAX_DIGITS
+  );
+}
+
+function hasNonZeroDigit(value: string): boolean {
+  return /[1-9]/.test(value);
+}
+
+function clampPercent(percent: number): number {
+  if (!Number.isFinite(percent)) {
+    return 0;
+  }
+  return Math.min(100, Math.max(0, percent));
+}

--- a/mobile/src/features/expenses/routeIntent.ts
+++ b/mobile/src/features/expenses/routeIntent.ts
@@ -1,0 +1,77 @@
+export type ExpenseRouteParam = string | string[] | undefined;
+
+export interface ExpensesRouteParams {
+  tripId: ExpenseRouteParam;
+}
+
+export interface ExpenseDetailRouteParams extends ExpensesRouteParams {
+  expenseId: ExpenseRouteParam;
+}
+
+export interface ExpenseFormRouteParams extends ExpensesRouteParams {
+  mode: ExpenseRouteParam;
+  expenseId: ExpenseRouteParam;
+}
+
+export interface ExpenseDashboardRouteIntent {
+  tripId: string;
+}
+
+export interface ExpenseDetailRouteIntent {
+  tripId: string;
+  expenseId: string;
+}
+
+export type ExpenseFormRouteIntent =
+  | { mode: 'create'; tripId: string }
+  | { mode: 'edit'; tripId: string; expenseId: string };
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function parseUuid(value: ExpenseRouteParam): string | null {
+  if (typeof value !== 'string' || value.length === 0 || value.trim() !== value) {
+    return null;
+  }
+  return UUID_PATTERN.test(value) ? value.toLowerCase() : null;
+}
+
+export function parseExpensesRouteIntent({
+  tripId,
+}: ExpensesRouteParams): ExpenseDashboardRouteIntent | null {
+  const parsedTripId = parseUuid(tripId);
+  return parsedTripId ? { tripId: parsedTripId } : null;
+}
+
+export const parseExpenseDashboardRouteIntent = parseExpensesRouteIntent;
+
+export function parseExpenseDetailRouteIntent({
+  tripId,
+  expenseId,
+}: ExpenseDetailRouteParams): ExpenseDetailRouteIntent | null {
+  const parsedTripId = parseUuid(tripId);
+  const parsedExpenseId = parseUuid(expenseId);
+  return parsedTripId && parsedExpenseId
+    ? { tripId: parsedTripId, expenseId: parsedExpenseId }
+    : null;
+}
+
+export function parseExpenseFormRouteIntent({
+  tripId,
+  mode,
+  expenseId,
+}: ExpenseFormRouteParams): ExpenseFormRouteIntent | null {
+  const parsedTripId = parseUuid(tripId);
+  if (!parsedTripId || (mode !== 'create' && mode !== 'edit')) {
+    return null;
+  }
+
+  if (mode === 'create') {
+    return expenseId === undefined ? { mode, tripId: parsedTripId } : null;
+  }
+
+  const parsedExpenseId = parseUuid(expenseId);
+  return parsedExpenseId
+    ? { mode, tripId: parsedTripId, expenseId: parsedExpenseId }
+    : null;
+}

--- a/mobile/src/features/expenses/screens/ExpenseDetailScreen.tsx
+++ b/mobile/src/features/expenses/screens/ExpenseDetailScreen.tsx
@@ -1,0 +1,984 @@
+import { Ionicons } from '@expo/vector-icons';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import {
+  Alert,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTripDetail } from '@/features/trips/hooks/useTripDetail';
+import type { ApiError } from '@/shared/api/errors';
+import { normalizeApiError } from '@/shared/api/errors';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { LoadingScreen } from '@/shared/ui/LoadingScreen';
+import { getExpenseItemActions } from '../actions';
+import {
+  deleteExpense,
+  setContribution,
+} from '../api';
+import { ContributionEditor } from '../components/ContributionEditor';
+import { publishExpenseEvent } from '../expenseEvents';
+import { buildContributionPayload } from '../formModel';
+import { useExpenseCompositionCoordinator } from '../hooks/useExpenseCompositionCoordinator';
+import { useExpenseDetail } from '../hooks/useExpenseDetail';
+import {
+  formatExpenseMoney,
+  getExpenseStatusLabel,
+  getExpenseStatusTone,
+} from '../money';
+import {
+  parseExpenseDetailRouteIntent,
+  type ExpenseDetailRouteIntent,
+} from '../routeIntent';
+import type {
+  ExpenseDetailResponse,
+  ExpenseParticipant,
+} from '../types';
+import { RouteUnavailableState } from './RouteState';
+
+function formatLockedAt(
+  value: string | null,
+  timeZone: string,
+): string | null {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+      timeZone,
+    }).format(date);
+  } catch {
+    return new Intl.DateTimeFormat('en-US', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(date);
+  }
+}
+
+function HeaderEditAction({
+  disabled,
+  onPress,
+}: {
+  disabled: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel="Edit expense"
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      hitSlop={spacing.sm}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.headerAction,
+        pressed && !disabled ? styles.pressed : null,
+        disabled ? styles.disabled : null,
+      ]}
+    >
+      <Text style={styles.headerActionText}>Edit</Text>
+    </Pressable>
+  );
+}
+
+function DetailMetric({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string;
+  tone?: 'danger' | 'success' | 'warning';
+}) {
+  return (
+    <View style={styles.metric}>
+      <Text style={styles.metricLabel}>{label}</Text>
+      <Text
+        style={[
+          styles.metricValue,
+          tone === 'danger' ? styles.dangerText : null,
+          tone === 'success' ? styles.successText : null,
+          tone === 'warning' ? styles.warningText : null,
+        ]}
+      >
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+interface HydratedExpenseDetailProps {
+  intent: ExpenseDetailRouteIntent;
+  detail: ExpenseDetailResponse;
+  tripDetail: NonNullable<
+    ReturnType<typeof useTripDetail>['detail']
+  >;
+  detailError: ApiError | null;
+  tripError: ApiError | null;
+  refreshing: boolean;
+  refreshAll: (
+    mode: 'initial' | 'refresh' | 'silent',
+  ) => Promise<void>;
+  requestReconcile: (forceInitial?: boolean) => Promise<void>;
+  invalidateDetail: () => void;
+  isScreenActive: () => boolean;
+}
+
+function HydratedExpenseDetail({
+  intent,
+  detail,
+  tripDetail,
+  detailError,
+  tripError,
+  refreshing,
+  refreshAll,
+  requestReconcile,
+  invalidateDetail,
+  isScreenActive,
+}: HydratedExpenseDetailProps) {
+  const router = useRouter();
+  const contributionLocksRef = useRef(new Set<string>());
+  const deleteAlertLockRef = useRef(false);
+  const mountedRef = useRef(true);
+  const [draftAmounts, setDraftAmounts] = useState<
+    Record<string, string>
+  >(() =>
+    Object.fromEntries(
+      detail.participants.map((participant) => [
+        participant.user_id,
+        participant.contributed_amount,
+      ]),
+    ),
+  );
+  const [editingUserIds, setEditingUserIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+  const [pendingUserIds, setPendingUserIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+  const [contributionErrors, setContributionErrors] = useState<
+    Record<string, string>
+  >({});
+  const [amountErrors, setAmountErrors] = useState<
+    Record<string, string>
+  >({});
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<ApiError | null>(
+    null,
+  );
+
+  const actions = getExpenseItemActions({
+    canManageExpenses:
+      tripDetail.my_membership.status === 'ACTIVE' &&
+      detail.permissions.can_manage_expenses,
+    tripStatus: tripDetail.trip.status,
+    locked: detail.locked,
+  });
+  const parentHref = `/trips/${intent.tripId}/expenses` as const;
+
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+      contributionLocksRef.current.clear();
+      deleteAlertLockRef.current = false;
+    },
+    [],
+  );
+
+  const openEditForm = useCallback(() => {
+    if (actions.canEditExpense) {
+      router.push(
+        `/trips/${intent.tripId}/expenses/expense-form?mode=edit&expenseId=${intent.expenseId}`,
+      );
+    }
+  }, [
+    actions.canEditExpense,
+    intent.expenseId,
+    intent.tripId,
+    router,
+  ]);
+
+  const startContributionEdit = useCallback(
+    (userId: string) => {
+      if (contributionLocksRef.current.has(userId)) {
+        return;
+      }
+      const currentParticipant = detail.participants.find(
+        (participant) => participant.user_id === userId,
+      );
+      if (currentParticipant) {
+        setDraftAmounts((current) => ({
+          ...current,
+          [userId]: currentParticipant.contributed_amount,
+        }));
+      }
+      setEditingUserIds((current) => new Set(current).add(userId));
+      setContributionErrors((current) => {
+        const next = { ...current };
+        delete next[userId];
+        return next;
+      });
+      setAmountErrors((current) => {
+        const next = { ...current };
+        delete next[userId];
+        return next;
+      });
+    },
+    [detail.participants],
+  );
+
+  const changeContributionDraft = useCallback(
+    (userId: string, value: string) => {
+      if (contributionLocksRef.current.has(userId)) {
+        return;
+      }
+      setDraftAmounts((current) => ({
+        ...current,
+        [userId]: value,
+      }));
+      setContributionErrors((current) => {
+        const next = { ...current };
+        delete next[userId];
+        return next;
+      });
+      setAmountErrors((current) => {
+        const next = { ...current };
+        delete next[userId];
+        return next;
+      });
+    },
+    [],
+  );
+
+  const cancelContributionEdit = useCallback(
+    (userId: string) => {
+      if (contributionLocksRef.current.has(userId)) {
+        return;
+      }
+      const currentParticipant = detail.participants.find(
+        (participant) => participant.user_id === userId,
+      );
+      if (currentParticipant) {
+        setDraftAmounts((current) => ({
+          ...current,
+          [userId]: currentParticipant.contributed_amount,
+        }));
+      }
+      setEditingUserIds((current) => {
+        const next = new Set(current);
+        next.delete(userId);
+        return next;
+      });
+      setContributionErrors((current) => {
+        const next = { ...current };
+        delete next[userId];
+        return next;
+      });
+      setAmountErrors((current) => {
+        const next = { ...current };
+        delete next[userId];
+        return next;
+      });
+    },
+    [detail.participants],
+  );
+
+  const submitContribution = useCallback(
+    async (userId: string) => {
+      if (
+        contributionLocksRef.current.has(userId) ||
+        !actions.canEditContributions
+      ) {
+        return;
+      }
+
+      const payload = buildContributionPayload(
+        draftAmounts[userId] ?? '',
+        detail.currency_code,
+      );
+      if (!payload) {
+        setAmountErrors((current) => ({
+          ...current,
+          [userId]: 'Enter a valid non-negative amount.',
+        }));
+        return;
+      }
+
+      contributionLocksRef.current.add(userId);
+      setPendingUserIds((current) => new Set(current).add(userId));
+      setContributionErrors((current) => {
+        const next = { ...current };
+        delete next[userId];
+        return next;
+      });
+      setAmountErrors((current) => {
+        const next = { ...current };
+        delete next[userId];
+        return next;
+      });
+      invalidateDetail();
+
+      try {
+        const response = await setContribution(
+          intent.tripId,
+          intent.expenseId,
+          userId,
+          payload,
+        );
+        if (mountedRef.current) {
+          setDraftAmounts((current) => ({
+            ...current,
+            [userId]: response.amount,
+          }));
+          setEditingUserIds((current) => {
+            const next = new Set(current);
+            next.delete(userId);
+            return next;
+          });
+        }
+        await publishExpenseEvent({
+          type: 'expensesChanged',
+          tripId: intent.tripId,
+        });
+      } catch (caught) {
+        const nextError = normalizeApiError(caught);
+        if (mountedRef.current) {
+          setContributionErrors((current) => ({
+            ...current,
+            [userId]: nextError.message,
+          }));
+        }
+        await publishExpenseEvent({
+          type: 'expensesChanged',
+          tripId: intent.tripId,
+        });
+      } finally {
+        contributionLocksRef.current.delete(userId);
+        if (mountedRef.current) {
+          setPendingUserIds((current) => {
+            const next = new Set(current);
+            next.delete(userId);
+            return next;
+          });
+        }
+      }
+    },
+    [
+      actions.canEditContributions,
+      detail.currency_code,
+      draftAmounts,
+      intent.expenseId,
+      intent.tripId,
+      invalidateDetail,
+    ],
+  );
+
+  const performDelete = useCallback(async () => {
+    setDeleting(true);
+    setDeleteError(null);
+    invalidateDetail();
+
+    try {
+      await deleteExpense(intent.tripId, intent.expenseId);
+      await publishExpenseEvent({
+        type: 'expensesChanged',
+        tripId: intent.tripId,
+      });
+      if (isScreenActive()) {
+        router.dismissTo(parentHref);
+      }
+    } catch (caught) {
+      const nextError = normalizeApiError(caught);
+      if (nextError.errorCode === 'EXPENSE_NOT_FOUND') {
+        await publishExpenseEvent({
+          type: 'expensesChanged',
+          tripId: intent.tripId,
+        });
+        if (isScreenActive()) {
+          router.dismissTo(parentHref);
+        }
+      } else {
+        if (mountedRef.current) {
+          setDeleteError(nextError);
+        }
+        await publishExpenseEvent({
+          type: 'expensesChanged',
+          tripId: intent.tripId,
+        });
+      }
+    } finally {
+      deleteAlertLockRef.current = false;
+      if (mountedRef.current) {
+        setDeleting(false);
+      }
+    }
+  }, [
+    intent.expenseId,
+    intent.tripId,
+    invalidateDetail,
+    isScreenActive,
+    parentHref,
+    router,
+  ]);
+
+  const confirmDelete = useCallback(() => {
+    if (
+      deleteAlertLockRef.current ||
+      !actions.canEditExpense
+    ) {
+      return;
+    }
+
+    deleteAlertLockRef.current = true;
+    let confirmed = false;
+    const release = () => {
+      deleteAlertLockRef.current = false;
+    };
+    Alert.alert(
+      'Delete expense?',
+      `Delete "${detail.title}" and its contribution records?`,
+      [
+        { text: 'Keep expense', style: 'cancel', onPress: release },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: () => {
+            confirmed = true;
+            void performDelete();
+          },
+        },
+      ],
+      {
+        cancelable: true,
+        onDismiss: () => {
+          if (!confirmed) {
+            release();
+          }
+        },
+      },
+    );
+  }, [actions.canEditExpense, detail.title, performDelete]);
+
+  const pullToRefresh = useCallback(() => {
+    void refreshAll('refresh');
+  }, [refreshAll]);
+
+  const backgroundError = deleteError ?? detailError ?? tripError;
+  const tone = getExpenseStatusTone(detail.status);
+  const lockedAtLabel = formatLockedAt(
+    detail.locked_at,
+    tripDetail.trip.timezone,
+  );
+  const header = (
+    <View style={styles.detailHeader}>
+      {backgroundError ? (
+        <View accessibilityRole="alert" style={styles.inlineError}>
+          <Ionicons
+            name="alert-circle-outline"
+            size={20}
+            color={colors.danger}
+          />
+          <Text style={styles.inlineErrorText}>
+            {backgroundError.message}
+          </Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Retry refreshing expense detail"
+            hitSlop={spacing.sm}
+            onPress={() => void requestReconcile()}
+            style={({ pressed }) => [
+              styles.retry,
+              pressed ? styles.pressed : null,
+            ]}
+          >
+            <Text style={styles.retryText}>Retry</Text>
+          </Pressable>
+        </View>
+      ) : null}
+      <View style={styles.summaryCard}>
+        <View style={styles.summaryHeading}>
+          <View style={styles.summaryTitleBlock}>
+            <Text accessibilityRole="header" style={styles.title}>
+              {detail.title}
+            </Text>
+            {detail.description ? (
+              <Text style={styles.description}>
+                {detail.description}
+              </Text>
+            ) : null}
+          </View>
+          <View
+            style={[
+              styles.statusBadge,
+              tone === 'success'
+                ? styles.successBadge
+                : tone === 'danger'
+                  ? styles.dangerBadge
+                  : styles.warningBadge,
+            ]}
+          >
+            <Text
+              style={[
+                styles.statusText,
+                tone === 'success'
+                  ? styles.successText
+                  : tone === 'danger'
+                    ? styles.dangerText
+                    : styles.warningText,
+              ]}
+            >
+              {getExpenseStatusLabel(detail.status)}
+            </Text>
+          </View>
+        </View>
+        <View style={styles.metrics}>
+          <DetailMetric
+            label="Total"
+            value={formatExpenseMoney(
+              detail.total_amount,
+              detail.currency_code,
+            )}
+          />
+          <DetailMetric
+            label="Collected"
+            value={formatExpenseMoney(
+              detail.paid_amount,
+              detail.currency_code,
+            )}
+            tone="success"
+          />
+          <DetailMetric
+            label="Missing"
+            value={formatExpenseMoney(
+              detail.missing_amount,
+              detail.currency_code,
+            )}
+            tone="warning"
+          />
+          <DetailMetric
+            label="Surplus"
+            value={formatExpenseMoney(
+              detail.surplus_amount,
+              detail.currency_code,
+            )}
+            tone="danger"
+          />
+        </View>
+        <View style={styles.collectorRow}>
+          <Ionicons
+            name="wallet-outline"
+            size={18}
+            color={colors.textMuted}
+          />
+          <View style={styles.collectorCopy}>
+            <Text style={styles.metricLabel}>Collector</Text>
+            <Text style={styles.collectorName}>
+              {detail.collector.display_name}
+            </Text>
+            {detail.collector.identify_tag ? (
+              <Text style={styles.collectorTag}>
+                {detail.collector.identify_tag}
+              </Text>
+            ) : null}
+          </View>
+          {detail.locked ? (
+            <View style={styles.lockedBadge}>
+              <Ionicons
+                name="lock-closed-outline"
+                size={15}
+                color={colors.textMuted}
+              />
+              <Text style={styles.lockedText}>Locked</Text>
+            </View>
+          ) : null}
+        </View>
+      </View>
+      {detail.locked ? (
+        <View style={styles.lockedNotice}>
+          <Text style={styles.lockedNoticeText}>
+            Settlement is finalized
+            {lockedAtLabel ? ` (locked on ${lockedAtLabel})` : ''}.
+            Reopen it before editing expenses or contributions.
+          </Text>
+        </View>
+      ) : null}
+      {actions.canEditExpense ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Delete expense"
+          accessibilityState={{ disabled: deleting }}
+          disabled={deleting}
+          onPress={confirmDelete}
+          style={({ pressed }) => [
+            styles.deleteButton,
+            pressed && !deleting ? styles.pressed : null,
+            deleting ? styles.disabled : null,
+          ]}
+        >
+          <Ionicons
+            name="trash-outline"
+            size={18}
+            color={colors.danger}
+          />
+          <Text style={styles.deleteText}>
+            {deleting ? 'Deleting…' : 'Delete expense'}
+          </Text>
+        </Pressable>
+      ) : null}
+      <Text accessibilityRole="header" style={styles.sectionTitle}>
+        Participants ({detail.participants.length})
+      </Text>
+    </View>
+  );
+
+  const renderParticipant = ({
+    item,
+  }: {
+    item: ExpenseParticipant;
+  }) => (
+    <ContributionEditor
+      participant={item}
+      currencyCode={detail.currency_code}
+      canEdit={actions.canEditContributions}
+      isEditing={editingUserIds.has(item.user_id)}
+      draftAmount={
+        draftAmounts[item.user_id] ?? item.contributed_amount
+      }
+      loading={pendingUserIds.has(item.user_id)}
+      error={contributionErrors[item.user_id] ?? null}
+      amountError={amountErrors[item.user_id]}
+      onStartEditing={startContributionEdit}
+      onDraftChange={changeContributionDraft}
+      onSubmit={(userId) => void submitContribution(userId)}
+      onCancel={cancelContributionEdit}
+    />
+  );
+
+  return (
+    <SafeAreaView
+      style={styles.safe}
+      edges={['left', 'right', 'bottom']}
+    >
+      <Stack.Screen
+        options={{
+          title: detail.title,
+          headerRight: actions.canEditExpense
+            ? () => (
+                <HeaderEditAction
+                  disabled={deleting}
+                  onPress={openEditForm}
+                />
+              )
+            : undefined,
+        }}
+      />
+      <FlatList
+        data={detail.participants}
+        keyExtractor={(participant) => participant.user_id}
+        renderItem={renderParticipant}
+        extraData={{
+          draftAmounts,
+          editingUserIds,
+          pendingUserIds,
+          contributionErrors,
+          amountErrors,
+        }}
+        refreshing={refreshing}
+        onRefresh={pullToRefresh}
+        keyboardShouldPersistTaps="handled"
+        contentInsetAdjustmentBehavior="automatic"
+        contentContainerStyle={styles.content}
+        ListHeaderComponent={header}
+      />
+    </SafeAreaView>
+  );
+}
+
+function ValidExpenseDetailScreen({
+  intent,
+}: {
+  intent: ExpenseDetailRouteIntent;
+}) {
+  const {
+    detail,
+    status: detailStatus,
+    error: detailError,
+    refreshing: detailRefreshing,
+    refresh: refreshDetail,
+    invalidate: invalidateDetail,
+  } = useExpenseDetail(intent.tripId, intent.expenseId, {
+    autoReconcile: false,
+  });
+  const {
+    detail: tripDetail,
+    status: tripStatus,
+    error: tripError,
+    refreshing: tripRefreshing,
+    refresh: refreshTrip,
+  } = useTripDetail(intent.tripId, { autoReconcile: false });
+  const {
+    refreshAll,
+    requestReconcile,
+    isScreenActive,
+  } = useExpenseCompositionCoordinator({
+    tripId: intent.tripId,
+    refreshExpense: refreshDetail,
+    refreshTrip,
+  });
+
+  const missingError =
+    (!detail ? detailError : null) ??
+    (!tripDetail ? tripError : null);
+  if (!detail || !tripDetail) {
+    const loading =
+      !missingError &&
+      (detailStatus === 'loading' || tripStatus === 'loading');
+    return (
+      <>
+        <Stack.Screen options={{ title: 'Expense' }} />
+        {loading ? (
+          <LoadingScreen />
+        ) : (
+          <RouteUnavailableState
+            title={
+              missingError?.errorCode === 'EXPENSE_NOT_FOUND'
+                ? 'Expense unavailable'
+                : missingError?.status === 404
+                  ? 'Expenses unavailable'
+                  : 'Could not load expense'
+            }
+            message="This expense no longer exists or is unavailable."
+            error={missingError}
+            onRetry={() => void requestReconcile(true)}
+          />
+        )}
+      </>
+    );
+  }
+
+  return (
+    <HydratedExpenseDetail
+      intent={intent}
+      detail={detail}
+      tripDetail={tripDetail}
+      detailError={detailError}
+      tripError={tripError}
+      refreshing={detailRefreshing || tripRefreshing}
+      refreshAll={refreshAll}
+      requestReconcile={requestReconcile}
+      invalidateDetail={invalidateDetail}
+      isScreenActive={isScreenActive}
+    />
+  );
+}
+
+export function ExpenseDetailScreen() {
+  const { tripId, expenseId } = useLocalSearchParams();
+  const intent = parseExpenseDetailRouteIntent({
+    tripId,
+    expenseId,
+  });
+
+  if (!intent) {
+    return (
+      <RouteUnavailableState
+        title="Expense unavailable"
+        message="This expense link is invalid or incomplete."
+      />
+    );
+  }
+
+  return (
+    <ValidExpenseDetailScreen
+      key={`${intent.tripId}:${intent.expenseId}`}
+      intent={intent}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: colors.surface,
+  },
+  content: {
+    flexGrow: 1,
+    gap: spacing.md,
+    padding: spacing.md,
+    paddingBottom: spacing.xl,
+  },
+  detailHeader: {
+    gap: spacing.md,
+  },
+  headerAction: {
+    minHeight: 44,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.xs,
+  },
+  headerActionText: {
+    ...typography.body,
+    color: colors.primary,
+    fontWeight: '600',
+  },
+  pressed: { opacity: 0.58 },
+  disabled: { opacity: 0.45 },
+  inlineError: {
+    minHeight: 52,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.dangerBorder,
+    borderRadius: radii.md,
+    backgroundColor: colors.dangerSoft,
+  },
+  inlineErrorText: {
+    ...typography.caption,
+    flex: 1,
+    color: colors.danger,
+  },
+  retry: {
+    minHeight: 44,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.xs,
+  },
+  retryText: {
+    ...typography.label,
+    color: colors.danger,
+  },
+  summaryCard: {
+    gap: spacing.md,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.lg,
+    backgroundColor: colors.background,
+  },
+  summaryHeading: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.sm,
+  },
+  summaryTitleBlock: {
+    minWidth: 0,
+    flex: 1,
+    gap: spacing.xs,
+  },
+  title: {
+    ...typography.heading,
+    color: colors.text,
+  },
+  description: {
+    ...typography.body,
+    color: colors.textMuted,
+  },
+  statusBadge: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radii.full,
+  },
+  successBadge: { backgroundColor: colors.successSoft },
+  dangerBadge: { backgroundColor: colors.dangerSoft },
+  warningBadge: { backgroundColor: colors.warningSoft },
+  statusText: { ...typography.label },
+  successText: { color: colors.success },
+  dangerText: { color: colors.danger },
+  warningText: { color: colors.warning },
+  metrics: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.md,
+    paddingTop: spacing.md,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+  },
+  metric: {
+    minWidth: '40%',
+    flexGrow: 1,
+    gap: spacing.xs,
+  },
+  metricLabel: {
+    ...typography.caption,
+    color: colors.textMuted,
+  },
+  metricValue: {
+    ...typography.body,
+    color: colors.text,
+    fontWeight: '600',
+  },
+  collectorRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingTop: spacing.md,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+  },
+  collectorCopy: { minWidth: 0, flex: 1 },
+  collectorName: {
+    ...typography.label,
+    color: colors.text,
+  },
+  collectorTag: {
+    ...typography.caption,
+    color: colors.textMuted,
+  },
+  lockedBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radii.full,
+    backgroundColor: colors.surface,
+  },
+  lockedText: {
+    ...typography.label,
+    color: colors.textMuted,
+  },
+  lockedNotice: {
+    padding: spacing.md,
+    borderRadius: radii.md,
+    backgroundColor: colors.warningSoft,
+  },
+  lockedNoticeText: {
+    ...typography.body,
+    color: colors.warning,
+  },
+  deleteButton: {
+    minHeight: 48,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.sm,
+    borderWidth: 1,
+    borderColor: colors.dangerBorder,
+    borderRadius: radii.md,
+    backgroundColor: colors.background,
+  },
+  deleteText: {
+    ...typography.label,
+    color: colors.danger,
+  },
+  sectionTitle: {
+    ...typography.heading,
+    color: colors.text,
+  },
+});

--- a/mobile/src/features/expenses/screens/ExpenseFormScreen.tsx
+++ b/mobile/src/features/expenses/screens/ExpenseFormScreen.tsx
@@ -1,0 +1,772 @@
+import { Ionicons } from '@expo/vector-icons';
+import {
+  Stack,
+  useFocusEffect,
+  useLocalSearchParams,
+  useRouter,
+} from 'expo-router';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { Pressable, StyleSheet, Text } from 'react-native';
+import { useTripDetail } from '@/features/trips/hooks/useTripDetail';
+import {
+  subscribeToTripEvents,
+  type TripEvent,
+} from '@/features/trips/tripEvents';
+import type { ApiError } from '@/shared/api/errors';
+import { normalizeApiError } from '@/shared/api/errors';
+import { useAppForegroundEffect } from '@/shared/hooks/useAppForegroundEffect';
+import { colors, spacing, typography } from '@/shared/theme/tokens';
+import { LoadingScreen } from '@/shared/ui/LoadingScreen';
+import {
+  getExpenseDashboardActions,
+  getExpenseItemActions,
+} from '../actions';
+import {
+  createExpense,
+  updateExpense,
+} from '../api';
+import { ExpenseForm } from '../components/ExpenseForm';
+import {
+  publishExpenseEvent,
+  subscribeToExpenseEvents,
+} from '../expenseEvents';
+import {
+  buildCreateExpensePayload,
+  buildPatchExpensePayload,
+  cloneExpenseDraft,
+  createExpenseDraft,
+  getDepartedCurrentCollector,
+  getEligibleCollectors,
+  getExpenseDirtyFields,
+  hydrateExpenseDraft,
+  validateExpenseDraft,
+  type ExpenseDraftField,
+  type ExpenseFormDirtyFields,
+  type ExpenseFormDraft,
+  type ExpenseFormFieldErrors,
+} from '../formModel';
+import { useExpenseDashboard } from '../hooks/useExpenseDashboard';
+import { useExpenseDetail } from '../hooks/useExpenseDetail';
+import {
+  parseExpenseFormRouteIntent,
+  type ExpenseFormRouteIntent,
+} from '../routeIntent';
+import type {
+  ExpenseDashboardResponse,
+  ExpenseDetailResponse,
+} from '../types';
+import { RouteUnavailableState } from './RouteState';
+
+interface HeaderCancelActionProps {
+  disabled: boolean;
+  onPress: () => void;
+}
+
+function HeaderCancelAction({
+  disabled,
+  onPress,
+}: HeaderCancelActionProps) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel="Cancel expense form"
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      hitSlop={spacing.sm}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.headerAction,
+        pressed && !disabled ? styles.pressed : null,
+        disabled ? styles.disabled : null,
+      ]}
+    >
+      <Ionicons
+        name="close"
+        size={20}
+        color={disabled ? colors.textMuted : colors.primary}
+      />
+      <Text
+        style={[
+          styles.headerActionText,
+          disabled ? styles.headerActionTextDisabled : null,
+        ]}
+      >
+        Cancel
+      </Text>
+    </Pressable>
+  );
+}
+
+function isTripEventForTrip(event: TripEvent, tripId: string): boolean {
+  return event.type === 'updated'
+    ? event.trip.id === tripId
+    : event.tripId === tripId;
+}
+
+function shouldReconcileAfterFailure(error: ApiError): boolean {
+  return (
+    error.status === 403 ||
+    error.status === 404 ||
+    error.status === 409
+  );
+}
+
+interface HydratedExpenseFormProps {
+  intent: ExpenseFormRouteIntent;
+  tripDetail: NonNullable<
+    ReturnType<typeof useTripDetail>['detail']
+  >;
+  dashboard: ExpenseDashboardResponse | null;
+  expenseDetail: ExpenseDetailResponse | null;
+  sourceError: ApiError | null;
+  tripError: ApiError | null;
+  refreshing: boolean;
+  refreshAll: (
+    mode: 'initial' | 'refresh' | 'silent',
+  ) => Promise<void>;
+  requestReconcile: (forceInitial?: boolean) => Promise<void>;
+  invalidateExpense: () => void;
+  submitLockRef: { current: boolean };
+  submissionCommittedRef: { current: boolean };
+  submitting: boolean;
+  setSubmitting: (submitting: boolean) => void;
+  isScreenActive: () => boolean;
+  isActiveGeneration: (generation: number) => boolean;
+  getGeneration: () => number;
+}
+
+interface ImmutableFormState {
+  initialDraft: ExpenseFormDraft;
+  participants: ExpenseDetailResponse['participants'] | null;
+  currentCollector: ExpenseDetailResponse['collector'] | null;
+}
+
+function buildImmutableFormState({
+  intent,
+  expenseDetail,
+}: Pick<
+  HydratedExpenseFormProps,
+  'intent' | 'expenseDetail'
+>): ImmutableFormState {
+  if (intent.mode === 'edit' && expenseDetail) {
+    return {
+      initialDraft: hydrateExpenseDraft(expenseDetail),
+      participants: [...expenseDetail.participants],
+      currentCollector: expenseDetail.collector,
+    };
+  }
+
+  return {
+    initialDraft: createExpenseDraft(),
+    participants: null,
+    currentCollector: null,
+  };
+}
+
+function getAuthorityMessage({
+  intent,
+  activeMembership,
+  terminal,
+  serverAllowsMutation,
+  locked,
+  currencyMatches,
+}: {
+  intent: ExpenseFormRouteIntent;
+  activeMembership: boolean;
+  terminal: boolean;
+  serverAllowsMutation: boolean;
+  locked: boolean;
+  currencyMatches: boolean;
+}): string | undefined {
+  if (!activeMembership) {
+    return 'You are no longer an active member of this trip.';
+  }
+  if (terminal) {
+    return 'Completed or cancelled trips cannot change expenses.';
+  }
+  if (locked) {
+    return 'Settlement is finalized. Reopen it before editing expenses.';
+  }
+  if (!currencyMatches) {
+    return 'Expense currency changed. Refresh before continuing.';
+  }
+  if (!serverAllowsMutation) {
+    return intent.mode === 'create'
+      ? 'Only the trip captain can add expenses.'
+      : 'You can no longer edit this expense.';
+  }
+  return undefined;
+}
+
+function HydratedExpenseForm({
+  intent,
+  tripDetail,
+  dashboard,
+  expenseDetail,
+  sourceError,
+  tripError,
+  refreshing,
+  refreshAll,
+  requestReconcile,
+  invalidateExpense,
+  submitLockRef,
+  submissionCommittedRef,
+  submitting,
+  setSubmitting,
+  isScreenActive,
+  isActiveGeneration,
+  getGeneration,
+}: HydratedExpenseFormProps) {
+  const router = useRouter();
+  const [immutable] = useState<ImmutableFormState>(() =>
+    buildImmutableFormState({ intent, expenseDetail }),
+  );
+  const [draft, setDraft] = useState<ExpenseFormDraft>(() =>
+    cloneExpenseDraft(immutable.initialDraft),
+  );
+  const [fieldErrors, setFieldErrors] =
+    useState<ExpenseFormFieldErrors>({});
+  const [submitError, setSubmitError] = useState<ApiError | null>(
+    null,
+  );
+  const dirtyFields = useMemo<ExpenseFormDirtyFields>(
+    () => getExpenseDirtyFields(immutable.initialDraft, draft),
+    [draft, immutable.initialDraft],
+  );
+  const dirty = Object.keys(dirtyFields).length > 0;
+  const collectors = useMemo(
+    () =>
+      getEligibleCollectors(
+        tripDetail.members,
+        immutable.participants ?? undefined,
+      ),
+    [immutable.participants, tripDetail.members],
+  );
+  const eligibleCollectorIds = useMemo(
+    () => new Set(collectors.map((member) => member.user.id)),
+    [collectors],
+  );
+  const currentCollector = immutable.currentCollector;
+  const departedCurrentCollector = currentCollector
+    ? getDepartedCurrentCollector(currentCollector, collectors)
+    : null;
+  const activeMembership =
+    tripDetail.my_membership.status === 'ACTIVE';
+  const terminal =
+    tripDetail.trip.status === 'COMPLETED' ||
+    tripDetail.trip.status === 'CANCELLED';
+  const currencyCode = tripDetail.trip.currency_code;
+  const currencyMatches =
+    intent.mode === 'create'
+      ? dashboard?.currency_code === currencyCode
+      : expenseDetail?.currency_code === currencyCode;
+  const dashboardActions =
+    intent.mode === 'create' && dashboard
+      ? getExpenseDashboardActions({
+          canManageExpenses:
+            activeMembership &&
+            dashboard.permissions.can_manage_expenses,
+          tripStatus: tripDetail.trip.status,
+          settlement: dashboard.settlement,
+          expenseCount: dashboard.expenses.length,
+        })
+      : null;
+  const itemActions =
+    intent.mode === 'edit' && expenseDetail
+      ? getExpenseItemActions({
+          canManageExpenses:
+            activeMembership &&
+            expenseDetail.permissions.can_manage_expenses,
+          tripStatus: tripDetail.trip.status,
+          locked: expenseDetail.locked,
+        })
+      : null;
+  const locked = expenseDetail?.locked ?? false;
+  const serverAllowsMutation =
+    intent.mode === 'create'
+      ? dashboardActions?.canAddExpense === true
+      : itemActions?.canEditExpense === true;
+  const canSubmit =
+    activeMembership &&
+    !terminal &&
+    currencyMatches &&
+    serverAllowsMutation;
+  const authorityMessage = getAuthorityMessage({
+    intent,
+    activeMembership,
+    terminal,
+    serverAllowsMutation,
+    locked,
+    currencyMatches,
+  });
+  const parentHref =
+    intent.mode === 'create'
+      ? (`/trips/${intent.tripId}/expenses` as const)
+      : (`/trips/${intent.tripId}/expenses/${intent.expenseId}` as const);
+
+  const changeDraft = useCallback(
+    (changes: Partial<ExpenseFormDraft>) => {
+      if (submitLockRef.current) {
+        return;
+      }
+      setDraft((current) => ({ ...current, ...changes }));
+      const changedFields = Object.keys(changes) as ExpenseDraftField[];
+      setFieldErrors((current) => {
+        const next = { ...current };
+        for (const field of changedFields) {
+          delete next[field];
+        }
+        return next;
+      });
+      setSubmitError(null);
+    },
+    [submitLockRef],
+  );
+
+  const submit = useCallback(async () => {
+    if (submitLockRef.current || !canSubmit) {
+      return;
+    }
+
+    const validation = validateExpenseDraft(
+      draft,
+      currencyCode,
+      {
+        mode: intent.mode,
+        eligibleCollectorIds,
+        initialCollectorId:
+          immutable.initialDraft.collector_id,
+      },
+    );
+    setFieldErrors(validation.fieldErrors);
+    setSubmitError(null);
+    if (!validation.isValid) {
+      return;
+    }
+
+    const createPayload =
+      intent.mode === 'create'
+        ? buildCreateExpensePayload(
+            draft,
+            currencyCode,
+            eligibleCollectorIds,
+          )
+        : null;
+    const patchPayload =
+      intent.mode === 'edit'
+        ? buildPatchExpensePayload(
+            immutable.initialDraft,
+            draft,
+            currencyCode,
+            dirtyFields,
+            eligibleCollectorIds,
+          )
+        : null;
+
+    if (intent.mode === 'create' && !createPayload) {
+      return;
+    }
+    if (intent.mode === 'edit' && !patchPayload) {
+      return;
+    }
+    if (
+      intent.mode === 'edit' &&
+      patchPayload &&
+      Object.keys(patchPayload).length === 0
+    ) {
+      if (isActiveGeneration(getGeneration())) {
+        router.dismissTo(parentHref);
+      }
+      return;
+    }
+
+    const generation = getGeneration();
+    submitLockRef.current = true;
+    setSubmitting(true);
+    invalidateExpense();
+
+    try {
+      if (intent.mode === 'create' && createPayload) {
+        await createExpense(intent.tripId, createPayload);
+      } else if (intent.mode === 'edit' && patchPayload) {
+        await updateExpense(
+          intent.tripId,
+          intent.expenseId,
+          patchPayload,
+        );
+      }
+      submissionCommittedRef.current = true;
+      await publishExpenseEvent({
+        type: 'expensesChanged',
+        tripId: intent.tripId,
+      });
+      if (isScreenActive()) {
+        router.dismissTo(parentHref);
+      }
+    } catch (caught) {
+      if (submissionCommittedRef.current) {
+        if (isScreenActive()) {
+          router.dismissTo(parentHref);
+        }
+        return;
+      }
+      if (!isActiveGeneration(generation)) {
+        return;
+      }
+
+      const nextError = normalizeApiError(caught);
+      setSubmitError(nextError);
+      if (shouldReconcileAfterFailure(nextError)) {
+        await refreshAll('silent');
+      }
+    } finally {
+      if (!submissionCommittedRef.current) {
+        submitLockRef.current = false;
+      }
+      if (!submissionCommittedRef.current && isScreenActive()) {
+        setSubmitting(false);
+      }
+    }
+  }, [
+    canSubmit,
+    currencyCode,
+    dirtyFields,
+    draft,
+    eligibleCollectorIds,
+    getGeneration,
+    immutable.initialDraft,
+    intent,
+    invalidateExpense,
+    isActiveGeneration,
+    isScreenActive,
+    parentHref,
+    refreshAll,
+    router,
+    setSubmitting,
+    submissionCommittedRef,
+    submitLockRef,
+  ]);
+
+  return (
+    <ExpenseForm
+      mode={intent.mode}
+      draft={draft}
+      fieldErrors={fieldErrors}
+      submitError={submitError}
+      collectors={collectors}
+      currentCollector={departedCurrentCollector}
+      currencyCode={currencyCode}
+      canSubmit={canSubmit}
+      dirty={dirty}
+      submitting={submitting}
+      refreshing={refreshing}
+      authorityMessage={authorityMessage}
+      backgroundError={sourceError ?? tripError}
+      onChange={changeDraft}
+      onSubmit={() => void submit()}
+      onRefresh={() => void refreshAll('refresh')}
+      onRetryBackground={() => void requestReconcile()}
+    />
+  );
+}
+
+function ValidExpenseFormScreen({
+  intent,
+}: {
+  intent: ExpenseFormRouteIntent;
+}) {
+  const router = useRouter();
+  const dashboardHook = useExpenseDashboard(
+    intent.mode === 'create' ? intent.tripId : undefined,
+    { autoReconcile: false },
+  );
+  const detailHook = useExpenseDetail(
+    intent.mode === 'edit' ? intent.tripId : undefined,
+    intent.mode === 'edit' ? intent.expenseId : undefined,
+    { autoReconcile: false },
+  );
+  const {
+    detail: tripDetail,
+    error: tripError,
+    status: tripStatus,
+    refreshing: tripRefreshing,
+    refresh: refreshTrip,
+  } = useTripDetail(intent.tripId, {
+    autoReconcile: false,
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const submitLockRef = useRef(false);
+  const submissionCommittedRef = useRef(false);
+  const activeRef = useRef(false);
+  const mountedRef = useRef(true);
+  const generationRef = useRef(0);
+  const hasRequestedInitialRef = useRef(false);
+  const parentHref =
+    intent.mode === 'create'
+      ? (`/trips/${intent.tripId}/expenses` as const)
+      : (`/trips/${intent.tripId}/expenses/${intent.expenseId}` as const);
+  const refreshExpense =
+    intent.mode === 'create'
+      ? dashboardHook.refresh
+      : detailHook.refresh;
+  const invalidateExpense =
+    intent.mode === 'create'
+      ? dashboardHook.invalidate
+      : detailHook.invalidate;
+
+  const refreshAll = useCallback(
+    async (mode: 'initial' | 'refresh' | 'silent') => {
+      await Promise.all([
+        refreshExpense(mode),
+        refreshTrip(mode),
+      ]);
+    },
+    [refreshExpense, refreshTrip],
+  );
+
+  const requestReconcile = useCallback(
+    (forceInitial = false) => {
+      const mode =
+        forceInitial || !hasRequestedInitialRef.current
+          ? 'initial'
+          : 'silent';
+      hasRequestedInitialRef.current = true;
+      return refreshAll(mode);
+    },
+    [refreshAll],
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      activeRef.current = true;
+      generationRef.current += 1;
+      if (submissionCommittedRef.current) {
+        router.dismissTo(parentHref);
+      } else {
+        if (!submitLockRef.current) {
+          setSubmitting(false);
+        }
+        void requestReconcile();
+      }
+
+      return () => {
+        activeRef.current = false;
+        generationRef.current += 1;
+      };
+    }, [parentHref, requestReconcile, router]),
+  );
+
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+      activeRef.current = false;
+      generationRef.current += 1;
+    },
+    [],
+  );
+
+  useAppForegroundEffect(
+    useCallback(() => {
+      if (
+        activeRef.current &&
+        !submissionCommittedRef.current
+      ) {
+        void requestReconcile();
+      }
+    }, [requestReconcile]),
+  );
+
+  useEffect(
+    () =>
+      subscribeToExpenseEvents(intent.tripId, () => {
+        if (
+          activeRef.current &&
+          !submissionCommittedRef.current
+        ) {
+          return requestReconcile();
+        }
+        return undefined;
+      }),
+    [intent.tripId, requestReconcile],
+  );
+
+  useEffect(
+    () =>
+      subscribeToTripEvents((event) => {
+        if (
+          activeRef.current &&
+          !submissionCommittedRef.current &&
+          isTripEventForTrip(event, intent.tripId)
+        ) {
+          void requestReconcile();
+        }
+      }),
+    [intent.tripId, requestReconcile],
+  );
+
+  const isActiveGeneration = useCallback((generation: number) => {
+    return (
+      mountedRef.current &&
+      activeRef.current &&
+      generationRef.current === generation
+    );
+  }, []);
+  const isScreenActive = useCallback(
+    () => mountedRef.current && activeRef.current,
+    [],
+  );
+  const getGeneration = useCallback(
+    () => generationRef.current,
+    [],
+  );
+  const cancel = useCallback(() => {
+    if (!submitLockRef.current) {
+      router.dismissTo(parentHref);
+    }
+  }, [parentHref, router]);
+
+  const dashboard =
+    intent.mode === 'create' ? dashboardHook.dashboard : null;
+  const expenseDetail =
+    intent.mode === 'edit' ? detailHook.detail : null;
+  const sourceStatus =
+    intent.mode === 'create'
+      ? dashboardHook.status
+      : detailHook.status;
+  const sourceError =
+    intent.mode === 'create'
+      ? dashboardHook.error
+      : detailHook.error;
+  const sourceRefreshing =
+    intent.mode === 'create'
+      ? dashboardHook.refreshing
+      : detailHook.refreshing;
+  const sourceReady =
+    intent.mode === 'create'
+      ? dashboard !== null
+      : expenseDetail !== null;
+  const missingError =
+    (!sourceReady ? sourceError : null) ??
+    (!tripDetail ? tripError : null);
+  const title =
+    intent.mode === 'create' ? 'Add Expense' : 'Edit Expense';
+
+  let content;
+  if (!sourceReady || !tripDetail) {
+    const loading =
+      !missingError &&
+      (sourceStatus === 'loading' ||
+        tripStatus === 'loading');
+    content = loading ? (
+      <LoadingScreen />
+    ) : (
+      <RouteUnavailableState
+        title={
+          missingError?.errorCode === 'EXPENSE_NOT_FOUND'
+            ? 'Expense unavailable'
+            : missingError?.status === 404
+              ? 'Expenses unavailable'
+              : 'Could not load expense form'
+        }
+        message="This form is no longer available."
+        error={missingError}
+        onRetry={() => void requestReconcile(true)}
+      />
+    );
+  } else {
+    content = (
+      <HydratedExpenseForm
+        intent={intent}
+        tripDetail={tripDetail}
+        dashboard={dashboard}
+        expenseDetail={expenseDetail}
+        sourceError={sourceError}
+        tripError={tripError}
+        refreshing={sourceRefreshing || tripRefreshing}
+        refreshAll={refreshAll}
+        requestReconcile={requestReconcile}
+        invalidateExpense={invalidateExpense}
+        submitLockRef={submitLockRef}
+        submissionCommittedRef={submissionCommittedRef}
+        submitting={submitting}
+        setSubmitting={setSubmitting}
+        isScreenActive={isScreenActive}
+        isActiveGeneration={isActiveGeneration}
+        getGeneration={getGeneration}
+      />
+    );
+  }
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          title,
+          gestureEnabled: !submitting,
+          headerLeft: () => (
+            <HeaderCancelAction
+              disabled={submitting}
+              onPress={cancel}
+            />
+          ),
+        }}
+      />
+      {content}
+    </>
+  );
+}
+
+export function ExpenseFormScreen() {
+  const { tripId, mode, expenseId } = useLocalSearchParams();
+  const intent = parseExpenseFormRouteIntent({
+    tripId,
+    mode,
+    expenseId,
+  });
+
+  if (!intent) {
+    return (
+      <RouteUnavailableState
+        title="Form unavailable"
+        message="This form link is invalid or incomplete."
+      />
+    );
+  }
+
+  const identity =
+    intent.mode === 'create'
+      ? `${intent.tripId}:create`
+      : `${intent.tripId}:edit:${intent.expenseId}`;
+  return (
+    <ValidExpenseFormScreen
+      key={identity}
+      intent={intent}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  headerAction: {
+    minHeight: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    marginLeft: -spacing.sm,
+    paddingHorizontal: spacing.sm,
+  },
+  headerActionText: {
+    ...typography.body,
+    color: colors.primary,
+  },
+  headerActionTextDisabled: {
+    color: colors.textMuted,
+  },
+  pressed: { opacity: 0.58 },
+  disabled: { opacity: 0.55 },
+});

--- a/mobile/src/features/expenses/screens/ExpensesScreen.tsx
+++ b/mobile/src/features/expenses/screens/ExpensesScreen.tsx
@@ -1,0 +1,605 @@
+import { Ionicons } from '@expo/vector-icons';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  Alert,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useSession } from '@/features/auth/session';
+import { useTripDetail } from '@/features/trips/hooks/useTripDetail';
+import type { ApiError } from '@/shared/api/errors';
+import { normalizeApiError } from '@/shared/api/errors';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { Button } from '@/shared/ui/Button';
+import { LoadingScreen } from '@/shared/ui/LoadingScreen';
+import { getExpenseDashboardActions } from '../actions';
+import {
+  confirmTransferReceived,
+  finalizeSettlement,
+  markTransferSent,
+  reopenSettlement,
+} from '../api';
+import { ExpenseRow } from '../components/ExpenseRow';
+import { ExpenseSummaryStrip } from '../components/ExpenseSummaryStrip';
+import { MemberBalanceRow } from '../components/MemberBalanceRow';
+import { SettlementPanel } from '../components/SettlementPanel';
+import { TransferRow } from '../components/TransferRow';
+import { publishExpenseEvent } from '../expenseEvents';
+import { useExpenseCompositionCoordinator } from '../hooks/useExpenseCompositionCoordinator';
+import { useExpenseDashboard } from '../hooks/useExpenseDashboard';
+import { parseExpensesRouteIntent } from '../routeIntent';
+import type { ExpenseDashboardRow } from '../viewModel';
+import {
+  buildExpenseDashboardRows,
+  getExpenseDashboardRowKey,
+} from '../viewModel';
+import { RouteUnavailableState } from './RouteState';
+
+type SettlementAction = 'finalize' | 'reopen';
+type TransferAction = 'sent' | 'received';
+
+function HeaderAddAction({
+  disabled,
+  onPress,
+}: {
+  disabled: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel="Add expense"
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      hitSlop={spacing.sm}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.headerAction,
+        pressed && !disabled ? styles.pressed : null,
+        disabled ? styles.disabled : null,
+      ]}
+    >
+      <Ionicons name="add" size={21} color={colors.primary} />
+      <Text style={styles.headerActionText}>Add</Text>
+    </Pressable>
+  );
+}
+
+function InlineError({
+  error,
+  onRetry,
+}: {
+  error: ApiError;
+  onRetry: () => void;
+}) {
+  return (
+    <View accessibilityRole="alert" style={styles.inlineError}>
+      <Ionicons
+        name="alert-circle-outline"
+        size={20}
+        color={colors.danger}
+      />
+      <Text style={styles.inlineErrorText}>{error.message}</Text>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Retry refreshing expenses"
+        hitSlop={spacing.sm}
+        onPress={onRetry}
+        style={({ pressed }) => [
+          styles.retry,
+          pressed ? styles.pressed : null,
+        ]}
+      >
+        <Text style={styles.retryText}>Retry</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function ValidExpensesScreen({ tripId }: { tripId: string }) {
+  const router = useRouter();
+  const { user } = useSession();
+  const {
+    dashboard,
+    status: dashboardStatus,
+    error: dashboardError,
+    refreshing: dashboardRefreshing,
+    refresh: refreshDashboard,
+    invalidate: invalidateDashboard,
+  } = useExpenseDashboard(tripId, { autoReconcile: false });
+  const {
+    detail: tripDetail,
+    status: tripStatus,
+    error: tripError,
+    refreshing: tripRefreshing,
+    refresh: refreshTrip,
+  } = useTripDetail(tripId, { autoReconcile: false });
+  const {
+    refreshAll,
+    requestReconcile,
+  } = useExpenseCompositionCoordinator({
+    tripId,
+    refreshExpense: refreshDashboard,
+    refreshTrip,
+  });
+  const settlementAlertLockRef = useRef(false);
+  const transferLocksRef = useRef(new Set<string>());
+  const [pendingSettlementAction, setPendingSettlementAction] =
+    useState<SettlementAction | null>(null);
+  const [settlementError, setSettlementError] =
+    useState<ApiError | null>(null);
+  const [pendingTransferIds, setPendingTransferIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+  const [transferErrors, setTransferErrors] = useState<
+    Record<string, ApiError>
+  >({});
+
+  const rows = useMemo(
+    () =>
+      dashboard && tripDetail
+        ? buildExpenseDashboardRows(dashboard, tripDetail.members)
+        : [],
+    [dashboard, tripDetail],
+  );
+
+  const actions = useMemo(() => {
+    if (!dashboard || !tripDetail) {
+      return {
+        canAddExpense: false,
+        canFinalize: false,
+        canReopen: false,
+      };
+    }
+
+    return getExpenseDashboardActions({
+      canManageExpenses:
+        tripDetail.my_membership.status === 'ACTIVE' &&
+        dashboard.permissions.can_manage_expenses,
+      tripStatus: tripDetail.trip.status,
+      settlement: dashboard.settlement,
+      expenseCount: dashboard.expenses.length,
+    });
+  }, [dashboard, tripDetail]);
+
+  const openCreateForm = useCallback(() => {
+    if (actions.canAddExpense) {
+      router.push(`/trips/${tripId}/expenses/expense-form?mode=create`);
+    }
+  }, [actions.canAddExpense, router, tripId]);
+
+  const openExpense = useCallback(
+    (expenseId: string) => {
+      router.push(`/trips/${tripId}/expenses/${expenseId}`);
+    },
+    [router, tripId],
+  );
+
+  const performSettlementAction = useCallback(
+    async (action: SettlementAction) => {
+      setPendingSettlementAction(action);
+      setSettlementError(null);
+      invalidateDashboard();
+
+      try {
+        if (action === 'finalize') {
+          await finalizeSettlement(tripId);
+        } else {
+          await reopenSettlement(tripId);
+        }
+        await publishExpenseEvent({
+          type: 'expensesChanged',
+          tripId,
+        });
+      } catch (caught) {
+        setSettlementError(normalizeApiError(caught));
+        await publishExpenseEvent({
+          type: 'expensesChanged',
+          tripId,
+        });
+      } finally {
+        settlementAlertLockRef.current = false;
+        setPendingSettlementAction(null);
+      }
+    },
+    [invalidateDashboard, tripId],
+  );
+
+  const confirmFinalize = useCallback(() => {
+    if (
+      settlementAlertLockRef.current ||
+      !actions.canFinalize
+    ) {
+      return;
+    }
+
+    settlementAlertLockRef.current = true;
+    let confirmed = false;
+    const release = () => {
+      settlementAlertLockRef.current = false;
+    };
+    Alert.alert(
+      'Finalize settlement?',
+      'All expenses will be locked and the transfer list will be created.',
+      [
+        { text: 'Cancel', style: 'cancel', onPress: release },
+        {
+          text: 'Finalize',
+          onPress: () => {
+            confirmed = true;
+            void performSettlementAction('finalize');
+          },
+        },
+      ],
+      {
+        cancelable: true,
+        onDismiss: () => {
+          if (!confirmed) {
+            release();
+          }
+        },
+      },
+    );
+  }, [actions.canFinalize, performSettlementAction]);
+
+  const performReopen = useCallback(() => {
+    if (
+      settlementAlertLockRef.current ||
+      !actions.canReopen
+    ) {
+      return;
+    }
+    settlementAlertLockRef.current = true;
+    void performSettlementAction('reopen');
+  }, [actions.canReopen, performSettlementAction]);
+
+  const performTransferAction = useCallback(
+    async (transferId: string, action: TransferAction) => {
+      if (transferLocksRef.current.has(transferId)) {
+        return;
+      }
+
+      transferLocksRef.current.add(transferId);
+      setPendingTransferIds(
+        (current) => new Set(current).add(transferId),
+      );
+      setTransferErrors((current) => {
+        const next = { ...current };
+        delete next[transferId];
+        return next;
+      });
+      invalidateDashboard();
+
+      try {
+        if (action === 'sent') {
+          await markTransferSent(tripId, transferId);
+        } else {
+          await confirmTransferReceived(tripId, transferId);
+        }
+        await publishExpenseEvent({
+          type: 'expensesChanged',
+          tripId,
+        });
+      } catch (caught) {
+        const nextError = normalizeApiError(caught);
+        setTransferErrors((current) => ({
+          ...current,
+          [transferId]: nextError,
+        }));
+        await publishExpenseEvent({
+          type: 'expensesChanged',
+          tripId,
+        });
+      } finally {
+        transferLocksRef.current.delete(transferId);
+        setPendingTransferIds((current) => {
+          const next = new Set(current);
+          next.delete(transferId);
+          return next;
+        });
+      }
+    },
+    [invalidateDashboard, tripId],
+  );
+
+  const markSent = useCallback(
+    (transferId: string) => {
+      void performTransferAction(transferId, 'sent');
+    },
+    [performTransferAction],
+  );
+
+  const confirmReceived = useCallback(
+    (transferId: string) => {
+      void performTransferAction(transferId, 'received');
+    },
+    [performTransferAction],
+  );
+
+  const retry = useCallback(() => {
+    void requestReconcile(true);
+  }, [requestReconcile]);
+
+  const pullToRefresh = useCallback(() => {
+    void refreshAll('refresh');
+  }, [refreshAll]);
+
+  const missingError =
+    (!dashboard ? dashboardError : null) ??
+    (!tripDetail ? tripError : null);
+  if (!dashboard || !tripDetail) {
+    const loading =
+      !missingError &&
+      (dashboardStatus === 'loading' || tripStatus === 'loading');
+    return (
+      <>
+        <Stack.Screen options={{ title: 'Expenses' }} />
+        {loading ? (
+          <LoadingScreen />
+        ) : (
+          <RouteUnavailableState
+            title={
+              missingError?.status === 404
+                ? 'Expenses unavailable'
+                : 'Could not load expenses'
+            }
+            message="This trip does not exist or you are not a member of it."
+            error={missingError}
+            onRetry={retry}
+          />
+        )}
+      </>
+    );
+  }
+
+  const backgroundError =
+    settlementError ?? dashboardError ?? tripError;
+  const firstTransferIndex = rows.findIndex(
+    (row) => row.type === 'transfer',
+  );
+  const firstBalanceIndex = rows.findIndex(
+    (row) => row.type === 'member-balance',
+  );
+  const firstExpenseIndex = rows.findIndex(
+    (row) => row.type === 'expense' || row.type === 'empty',
+  );
+
+  const renderRow = ({
+    item,
+    index,
+  }: {
+    item: ExpenseDashboardRow;
+    index: number;
+  }) => {
+    const sectionTitle =
+      index === firstTransferIndex
+        ? 'Transfers'
+        : index === firstBalanceIndex
+          ? 'Member balances'
+          : index === firstExpenseIndex
+            ? 'Expenses'
+            : null;
+
+    return (
+      <View style={styles.rowWrap}>
+        {sectionTitle ? (
+          <Text accessibilityRole="header" style={styles.sectionTitle}>
+            {sectionTitle}
+          </Text>
+        ) : null}
+        {item.type === 'transfer' ? (
+          <TransferRow
+            transfer={item.transfer}
+            currencyCode={dashboard.currency_code}
+            viewerId={user?.id ?? null}
+            loading={pendingTransferIds.has(item.transfer.id)}
+            error={transferErrors[item.transfer.id] ?? null}
+            onMarkSent={markSent}
+            onConfirmReceived={confirmReceived}
+          />
+        ) : item.type === 'member-balance' ? (
+          <MemberBalanceRow
+            memberName={item.displayName}
+            identifyTag={item.identifyTag}
+            balance={item.balance}
+            currencyCode={dashboard.currency_code}
+          />
+        ) : item.type === 'expense' ? (
+          <ExpenseRow
+            expense={item.expense}
+            onPress={openExpense}
+          />
+        ) : (
+          <View style={styles.emptyCard}>
+            <Ionicons
+              name="receipt-outline"
+              size={30}
+              color={colors.textMuted}
+            />
+            <Text style={styles.emptyTitle}>No expenses yet</Text>
+            <Text style={styles.emptyText}>
+              Add the first shared cost to start tracking contributions.
+            </Text>
+          </View>
+        )}
+      </View>
+    );
+  };
+
+  return (
+    <SafeAreaView
+      style={styles.safe}
+      edges={['left', 'right', 'bottom']}
+    >
+      <Stack.Screen
+        options={{
+          title: 'Expenses',
+          headerRight: actions.canAddExpense
+            ? () => (
+                <HeaderAddAction
+                  disabled={pendingSettlementAction !== null}
+                  onPress={openCreateForm}
+                />
+              )
+            : undefined,
+        }}
+      />
+      <FlatList
+        data={rows}
+        keyExtractor={getExpenseDashboardRowKey}
+        renderItem={renderRow}
+        extraData={{
+          pendingTransferIds,
+          transferErrors,
+        }}
+        refreshing={dashboardRefreshing || tripRefreshing}
+        onRefresh={pullToRefresh}
+        contentInsetAdjustmentBehavior="automatic"
+        contentContainerStyle={styles.content}
+        ListHeaderComponent={
+          <View style={styles.header}>
+            {backgroundError ? (
+              <InlineError
+                error={backgroundError}
+                onRetry={() => void requestReconcile()}
+              />
+            ) : null}
+            <ExpenseSummaryStrip
+              summary={dashboard.summary}
+              myBalance={dashboard.my_balance}
+              currencyCode={dashboard.currency_code}
+            />
+            {dashboard.settlement ? (
+              <SettlementPanel
+                settlement={dashboard.settlement}
+                canReopen={actions.canReopen}
+                reopening={pendingSettlementAction === 'reopen'}
+                error={
+                  pendingSettlementAction === 'reopen'
+                    ? settlementError
+                    : null
+                }
+                onReopen={performReopen}
+              />
+            ) : actions.canFinalize ? (
+              <Button
+                title="Finalize settlement"
+                loading={pendingSettlementAction === 'finalize'}
+                onPress={confirmFinalize}
+              />
+            ) : null}
+          </View>
+        }
+      />
+    </SafeAreaView>
+  );
+}
+
+export function ExpensesScreen() {
+  const { tripId } = useLocalSearchParams();
+  const intent = parseExpensesRouteIntent({ tripId });
+
+  if (!intent) {
+    return (
+      <RouteUnavailableState
+        title="Expenses unavailable"
+        message="This expenses link is invalid or incomplete."
+      />
+    );
+  }
+
+  return (
+    <ValidExpensesScreen key={intent.tripId} tripId={intent.tripId} />
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: colors.surface,
+  },
+  content: {
+    flexGrow: 1,
+    gap: spacing.md,
+    padding: spacing.md,
+    paddingBottom: spacing.xl,
+  },
+  header: {
+    gap: spacing.md,
+  },
+  headerAction: {
+    minHeight: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.xs,
+  },
+  headerActionText: {
+    ...typography.body,
+    color: colors.primary,
+    fontWeight: '600',
+  },
+  pressed: { opacity: 0.58 },
+  disabled: { opacity: 0.45 },
+  inlineError: {
+    minHeight: 52,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.dangerBorder,
+    borderRadius: radii.md,
+    backgroundColor: colors.dangerSoft,
+  },
+  inlineErrorText: {
+    ...typography.caption,
+    flex: 1,
+    color: colors.danger,
+  },
+  retry: {
+    minHeight: 44,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.xs,
+  },
+  retryText: {
+    ...typography.label,
+    color: colors.danger,
+  },
+  rowWrap: {
+    gap: spacing.sm,
+  },
+  sectionTitle: {
+    ...typography.heading,
+    color: colors.text,
+  },
+  emptyCard: {
+    alignItems: 'center',
+    gap: spacing.sm,
+    padding: spacing.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.lg,
+    backgroundColor: colors.background,
+  },
+  emptyTitle: {
+    ...typography.heading,
+    color: colors.text,
+    textAlign: 'center',
+  },
+  emptyText: {
+    ...typography.body,
+    color: colors.textMuted,
+    textAlign: 'center',
+  },
+});

--- a/mobile/src/features/expenses/screens/RouteState.tsx
+++ b/mobile/src/features/expenses/screens/RouteState.tsx
@@ -1,0 +1,69 @@
+import { Ionicons } from '@expo/vector-icons';
+import type { ComponentProps } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import type { ApiError } from '@/shared/api/errors';
+import { colors, spacing, typography } from '@/shared/theme/tokens';
+import { Button } from '@/shared/ui/Button';
+
+interface RouteUnavailableStateProps {
+  title: string;
+  message: string;
+  error?: ApiError | null;
+  onRetry?: () => void;
+}
+
+export function RouteUnavailableState({
+  title,
+  message,
+  error,
+  onRetry,
+}: RouteUnavailableStateProps) {
+  const notFound = error?.status === 404;
+  const icon = (
+    notFound
+      ? 'help-circle-outline'
+      : error
+        ? 'cloud-offline-outline'
+        : 'help-circle-outline'
+  ) satisfies ComponentProps<typeof Ionicons>['name'];
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['left', 'right', 'bottom']}>
+      <View style={styles.centered}>
+        <Ionicons name={icon} size={44} color={colors.textMuted} />
+        <Text accessibilityRole="header" style={styles.title}>
+          {title}
+        </Text>
+        <Text style={styles.message}>{error?.message ?? message}</Text>
+        {onRetry && !notFound ? (
+          <Button title="Try again" onPress={onRetry} />
+        ) : null}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.md,
+    padding: spacing.lg,
+  },
+  title: {
+    ...typography.heading,
+    color: colors.text,
+    textAlign: 'center',
+  },
+  message: {
+    ...typography.body,
+    color: colors.textMuted,
+    textAlign: 'center',
+  },
+});

--- a/mobile/src/features/expenses/types.ts
+++ b/mobile/src/features/expenses/types.ts
@@ -1,0 +1,111 @@
+export type ExpenseStatus = 'UNDERFUNDED' | 'FUNDED' | 'OVERFUNDED';
+export type ExpenseSettlementStatus = 'FINALIZED' | 'REOPENED';
+
+export interface ExpensePerson {
+  id: string;
+  display_name: string;
+  identify_tag: string | null;
+}
+
+export interface ExpenseMoneySummary {
+  total_amount: string;
+  paid_amount: string;
+  missing_amount: string;
+  surplus_amount: string;
+}
+
+export type ExpenseDashboardSummary = ExpenseMoneySummary;
+
+export interface ExpensePermissions {
+  can_manage_expenses: boolean;
+}
+
+export interface ExpenseListItem extends ExpenseMoneySummary {
+  id: string;
+  title: string;
+  description: string;
+  currency_code: string;
+  status: ExpenseStatus;
+  collector: ExpensePerson;
+  locked: boolean;
+}
+
+export interface ExpenseParticipant {
+  user_id: string;
+  display_name: string;
+  identify_tag: string | null;
+  share_amount: string;
+  contributed_amount: string;
+  balance: string;
+  surplus_held: string;
+}
+
+export type ExpenseParticipantContribution = ExpenseParticipant;
+
+export interface ExpenseDetailResponse extends ExpenseListItem {
+  locked_at: string | null;
+  created_at: string;
+  permissions: ExpensePermissions;
+  participants: ExpenseParticipant[];
+}
+
+export interface SettlementTransfer {
+  id: string;
+  payer: ExpensePerson;
+  recipient: ExpensePerson;
+  amount: string;
+  payer_marked_sent_at: string | null;
+  recipient_confirmed_at: string | null;
+}
+
+export interface TripSettlement {
+  id: string;
+  status: ExpenseSettlementStatus;
+  finalized_at: string | null;
+  transfers: SettlementTransfer[];
+}
+
+export interface ExpenseDashboardResponse {
+  currency_code: string;
+  summary: ExpenseMoneySummary;
+  permissions: ExpensePermissions;
+  my_balance: {
+    balance: string;
+    surplus_held: string;
+  };
+  member_balances: Record<string, { balance: string }>;
+  settlement: TripSettlement | null;
+  expenses: ExpenseListItem[];
+}
+
+export interface CreateExpensePayload {
+  title: string;
+  description?: string;
+  total_amount: string;
+  collector_id?: string;
+}
+
+export type UpdateExpensePayload = Partial<CreateExpensePayload>;
+
+export interface SetContributionPayload {
+  amount: string;
+}
+
+export interface ExpenseResponse {
+  id: string;
+  title: string;
+  description: string;
+  total_amount: string;
+  currency_code: string;
+  locked_at: string | null;
+  created_at: string;
+}
+
+export type CreateExpenseResponse = ExpenseResponse;
+
+export interface ContributionResponse {
+  id: string;
+  user: ExpensePerson;
+  amount: string;
+  updated_at: string;
+}

--- a/mobile/src/features/expenses/viewModel.ts
+++ b/mobile/src/features/expenses/viewModel.ts
@@ -1,0 +1,142 @@
+import type { TripMember } from '@/features/trips/types';
+import type {
+  ExpenseDashboardResponse,
+  ExpenseListItem,
+  ExpensePerson,
+  SettlementTransfer,
+} from './types';
+
+export interface ExpenseTransferDashboardRow {
+  type: 'transfer';
+  key: string;
+  transfer: SettlementTransfer;
+}
+
+export interface ExpenseMemberBalanceDashboardRow {
+  type: 'member-balance';
+  key: string;
+  userId: string;
+  displayName: string;
+  identifyTag: string | null;
+  balance: string;
+}
+
+export interface ExpenseItemDashboardRow {
+  type: 'expense';
+  key: string;
+  expense: ExpenseListItem;
+}
+
+export interface ExpenseEmptyDashboardRow {
+  type: 'empty';
+  key: 'expense:empty';
+}
+
+export type ExpenseDashboardRow =
+  | ExpenseTransferDashboardRow
+  | ExpenseMemberBalanceDashboardRow
+  | ExpenseItemDashboardRow
+  | ExpenseEmptyDashboardRow;
+
+interface ResolvedMemberName {
+  displayName: string;
+  identifyTag: string | null;
+}
+
+export function buildExpenseDashboardRows(
+  dashboard: ExpenseDashboardResponse,
+  activeMembers: readonly TripMember[] = [],
+): ExpenseDashboardRow[] {
+  const rows: ExpenseDashboardRow[] = [];
+  const transfers = dashboard.settlement?.transfers ?? [];
+
+  for (const transfer of transfers) {
+    rows.push({
+      type: 'transfer',
+      key: `transfer:${transfer.id}`,
+      transfer,
+    });
+  }
+
+  const memberNames = buildMemberNameMap(activeMembers, transfers);
+  for (const [userId, memberBalance] of Object.entries(
+    dashboard.member_balances,
+  )) {
+    const member = memberNames.get(userId);
+    rows.push({
+      type: 'member-balance',
+      key: `member-balance:${userId}`,
+      userId,
+      displayName: member?.displayName ?? 'Member',
+      identifyTag: member?.identifyTag ?? null,
+      balance: memberBalance.balance,
+    });
+  }
+
+  if (dashboard.expenses.length === 0) {
+    rows.push({
+      type: 'empty',
+      key: 'expense:empty',
+    });
+  } else {
+    for (const expense of dashboard.expenses) {
+      rows.push({
+        type: 'expense',
+        key: `expense:${expense.id}`,
+        expense,
+      });
+    }
+  }
+
+  return rows;
+}
+
+export function getExpenseDashboardRowKey(
+  row: ExpenseDashboardRow,
+): string {
+  return row.key;
+}
+
+function buildMemberNameMap(
+  activeMembers: readonly TripMember[],
+  transfers: readonly SettlementTransfer[],
+): Map<string, ResolvedMemberName> {
+  const namesByUserId = new Map<string, ResolvedMemberName>();
+
+  for (const member of activeMembers) {
+    namesByUserId.set(member.user.id, {
+      displayName: safeDisplayName(member.user.display_name),
+      identifyTag: safeIdentifyTag(member.user.identify_tag),
+    });
+  }
+
+  for (const transfer of transfers) {
+    addTransferPartyFallback(namesByUserId, transfer.payer);
+    addTransferPartyFallback(namesByUserId, transfer.recipient);
+  }
+
+  return namesByUserId;
+}
+
+function addTransferPartyFallback(
+  namesByUserId: Map<string, ResolvedMemberName>,
+  person: ExpensePerson,
+): void {
+  if (namesByUserId.has(person.id)) {
+    return;
+  }
+
+  namesByUserId.set(person.id, {
+    displayName: safeDisplayName(person.display_name),
+    identifyTag: safeIdentifyTag(person.identify_tag),
+  });
+}
+
+function safeDisplayName(displayName: string): string {
+  return displayName.trim() || 'Member';
+}
+
+function safeIdentifyTag(identifyTag: string | null): string | null {
+  const normalized = identifyTag?.trim() ?? '';
+  return normalized || null;
+}

--- a/mobile/src/features/trips/__tests__/TripDetailScreen.test.tsx
+++ b/mobile/src/features/trips/__tests__/TripDetailScreen.test.tsx
@@ -171,7 +171,7 @@ describe('TripDetailScreen', () => {
     expect(mockRouter.push).toHaveBeenCalledWith('/trips/trip-123/invite');
   });
 
-  it('shows only the Timeline Planning entry to every readable trip', async () => {
+  it('shows Timeline and Expenses Planning entries to every readable trip', async () => {
     mockUseTripDetail.mockReturnValue(
       readyHook({
         ...tripDetail,
@@ -183,10 +183,12 @@ describe('TripDetailScreen', () => {
 
     expect(screen.getByRole('header', { name: 'Planning' })).toBeTruthy();
     expect(screen.getByText('Timeline')).toBeTruthy();
-    expect(screen.queryByText('Expenses')).toBeNull();
+    expect(screen.getByText('Expenses')).toBeTruthy();
 
     await fireEvent.press(screen.getByRole('button', { name: 'Open Timeline' }));
     expect(mockRouter.push).toHaveBeenCalledWith('/trips/trip-123/timeline');
+    await fireEvent.press(screen.getByRole('button', { name: 'Open Expenses' }));
+    expect(mockRouter.push).toHaveBeenCalledWith('/trips/trip-123/expenses');
   });
 
   it('shows only leave for an active member and no actions for a terminal trip', async () => {

--- a/mobile/src/features/trips/screens/TripDetailScreen.tsx
+++ b/mobile/src/features/trips/screens/TripDetailScreen.tsx
@@ -166,6 +166,10 @@ export function TripDetailScreen() {
     router.push(`/trips/${tripId}/timeline`);
   }, [router, tripId]);
 
+  const openExpenses = useCallback(() => {
+    router.push(`/trips/${tripId}/expenses`);
+  }, [router, tripId]);
+
   if (status === 'loading') {
     return <LoadingScreen />;
   }
@@ -269,6 +273,7 @@ export function TripDetailScreen() {
               onPress={openTimeline}
               style={({ pressed }) => [
                 styles.planningRow,
+                styles.rowDivider,
                 pressed ? styles.planningRowPressed : null,
               ]}
             >
@@ -279,6 +284,26 @@ export function TripDetailScreen() {
                 <Text style={styles.infoText}>Timeline</Text>
                 <Text style={styles.planningDescription}>
                   Plan days, activities, and reminders
+                </Text>
+              </View>
+              <Ionicons name="chevron-forward" size={20} color={colors.textMuted} />
+            </Pressable>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Open Expenses"
+              onPress={openExpenses}
+              style={({ pressed }) => [
+                styles.planningRow,
+                pressed ? styles.planningRowPressed : null,
+              ]}
+            >
+              <View style={styles.infoIcon}>
+                <Ionicons name="wallet-outline" size={18} color={colors.primary} />
+              </View>
+              <View style={styles.planningCopy}>
+                <Text style={styles.infoText}>Expenses</Text>
+                <Text style={styles.planningDescription}>
+                  Track shared costs and settlement
                 </Text>
               </View>
               <Ionicons name="chevron-forward" size={20} color={colors.textMuted} />

--- a/mobile/src/shared/theme/tokens.ts
+++ b/mobile/src/shared/theme/tokens.ts
@@ -14,6 +14,8 @@ export const colors = {
   border: '#D8DFE8',
   danger: '#C0392B',
   success: '#1E7A45',
+  warning: '#A16207',
+  warningSoft: '#FEF3C7',
   sky: '#0369A1',
   skySoft: '#E0F2FE',
   amber: '#A16207',


### PR DESCRIPTION
## Summary

- Complete all 13 planned iOS Expenses work items: dashboard, summary, balances, virtualized expense rows, participant snapshots, create/edit/delete, contributions, settlement, transfers, and solo settlement.
- Integrate all 10 existing Django Expense operations using raw server responses and server-authoritative permission/action matrices.
- Add decimal-string money handling, composed-source reconciliation, race guards, strict form lifecycle, nested DRF error handling, and invalid-route guards.
- Add Expenses navigation to Trip Detail and register dashboard, detail, and form-sheet routes.

## Why

This completes PR3 of Issue #58 and brings the iOS Expenses experience onto the contracts and navigation patterns established by the merged Timeline work.

## User impact

Captains can manage expenses, contributions, and settlement. Members can inspect participant snapshots and balances, while eligible payers and recipients can confirm transfers even after a trip becomes terminal. Solo settlements remain finalized without generating unnecessary transfer rows.

## Scope notes

- No backend, database schema, migration, or API-contract changes.
- Former-party records remain visible in server snapshots, but mobile write controls expose ACTIVE members only as specified.
- Android and realtime updates remain out of scope.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- Targeted Expenses and Trip integration tests: 19 suites / 342 tests passed
- Full mobile suite: 79 suites / 936 tests passed
- `git diff --check`
- Manual QA on iPhone 17 Pro Max, iOS 26.3, covering captain/member permissions, CRUD, contributions, underfunded and overfunded settlement, finalize/reopen, sent/received transfers, terminal trips, solo settlement, offline refresh recovery, foreground reconciliation, and VND zero-decimal behavior

Closes #58
