### PR TITLE
feat(mobile): trip cover upload and structured destination picker

### DIFF
--- a/mobile/src/features/timeline/__tests__/ActivityFormScreen.test.tsx
+++ b/mobile/src/features/timeline/__tests__/ActivityFormScreen.test.tsx
@@ -1,7 +1,7 @@
 import type { ComponentProps, ReactNode } from 'react';
 import { View } from 'react-native';
+import type { PlacePicker } from '@/shared/location/PlacePicker';
 import type { ActivityForm } from '../components/ActivityForm';
-import type { PlacePicker } from '../components/PlacePicker';
 
 let mockParams: Record<string, string | string[] | undefined> = {};
 const mockRouter = {
@@ -82,7 +82,7 @@ jest.mock('@/features/trips/hooks/useTripDetail', () => ({
 jest.mock('../components/ActivityForm', () => ({
   ActivityForm: mockRenderActivityForm,
 }));
-jest.mock('../components/PlacePicker', () => ({
+jest.mock('@/shared/location/PlacePicker', () => ({
   PlacePicker: mockRenderPlacePicker,
 }));
 jest.mock('../api', () => ({
@@ -489,22 +489,19 @@ describe('ActivityFormScreen', () => {
 
     const picker = currentPlacePickerProps();
     expect(picker.value).toEqual({
-      location_label: 'Existing manual label',
+      label: 'Existing manual label',
       place: null,
     });
     expect(picker.error).toBe('Provider id is invalid.');
 
-    picker.onSelectLocation({
-      location_mode: 'STRUCTURED',
-      location_label: 'Canonical place',
-      place: {
-        provider: 'here',
-        provider_id: 'canonical-id',
-        title: 'Canonical place',
-        address: 'Da Nang',
-        lat: 16,
-        lng: 108,
-      },
+    picker.onSelectPlace({
+      provider: 'here',
+      provider_id: 'canonical-id',
+      label: 'Canonical place',
+      address: 'Da Nang',
+      lat: 16,
+      lng: 108,
+      country_code: 'VN',
     });
     expect(onChange).toHaveBeenCalledWith({
       location_label: 'Canonical place',
@@ -512,9 +509,7 @@ describe('ActivityFormScreen', () => {
     });
 
     picker.onLookupFailure({
-      location_mode: 'MANUAL',
-      location_label: 'Unverified suggestion',
-      place: null,
+      label: 'Unverified suggestion',
       error: {
         kind: 'network',
         message: 'Cannot reach the server.',

--- a/mobile/src/features/timeline/__tests__/api.test.ts
+++ b/mobile/src/features/timeline/__tests__/api.test.ts
@@ -18,11 +18,9 @@ import {
   deleteCustomType,
   deleteSection,
   getTimeline,
-  lookupLocation,
   patchActivity,
   patchCustomType,
   patchSection,
-  suggestLocations,
   updateActivityStatus,
 } from '../api';
 
@@ -222,48 +220,6 @@ describe('timeline api', () => {
     expect(mockDelete).toHaveBeenCalledWith(
       '/trips/trip-1/timeline/custom-types/type-1',
     );
-  });
-
-  it('suggests locations and unwraps suggestions with cancellation support', async () => {
-    const controller = new AbortController();
-    const suggestions = [
-      {
-        provider: 'here',
-        provider_id: 'here:place:1',
-        title: 'Da Nang',
-        subtitle: 'Vietnam',
-      },
-    ];
-    mockGet.mockResolvedValue({ data: { suggestions } } as never);
-
-    await expect(
-      suggestLocations('Da Nang', controller.signal),
-    ).resolves.toEqual(suggestions);
-    expect(mockGet).toHaveBeenCalledWith('/location-search/suggest', {
-      params: { q: 'Da Nang' },
-      signal: controller.signal,
-    });
-  });
-
-  it('looks up a canonical location from the direct response with cancellation support', async () => {
-    const controller = new AbortController();
-    const lookup = {
-      destination: 'Da Nang, Vietnam',
-      destination_provider: 'here',
-      destination_provider_id: 'here:place:canonical',
-      destination_lat: 16.0544,
-      destination_lng: 108.2022,
-      destination_country_code: 'VN',
-    };
-    mockGet.mockResolvedValue({ data: lookup } as never);
-
-    await expect(
-      lookupLocation('here:place:1', controller.signal),
-    ).resolves.toEqual(lookup);
-    expect(mockGet).toHaveBeenCalledWith('/location-search/lookup', {
-      params: { id: 'here:place:1' },
-      signal: controller.signal,
-    });
   });
 
   it('lets API failures propagate for callers to normalize', async () => {

--- a/mobile/src/features/timeline/__tests__/viewModel.test.ts
+++ b/mobile/src/features/timeline/__tests__/viewModel.test.ts
@@ -1,6 +1,8 @@
 import type {
-  LocationSuggestion,
-  ResolvedLookup,
+  PlaceSuggestion,
+  ResolvedPlaceLookup,
+} from '@/shared/location/types';
+import type {
   TimelineActivity,
   TimelineSection,
 } from '../types';
@@ -75,7 +77,7 @@ function buildSection(
   };
 }
 
-const suggestion: LocationSuggestion = {
+const suggestion: PlaceSuggestion = {
   provider: 'here',
   provider_id: 'unverified-suggestion-id',
   title: 'Hội An',
@@ -83,8 +85,8 @@ const suggestion: LocationSuggestion = {
 };
 
 function buildLookup(
-  overrides: Partial<ResolvedLookup> = {},
-): ResolvedLookup {
+  overrides: Partial<ResolvedPlaceLookup> = {},
+): ResolvedPlaceLookup {
   return {
     destination: 'Hội An, Quảng Nam, Việt Nam',
     destination_provider: 'here',

--- a/mobile/src/features/timeline/api.ts
+++ b/mobile/src/features/timeline/api.ts
@@ -3,11 +3,9 @@ import type {
   CreateActivityPayload,
   CreateCustomTypePayload,
   CreateSectionPayload,
-  LocationSuggestion,
   PatchActivityPayload,
   PatchCustomTypePayload,
   PatchSectionPayload,
-  ResolvedLocationLookup,
   TimelineActivity,
   TimelineCustomTypeMeta,
   TimelineResponse,
@@ -26,10 +24,6 @@ interface ActivityResponse {
 
 interface CustomTypeResponse {
   custom_type: TimelineCustomTypeMeta;
-}
-
-interface LocationSuggestionsResponse {
-  suggestions: LocationSuggestion[];
 }
 
 export async function getTimeline(
@@ -146,32 +140,4 @@ export async function deleteCustomType(
   typeId: string,
 ): Promise<void> {
   await apiClient.delete(`/trips/${tripId}/timeline/custom-types/${typeId}`);
-}
-
-export async function suggestLocations(
-  query: string,
-  signal?: AbortSignal,
-): Promise<LocationSuggestion[]> {
-  const { data } = await apiClient.get<LocationSuggestionsResponse>(
-    '/location-search/suggest',
-    {
-      params: { q: query },
-      signal,
-    },
-  );
-  return data.suggestions;
-}
-
-export async function lookupLocation(
-  providerId: string,
-  signal?: AbortSignal,
-): Promise<ResolvedLocationLookup> {
-  const { data } = await apiClient.get<ResolvedLocationLookup>(
-    '/location-search/lookup',
-    {
-      params: { id: providerId },
-      signal,
-    },
-  );
-  return data;
 }

--- a/mobile/src/features/timeline/screens/ActivityFormScreen.tsx
+++ b/mobile/src/features/timeline/screens/ActivityFormScreen.tsx
@@ -22,6 +22,7 @@ import {
 import type { TripDetailResponse } from '@/features/trips/types';
 import { normalizeApiError, type ApiError } from '@/shared/api/errors';
 import { useAppForegroundEffect } from '@/shared/hooks/useAppForegroundEffect';
+import { PlacePicker } from '@/shared/location/PlacePicker';
 import { colors, spacing, typography } from '@/shared/theme/tokens';
 import { Button } from '@/shared/ui/Button';
 import { LoadingScreen } from '@/shared/ui/LoadingScreen';
@@ -30,7 +31,6 @@ import {
   ActivityForm,
   type StructuredLocationEditorProps,
 } from '../components/ActivityForm';
-import { PlacePicker } from '../components/PlacePicker';
 import {
   buildCreateActivityPayload,
   buildPatchActivityPayload,
@@ -122,23 +122,28 @@ function renderStructuredLocationEditor({
   return (
     <PlacePicker
       value={{
-        location_label: locationLabel,
-        place: value?.place ?? null,
+        label: locationLabel,
+        place: value?.place
+          ? { title: value.place.title, address: value.place.address ?? '' }
+          : null,
       }}
       disabled={disabled}
       error={getPlaceEditorError(fieldErrors)}
-      onSelectLocation={(selection) =>
+      onSelectPlace={(place) =>
         onChange({
-          location_label: selection.location_label,
-          place: selection.place,
+          location_label: place.label,
+          place: {
+            provider: place.provider,
+            provider_id: place.provider_id,
+            title: place.label,
+            address: place.address,
+            lat: place.lat,
+            lng: place.lng,
+          },
         })
       }
-      onUseManualEntry={(manual) =>
-        onUseManual(manual.location_label)
-      }
-      onLookupFailure={(failure) =>
-        onUseManual(failure.location_label)
-      }
+      onUseManualEntry={(entry) => onUseManual(entry.label)}
+      onLookupFailure={(failure) => onUseManual(failure.label)}
     />
   );
 }

--- a/mobile/src/features/timeline/types.ts
+++ b/mobile/src/features/timeline/types.ts
@@ -195,21 +195,3 @@ export type PatchCustomTypePayload = Partial<{
   icon_key: string;
   is_active: boolean;
 }>;
-
-export interface LocationSuggestion {
-  provider: 'here';
-  provider_id: string;
-  title: string;
-  subtitle: string;
-}
-
-export interface ResolvedLocationLookup {
-  destination: string;
-  destination_provider: 'here';
-  destination_provider_id: string;
-  destination_lat: number | null;
-  destination_lng: number | null;
-  destination_country_code: string;
-}
-
-export type ResolvedLookup = ResolvedLocationLookup;

--- a/mobile/src/features/timeline/viewModel.ts
+++ b/mobile/src/features/timeline/viewModel.ts
@@ -1,16 +1,15 @@
+import { resolvePlace } from '@/shared/location/resolvePlace';
+import type {
+  PlaceSuggestion,
+  ResolvedPlaceLookup,
+} from '@/shared/location/types';
 import type {
   ActivityPlacePayload,
-  LocationSuggestion,
-  ResolvedLookup,
   TimelineActivity,
   TimelineSection,
 } from './types';
 
 const MINUTES_PER_DAY = 24 * 60;
-const MAX_LOCATION_LABEL_LENGTH = 200;
-const MAX_PLACE_TITLE_LENGTH = 200;
-const MAX_PLACE_ADDRESS_LENGTH = 255;
-const MAX_PROVIDER_ID_LENGTH = 255;
 
 const SECTION_DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
   weekday: 'short',
@@ -255,36 +254,24 @@ export function formatActivityTime(activity: TimelineActivity): string {
 }
 
 export function buildStructuredLocation(
-  suggestion: LocationSuggestion,
-  lookup: ResolvedLookup,
+  suggestion: PlaceSuggestion,
+  lookup: ResolvedPlaceLookup,
 ): StructuredLocationValue | null {
-  const canonicalProviderId = lookup.destination_provider_id;
-  if (
-    typeof canonicalProviderId !== 'string' ||
-    canonicalProviderId.trim().length === 0 ||
-    codePointLength(canonicalProviderId) > MAX_PROVIDER_ID_LENGTH
-  ) {
+  const place = resolvePlace(suggestion, lookup);
+  if (!place) {
     return null;
   }
-
-  const safeTitle = truncateText(
-    suggestion.title,
-    Math.min(MAX_LOCATION_LABEL_LENGTH, MAX_PLACE_TITLE_LENGTH),
-  );
-  const safeAddress = truncateText(
-    lookup.destination ?? suggestion.subtitle,
-    MAX_PLACE_ADDRESS_LENGTH,
-  );
-
+  // The shared caps already match the activity caps; this mapping is a rename,
+  // not a second truncation pass.
   return {
-    location_label: safeTitle,
+    location_label: place.label,
     place: {
-      provider: 'here',
-      provider_id: canonicalProviderId,
-      title: safeTitle,
-      address: safeAddress,
-      lat: lookup.destination_lat ?? null,
-      lng: lookup.destination_lng ?? null,
+      provider: place.provider,
+      provider_id: place.provider_id,
+      title: place.label,
+      address: place.address,
+      lat: place.lat,
+      lng: place.lng,
     },
   };
 }
@@ -419,12 +406,4 @@ function parseIsoDate(value: string): Date | null {
     return null;
   }
   return date;
-}
-
-function truncateText(value: string, maxLength: number): string {
-  return Array.from(value).slice(0, maxLength).join('');
-}
-
-function codePointLength(value: string): number {
-  return Array.from(value).length;
 }

--- a/mobile/src/features/trips/__tests__/CoverImageField.test.tsx
+++ b/mobile/src/features/trips/__tests__/CoverImageField.test.tsx
@@ -1,0 +1,78 @@
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('expo-image', () => {
+  const { View } = jest.requireActual('react-native');
+  return { Image: View };
+});
+
+// eslint-disable-next-line import/first
+import type { ComponentProps } from 'react';
+// eslint-disable-next-line import/first
+import { fireEvent, render, screen } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { CoverImageField } from '../components/CoverImageField';
+
+const COVER_URL = '/media/trip-covers/8f0e.webp';
+
+async function renderField(
+  overrides: Partial<ComponentProps<typeof CoverImageField>> = {},
+) {
+  const props = {
+    coverUrl: '',
+    status: 'idle' as const,
+    error: null,
+    onChoose: jest.fn(),
+    onRemove: jest.fn(),
+    ...overrides,
+  };
+  await render(<CoverImageField {...props} />);
+  return props;
+}
+
+describe('CoverImageField', () => {
+  it('offers only a choose action while the trip has no cover', async () => {
+    const props = await renderField();
+
+    expect(screen.getByText('No cover photo yet')).toBeTruthy();
+    expect(screen.queryByLabelText('Remove photo')).toBeNull();
+
+    await fireEvent.press(screen.getByLabelText('Choose photo'));
+    expect(props.onChoose).toHaveBeenCalledTimes(1);
+  });
+
+  it('previews an existing cover and offers replace and remove', async () => {
+    const props = await renderField({ coverUrl: COVER_URL });
+
+    expect(screen.getByLabelText('Trip cover preview')).toBeTruthy();
+    expect(screen.queryByText('No cover photo yet')).toBeNull();
+
+    await fireEvent.press(screen.getByLabelText('Replace photo'));
+    await fireEvent.press(screen.getByLabelText('Remove photo'));
+    expect(props.onChoose).toHaveBeenCalledTimes(1);
+    expect(props.onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['picking', 'uploading'] as const)(
+    'announces progress and swallows presses while %s',
+    async (status) => {
+      const props = await renderField({ coverUrl: COVER_URL, status });
+
+      expect(screen.getByLabelText('Uploading cover')).toBeTruthy();
+      await fireEvent.press(screen.getByLabelText('Replace photo'));
+      await fireEvent.press(screen.getByLabelText('Remove photo'));
+
+      expect(props.onChoose).not.toHaveBeenCalled();
+      expect(props.onRemove).not.toHaveBeenCalled();
+      expect(
+        screen.getByLabelText('Replace photo').props.accessibilityState,
+      ).toEqual(expect.objectContaining({ disabled: true }));
+    },
+  );
+
+  it('renders an error as an alert while keeping retry available', async () => {
+    const props = await renderField({ error: 'Unsupported image format.' });
+
+    expect(screen.getByText('Unsupported image format.')).toBeTruthy();
+    await fireEvent.press(screen.getByLabelText('Choose photo'));
+    expect(props.onChoose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/src/features/trips/__tests__/CreateTripScreen.test.tsx
+++ b/mobile/src/features/trips/__tests__/CreateTripScreen.test.tsx
@@ -97,10 +97,12 @@ const processedImage = {
 } as const;
 const UPLOADED_COVER_URL = '/media/trip-covers/8f0e.webp';
 
+// Short suggestion title vs canonical lookup destination — the payload must take
+// the canonical one, the same value the web picker persists.
 const verifiedPlace: ResolvedPlace = {
   provider: 'here',
   provider_id: 'canonical-here-id',
-  label: 'Hội An, Quảng Nam',
+  label: 'Hội An',
   address: 'Hội An, Quảng Nam, Việt Nam',
   lat: 15.8801,
   lng: 108.338,
@@ -186,7 +188,7 @@ describe('CreateTripScreen', () => {
     await waitFor(() =>
       expect(mockCreateTrip).toHaveBeenCalledWith(
         expect.objectContaining({
-          destination: 'Hội An, Quảng Nam',
+          destination: 'Hội An, Quảng Nam, Việt Nam',
           destination_provider: 'here',
           destination_provider_id: 'canonical-here-id',
           destination_lat: 15.8801,

--- a/mobile/src/features/trips/__tests__/CreateTripScreen.test.tsx
+++ b/mobile/src/features/trips/__tests__/CreateTripScreen.test.tsx
@@ -1,6 +1,12 @@
 import { Pressable, Text, View } from 'react-native';
 
 const mockRouter = { replace: jest.fn(), push: jest.fn(), back: jest.fn() };
+let mockPlacePickerProps: unknown;
+
+function mockRenderPlacePicker(props: unknown) {
+  mockPlacePickerProps = props;
+  return null;
+}
 
 jest.mock('expo-router', () => ({
   useRouter: () => mockRouter,
@@ -8,6 +14,12 @@ jest.mock('expo-router', () => ({
 
 jest.mock('../api', () => ({
   createTrip: jest.fn(),
+}));
+
+// The picker owns its own debounce, abort controllers and HTTP calls; those are
+// proven in src/shared/location. Mocking it keeps this suite about the payload.
+jest.mock('@/shared/location/PlacePicker', () => ({
+  PlacePicker: mockRenderPlacePicker,
 }));
 
 interface MockDateFieldProps {
@@ -39,15 +51,46 @@ function mockDateField({ label, onChange, error }: MockDateFieldProps) {
 jest.mock('@/shared/ui/DateField', () => ({ DateField: mockDateField }));
 
 // eslint-disable-next-line import/first
+import type { ComponentProps } from 'react';
+// eslint-disable-next-line import/first
 import { AxiosError, AxiosHeaders } from 'axios';
 // eslint-disable-next-line import/first
-import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import type { PlacePicker } from '@/shared/location/PlacePicker';
+// eslint-disable-next-line import/first
+import type { ResolvedPlace } from '@/shared/location/types';
 // eslint-disable-next-line import/first
 import { createTrip } from '../api';
 // eslint-disable-next-line import/first
 import { CreateTripScreen } from '../screens/CreateTripScreen';
 
 const mockCreateTrip = createTrip as jest.MockedFunction<typeof createTrip>;
+
+const verifiedPlace: ResolvedPlace = {
+  provider: 'here',
+  provider_id: 'canonical-here-id',
+  label: 'Hội An, Quảng Nam',
+  address: 'Hội An, Quảng Nam, Việt Nam',
+  lat: 15.8801,
+  lng: 108.338,
+  country_code: 'VN',
+};
+
+const emptyDestinationFields = {
+  destination_provider: '',
+  destination_provider_id: '',
+  destination_lat: null,
+  destination_lng: null,
+  destination_country_code: '',
+};
+
+function currentPickerProps(): ComponentProps<typeof PlacePicker> {
+  if (!mockPlacePickerProps) {
+    throw new Error('Expected PlacePicker to be rendered.');
+  }
+  return mockPlacePickerProps as ComponentProps<typeof PlacePicker>;
+}
 
 function axiosErrorWith(status: number, data: unknown): AxiosError {
   const config = { headers: new AxiosHeaders() };
@@ -66,7 +109,10 @@ async function fillRequiredFields(): Promise<void> {
 }
 
 describe('CreateTripScreen', () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPlacePickerProps = undefined;
+  });
 
   it('submits optional values and replaces the route with the created trip detail', async () => {
     mockCreateTrip.mockResolvedValue({ id: 'trip-123' } as never);
@@ -84,6 +130,7 @@ describe('CreateTripScreen', () => {
       expect(mockCreateTrip).toHaveBeenCalledWith({
         name: 'Summer escape',
         destination: 'Da Lat, Vietnam',
+        ...emptyDestinationFields,
         start_date: '2026-06-01',
         end_date: '2026-06-03',
         description: 'Mountain air',
@@ -92,6 +139,88 @@ describe('CreateTripScreen', () => {
       }),
     );
     expect(mockRouter.replace).toHaveBeenCalledWith('/trips/trip-123');
+  });
+
+  it('sends every structured field from one verified place', async () => {
+    mockCreateTrip.mockResolvedValue({ id: 'trip-123' } as never);
+
+    await render(<CreateTripScreen />);
+    await fireEvent.changeText(screen.getByLabelText('Trip name'), 'Hoi An trip');
+    await act(async () => {
+      currentPickerProps().onSelectPlace(verifiedPlace);
+    });
+    await fireEvent.press(screen.getByLabelText('Set Start date to June 1'));
+    await fireEvent.press(screen.getByLabelText('Set End date to June 3'));
+    await fireEvent.press(screen.getByText('Create trip'));
+
+    await waitFor(() =>
+      expect(mockCreateTrip).toHaveBeenCalledWith(
+        expect.objectContaining({
+          destination: 'Hội An, Quảng Nam',
+          destination_provider: 'here',
+          destination_provider_id: 'canonical-here-id',
+          destination_lat: 15.8801,
+          destination_lng: 108.338,
+          destination_country_code: 'VN',
+        }),
+      ),
+    );
+  });
+
+  it('sends explicitly empty structured fields for a manual destination', async () => {
+    mockCreateTrip.mockResolvedValue({ id: 'trip-123' } as never);
+
+    await render(<CreateTripScreen />);
+    await fillRequiredFields();
+    await fireEvent.press(screen.getByText('Create trip'));
+
+    await waitFor(() => expect(mockCreateTrip).toHaveBeenCalled());
+    const payload = mockCreateTrip.mock.calls[0]?.[0];
+    // An omitted key is not the same as an empty one on the server side, so the
+    // manual path must state every column rather than leaving it undefined.
+    expect(payload).toMatchObject({
+      destination: 'Da Lat, Vietnam',
+      ...emptyDestinationFields,
+    });
+    for (const field of Object.keys(emptyDestinationFields)) {
+      expect(payload).toHaveProperty(field);
+    }
+  });
+
+  it('degrades to manual entry and still submits after a lookup failure', async () => {
+    mockCreateTrip.mockResolvedValue({ id: 'trip-123' } as never);
+
+    await render(<CreateTripScreen />);
+    await fireEvent.changeText(screen.getByLabelText('Trip name'), 'Fallback trip');
+    await act(async () => {
+      currentPickerProps().onLookupFailure({
+        label: 'Unverified suggestion',
+        error: { kind: 'network', message: 'Cannot reach the server.' },
+        guidance: 'Enter the location manually.',
+      });
+    });
+    await fireEvent.press(screen.getByText('Create trip'));
+
+    await waitFor(() =>
+      expect(mockCreateTrip).toHaveBeenCalledWith(
+        expect.objectContaining({
+          destination: 'Unverified suggestion',
+          ...emptyDestinationFields,
+        }),
+      ),
+    );
+  });
+
+  it('keeps submit available when place search is unavailable', async () => {
+    await render(<CreateTripScreen />);
+    await fillRequiredFields();
+
+    // The picker renders its own unavailable notice; what matters here is that
+    // the form never depends on it.
+    expect(
+      screen.getByRole('button', { name: 'Create trip' }).props
+        .accessibilityState,
+    ).toEqual(expect.objectContaining({ disabled: false }));
   });
 
   it('blocks a local end-date-before-start-date submission', async () => {

--- a/mobile/src/features/trips/__tests__/CreateTripScreen.test.tsx
+++ b/mobile/src/features/trips/__tests__/CreateTripScreen.test.tsx
@@ -14,6 +14,18 @@ jest.mock('expo-router', () => ({
 
 jest.mock('../api', () => ({
   createTrip: jest.fn(),
+  uploadTripCover: jest.fn(),
+}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('expo-image', () => {
+  const { View } = jest.requireActual('react-native');
+  return { Image: View };
+});
+jest.mock('@/shared/media/pickImage', () => ({ pickImage: jest.fn() }));
+jest.mock('@/shared/media/preprocessImage', () => ({ preprocessImage: jest.fn() }));
+jest.mock('@/shared/media/imageCodec', () => ({
+  nativeImageCodec: { encode: jest.fn(), discard: jest.fn(async () => undefined) },
 }));
 
 // The picker owns its own debounce, abort controllers and HTTP calls; those are
@@ -61,11 +73,29 @@ import type { PlacePicker } from '@/shared/location/PlacePicker';
 // eslint-disable-next-line import/first
 import type { ResolvedPlace } from '@/shared/location/types';
 // eslint-disable-next-line import/first
-import { createTrip } from '../api';
+import { pickImage } from '@/shared/media/pickImage';
+// eslint-disable-next-line import/first
+import { preprocessImage } from '@/shared/media/preprocessImage';
+// eslint-disable-next-line import/first
+import { createTrip, uploadTripCover } from '../api';
 // eslint-disable-next-line import/first
 import { CreateTripScreen } from '../screens/CreateTripScreen';
 
 const mockCreateTrip = createTrip as jest.MockedFunction<typeof createTrip>;
+const mockPick = pickImage as jest.MockedFunction<typeof pickImage>;
+const mockPreprocess = preprocessImage as jest.MockedFunction<typeof preprocessImage>;
+const mockUploadCover = uploadTripCover as jest.MockedFunction<typeof uploadTripCover>;
+
+const pickedImage = { uri: 'file:///cover.heic', width: 4032, height: 3024, fileName: 'IMG_9.HEIC' };
+const processedImage = {
+  uri: 'file:///cover.jpg',
+  name: 'IMG_9.jpg',
+  type: 'image/jpeg',
+  width: 2560,
+  height: 1440,
+  bytes: 900_000,
+} as const;
+const UPLOADED_COVER_URL = '/media/trip-covers/8f0e.webp';
 
 const verifiedPlace: ResolvedPlace = {
   provider: 'here',
@@ -209,6 +239,55 @@ describe('CreateTripScreen', () => {
         }),
       ),
     );
+  });
+
+  it('sends the uploaded cover url with the created trip', async () => {
+    mockCreateTrip.mockResolvedValue({ id: 'trip-123' } as never);
+    mockPick.mockResolvedValue({ status: 'picked', image: pickedImage });
+    mockPreprocess.mockResolvedValue(processedImage);
+    mockUploadCover.mockResolvedValue(UPLOADED_COVER_URL);
+
+    await render(<CreateTripScreen />);
+    await fillRequiredFields();
+    await fireEvent.press(screen.getByLabelText('Choose photo'));
+    await waitFor(() => expect(mockUploadCover).toHaveBeenCalledWith(processedImage));
+    await fireEvent.press(screen.getByText('Create trip'));
+
+    await waitFor(() =>
+      expect(mockCreateTrip).toHaveBeenCalledWith(
+        expect.objectContaining({ cover_image_url: UPLOADED_COVER_URL }),
+      ),
+    );
+  });
+
+  it('omits cover_image_url entirely when no cover was chosen', async () => {
+    mockCreateTrip.mockResolvedValue({ id: 'trip-123' } as never);
+
+    await render(<CreateTripScreen />);
+    await fillRequiredFields();
+    await fireEvent.press(screen.getByText('Create trip'));
+
+    await waitFor(() => expect(mockCreateTrip).toHaveBeenCalled());
+    expect(mockCreateTrip.mock.calls[0]?.[0]).not.toHaveProperty('cover_image_url');
+  });
+
+  it('blocks submit until an in-flight cover upload settles', async () => {
+    mockPick.mockResolvedValue({ status: 'picked', image: pickedImage });
+    mockPreprocess.mockResolvedValue(processedImage);
+    mockUploadCover.mockImplementation(() => new Promise(() => undefined));
+
+    await render(<CreateTripScreen />);
+    await fillRequiredFields();
+    await fireEvent.press(screen.getByLabelText('Choose photo'));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Create trip' }).props.accessibilityState,
+      ).toEqual(expect.objectContaining({ disabled: true })),
+    );
+    expect(screen.getByText('Wait for the cover upload to finish.')).toBeTruthy();
+    await fireEvent.press(screen.getByText('Create trip'));
+    expect(mockCreateTrip).not.toHaveBeenCalled();
   });
 
   it('keeps submit available when place search is unavailable', async () => {

--- a/mobile/src/features/trips/__tests__/CreateTripScreen.test.tsx
+++ b/mobile/src/features/trips/__tests__/CreateTripScreen.test.tsx
@@ -316,7 +316,7 @@ describe('CreateTripScreen', () => {
   it('renders DRF field errors beside their corresponding fields', async () => {
     mockCreateTrip.mockRejectedValue(
       axiosErrorWith(400, {
-        destination: ['Choose a valid destination.'],
+        destination_lat: ['Ensure that there are no more than 6 decimal places.'],
         budget_estimate: ['A non-negative number is required.'],
         currency_code: ['Unsupported trip currency code.'],
       }),
@@ -326,7 +326,11 @@ describe('CreateTripScreen', () => {
     await fillRequiredFields();
     await fireEvent.press(screen.getByText('Create trip'));
 
-    expect(await screen.findByText('Choose a valid destination.')).toBeTruthy();
+    expect(
+      await screen.findByText(
+        'Ensure that there are no more than 6 decimal places.',
+      ),
+    ).toBeTruthy();
     expect(await screen.findByText('A non-negative number is required.')).toBeTruthy();
     expect(await screen.findByText('Unsupported trip currency code.')).toBeTruthy();
   });

--- a/mobile/src/features/trips/__tests__/DestinationField.test.tsx
+++ b/mobile/src/features/trips/__tests__/DestinationField.test.tsx
@@ -1,0 +1,144 @@
+let mockPlacePickerProps: unknown;
+
+function mockRenderPlacePicker(props: unknown) {
+  mockPlacePickerProps = props;
+  return null;
+}
+
+jest.mock('@/shared/location/PlacePicker', () => ({
+  PlacePicker: mockRenderPlacePicker,
+}));
+
+// eslint-disable-next-line import/first
+import type { ComponentProps } from 'react';
+// eslint-disable-next-line import/first
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import type { PlacePicker } from '@/shared/location/PlacePicker';
+// eslint-disable-next-line import/first
+import type { ResolvedPlace } from '@/shared/location/types';
+// eslint-disable-next-line import/first
+import { DestinationField } from '../components/DestinationField';
+// eslint-disable-next-line import/first
+import type { TripDestinationValue } from '../destination';
+
+const place: ResolvedPlace = {
+  provider: 'here',
+  provider_id: 'canonical-here-id',
+  label: 'Hội An, Quảng Nam',
+  address: 'Hội An, Quảng Nam, Việt Nam',
+  lat: 15.8801,
+  lng: 108.338,
+  country_code: 'VN',
+};
+
+const structuredValue: TripDestinationValue = {
+  label: place.label,
+  place,
+};
+
+function currentPickerProps(): ComponentProps<typeof PlacePicker> {
+  if (!mockPlacePickerProps) {
+    throw new Error('Expected PlacePicker to be rendered.');
+  }
+  return mockPlacePickerProps as ComponentProps<typeof PlacePicker>;
+}
+
+describe('DestinationField', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPlacePickerProps = undefined;
+  });
+
+  it('adopts a verified place as a structured destination value', async () => {
+    const onChange = jest.fn();
+    await render(
+      <DestinationField
+        value={{ label: '', place: null }}
+        onChange={onChange}
+      />,
+    );
+
+    await act(async () => {
+      currentPickerProps().onSelectPlace(place);
+    });
+
+    expect(onChange).toHaveBeenCalledWith({ label: place.label, place });
+  });
+
+  it('drops the structured half when the user chooses manual entry', async () => {
+    const onChange = jest.fn();
+    await render(
+      <DestinationField value={structuredValue} onChange={onChange} />,
+    );
+
+    await act(async () => {
+      currentPickerProps().onUseManualEntry({ label: 'Somewhere else' });
+    });
+
+    expect(onChange).toHaveBeenCalledWith({
+      label: 'Somewhere else',
+      place: null,
+    });
+  });
+
+  it('degrades to the suggestion label after a lookup failure', async () => {
+    const onChange = jest.fn();
+    await render(
+      <DestinationField value={structuredValue} onChange={onChange} />,
+    );
+
+    await act(async () => {
+      currentPickerProps().onLookupFailure({
+        label: 'Unverified suggestion',
+        error: { kind: 'network', message: 'Cannot reach the server.' },
+        guidance: 'Enter the location manually.',
+      });
+    });
+
+    expect(onChange).toHaveBeenCalledWith({
+      label: 'Unverified suggestion',
+      place: null,
+    });
+  });
+
+  it('drops a stale verified place as soon as the label is typed over', async () => {
+    const onChange = jest.fn();
+    await render(
+      <DestinationField value={structuredValue} onChange={onChange} />,
+    );
+
+    await fireEvent.changeText(
+      screen.getByLabelText('Destination'),
+      'Hoi An old town',
+    );
+
+    expect(onChange).toHaveBeenCalledWith({
+      label: 'Hoi An old town',
+      place: null,
+    });
+  });
+
+  it('shows the verified place to the picker as a display-only card', async () => {
+    await render(
+      <DestinationField value={structuredValue} onChange={jest.fn()} />,
+    );
+
+    expect(currentPickerProps().value).toEqual({
+      label: place.label,
+      place: { title: place.label, address: place.address },
+    });
+  });
+
+  it('renders a backend destination field error beside the manual input', async () => {
+    await render(
+      <DestinationField
+        value={{ label: 'Da Lat', place: null }}
+        error="Choose a valid destination."
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Choose a valid destination.')).toBeTruthy();
+  });
+});

--- a/mobile/src/features/trips/__tests__/DestinationField.test.tsx
+++ b/mobile/src/features/trips/__tests__/DestinationField.test.tsx
@@ -20,22 +20,21 @@ import type { ResolvedPlace } from '@/shared/location/types';
 // eslint-disable-next-line import/first
 import { DestinationField } from '../components/DestinationField';
 // eslint-disable-next-line import/first
-import type { TripDestinationValue } from '../destination';
+import { destinationValueFromPlace } from '../destination';
 
 const place: ResolvedPlace = {
   provider: 'here',
   provider_id: 'canonical-here-id',
-  label: 'Hội An, Quảng Nam',
+  label: 'Hội An',
   address: 'Hội An, Quảng Nam, Việt Nam',
   lat: 15.8801,
   lng: 108.338,
   country_code: 'VN',
 };
 
-const structuredValue: TripDestinationValue = {
-  label: place.label,
-  place,
-};
+const CANONICAL_DESTINATION = 'Hội An, Quảng Nam, Việt Nam';
+
+const structuredValue = destinationValueFromPlace(place);
 
 function currentPickerProps(): ComponentProps<typeof PlacePicker> {
   if (!mockPlacePickerProps) {
@@ -50,7 +49,7 @@ describe('DestinationField', () => {
     mockPlacePickerProps = undefined;
   });
 
-  it('adopts a verified place as a structured destination value', async () => {
+  it('adopts a verified place under its canonical destination label', async () => {
     const onChange = jest.fn();
     await render(
       <DestinationField
@@ -63,7 +62,7 @@ describe('DestinationField', () => {
       currentPickerProps().onSelectPlace(place);
     });
 
-    expect(onChange).toHaveBeenCalledWith({ label: place.label, place });
+    expect(onChange).toHaveBeenCalledWith({ label: CANONICAL_DESTINATION, place });
   });
 
   it('drops the structured half when the user chooses manual entry', async () => {
@@ -124,9 +123,11 @@ describe('DestinationField', () => {
       <DestinationField value={structuredValue} onChange={jest.fn()} />,
     );
 
+    // The manual input shows what will be submitted; the card keeps the short
+    // title the picker itself displays.
     expect(currentPickerProps().value).toEqual({
-      label: place.label,
-      place: { title: place.label, address: place.address },
+      label: CANONICAL_DESTINATION,
+      place: { title: 'Hội An', address: place.address },
     });
   });
 

--- a/mobile/src/features/trips/__tests__/EditTripScreen.test.tsx
+++ b/mobile/src/features/trips/__tests__/EditTripScreen.test.tsx
@@ -149,10 +149,12 @@ const DESTINATION_KEYS = [
   'destination_country_code',
 ] as const;
 
+// Short suggestion title vs canonical lookup destination — the PATCH must take
+// the canonical one, the same value the web picker persists.
 const verifiedPlace: ResolvedPlace = {
   provider: 'here',
   provider_id: 'canonical-here-id',
-  label: 'Hội An, Quảng Nam',
+  label: 'Hội An',
   address: 'Hội An, Quảng Nam, Việt Nam',
   lat: 15.8801,
   lng: 108.338,
@@ -251,7 +253,7 @@ describe('EditTripScreen', () => {
       expect(mockUpdateTrip).toHaveBeenCalledWith(
         'trip-123',
         expect.objectContaining({
-          destination: 'Hội An, Quảng Nam',
+          destination: 'Hội An, Quảng Nam, Việt Nam',
           destination_provider: 'here',
           destination_provider_id: 'canonical-here-id',
           destination_lat: 15.8801,

--- a/mobile/src/features/trips/__tests__/EditTripScreen.test.tsx
+++ b/mobile/src/features/trips/__tests__/EditTripScreen.test.tsx
@@ -4,6 +4,18 @@ const mockParams = { tripId: 'trip-123' };
 const mockRouter = { dismissTo: jest.fn() };
 const mockUseTripDetail = jest.fn();
 const mockPublishTripEvent = jest.fn();
+let mockPlacePickerProps: unknown;
+
+function mockRenderPlacePicker(props: unknown) {
+  mockPlacePickerProps = props;
+  return null;
+}
+
+// The picker's own debounce/abort/HTTP behaviour is proven in
+// src/shared/location; this suite is about what the PATCH carries.
+jest.mock('@/shared/location/PlacePicker', () => ({
+  PlacePicker: mockRenderPlacePicker,
+}));
 
 jest.mock('expo-router', () => ({
   Stack: { Screen: () => null },
@@ -35,9 +47,15 @@ function MockDateField({ label, onChange, error }: MockDateFieldProps) {
 jest.mock('@/shared/ui/DateField', () => ({ DateField: MockDateField }));
 
 // eslint-disable-next-line import/first
+import type { ComponentProps } from 'react';
+// eslint-disable-next-line import/first
 import { AxiosError, AxiosHeaders } from 'axios';
 // eslint-disable-next-line import/first
-import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import type { PlacePicker } from '@/shared/location/PlacePicker';
+// eslint-disable-next-line import/first
+import type { ResolvedPlace } from '@/shared/location/types';
 // eslint-disable-next-line import/first
 import { updateTrip } from '../api';
 // eslint-disable-next-line import/first
@@ -95,14 +113,41 @@ function readyHook(nextDetail: TripDetailResponse = detail) {
   };
 }
 
+const DESTINATION_KEYS = [
+  'destination',
+  'destination_provider',
+  'destination_provider_id',
+  'destination_lat',
+  'destination_lng',
+  'destination_country_code',
+] as const;
+
+const verifiedPlace: ResolvedPlace = {
+  provider: 'here',
+  provider_id: 'canonical-here-id',
+  label: 'Hội An, Quảng Nam',
+  address: 'Hội An, Quảng Nam, Việt Nam',
+  lat: 15.8801,
+  lng: 108.338,
+  country_code: 'VN',
+};
+
 async function save(): Promise<void> {
   await fireEvent.press(screen.getByText('Save changes'));
+}
+
+function currentPickerProps(): ComponentProps<typeof PlacePicker> {
+  if (!mockPlacePickerProps) {
+    throw new Error('Expected PlacePicker to be rendered.');
+  }
+  return mockPlacePickerProps as ComponentProps<typeof PlacePicker>;
 }
 
 describe('EditTripScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockParams.tripId = 'trip-123';
+    mockPlacePickerProps = undefined;
     mockUseTripDetail.mockReturnValue(readyHook());
   });
 
@@ -139,13 +184,64 @@ describe('EditTripScreen', () => {
     expect(mockRouter.dismissTo).toHaveBeenCalledWith('/trips/trip-123');
   });
 
+  it('keeps the stored destination when only the name changes', async () => {
+    mockUpdateTrip.mockResolvedValue(detail.trip);
+    await render(<EditTripScreen />);
+    await fireEvent.changeText(screen.getByLabelText('Trip name'), 'Renamed trip');
+    await save();
+
+    await waitFor(() => expect(mockUpdateTrip).toHaveBeenCalled());
+    const payload = mockUpdateTrip.mock.calls[0]?.[1];
+    expect(payload).toMatchObject({ name: 'Renamed trip' });
+    // A PATCH that mentions no destination key cannot clear the stored
+    // coordinates the web client also writes.
+    for (const key of DESTINATION_KEYS) {
+      expect(payload).not.toHaveProperty(key);
+    }
+  });
+
   it('does not clear destination metadata when the destination is unchanged', async () => {
     mockUpdateTrip.mockResolvedValue(detail.trip);
     await render(<EditTripScreen />);
     await save();
 
     await waitFor(() => expect(mockUpdateTrip).toHaveBeenCalled());
-    expect(mockUpdateTrip.mock.calls[0]?.[1]).not.toHaveProperty('destination_provider');
+    const payload = mockUpdateTrip.mock.calls[0]?.[1];
+    for (const key of DESTINATION_KEYS) {
+      expect(payload).not.toHaveProperty(key);
+    }
+  });
+
+  it('writes all six destination keys after re-picking a place', async () => {
+    mockUpdateTrip.mockResolvedValue(detail.trip);
+    await render(<EditTripScreen />);
+    await act(async () => {
+      currentPickerProps().onSelectPlace(verifiedPlace);
+    });
+    await save();
+
+    await waitFor(() =>
+      expect(mockUpdateTrip).toHaveBeenCalledWith(
+        'trip-123',
+        expect.objectContaining({
+          destination: 'Hội An, Quảng Nam',
+          destination_provider: 'here',
+          destination_provider_id: 'canonical-here-id',
+          destination_lat: 15.8801,
+          destination_lng: 108.338,
+          destination_country_code: 'VN',
+        }),
+      ),
+    );
+  });
+
+  it('hydrates the picker from the stored structured destination', async () => {
+    await render(<EditTripScreen />);
+
+    expect(currentPickerProps().value).toEqual({
+      label: 'Da Lat, Vietnam',
+      place: { title: 'Da Lat, Vietnam', address: '' },
+    });
   });
 
   it('blocks duplicate submission while the PATCH is pending', async () => {

--- a/mobile/src/features/trips/__tests__/EditTripScreen.test.tsx
+++ b/mobile/src/features/trips/__tests__/EditTripScreen.test.tsx
@@ -345,11 +345,18 @@ describe('EditTripScreen', () => {
 
   it('renders backend field and business errors exactly as returned', async () => {
     mockUpdateTrip.mockRejectedValueOnce(
-      axiosErrorWith(400, { destination: ['Choose a valid destination.'], timezone: ['Use a valid timezone.'] }),
+      axiosErrorWith(400, {
+        destination_lng: ['Ensure that there are no more than 6 decimal places.'],
+        timezone: ['Use a valid timezone.'],
+      }),
     );
     await render(<EditTripScreen />);
     await save();
-    expect(await screen.findByText('Choose a valid destination.')).toBeTruthy();
+    expect(
+      await screen.findByText(
+        'Ensure that there are no more than 6 decimal places.',
+      ),
+    ).toBeTruthy();
     expect(await screen.findByText('Use a valid timezone.')).toBeTruthy();
 
     mockUpdateTrip.mockRejectedValueOnce(axiosErrorWith(409, { detail: 'Trip has already been cancelled.' }));

--- a/mobile/src/features/trips/__tests__/EditTripScreen.test.tsx
+++ b/mobile/src/features/trips/__tests__/EditTripScreen.test.tsx
@@ -26,7 +26,16 @@ jest.mock('expo-router', () => ({
 jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
 jest.mock('../hooks/useTripDetail', () => ({ useTripDetail: (...args: unknown[]) => mockUseTripDetail(...args) }));
 jest.mock('../tripEvents', () => ({ publishTripEvent: (...args: unknown[]) => mockPublishTripEvent(...args) }));
-jest.mock('../api', () => ({ updateTrip: jest.fn() }));
+jest.mock('../api', () => ({ updateTrip: jest.fn(), uploadTripCover: jest.fn() }));
+jest.mock('expo-image', () => {
+  const { View } = jest.requireActual('react-native');
+  return { Image: View };
+});
+jest.mock('@/shared/media/pickImage', () => ({ pickImage: jest.fn() }));
+jest.mock('@/shared/media/preprocessImage', () => ({ preprocessImage: jest.fn() }));
+jest.mock('@/shared/media/imageCodec', () => ({
+  nativeImageCodec: { encode: jest.fn(), discard: jest.fn(async () => undefined) },
+}));
 
 interface MockDateFieldProps {
   label: string;
@@ -57,7 +66,11 @@ import type { PlacePicker } from '@/shared/location/PlacePicker';
 // eslint-disable-next-line import/first
 import type { ResolvedPlace } from '@/shared/location/types';
 // eslint-disable-next-line import/first
-import { updateTrip } from '../api';
+import { pickImage } from '@/shared/media/pickImage';
+// eslint-disable-next-line import/first
+import { preprocessImage } from '@/shared/media/preprocessImage';
+// eslint-disable-next-line import/first
+import { updateTrip, uploadTripCover } from '../api';
 // eslint-disable-next-line import/first
 import { EditTripScreen } from '../screens/EditTripScreen';
 // eslint-disable-next-line import/first
@@ -66,6 +79,20 @@ import type { TripDetailResponse } from '../types';
 import type { ApiError } from '@/shared/api/errors';
 
 const mockUpdateTrip = updateTrip as jest.MockedFunction<typeof updateTrip>;
+const mockPick = pickImage as jest.MockedFunction<typeof pickImage>;
+const mockPreprocess = preprocessImage as jest.MockedFunction<typeof preprocessImage>;
+const mockUploadCover = uploadTripCover as jest.MockedFunction<typeof uploadTripCover>;
+
+const pickedImage = { uri: 'file:///cover.heic', width: 4032, height: 3024, fileName: 'IMG_9.HEIC' };
+const processedImage = {
+  uri: 'file:///cover.jpg',
+  name: 'IMG_9.jpg',
+  type: 'image/jpeg',
+  width: 2560,
+  height: 1440,
+  bytes: 900_000,
+} as const;
+const UPLOADED_COVER_URL = '/media/trip-covers/8f0e.webp';
 const notFoundError: ApiError = { kind: 'message', message: 'Trip not found.', errorCode: 'TRIP_NOT_FOUND', status: 404 };
 
 function axiosErrorWith(status: number, data: unknown): AxiosError {
@@ -242,6 +269,66 @@ describe('EditTripScreen', () => {
       label: 'Da Lat, Vietnam',
       place: { title: 'Da Lat, Vietnam', address: '' },
     });
+  });
+
+  it('omits cover_image_url when the cover is never touched', async () => {
+    mockUpdateTrip.mockResolvedValue(detail.trip);
+    await render(<EditTripScreen />);
+    await save();
+
+    await waitFor(() => expect(mockUpdateTrip).toHaveBeenCalled());
+    expect(mockUpdateTrip.mock.calls[0]?.[1]).not.toHaveProperty('cover_image_url');
+  });
+
+  it('clears the cover with an empty string after Remove', async () => {
+    mockUpdateTrip.mockResolvedValue(detail.trip);
+    await render(<EditTripScreen />);
+    await fireEvent.press(screen.getByLabelText('Remove photo'));
+    await save();
+
+    await waitFor(() =>
+      expect(mockUpdateTrip).toHaveBeenCalledWith(
+        'trip-123',
+        expect.objectContaining({ cover_image_url: '' }),
+      ),
+    );
+  });
+
+  it('replaces the cover with the newly uploaded url', async () => {
+    mockUpdateTrip.mockResolvedValue(detail.trip);
+    mockPick.mockResolvedValue({ status: 'picked', image: pickedImage });
+    mockPreprocess.mockResolvedValue(processedImage);
+    mockUploadCover.mockResolvedValue(UPLOADED_COVER_URL);
+
+    await render(<EditTripScreen />);
+    await fireEvent.press(screen.getByLabelText('Replace photo'));
+    await waitFor(() => expect(mockUploadCover).toHaveBeenCalledWith(processedImage));
+    await save();
+
+    await waitFor(() =>
+      expect(mockUpdateTrip).toHaveBeenCalledWith(
+        'trip-123',
+        expect.objectContaining({ cover_image_url: UPLOADED_COVER_URL }),
+      ),
+    );
+  });
+
+  it('blocks submit until an in-flight cover upload settles', async () => {
+    mockPick.mockResolvedValue({ status: 'picked', image: pickedImage });
+    mockPreprocess.mockResolvedValue(processedImage);
+    mockUploadCover.mockImplementation(() => new Promise(() => undefined));
+
+    await render(<EditTripScreen />);
+    await fireEvent.press(screen.getByLabelText('Replace photo'));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Save changes' }).props.accessibilityState,
+      ).toEqual(expect.objectContaining({ disabled: true })),
+    );
+    expect(screen.getByText('Wait for the cover upload to finish.')).toBeTruthy();
+    await save();
+    expect(mockUpdateTrip).not.toHaveBeenCalled();
   });
 
   it('blocks duplicate submission while the PATCH is pending', async () => {

--- a/mobile/src/features/trips/__tests__/TripDetailScreen.test.tsx
+++ b/mobile/src/features/trips/__tests__/TripDetailScreen.test.tsx
@@ -25,7 +25,16 @@ jest.mock('expo-router', () => ({
 }));
 
 jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
-jest.mock('expo-image', () => ({ Image: () => null }));
+// A testID-bearing stand-in, so a coverless trip is distinguishable from one
+// that renders a cover — `() => null` would look identical either way.
+jest.mock('expo-image', () => {
+  const { View } = jest.requireActual('react-native');
+  const { createElement } = jest.requireActual('react');
+  return {
+    Image: (props: Record<string, unknown>) =>
+      createElement(View, { ...props, testID: 'trip-cover-image' }),
+  };
+});
 jest.mock('../hooks/useTripDetail', () => ({ useTripDetail: (...args: unknown[]) => mockUseTripDetail(...args) }));
 jest.mock('../hooks/usePendingInvitations', () => ({
   usePendingInvitations: (...args: unknown[]) => mockUsePendingInvitations(...args),
@@ -169,6 +178,19 @@ describe('TripDetailScreen', () => {
     expect(mockRouter.push).toHaveBeenCalledWith('/trips/trip-123/edit');
     await fireEvent.press(screen.getByRole('button', { name: 'Invite friends' }));
     expect(mockRouter.push).toHaveBeenCalledWith('/trips/trip-123/invite');
+  });
+
+  it('renders the stored cover, and the placeholder when the trip has none', async () => {
+    await render(<TripDetailScreen />);
+    expect(await screen.findByTestId('trip-cover-image')).toBeTruthy();
+
+    mockUseTripDetail.mockReturnValue(
+      readyHook({ ...tripDetail, trip: { ...tripDetail.trip, cover_image_url: '' } }),
+    );
+    await render(<TripDetailScreen />);
+
+    expect(screen.queryByTestId('trip-cover-image')).toBeNull();
+    expect(await screen.findByText('Overview')).toBeTruthy();
   });
 
   it('shows Timeline and Expenses Planning entries to every readable trip', async () => {

--- a/mobile/src/features/trips/__tests__/destination.test.ts
+++ b/mobile/src/features/trips/__tests__/destination.test.ts
@@ -53,6 +53,21 @@ describe('destinationFields', () => {
     });
   });
 
+  it('rounds structured coordinates to the backend six-decimal contract', () => {
+    expect(
+      destinationFields(
+        destinationValueFromPlace({
+          ...place,
+          lat: 15.880123789,
+          lng: 108.338987654,
+        }),
+      ),
+    ).toMatchObject({
+      destination_lat: 15.880124,
+      destination_lng: 108.338988,
+    });
+  });
+
   it('clears all five structured columns for a manual value', () => {
     expect(
       destinationFields(manualDestinationValue('  Nha Trang, Vietnam  ')),

--- a/mobile/src/features/trips/__tests__/destination.test.ts
+++ b/mobile/src/features/trips/__tests__/destination.test.ts
@@ -1,0 +1,130 @@
+import type { ResolvedPlace } from '@/shared/location/types';
+import {
+  destinationFields,
+  destinationValueFromPlace,
+  destinationValueFromTrip,
+  manualDestinationValue,
+} from '../destination';
+import type { Trip } from '../types';
+
+const place: ResolvedPlace = {
+  provider: 'here',
+  provider_id: 'canonical-here-id',
+  label: 'Hội An, Quảng Nam',
+  address: 'Hội An, Quảng Nam, Việt Nam',
+  lat: 15.8801,
+  lng: 108.338,
+  country_code: 'VN',
+};
+
+function buildTrip(overrides: Partial<Trip> = {}): Trip {
+  return {
+    id: 'trip-1',
+    name: 'Da Lat escape',
+    destination: 'Da Lat, Vietnam',
+    destination_provider: 'here',
+    destination_provider_id: 'here:place:da-lat',
+    destination_lat: '11.940400',
+    destination_lng: '108.458300',
+    destination_country_code: 'VN',
+    cover_image_url: '',
+    start_date: '2026-06-01',
+    end_date: '2026-06-03',
+    description: '',
+    status: 'PLANNING',
+    currency_code: 'VND',
+    timezone: 'Asia/Ho_Chi_Minh',
+    budget_estimate: null,
+    cancelled_at: null,
+    created_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('destinationFields', () => {
+  it('writes all five structured columns from one verified place', () => {
+    expect(destinationFields(destinationValueFromPlace(place))).toEqual({
+      destination: place.label,
+      destination_provider: 'here',
+      destination_provider_id: 'canonical-here-id',
+      destination_lat: 15.8801,
+      destination_lng: 108.338,
+      destination_country_code: 'VN',
+    });
+  });
+
+  it('clears all five structured columns for a manual value', () => {
+    expect(
+      destinationFields(manualDestinationValue('  Nha Trang, Vietnam  ')),
+    ).toEqual({
+      destination: 'Nha Trang, Vietnam',
+      destination_provider: '',
+      destination_provider_id: '',
+      destination_lat: null,
+      destination_lng: null,
+      destination_country_code: '',
+    });
+  });
+
+  it('never emits undefined for a structured column on a manual value', () => {
+    // An omitted key on a PATCH leaves the stored value in place, which is the
+    // exact data corruption this milestone exists to prevent.
+    const fields = destinationFields(manualDestinationValue('Sa Pa'));
+
+    for (const value of Object.values(fields)) {
+      expect(value).not.toBeUndefined();
+    }
+    expect(Object.keys(fields)).toHaveLength(6);
+  });
+});
+
+describe('destinationValueFromTrip', () => {
+  it('rebuilds a display place from a structured trip', () => {
+    const value = destinationValueFromTrip(buildTrip());
+
+    expect(value.label).toBe('Da Lat, Vietnam');
+    expect(value.place).toEqual({
+      provider: 'here',
+      provider_id: 'here:place:da-lat',
+      label: 'Da Lat, Vietnam',
+      address: '',
+      lat: 11.9404,
+      lng: 108.4583,
+      country_code: 'VN',
+    });
+  });
+
+  it('treats a trip without a provider id as manual', () => {
+    const value = destinationValueFromTrip(
+      buildTrip({
+        destination_provider: '',
+        destination_provider_id: '',
+        destination_lat: null,
+        destination_lng: null,
+        destination_country_code: '',
+      }),
+    );
+
+    expect(value.label).toBe('Da Lat, Vietnam');
+    expect(value.place).toBeNull();
+  });
+
+  it('keeps a structured trip whose stored coordinates are null', () => {
+    const value = destinationValueFromTrip(
+      buildTrip({ destination_lat: null, destination_lng: null }),
+    );
+
+    expect(value.place).not.toBeNull();
+    expect(value.place?.lat).toBeNull();
+    expect(value.place?.lng).toBeNull();
+  });
+
+  it('never produces NaN from an unparseable stored coordinate', () => {
+    const value = destinationValueFromTrip(
+      buildTrip({ destination_lat: 'not-a-number', destination_lng: '' }),
+    );
+
+    expect(value.place?.lat).toBeNull();
+    expect(value.place?.lng).toBeNull();
+  });
+});

--- a/mobile/src/features/trips/__tests__/destination.test.ts
+++ b/mobile/src/features/trips/__tests__/destination.test.ts
@@ -4,13 +4,16 @@ import {
   destinationValueFromPlace,
   destinationValueFromTrip,
   manualDestinationValue,
+  TRIP_DESTINATION_MAX_LENGTH,
 } from '../destination';
 import type { Trip } from '../types';
 
+// The short suggestion title and the canonical lookup destination differ on
+// purpose: that difference is the whole point of these expectations.
 const place: ResolvedPlace = {
   provider: 'here',
   provider_id: 'canonical-here-id',
-  label: 'Hội An, Quảng Nam',
+  label: 'Hội An',
   address: 'Hội An, Quảng Nam, Việt Nam',
   lat: 15.8801,
   lng: 108.338,
@@ -41,10 +44,33 @@ function buildTrip(overrides: Partial<Trip> = {}): Trip {
   };
 }
 
+describe('destinationValueFromPlace', () => {
+  it('adopts the canonical lookup destination, not the short suggestion title', () => {
+    expect(destinationValueFromPlace(place).label).toBe(
+      'Hội An, Quảng Nam, Việt Nam',
+    );
+  });
+
+  it('truncates a canonical destination past the 200 cap by code point', () => {
+    const address = `${'🏝'.repeat(210)}`;
+
+    const { label } = destinationValueFromPlace({ ...place, address });
+
+    expect(Array.from(label)).toHaveLength(TRIP_DESTINATION_MAX_LENGTH);
+    expect(label).toBe('🏝'.repeat(TRIP_DESTINATION_MAX_LENGTH));
+  });
+
+  it('falls back to the label when the lookup carried no canonical destination', () => {
+    expect(destinationValueFromPlace({ ...place, address: '   ' }).label).toBe(
+      'Hội An',
+    );
+  });
+});
+
 describe('destinationFields', () => {
   it('writes all five structured columns from one verified place', () => {
     expect(destinationFields(destinationValueFromPlace(place))).toEqual({
-      destination: place.label,
+      destination: 'Hội An, Quảng Nam, Việt Nam',
       destination_provider: 'here',
       destination_provider_id: 'canonical-here-id',
       destination_lat: 15.8801,

--- a/mobile/src/features/trips/__tests__/uploadTripCover.test.ts
+++ b/mobile/src/features/trips/__tests__/uploadTripCover.test.ts
@@ -1,0 +1,32 @@
+jest.mock('@/shared/media/uploadFile', () => ({ uploadFile: jest.fn() }));
+
+// eslint-disable-next-line import/first
+import type { UploadableFile } from '@/shared/media/types';
+// eslint-disable-next-line import/first
+import { uploadFile } from '@/shared/media/uploadFile';
+// eslint-disable-next-line import/first
+import { TRIP_COVER_UPLOAD_TIMEOUT_MS, uploadTripCover } from '../api';
+
+// Lives apart from api.test.ts: that file mocks the axios client itself, while a
+// cover goes out through the shared multipart helper.
+const mockUploadFile = uploadFile as jest.MockedFunction<typeof uploadFile>;
+
+const file: UploadableFile = { uri: 'file:///cover.jpg', name: 'cover.jpg', type: 'image/jpeg' };
+
+describe('uploadTripCover', () => {
+  beforeEach(() => mockUploadFile.mockReset());
+
+  it('posts the cover with a timeout long enough for a 10 MB body', async () => {
+    mockUploadFile.mockResolvedValue({ url: '/media/trip-covers/abc.webp' });
+
+    await expect(uploadTripCover(file)).resolves.toBe('/media/trip-covers/abc.webp');
+
+    expect(mockUploadFile).toHaveBeenCalledWith('/media/trip-covers', 'file', file, 'post', {
+      timeoutMs: TRIP_COVER_UPLOAD_TIMEOUT_MS,
+    });
+  });
+
+  it('keeps a cover timeout well above the 15s client default', () => {
+    expect(TRIP_COVER_UPLOAD_TIMEOUT_MS).toBeGreaterThanOrEqual(120_000);
+  });
+});

--- a/mobile/src/features/trips/__tests__/useTripCoverUpload.test.tsx
+++ b/mobile/src/features/trips/__tests__/useTripCoverUpload.test.tsx
@@ -1,0 +1,219 @@
+jest.mock('@/shared/media/pickImage', () => ({ pickImage: jest.fn() }));
+jest.mock('@/shared/media/preprocessImage', () => ({ preprocessImage: jest.fn() }));
+jest.mock('@/shared/media/imageCodec', () => ({
+  nativeImageCodec: { encode: jest.fn(), discard: jest.fn(async () => undefined) },
+}));
+jest.mock('../api', () => ({ uploadTripCover: jest.fn() }));
+
+// eslint-disable-next-line import/first
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+// eslint-disable-next-line import/first
+import { axiosError } from '@test/axiosError';
+// eslint-disable-next-line import/first
+import { nativeImageCodec } from '@/shared/media/imageCodec';
+// eslint-disable-next-line import/first
+import { pickImage } from '@/shared/media/pickImage';
+// eslint-disable-next-line import/first
+import { preprocessImage } from '@/shared/media/preprocessImage';
+// eslint-disable-next-line import/first
+import { ImagePreprocessError } from '@/shared/media/types';
+// eslint-disable-next-line import/first
+import { uploadTripCover } from '../api';
+// eslint-disable-next-line import/first
+import { useTripCoverUpload } from '../hooks/useTripCoverUpload';
+
+const mockPick = pickImage as jest.MockedFunction<typeof pickImage>;
+const mockPreprocess = preprocessImage as jest.MockedFunction<typeof preprocessImage>;
+const mockUpload = uploadTripCover as jest.MockedFunction<typeof uploadTripCover>;
+
+const picked = { uri: 'file:///cover.heic', width: 4032, height: 3024, fileName: 'IMG_9.HEIC' };
+const processed = {
+  uri: 'file:///cover.jpg',
+  name: 'IMG_9.jpg',
+  type: 'image/jpeg',
+  width: 2560,
+  height: 1920,
+  bytes: 1_200_000,
+} as const;
+const UPLOADED_URL = '/media/trip-covers/8f0e.webp';
+
+function pickAndUploadSucceed(): void {
+  mockPick.mockResolvedValue({ status: 'picked', image: picked });
+  mockPreprocess.mockResolvedValue(processed);
+  mockUpload.mockResolvedValue(UPLOADED_URL);
+}
+
+describe('useTripCoverUpload', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // clearAllMocks keeps implementations, so restore the default rather than
+    // letting one test's rejecting discard leak into the next.
+    (nativeImageCodec.discard as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it('starts from the trip cover it was given', async () => {
+    const { result } = await renderHook(() => useTripCoverUpload('/media/trip-covers/a.webp'));
+
+    expect(result.current.coverUrl).toBe('/media/trip-covers/a.webp');
+    expect(result.current.changed).toBe(false);
+    expect(result.current.busy).toBe(false);
+  });
+
+  it('holds the server-returned url after a successful upload', async () => {
+    pickAndUploadSucceed();
+
+    const { result } = await renderHook(() => useTripCoverUpload());
+    await act(async () => { await result.current.chooseCover(); });
+
+    expect(mockPick).toHaveBeenCalledWith({ square: false });
+    expect(mockPreprocess).toHaveBeenCalledWith(
+      picked,
+      { maxEdgePx: 2560, maxBytes: 10_485_760 },
+      expect.anything(),
+    );
+    expect(mockUpload).toHaveBeenCalledWith(processed);
+    await waitFor(() => expect(result.current.status).toBe('idle'));
+    expect(result.current.coverUrl).toBe(UPLOADED_URL);
+    expect(result.current.changed).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('treats cancellation as a no-op', async () => {
+    mockPick.mockResolvedValue({ status: 'cancelled' });
+
+    const { result } = await renderHook(() => useTripCoverUpload('/media/trip-covers/a.webp'));
+    await act(async () => { await result.current.chooseCover(); });
+
+    expect(mockUpload).not.toHaveBeenCalled();
+    expect(result.current.status).toBe('idle');
+    expect(result.current.coverUrl).toBe('/media/trip-covers/a.webp');
+    expect(result.current.changed).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('reports a preprocess failure in our own words without contacting the server', async () => {
+    mockPick.mockResolvedValue({ status: 'picked', image: picked });
+    mockPreprocess.mockRejectedValue(new ImagePreprocessError('BUDGET_UNREACHABLE', 'internal'));
+
+    const { result } = await renderHook(() => useTripCoverUpload('/media/trip-covers/a.webp'));
+    await act(async () => { await result.current.chooseCover(); });
+
+    expect(mockUpload).not.toHaveBeenCalled();
+    expect(result.current.error).toBe('Could not prepare that photo. Try another one.');
+    expect(result.current.coverUrl).toBe('/media/trip-covers/a.webp');
+    expect(result.current.status).toBe('idle');
+  });
+
+  it.each([
+    ['NO_FILE', 'No file was uploaded.'],
+    ['UNSUPPORTED_IMAGE_FORMAT', 'Unsupported image format.'],
+  ])('surfaces the server message for %s exactly as returned', async (errorCode, detail) => {
+    mockPick.mockResolvedValue({ status: 'picked', image: picked });
+    mockPreprocess.mockResolvedValue(processed);
+    mockUpload.mockRejectedValue(axiosError(400, { detail, error_code: errorCode }));
+
+    const { result } = await renderHook(() => useTripCoverUpload());
+    await act(async () => { await result.current.chooseCover(); });
+
+    expect(result.current.error).toBe(detail);
+    expect(result.current.coverUrl).toBe('');
+    expect(result.current.status).toBe('idle');
+  });
+
+  it('surfaces an exhausted media_upload budget as the throttle message', async () => {
+    mockPick.mockResolvedValue({ status: 'picked', image: picked });
+    mockPreprocess.mockResolvedValue(processed);
+    mockUpload.mockRejectedValue(axiosError(429, {}));
+
+    const { result } = await renderHook(() => useTripCoverUpload());
+    await act(async () => { await result.current.chooseCover(); });
+
+    expect(result.current.error).toBe('Too many attempts. Please wait a moment and try again.');
+  });
+
+  it('clears the previous error when a retry succeeds', async () => {
+    mockPick.mockResolvedValue({ status: 'picked', image: picked });
+    mockPreprocess.mockResolvedValue(processed);
+    mockUpload.mockRejectedValueOnce(axiosError(429, {})).mockResolvedValueOnce(UPLOADED_URL);
+
+    const { result } = await renderHook(() => useTripCoverUpload());
+    await act(async () => { await result.current.chooseCover(); });
+    expect(result.current.error).not.toBeNull();
+
+    await act(async () => { await result.current.chooseCover(); });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.coverUrl).toBe(UPLOADED_URL);
+  });
+
+  it('ignores a second tap that lands before the first upload finishes', async () => {
+    pickAndUploadSucceed();
+
+    const { result } = await renderHook(() => useTripCoverUpload());
+    // Both taps are dispatched before React can re-render and disable the
+    // button, which is exactly what a fast double tap produces on device.
+    await act(async () => {
+      await Promise.all([result.current.chooseCover(), result.current.chooseCover()]);
+    });
+
+    expect(mockPick).toHaveBeenCalledTimes(1);
+    expect(mockUpload).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the cover locally without calling any delete endpoint', async () => {
+    pickAndUploadSucceed();
+
+    const { result } = await renderHook(() => useTripCoverUpload('/media/trip-covers/a.webp'));
+    await act(async () => { result.current.removeCover(); });
+
+    expect(result.current.coverUrl).toBe('');
+    expect(result.current.changed).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('discards both temp files once the upload is done', async () => {
+    pickAndUploadSucceed();
+
+    const { result } = await renderHook(() => useTripCoverUpload());
+    await act(async () => { await result.current.chooseCover(); });
+
+    expect(nativeImageCodec.discard).toHaveBeenCalledWith(picked.uri);
+    expect(nativeImageCodec.discard).toHaveBeenCalledWith(processed.uri);
+  });
+
+  it('discards the picked source on the failure path too', async () => {
+    mockPick.mockResolvedValue({ status: 'picked', image: picked });
+    mockPreprocess.mockResolvedValue(processed);
+    mockUpload.mockRejectedValue(axiosError(400, { detail: 'Unsupported image format.' }));
+
+    const { result } = await renderHook(() => useTripCoverUpload());
+    await act(async () => { await result.current.chooseCover(); });
+
+    expect(nativeImageCodec.discard).toHaveBeenCalledWith(picked.uri);
+    expect(nativeImageCodec.discard).toHaveBeenCalledWith(processed.uri);
+    expect(result.current.error).not.toBeNull();
+  });
+
+  it('still reports success when discarding a temp file fails', async () => {
+    pickAndUploadSucceed();
+    (nativeImageCodec.discard as jest.Mock).mockRejectedValue(new Error('delete failed'));
+
+    const { result } = await renderHook(() => useTripCoverUpload());
+    await act(async () => { await result.current.chooseCover(); });
+
+    expect(result.current.coverUrl).toBe(UPLOADED_URL);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('dismissError clears a previous failure', async () => {
+    mockPick.mockResolvedValue({ status: 'picked', image: picked });
+    mockPreprocess.mockRejectedValue(new ImagePreprocessError('UNREADABLE', 'internal'));
+
+    const { result } = await renderHook(() => useTripCoverUpload());
+    await act(async () => { await result.current.chooseCover(); });
+    expect(result.current.error).not.toBeNull();
+
+    await act(async () => { result.current.dismissError(); });
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/mobile/src/features/trips/api.ts
+++ b/mobile/src/features/trips/api.ts
@@ -91,11 +91,22 @@ export async function removeTripMember(tripId: string, userId: string): Promise<
 }
 
 /**
+ * A cover is preprocessed down to at most 10 MB, which is roughly 80 megabits of
+ * body before multipart overhead — past the client's 15s default at any mobile
+ * uplink below ~6 Mbps, before the server has read, validated and re-encoded it.
+ * Two minutes covers ~10 MB near 1 Mbps plus that processing, and still bounds a
+ * dead request instead of leaving the form stuck on "uploading" forever.
+ */
+export const TRIP_COVER_UPLOAD_TIMEOUT_MS = 120_000;
+
+/**
  * The upload does not attach itself to a trip; the returned `/media/...` path is
  * an input to the next trip create or update.
  */
 export async function uploadTripCover(file: UploadableFile): Promise<string> {
   // Field name is `file` — /api/auth/avatar uses `avatar`, this endpoint does not.
-  const data = await uploadFile<{ url: string }>('/media/trip-covers', 'file', file, 'post');
+  const data = await uploadFile<{ url: string }>('/media/trip-covers', 'file', file, 'post', {
+    timeoutMs: TRIP_COVER_UPLOAD_TIMEOUT_MS,
+  });
   return data.url;
 }

--- a/mobile/src/features/trips/api.ts
+++ b/mobile/src/features/trips/api.ts
@@ -1,5 +1,7 @@
 import { apiClient } from '@/shared/api/client';
 import { extractCursor, type CursorPaginatedResponse } from '@/shared/api/pagination';
+import type { UploadableFile } from '@/shared/media/types';
+import { uploadFile } from '@/shared/media/uploadFile';
 import type {
   CreateTripInput,
   InvitableFriend,
@@ -86,4 +88,14 @@ export async function sendTripInvitations(
 
 export async function removeTripMember(tripId: string, userId: string): Promise<void> {
   await apiClient.delete(`/trips/${tripId}/members/${userId}`);
+}
+
+/**
+ * The upload does not attach itself to a trip; the returned `/media/...` path is
+ * an input to the next trip create or update.
+ */
+export async function uploadTripCover(file: UploadableFile): Promise<string> {
+  // Field name is `file` — /api/auth/avatar uses `avatar`, this endpoint does not.
+  const data = await uploadFile<{ url: string }>('/media/trip-covers', 'file', file, 'post');
+  return data.url;
 }

--- a/mobile/src/features/trips/components/CoverImageField.tsx
+++ b/mobile/src/features/trips/components/CoverImageField.tsx
@@ -1,0 +1,119 @@
+import { Ionicons } from '@expo/vector-icons';
+import { Image } from 'expo-image';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { resolveMediaUrl } from '@/shared/api/base-url';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { Button } from '@/shared/ui/Button';
+import type { TripCoverStatus } from '../hooks/useTripCoverUpload';
+
+interface CoverImageFieldProps {
+  coverUrl: string;
+  status: TripCoverStatus;
+  error: string | null;
+  disabled?: boolean;
+  onChoose: () => void;
+  onRemove: () => void;
+}
+
+export function CoverImageField({
+  coverUrl,
+  status,
+  error,
+  disabled = false,
+  onChoose,
+  onRemove,
+}: CoverImageFieldProps) {
+  const busy = status !== 'idle';
+  const previewUrl = resolveMediaUrl(coverUrl || null);
+
+  return (
+    <View style={styles.wrap}>
+      {previewUrl ? (
+        <Image
+          accessibilityLabel="Trip cover preview"
+          source={{ uri: previewUrl }}
+          style={styles.preview}
+          contentFit="cover"
+          transition={150}
+        />
+      ) : (
+        <View style={styles.placeholder}>
+          <Ionicons name="image-outline" size={28} color={colors.textMuted} />
+          <Text style={styles.placeholderText}>No cover photo yet</Text>
+        </View>
+      )}
+
+      {busy ? (
+        <View
+          accessibilityLabel="Uploading cover"
+          accessibilityRole="progressbar"
+          style={styles.uploading}
+        >
+          <ActivityIndicator color={colors.primary} size="small" />
+          <Text style={styles.uploadingText}>Uploading cover…</Text>
+        </View>
+      ) : null}
+
+      <View style={styles.actions}>
+        <View style={styles.action}>
+          <Button
+            title={coverUrl ? 'Replace photo' : 'Choose photo'}
+            variant="secondary"
+            onPress={onChoose}
+            disabled={disabled || busy}
+          />
+        </View>
+        {coverUrl ? (
+          <View style={styles.action}>
+            <Button
+              title="Remove photo"
+              variant="secondary"
+              onPress={onRemove}
+              disabled={disabled || busy}
+            />
+          </View>
+        ) : null}
+      </View>
+
+      {/* Buttons stay enabled behind an error: that is the retry path. */}
+      {error ? (
+        <Text accessibilityRole="alert" style={styles.error}>
+          {error}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { gap: spacing.sm },
+  preview: {
+    width: '100%',
+    aspectRatio: 16 / 9,
+    borderRadius: radii.md,
+    backgroundColor: colors.background,
+  },
+  placeholder: {
+    width: '100%',
+    aspectRatio: 16 / 9,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xs,
+    borderWidth: 1,
+    borderStyle: 'dashed',
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    backgroundColor: colors.background,
+  },
+  placeholderText: { ...typography.caption, color: colors.textMuted },
+  uploading: {
+    minHeight: 28,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  uploadingText: { ...typography.caption, color: colors.textMuted },
+  actions: { flexDirection: 'row', gap: spacing.sm },
+  action: { flex: 1 },
+  error: { ...typography.caption, color: colors.danger },
+});

--- a/mobile/src/features/trips/components/DestinationField.tsx
+++ b/mobile/src/features/trips/components/DestinationField.tsx
@@ -1,0 +1,67 @@
+import { StyleSheet, View } from 'react-native';
+import { PlacePicker } from '@/shared/location/PlacePicker';
+import { spacing } from '@/shared/theme/tokens';
+import { TextField } from '@/shared/ui/TextField';
+import {
+  destinationValueFromPlace,
+  manualDestinationValue,
+  TRIP_DESTINATION_MAX_LENGTH,
+  type TripDestinationValue,
+} from '../destination';
+
+interface DestinationFieldProps {
+  value: TripDestinationValue;
+  disabled?: boolean;
+  error?: string;
+  onChange: (next: TripDestinationValue) => void;
+}
+
+/**
+ * The trips-side adapter around the shared picker: it owns the mapping from a
+ * neutral ResolvedPlace onto the trip destination model, so neither trip screen
+ * repeats it.
+ *
+ * The manual text field below the picker is what keeps the form submittable when
+ * HERE is unavailable — the picker's unavailable/429/network states are advisory,
+ * never blocking. Typing there also drops a stale structured place, because a
+ * hand-edited label no longer describes the verified one.
+ */
+export function DestinationField({
+  value,
+  disabled = false,
+  error,
+  onChange,
+}: DestinationFieldProps) {
+  return (
+    <View style={styles.wrap}>
+      <PlacePicker
+        value={{
+          label: value.label,
+          place: value.place
+            ? { title: value.place.label, address: value.place.address }
+            : null,
+        }}
+        disabled={disabled}
+        onSelectPlace={(place) => onChange(destinationValueFromPlace(place))}
+        onUseManualEntry={(entry) => onChange(manualDestinationValue(entry.label))}
+        onLookupFailure={(failure) =>
+          onChange(manualDestinationValue(failure.label))
+        }
+      />
+      <TextField
+        label="Destination *"
+        accessibilityLabel="Destination"
+        placeholder="Da Lat, Vietnam"
+        value={value.label}
+        onChangeText={(text) => onChange(manualDestinationValue(text))}
+        maxLength={TRIP_DESTINATION_MAX_LENGTH}
+        editable={!disabled}
+        error={error}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { gap: spacing.md },
+});

--- a/mobile/src/features/trips/coverMedia.ts
+++ b/mobile/src/features/trips/coverMedia.ts
@@ -1,0 +1,26 @@
+import { normalizeApiError } from '@/shared/api/errors';
+import { ImagePreprocessError, type PreprocessTarget } from '@/shared/media/types';
+
+/**
+ * Mirrors backend TRIP_COVER_MAX_EDGE / TRIP_COVER_MAX_BYTES, and the web target
+ * in frontend/features/trips/presentation/cover-image-picker.tsx. Preprocessing
+ * is a transport-size optimisation; the server re-encodes every accepted upload
+ * to WebP and remains the sole validator.
+ */
+export const TRIP_COVER_TARGET: PreprocessTarget = {
+  maxEdgePx: 2560,
+  maxBytes: 10 * 1024 * 1024,
+};
+
+const PREPROCESS_FAILED_MESSAGE = 'Could not prepare that photo. Try another one.';
+
+/**
+ * Server error copy is already user-facing and per-error-code distinct, so it is
+ * shown as returned. Only genuinely client-side failures get our own wording.
+ */
+export function describeCoverError(error: unknown): string {
+  if (error instanceof ImagePreprocessError) {
+    return PREPROCESS_FAILED_MESSAGE;
+  }
+  return normalizeApiError(error).message;
+}

--- a/mobile/src/features/trips/destination.ts
+++ b/mobile/src/features/trips/destination.ts
@@ -31,7 +31,9 @@ export interface TripDestinationFields {
  *
  * The rebuilt place is display-only: it drives the "Selected place" card and the
  * initial label, and never reaches a payload unless the user re-picks. A stored
- * trip has no separate address, so that field stays empty.
+ * trip has no separate address, so that field stays empty, and `provider` is the
+ * only value ResolvedPlace admits — a row written by an older provider still
+ * renders correctly, and re-picking replaces the whole place from a fresh lookup.
  */
 export function destinationValueFromTrip(trip: Trip): TripDestinationValue {
   if (trip.destination_provider_id === '') {

--- a/mobile/src/features/trips/destination.ts
+++ b/mobile/src/features/trips/destination.ts
@@ -1,0 +1,106 @@
+import type { ResolvedPlace } from '@/shared/location/types';
+import type { Trip } from './types';
+
+/** Trip.destination is max_length=200, the same cap the shared picker enforces. */
+export const TRIP_DESTINATION_MAX_LENGTH = 200;
+
+/** What a trip form holds for the destination field. */
+export interface TripDestinationValue {
+  /** Goes to `destination`. Trimmed at submit time, not while typing. */
+  label: string;
+  /** Null in manual mode. */
+  place: ResolvedPlace | null;
+}
+
+/**
+ * Every key is required on purpose. `Pick<UpdateTripInput, …>` would inherit the
+ * optional modifiers, and an accidentally omitted key on a PATCH leaves stale
+ * data in the column instead of clearing it.
+ */
+export interface TripDestinationFields {
+  destination: string;
+  destination_provider: string;
+  destination_provider_id: string;
+  destination_lat: number | null;
+  destination_lng: number | null;
+  destination_country_code: string;
+}
+
+/**
+ * Hydrate the edit form from a stored trip.
+ *
+ * The rebuilt place is display-only: it drives the "Selected place" card and the
+ * initial label, and never reaches a payload unless the user re-picks. A stored
+ * trip has no separate address, so that field stays empty.
+ */
+export function destinationValueFromTrip(trip: Trip): TripDestinationValue {
+  if (trip.destination_provider_id === '') {
+    return { label: trip.destination, place: null };
+  }
+
+  return {
+    label: trip.destination,
+    place: {
+      provider: 'here',
+      provider_id: trip.destination_provider_id,
+      label: trip.destination,
+      address: '',
+      lat: parseStoredCoordinate(trip.destination_lat),
+      lng: parseStoredCoordinate(trip.destination_lng),
+      country_code: trip.destination_country_code,
+    },
+  };
+}
+
+/** Adopt a verified place. */
+export function destinationValueFromPlace(
+  place: ResolvedPlace,
+): TripDestinationValue {
+  return { label: place.label, place };
+}
+
+/** Adopt typed text; always drops the structured half. */
+export function manualDestinationValue(label: string): TripDestinationValue {
+  return { label, place: null };
+}
+
+/**
+ * All six fields, always together. A structured value writes all five columns
+ * from one lookup; a manual value clears all five. There is no third shape.
+ */
+export function destinationFields(
+  value: TripDestinationValue,
+): TripDestinationFields {
+  if (value.place) {
+    return {
+      destination: value.place.label,
+      destination_provider: value.place.provider,
+      destination_provider_id: value.place.provider_id,
+      destination_lat: value.place.lat,
+      destination_lng: value.place.lng,
+      destination_country_code: value.place.country_code,
+    };
+  }
+
+  return {
+    destination: value.label.trim(),
+    destination_provider: '',
+    destination_provider_id: '',
+    destination_lat: null,
+    destination_lng: null,
+    destination_country_code: '',
+  };
+}
+
+/**
+ * Django serialises DecimalField as a string, so the stored value arrives as
+ * text. An unparseable one becomes null rather than NaN, which would serialise
+ * back out as an invalid number.
+ */
+function parseStoredCoordinate(value: string | null): number | null {
+  if (value === null || value.trim() === '') {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}

--- a/mobile/src/features/trips/destination.ts
+++ b/mobile/src/features/trips/destination.ts
@@ -1,3 +1,4 @@
+import { truncateCodePoints } from '@/shared/location/resolvePlace';
 import type { ResolvedPlace } from '@/shared/location/types';
 import type { Trip } from './types';
 
@@ -63,11 +64,31 @@ export function destinationValueFromTrip(trip: Trip): TripDestinationValue {
   };
 }
 
-/** Adopt a verified place. */
+/**
+ * Adopt a verified place.
+ *
+ * A trip stores the canonical destination the HERE lookup returned, which the
+ * shared place carries in `address` ("Hội An, Quảng Nam, Việt Nam") — `label` is
+ * the short suggestion title ("Hội An") that the timeline wants for an activity.
+ * Taking the label here would persist a label from one representation next to
+ * five structured columns from another, and the same place would land in the
+ * column differently on web and on mobile.
+ *
+ * The address is capped at 255 for the shared picker but `destination` is 200,
+ * so it is re-truncated by code point — `slice` counts UTF-16 units and would
+ * split an emoji in half.
+ */
 export function destinationValueFromPlace(
   place: ResolvedPlace,
 ): TripDestinationValue {
-  return { label: place.label, place };
+  // A place rebuilt from a stored trip has no address; so does a lookup that
+  // returned no usable canonical destination.
+  const canonical = place.address.trim() || place.label;
+
+  return {
+    label: truncateCodePoints(canonical, TRIP_DESTINATION_MAX_LENGTH),
+    place,
+  };
 }
 
 /** Adopt typed text; always drops the structured half. */
@@ -82,9 +103,14 @@ export function manualDestinationValue(label: string): TripDestinationValue {
 export function destinationFields(
   value: TripDestinationValue,
 ): TripDestinationFields {
+  // Both shapes submit the label the form is holding: a structured value already
+  // normalised it to the canonical destination, and a hand-edited label always
+  // arrives with `place` dropped, so it can never disagree with the metadata.
+  const destination = value.label.trim();
+
   if (value.place) {
     return {
-      destination: value.place.label,
+      destination,
       destination_provider: value.place.provider,
       destination_provider_id: value.place.provider_id,
       destination_lat: normalizeCoordinate(value.place.lat),
@@ -94,7 +120,7 @@ export function destinationFields(
   }
 
   return {
-    destination: value.label.trim(),
+    destination,
     destination_provider: '',
     destination_provider_id: '',
     destination_lat: null,

--- a/mobile/src/features/trips/destination.ts
+++ b/mobile/src/features/trips/destination.ts
@@ -26,6 +26,15 @@ export interface TripDestinationFields {
   destination_country_code: string;
 }
 
+const DESTINATION_ERROR_FIELDS = [
+  'destination',
+  'destination_provider',
+  'destination_provider_id',
+  'destination_lat',
+  'destination_lng',
+  'destination_country_code',
+] as const;
+
 /**
  * Hydrate the edit form from a stored trip.
  *
@@ -78,8 +87,8 @@ export function destinationFields(
       destination: value.place.label,
       destination_provider: value.place.provider,
       destination_provider_id: value.place.provider_id,
-      destination_lat: value.place.lat,
-      destination_lng: value.place.lng,
+      destination_lat: normalizeCoordinate(value.place.lat),
+      destination_lng: normalizeCoordinate(value.place.lng),
       destination_country_code: value.place.country_code,
     };
   }
@@ -92,6 +101,24 @@ export function destinationFields(
     destination_lng: null,
     destination_country_code: '',
   };
+}
+
+/** Surface any backend error for the structured destination as one field error. */
+export function destinationFieldError(
+  fieldErrors: Readonly<Record<string, string>> | undefined,
+): string | undefined {
+  for (const field of DESTINATION_ERROR_FIELDS) {
+    const message = fieldErrors?.[field];
+    if (message !== undefined) {
+      return message;
+    }
+  }
+  return undefined;
+}
+
+/** Django stores both coordinates with decimal_places=6. */
+function normalizeCoordinate(value: number | null): number | null {
+  return value === null ? null : Number(value.toFixed(6));
 }
 
 /**

--- a/mobile/src/features/trips/hooks/useTripCoverUpload.ts
+++ b/mobile/src/features/trips/hooks/useTripCoverUpload.ts
@@ -1,0 +1,100 @@
+import { useCallback, useRef, useState } from 'react';
+import { nativeImageCodec } from '@/shared/media/imageCodec';
+import { pickImage } from '@/shared/media/pickImage';
+import { preprocessImage } from '@/shared/media/preprocessImage';
+import { uploadTripCover } from '../api';
+import { describeCoverError, TRIP_COVER_TARGET } from '../coverMedia';
+
+export type TripCoverStatus = 'idle' | 'picking' | 'uploading';
+
+export interface TripCoverUpload {
+  /** '' means "no cover". Always either '' or a server-returned /media/... URL. */
+  coverUrl: string;
+  status: TripCoverStatus;
+  error: string | null;
+  /** True while picking or uploading — the form blocks submit on this. */
+  busy: boolean;
+  /** True once the user picked or removed; drives "send cover_image_url or omit it". */
+  changed: boolean;
+  chooseCover: () => Promise<void>;
+  removeCover: () => void;
+  dismissError: () => void;
+}
+
+export function useTripCoverUpload(initialUrl = ''): TripCoverUpload {
+  const [coverUrl, setCoverUrl] = useState(initialUrl);
+  const [status, setStatus] = useState<TripCoverStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [changed, setChanged] = useState(false);
+  /**
+   * `status` only disables the button once React has re-rendered, so a fast
+   * double tap can enter this callback twice and run two uploads whose responses
+   * race — the later one silently wins. This ref closes the window synchronously,
+   * the same lock the account screens use.
+   */
+  const busyRef = useRef(false);
+
+  const chooseCover = useCallback(async () => {
+    if (busyRef.current) {
+      return;
+    }
+    busyRef.current = true;
+    setError(null);
+    setStatus('picking');
+    try {
+      // Photo library only (decision D7): a camera photo is reachable through
+      // it, and no new native permission or rebuild is involved.
+      const outcome = await pickImage({ square: false });
+      if (outcome.status === 'cancelled') {
+        setStatus('idle');
+        return;
+      }
+      setStatus('uploading');
+      // Every temp file this flow creates: the picker's full-resolution copy and
+      // the encoded upload. Both sit in the cache directory and nothing reads
+      // them once the request is done.
+      const temporaries = [outcome.image.uri];
+      let uploadedUrl: string;
+      try {
+        const file = await preprocessImage(outcome.image, TRIP_COVER_TARGET, nativeImageCodec);
+        temporaries.push(file.uri);
+        uploadedUrl = await uploadTripCover(file);
+      } finally {
+        // Cleanup runs on the failure path too, and must never replace the
+        // outcome the user is actually waiting on with a delete error.
+        await Promise.all(
+          temporaries.map((uri) => nativeImageCodec.discard(uri).catch(() => undefined)),
+        );
+      }
+      // The only legal source of a cover_image_url is this response.
+      setCoverUrl(uploadedUrl);
+      setChanged(true);
+      setStatus('idle');
+    } catch (caught) {
+      setStatus('idle');
+      setError(describeCoverError(caught));
+    } finally {
+      busyRef.current = false;
+    }
+  }, []);
+
+  /** No delete endpoint exists; clearing the field is what removes the cover. */
+  const removeCover = useCallback(() => {
+    setError(null);
+    setCoverUrl('');
+    setChanged(true);
+  }, []);
+
+  const dismissError = useCallback(() => setError(null), []);
+
+  return {
+    coverUrl,
+    status,
+    error,
+    busy: status !== 'idle',
+    changed,
+    chooseCover,
+    removeCover,
+    dismissError,
+  };
+}

--- a/mobile/src/features/trips/screens/CreateTripScreen.tsx
+++ b/mobile/src/features/trips/screens/CreateTripScreen.tsx
@@ -9,7 +9,9 @@ import { FormError } from '@/shared/ui/FormError';
 import { Screen } from '@/shared/ui/Screen';
 import { TextField } from '@/shared/ui/TextField';
 import { createTrip } from '../api';
+import { DestinationField } from '../components/DestinationField';
 import { formatDateParam } from '../dates';
+import { destinationFields, type TripDestinationValue } from '../destination';
 import { TRIP_CURRENCY_CODES } from '../options';
 import type { CreateTripInput } from '../types';
 
@@ -27,7 +29,10 @@ function FormSection({ title, children }: PropsWithChildren<{ title: string }>) 
 export function CreateTripScreen() {
   const router = useRouter();
   const [name, setName] = useState('');
-  const [destination, setDestination] = useState('');
+  const [destination, setDestination] = useState<TripDestinationValue>({
+    label: '',
+    place: null,
+  });
   const [startDate, setStartDate] = useState(new Date());
   const [endDate, setEndDate] = useState(new Date());
   const [description, setDescription] = useState('');
@@ -36,7 +41,7 @@ export function CreateTripScreen() {
   const [dateError, setDateError] = useState<string | undefined>(undefined);
   const [error, setError] = useState<ApiError | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const canSubmit = Boolean(name.trim() && destination.trim());
+  const canSubmit = Boolean(name.trim() && destination.label.trim());
 
   function onStartDateChange(date: Date) {
     setStartDate(date);
@@ -57,7 +62,7 @@ export function CreateTripScreen() {
     }
     const input: CreateTripInput = {
       name: name.trim(),
-      destination: destination.trim(),
+      ...destinationFields(destination),
       start_date: start,
       end_date: end,
       currency_code: currency,
@@ -108,13 +113,9 @@ export function CreateTripScreen() {
           maxLength={120}
           error={error?.fieldErrors?.name}
         />
-        <TextField
-          label="Destination *"
-          accessibilityLabel="Destination"
-          placeholder="Da Lat, Vietnam"
+        <DestinationField
           value={destination}
-          onChangeText={setDestination}
-          maxLength={200}
+          onChange={setDestination}
           error={error?.fieldErrors?.destination}
         />
       </FormSection>

--- a/mobile/src/features/trips/screens/CreateTripScreen.tsx
+++ b/mobile/src/features/trips/screens/CreateTripScreen.tsx
@@ -12,7 +12,11 @@ import { createTrip } from '../api';
 import { CoverImageField } from '../components/CoverImageField';
 import { DestinationField } from '../components/DestinationField';
 import { formatDateParam } from '../dates';
-import { destinationFields, type TripDestinationValue } from '../destination';
+import {
+  destinationFieldError,
+  destinationFields,
+  type TripDestinationValue,
+} from '../destination';
 import { useTripCoverUpload } from '../hooks/useTripCoverUpload';
 import { TRIP_CURRENCY_CODES } from '../options';
 import type { CreateTripInput } from '../types';
@@ -129,7 +133,7 @@ export function CreateTripScreen() {
         <DestinationField
           value={destination}
           onChange={setDestination}
-          error={error?.fieldErrors?.destination}
+          error={destinationFieldError(error?.fieldErrors)}
         />
       </FormSection>
 

--- a/mobile/src/features/trips/screens/CreateTripScreen.tsx
+++ b/mobile/src/features/trips/screens/CreateTripScreen.tsx
@@ -9,9 +9,11 @@ import { FormError } from '@/shared/ui/FormError';
 import { Screen } from '@/shared/ui/Screen';
 import { TextField } from '@/shared/ui/TextField';
 import { createTrip } from '../api';
+import { CoverImageField } from '../components/CoverImageField';
 import { DestinationField } from '../components/DestinationField';
 import { formatDateParam } from '../dates';
 import { destinationFields, type TripDestinationValue } from '../destination';
+import { useTripCoverUpload } from '../hooks/useTripCoverUpload';
 import { TRIP_CURRENCY_CODES } from '../options';
 import type { CreateTripInput } from '../types';
 
@@ -41,6 +43,7 @@ export function CreateTripScreen() {
   const [dateError, setDateError] = useState<string | undefined>(undefined);
   const [error, setError] = useState<ApiError | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const cover = useTripCoverUpload();
   const canSubmit = Boolean(name.trim() && destination.label.trim());
 
   function onStartDateChange(date: Date) {
@@ -67,6 +70,10 @@ export function CreateTripScreen() {
       end_date: end,
       currency_code: currency,
     };
+    // Create defaults cover_image_url to '' server-side, so an empty key is noise.
+    if (cover.coverUrl !== '') {
+      input.cover_image_url = cover.coverUrl;
+    }
     const trimmedDescription = description.trim();
     if (trimmedDescription) {
       input.description = trimmedDescription;
@@ -93,7 +100,13 @@ export function CreateTripScreen() {
         <>
           <FormError error={error} />
           {!canSubmit ? <Text style={styles.submitHint}>Add a trip name and destination to continue.</Text> : null}
-          <Button title="Create trip" onPress={onSubmit} loading={submitting} disabled={!canSubmit} />
+          {cover.busy ? <Text style={styles.submitHint}>Wait for the cover upload to finish.</Text> : null}
+          <Button
+            title="Create trip"
+            onPress={onSubmit}
+            loading={submitting}
+            disabled={!canSubmit || cover.busy}
+          />
         </>
       }
     >
@@ -117,6 +130,16 @@ export function CreateTripScreen() {
           value={destination}
           onChange={setDestination}
           error={error?.fieldErrors?.destination}
+        />
+      </FormSection>
+
+      <FormSection title="Cover photo">
+        <CoverImageField
+          coverUrl={cover.coverUrl}
+          status={cover.status}
+          error={cover.error ?? error?.fieldErrors?.cover_image_url ?? null}
+          onChoose={() => void cover.chooseCover()}
+          onRemove={cover.removeCover}
         />
       </FormSection>
 

--- a/mobile/src/features/trips/screens/EditTripScreen.tsx
+++ b/mobile/src/features/trips/screens/EditTripScreen.tsx
@@ -12,7 +12,13 @@ import { LoadingScreen } from '@/shared/ui/LoadingScreen';
 import { Screen } from '@/shared/ui/Screen';
 import { TextField } from '@/shared/ui/TextField';
 import { updateTrip } from '../api';
+import { DestinationField } from '../components/DestinationField';
 import { formatDateParam, parseDateOnly } from '../dates';
+import {
+  destinationFields,
+  destinationValueFromTrip,
+  type TripDestinationValue,
+} from '../destination';
 import { useTripDetail } from '../hooks/useTripDetail';
 import { getTimezoneOptions, TRIP_CURRENCY_CODES } from '../options';
 import { publishTripEvent } from '../tripEvents';
@@ -46,7 +52,10 @@ function EditTripForm({ detail }: { detail: TripDetailResponse }) {
   const router = useRouter();
   const original = detail.trip;
   const [name, setName] = useState(original.name);
-  const [destination, setDestination] = useState(original.destination);
+  const [destination, setDestination] = useState<TripDestinationValue>(() =>
+    destinationValueFromTrip(original),
+  );
+  const [destinationTouched, setDestinationTouched] = useState(false);
   const [startDate, setStartDate] = useState(() => parseDateOnly(original.start_date));
   const [endDate, setEndDate] = useState(() => parseDateOnly(original.end_date));
   const [description, setDescription] = useState(original.description);
@@ -58,7 +67,12 @@ function EditTripForm({ detail }: { detail: TripDetailResponse }) {
   const [submitting, setSubmitting] = useState(false);
   const submitLockRef = useRef(false);
   const timezoneOptions = getTimezoneOptions(original.timezone);
-  const canSubmit = Boolean(name.trim() && destination.trim());
+  const canSubmit = Boolean(name.trim() && destination.label.trim());
+
+  function onDestinationChange(next: TripDestinationValue) {
+    setDestinationTouched(true);
+    setDestination(next);
+  }
 
   function onStartDateChange(date: Date) {
     setStartDate(date);
@@ -82,11 +96,9 @@ function EditTripForm({ detail }: { detail: TripDetailResponse }) {
       return;
     }
 
-    const trimmedDestination = destination.trim();
     const trimmedBudget = budget.trim();
     const input: UpdateTripInput = {
       name: name.trim(),
-      destination: trimmedDestination,
       start_date: start,
       end_date: end,
       description: description.trim(),
@@ -94,12 +106,11 @@ function EditTripForm({ detail }: { detail: TripDetailResponse }) {
       currency_code: currency,
       timezone,
     };
-    if (trimmedDestination !== original.destination) {
-      input.destination_provider = '';
-      input.destination_provider_id = '';
-      input.destination_lat = null;
-      input.destination_lng = null;
-      input.destination_country_code = '';
+    // Destination is omitted entirely unless the user changed it. A PATCH that
+    // never mentions destination cannot clear the stored coordinates, which is
+    // the one failure mode here that produces no error and no visible symptom.
+    if (destinationTouched) {
+      Object.assign(input, destinationFields(destination));
     }
 
     submitLockRef.current = true;
@@ -137,12 +148,9 @@ function EditTripForm({ detail }: { detail: TripDetailResponse }) {
           maxLength={120}
           error={error?.fieldErrors?.name}
         />
-        <TextField
-          label="Destination *"
-          accessibilityLabel="Destination"
+        <DestinationField
           value={destination}
-          onChangeText={setDestination}
-          maxLength={200}
+          onChange={onDestinationChange}
           error={error?.fieldErrors?.destination}
         />
       </FormSection>

--- a/mobile/src/features/trips/screens/EditTripScreen.tsx
+++ b/mobile/src/features/trips/screens/EditTripScreen.tsx
@@ -12,6 +12,7 @@ import { LoadingScreen } from '@/shared/ui/LoadingScreen';
 import { Screen } from '@/shared/ui/Screen';
 import { TextField } from '@/shared/ui/TextField';
 import { updateTrip } from '../api';
+import { CoverImageField } from '../components/CoverImageField';
 import { DestinationField } from '../components/DestinationField';
 import { formatDateParam, parseDateOnly } from '../dates';
 import {
@@ -19,6 +20,7 @@ import {
   destinationValueFromTrip,
   type TripDestinationValue,
 } from '../destination';
+import { useTripCoverUpload } from '../hooks/useTripCoverUpload';
 import { useTripDetail } from '../hooks/useTripDetail';
 import { getTimezoneOptions, TRIP_CURRENCY_CODES } from '../options';
 import { publishTripEvent } from '../tripEvents';
@@ -66,6 +68,7 @@ function EditTripForm({ detail }: { detail: TripDetailResponse }) {
   const [error, setError] = useState<ApiError | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const submitLockRef = useRef(false);
+  const cover = useTripCoverUpload(original.cover_image_url);
   const timezoneOptions = getTimezoneOptions(original.timezone);
   const canSubmit = Boolean(name.trim() && destination.label.trim());
 
@@ -112,6 +115,11 @@ function EditTripForm({ detail }: { detail: TripDetailResponse }) {
     if (destinationTouched) {
       Object.assign(input, destinationFields(destination));
     }
+    // '' after Remove clears the cover, a new URL replaces it, and an untouched
+    // cover is never mentioned at all.
+    if (cover.changed) {
+      input.cover_image_url = cover.coverUrl;
+    }
 
     submitLockRef.current = true;
     setSubmitting(true);
@@ -135,7 +143,13 @@ function EditTripForm({ detail }: { detail: TripDetailResponse }) {
         <>
           <FormError error={error} />
           {!canSubmit ? <Text style={styles.submitHint}>Add a trip name and destination to continue.</Text> : null}
-          <Button title="Save changes" onPress={onSubmit} loading={submitting} disabled={!canSubmit} />
+          {cover.busy ? <Text style={styles.submitHint}>Wait for the cover upload to finish.</Text> : null}
+          <Button
+            title="Save changes"
+            onPress={onSubmit}
+            loading={submitting}
+            disabled={!canSubmit || cover.busy}
+          />
         </>
       }
     >
@@ -152,6 +166,16 @@ function EditTripForm({ detail }: { detail: TripDetailResponse }) {
           value={destination}
           onChange={onDestinationChange}
           error={error?.fieldErrors?.destination}
+        />
+      </FormSection>
+
+      <FormSection title="Cover photo">
+        <CoverImageField
+          coverUrl={cover.coverUrl}
+          status={cover.status}
+          error={cover.error ?? error?.fieldErrors?.cover_image_url ?? null}
+          onChoose={() => void cover.chooseCover()}
+          onRemove={cover.removeCover}
         />
       </FormSection>
 

--- a/mobile/src/features/trips/screens/EditTripScreen.tsx
+++ b/mobile/src/features/trips/screens/EditTripScreen.tsx
@@ -16,6 +16,7 @@ import { CoverImageField } from '../components/CoverImageField';
 import { DestinationField } from '../components/DestinationField';
 import { formatDateParam, parseDateOnly } from '../dates';
 import {
+  destinationFieldError,
   destinationFields,
   destinationValueFromTrip,
   type TripDestinationValue,
@@ -165,7 +166,7 @@ function EditTripForm({ detail }: { detail: TripDetailResponse }) {
         <DestinationField
           value={destination}
           onChange={onDestinationChange}
-          error={error?.fieldErrors?.destination}
+          error={destinationFieldError(error?.fieldErrors)}
         />
       </FormSection>
 

--- a/mobile/src/features/trips/types.ts
+++ b/mobile/src/features/trips/types.ts
@@ -85,6 +85,17 @@ export interface TripListPage {
 export interface CreateTripInput {
   name: string;
   destination: string;
+  destination_provider?: string;
+  destination_provider_id?: string;
+  /**
+   * Requests carry coordinates as JSON numbers (what the lookup endpoint returns
+   * and what the web client forwards). Responses carry them as strings, because
+   * Django serialises Decimal that way — hence the asymmetry with `Trip`.
+   */
+  destination_lat?: number | null;
+  destination_lng?: number | null;
+  destination_country_code?: string;
+  cover_image_url?: string;
   start_date: string;
   end_date: string;
   description?: string;
@@ -97,8 +108,9 @@ export interface UpdateTripInput {
   destination?: string;
   destination_provider?: string;
   destination_provider_id?: string;
-  destination_lat?: string | null;
-  destination_lng?: string | null;
+  /** Numbers on the request, strings on the response — see CreateTripInput. */
+  destination_lat?: number | null;
+  destination_lng?: number | null;
   destination_country_code?: string;
   cover_image_url?: string;
   start_date?: string;

--- a/mobile/src/shared/location/PlacePicker.tsx
+++ b/mobile/src/shared/location/PlacePicker.tsx
@@ -10,30 +10,39 @@ import {
 } from 'react-native';
 import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
 import { TextField } from '@/shared/ui/TextField';
+import type { PlaceSuggestion, ResolvedPlace } from './types';
 import {
   MANUAL_LOCATION_GUIDANCE,
   PLACE_SEARCH_UNAVAILABLE_MESSAGE,
-  type ManualLocationValue,
-  type PlacePickerValue,
-  type SettledLocationLookupFailure,
-  type StructuredLocationSelection,
+  type ManualPlaceEntry,
+  type PlaceLookupFailure,
   useLocationSearch,
-} from '../hooks/useLocationSearch';
-import type { LocationSuggestion } from '../types';
+} from './useLocationSearch';
+
+export interface PlacePickerValue {
+  /** The label the form currently holds, whether verified or manual. */
+  label: string;
+  /**
+   * Present only while the form holds a verified place. This is a display
+   * shape, not a ResolvedPlace: the card renders a title and an address and
+   * nothing else, and no caller stores the full place in that shape.
+   */
+  place: { title: string; address: string } | null;
+}
 
 export interface PlacePickerProps {
   value: PlacePickerValue | null;
   disabled?: boolean;
   error?: string;
-  onSelectLocation: (selection: StructuredLocationSelection) => void;
-  onUseManualEntry: (value: ManualLocationValue) => void;
-  onLookupFailure: (failure: SettledLocationLookupFailure) => void;
+  onSelectPlace: (place: ResolvedPlace) => void;
+  onUseManualEntry: (entry: ManualPlaceEntry) => void;
+  onLookupFailure: (failure: PlaceLookupFailure) => void;
 }
 
 interface SuggestionChoiceProps {
-  suggestion: LocationSuggestion;
+  suggestion: PlaceSuggestion;
   disabled: boolean;
-  onSelect: (suggestion: LocationSuggestion) => void;
+  onSelect: (suggestion: PlaceSuggestion) => void;
 }
 
 const SuggestionChoice = memo(function SuggestionChoice({
@@ -75,7 +84,7 @@ export function PlacePicker({
   value,
   disabled = false,
   error,
-  onSelectLocation,
+  onSelectPlace,
   onUseManualEntry,
   onLookupFailure,
 }: PlacePickerProps) {
@@ -96,27 +105,27 @@ export function PlacePicker({
   const lookupPending = lookupStatus === 'loading';
 
   const chooseSuggestion = useCallback(
-    (suggestion: LocationSuggestion) => {
+    (suggestion: PlaceSuggestion) => {
       void selectSuggestion(suggestion).then((result) => {
         if (result.kind === 'success') {
-          onSelectLocation(result.selection);
+          onSelectPlace(result.place);
           clear();
         } else if (result.kind === 'failure') {
           onLookupFailure(result.fallback);
         }
       });
     },
-    [clear, onLookupFailure, onSelectLocation, selectSuggestion],
+    [clear, onLookupFailure, onSelectPlace, selectSuggestion],
   );
 
   const useManualEntry = useCallback(() => {
-    const manualValue = createManualValue(value?.location_label ?? '');
+    const manualValue = createManualValue(value?.label ?? '');
     clear();
     onUseManualEntry(manualValue);
-  }, [clear, createManualValue, onUseManualEntry, value?.location_label]);
+  }, [clear, createManualValue, onUseManualEntry, value?.label]);
 
   const renderSuggestion = useCallback(
-    ({ item }: ListRenderItemInfo<LocationSuggestion>) => (
+    ({ item }: ListRenderItemInfo<PlaceSuggestion>) => (
       <SuggestionChoice
         suggestion={item}
         disabled={disabled || lookupPending}
@@ -134,12 +143,12 @@ export function PlacePicker({
     <View style={styles.wrap}>
       {value?.place ? (
         <View
-          accessibilityLabel={`Selected place ${value.location_label}`}
+          accessibilityLabel={`Selected place ${value.label}`}
           style={styles.selected}
         >
           <Text style={styles.selectedEyebrow}>Selected place</Text>
           <Text style={styles.selectedTitle}>
-            {value.place.title || value.location_label}
+            {value.place.title || value.label}
           </Text>
           {value.place.address ? (
             <Text style={styles.selectedAddress}>{value.place.address}</Text>
@@ -227,7 +236,7 @@ export function PlacePicker({
   );
 }
 
-function suggestionKey(suggestion: LocationSuggestion): string {
+function suggestionKey(suggestion: PlaceSuggestion): string {
   return suggestion.provider_id;
 }
 

--- a/mobile/src/shared/location/PlacePicker.tsx
+++ b/mobile/src/shared/location/PlacePicker.tsx
@@ -103,6 +103,8 @@ export function PlacePicker({
     createManualValue,
   } = useLocationSearch({ enabled: !disabled });
   const lookupPending = lookupStatus === 'loading';
+  const noResults =
+    searchStatus === 'ready' && suggestions.length === 0;
 
   const chooseSuggestion = useCallback(
     (suggestion: PlaceSuggestion) => {
@@ -206,6 +208,12 @@ export function PlacePicker({
           style={styles.notice}
         >
           {searchMessage}
+        </Text>
+      ) : null}
+
+      {noResults ? (
+        <Text accessibilityLiveRegion="polite" style={styles.notice}>
+          No results.
         </Text>
       ) : null}
 

--- a/mobile/src/shared/location/__tests__/PlacePicker.test.tsx
+++ b/mobile/src/shared/location/__tests__/PlacePicker.test.tsx
@@ -190,6 +190,24 @@ describe('PlacePicker', () => {
     rendered.unmount();
   });
 
+  it('shows an explicit empty state when search succeeds with no results', async () => {
+    mockSuggestLocations.mockResolvedValue([]);
+    const callbacks = pickerCallbacks();
+    const rendered = await render(
+      <PlacePicker value={selectedPlace} {...callbacks} />,
+    );
+
+    await enterSearch('Nowhere');
+    await advanceDebounce();
+
+    expect(screen.getByText('No results.')).toBeTruthy();
+    expect(screen.getByText('Existing Station')).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: 'Enter location manually' }),
+    ).toBeTruthy();
+    rendered.unmount();
+  });
+
   it('emits only the canonical structured selection after lookup succeeds', async () => {
     mockSuggestLocations.mockResolvedValue([suggestion]);
     mockLookupLocation.mockResolvedValue(lookup);

--- a/mobile/src/shared/location/__tests__/PlacePicker.test.tsx
+++ b/mobile/src/shared/location/__tests__/PlacePicker.test.tsx
@@ -15,18 +15,18 @@ import {
 // eslint-disable-next-line import/first
 import { lookupLocation, suggestLocations } from '../api';
 // eslint-disable-next-line import/first
-import { PlacePicker, type PlacePickerProps } from '../components/PlacePicker';
+import { PlacePicker, type PlacePickerProps } from '../PlacePicker';
+// eslint-disable-next-line import/first
+import type {
+  PlaceSuggestion,
+  ResolvedPlaceLookup,
+} from '../types';
 // eslint-disable-next-line import/first
 import {
   LOCATION_SEARCH_DEBOUNCE_MS,
   MANUAL_LOCATION_GUIDANCE,
   PLACE_SEARCH_UNAVAILABLE_MESSAGE,
-} from '../hooks/useLocationSearch';
-// eslint-disable-next-line import/first
-import type {
-  LocationSuggestion,
-  ResolvedLocationLookup,
-} from '../types';
+} from '../useLocationSearch';
 
 const mockSuggestLocations = suggestLocations as jest.MockedFunction<
   typeof suggestLocations
@@ -35,14 +35,14 @@ const mockLookupLocation = lookupLocation as jest.MockedFunction<
   typeof lookupLocation
 >;
 
-const suggestion: LocationSuggestion = {
+const suggestion: PlaceSuggestion = {
   provider: 'here',
   provider_id: 'unverified-suggestion-id',
   title: 'Da Nang International Airport',
   subtitle: 'Da Nang, Vietnam',
 };
 
-const lookup: ResolvedLocationLookup = {
+const lookup: ResolvedPlaceLookup = {
   destination: 'Duy Tan, Hoa Thuan Tay, Da Nang, Vietnam',
   destination_provider: 'here',
   destination_provider_id: 'canonical-here-id',
@@ -52,14 +52,10 @@ const lookup: ResolvedLocationLookup = {
 };
 
 const selectedPlace: PlacePickerProps['value'] = {
-  location_label: 'Existing Station',
+  label: 'Existing Station',
   place: {
-    provider: 'here',
-    provider_id: 'existing-canonical-id',
     title: 'Existing Station',
     address: 'Existing address',
-    lat: 16,
-    lng: 108,
   },
 };
 
@@ -84,7 +80,7 @@ function deferred<T>() {
 
 function pickerCallbacks() {
   return {
-    onSelectLocation: jest.fn(),
+    onSelectPlace: jest.fn(),
     onUseManualEntry: jest.fn(),
     onLookupFailure: jest.fn(),
   };
@@ -160,7 +156,7 @@ describe('PlacePicker', () => {
       expect(screen.getByLabelText('Search places').props.value).toBe(
         'Da Nang',
       );
-      expect(callbacks.onSelectLocation).not.toHaveBeenCalled();
+      expect(callbacks.onSelectPlace).not.toHaveBeenCalled();
       expect(callbacks.onUseManualEntry).not.toHaveBeenCalled();
       expect(callbacks.onLookupFailure).not.toHaveBeenCalled();
       rendered.unmount();
@@ -188,11 +184,9 @@ describe('PlacePicker', () => {
     );
 
     expect(callbacks.onUseManualEntry).toHaveBeenCalledWith({
-      location_mode: 'MANUAL',
-      location_label: 'Hotel lobby',
-      place: null,
+      label: 'Hotel lobby',
     });
-    expect(callbacks.onSelectLocation).not.toHaveBeenCalled();
+    expect(callbacks.onSelectPlace).not.toHaveBeenCalled();
     rendered.unmount();
   });
 
@@ -213,17 +207,14 @@ describe('PlacePicker', () => {
     );
     await flushPromises();
 
-    expect(callbacks.onSelectLocation).toHaveBeenCalledWith({
-      location_mode: 'STRUCTURED',
-      location_label: suggestion.title,
-      place: {
-        provider: 'here',
-        provider_id: lookup.destination_provider_id,
-        title: suggestion.title,
-        address: lookup.destination,
-        lat: lookup.destination_lat,
-        lng: lookup.destination_lng,
-      },
+    expect(callbacks.onSelectPlace).toHaveBeenCalledWith({
+      provider: 'here',
+      provider_id: lookup.destination_provider_id,
+      label: suggestion.title,
+      address: lookup.destination,
+      lat: lookup.destination_lat,
+      lng: lookup.destination_lng,
+      country_code: lookup.destination_country_code,
     });
     expect(callbacks.onLookupFailure).not.toHaveBeenCalled();
     expect(callbacks.onUseManualEntry).not.toHaveBeenCalled();
@@ -254,9 +245,7 @@ describe('PlacePicker', () => {
     await flushPromises();
 
     expect(callbacks.onLookupFailure).toHaveBeenCalledWith({
-      location_mode: 'MANUAL',
-      location_label: suggestion.title,
-      place: null,
+      label: suggestion.title,
       guidance: MANUAL_LOCATION_GUIDANCE,
       error: {
         kind: 'message',
@@ -265,7 +254,7 @@ describe('PlacePicker', () => {
         errorCode: 'LOCATION_LOOKUP_FAILED',
       },
     });
-    expect(callbacks.onSelectLocation).not.toHaveBeenCalled();
+    expect(callbacks.onSelectPlace).not.toHaveBeenCalled();
     expect(callbacks.onUseManualEntry).not.toHaveBeenCalled();
     expect(screen.getByText(MANUAL_LOCATION_GUIDANCE)).toBeTruthy();
     expect(screen.queryByText(suggestion.provider_id)).toBeNull();
@@ -273,7 +262,7 @@ describe('PlacePicker', () => {
   });
 
   it('does not emit any commit callback for an aborted stale lookup', async () => {
-    const pendingLookup = deferred<ResolvedLocationLookup>();
+    const pendingLookup = deferred<ResolvedPlaceLookup>();
     mockSuggestLocations.mockResolvedValue([suggestion]);
     mockLookupLocation.mockReturnValue(pendingLookup.promise);
     const callbacks = pickerCallbacks();
@@ -297,7 +286,7 @@ describe('PlacePicker', () => {
       await Promise.resolve();
     });
 
-    expect(callbacks.onSelectLocation).not.toHaveBeenCalled();
+    expect(callbacks.onSelectPlace).not.toHaveBeenCalled();
     expect(callbacks.onLookupFailure).not.toHaveBeenCalled();
     expect(callbacks.onUseManualEntry).not.toHaveBeenCalled();
     rendered.unmount();
@@ -314,9 +303,7 @@ describe('PlacePicker', () => {
     );
 
     expect(callbacks.onUseManualEntry).toHaveBeenCalledWith({
-      location_mode: 'MANUAL',
-      location_label: selectedPlace?.location_label,
-      place: null,
+      label: selectedPlace?.label,
     });
     rendered.unmount();
   });

--- a/mobile/src/shared/location/__tests__/api.test.ts
+++ b/mobile/src/shared/location/__tests__/api.test.ts
@@ -1,0 +1,58 @@
+jest.mock('@/shared/api/client', () => ({
+  apiClient: {
+    get: jest.fn(),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { apiClient } from '@/shared/api/client';
+// eslint-disable-next-line import/first
+import { lookupLocation, suggestLocations } from '../api';
+
+const mockGet = apiClient.get as jest.MockedFunction<typeof apiClient.get>;
+
+describe('shared location api', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('suggests locations and unwraps suggestions with cancellation support', async () => {
+    const controller = new AbortController();
+    const suggestions = [
+      {
+        provider: 'here',
+        provider_id: 'here:place:1',
+        title: 'Da Nang',
+        subtitle: 'Vietnam',
+      },
+    ];
+    mockGet.mockResolvedValue({ data: { suggestions } } as never);
+
+    await expect(
+      suggestLocations('Da Nang', controller.signal),
+    ).resolves.toEqual(suggestions);
+    expect(mockGet).toHaveBeenCalledWith('/location-search/suggest', {
+      params: { q: 'Da Nang' },
+      signal: controller.signal,
+    });
+  });
+
+  it('looks up a canonical location from the direct response with cancellation support', async () => {
+    const controller = new AbortController();
+    const lookup = {
+      destination: 'Da Nang, Vietnam',
+      destination_provider: 'here',
+      destination_provider_id: 'here:place:canonical',
+      destination_lat: 16.0544,
+      destination_lng: 108.2022,
+      destination_country_code: 'VN',
+    };
+    mockGet.mockResolvedValue({ data: lookup } as never);
+
+    await expect(
+      lookupLocation('here:place:1', controller.signal),
+    ).resolves.toEqual(lookup);
+    expect(mockGet).toHaveBeenCalledWith('/location-search/lookup', {
+      params: { id: 'here:place:1' },
+      signal: controller.signal,
+    });
+  });
+});

--- a/mobile/src/shared/location/__tests__/resolvePlace.test.ts
+++ b/mobile/src/shared/location/__tests__/resolvePlace.test.ts
@@ -1,0 +1,112 @@
+import {
+  codePointLength,
+  resolvePlace,
+  truncateCodePoints,
+} from '../resolvePlace';
+import type { PlaceSuggestion, ResolvedPlaceLookup } from '../types';
+
+const suggestion: PlaceSuggestion = {
+  provider: 'here',
+  provider_id: 'unverified-suggestion-id',
+  title: 'Hội An',
+  subtitle: 'Quảng Nam, Việt Nam',
+};
+
+function buildLookup(
+  overrides: Partial<ResolvedPlaceLookup> = {},
+): ResolvedPlaceLookup {
+  return {
+    destination: 'Hội An, Quảng Nam, Việt Nam',
+    destination_provider: 'here',
+    destination_provider_id: 'canonical-here-id',
+    destination_lat: 15.8801,
+    destination_lng: 108.338,
+    destination_country_code: 'VN',
+    ...overrides,
+  };
+}
+
+describe('code point helpers', () => {
+  it('counts and truncates astral-plane characters as single units', () => {
+    expect(codePointLength('😀😀😀')).toBe(3);
+    expect(truncateCodePoints('😀😀😀', 2)).toBe('😀😀');
+    expect(truncateCodePoints('Hội An', 20)).toBe('Hội An');
+  });
+});
+
+describe('resolvePlace', () => {
+  it('uses only the successful canonical lookup id and canonical lookup values', () => {
+    expect(resolvePlace(suggestion, buildLookup())).toEqual({
+      provider: 'here',
+      provider_id: 'canonical-here-id',
+      label: 'Hội An',
+      address: 'Hội An, Quảng Nam, Việt Nam',
+      lat: 15.8801,
+      lng: 108.338,
+      country_code: 'VN',
+    });
+  });
+
+  it('truncates label and address to backend code-point caps', () => {
+    const title = '😀'.repeat(201);
+    const destination = 'Đ'.repeat(256);
+    const result = resolvePlace(
+      { ...suggestion, title },
+      buildLookup({ destination }),
+    );
+
+    expect(Array.from(result?.label ?? '')).toHaveLength(200);
+    expect(Array.from(result?.address ?? '')).toHaveLength(255);
+  });
+
+  it('falls back to the suggestion subtitle when the lookup carries no address', () => {
+    // The `??` in resolvePlace guards a runtime shape the declared type forbids,
+    // so reaching that branch at all requires stepping outside the type once.
+    const result = resolvePlace(
+      suggestion,
+      buildLookup({ destination: undefined as unknown as string }),
+    );
+
+    expect(result?.address).toBe(suggestion.subtitle);
+  });
+
+  it.each([
+    '',
+    '   ',
+    'x'.repeat(256),
+  ])('rejects invalid canonical id %p without suggestion-id fallback', (id) => {
+    expect(
+      resolvePlace(suggestion, buildLookup({ destination_provider_id: id })),
+    ).toBeNull();
+  });
+
+  it('accepts a canonical id exactly at the 255-character cap', () => {
+    const id = 'x'.repeat(255);
+    expect(
+      resolvePlace(suggestion, buildLookup({ destination_provider_id: id }))
+        ?.provider_id,
+    ).toBe(id);
+  });
+
+  it('keeps null coordinates null instead of coercing them to zero', () => {
+    const result = resolvePlace(
+      suggestion,
+      buildLookup({ destination_lat: null, destination_lng: null }),
+    );
+
+    expect(result?.lat).toBeNull();
+    expect(result?.lng).toBeNull();
+  });
+
+  it.each([
+    ['a three-letter code', 'VNM'],
+    ['an empty code', ''],
+  ])('drops %s that the destination column cannot store', (_case, code) => {
+    expect(
+      resolvePlace(
+        suggestion,
+        buildLookup({ destination_country_code: code }),
+      )?.country_code,
+    ).toBe('');
+  });
+});

--- a/mobile/src/shared/location/__tests__/useLocationSearch.test.tsx
+++ b/mobile/src/shared/location/__tests__/useLocationSearch.test.tsx
@@ -10,16 +10,16 @@ import { act, renderHook } from '@testing-library/react-native';
 // eslint-disable-next-line import/first
 import { lookupLocation, suggestLocations } from '../api';
 // eslint-disable-next-line import/first
+import type {
+  PlaceSuggestion,
+  ResolvedPlaceLookup,
+} from '../types';
+// eslint-disable-next-line import/first
 import {
   LOCATION_SEARCH_DEBOUNCE_MS,
   MANUAL_LOCATION_GUIDANCE,
   useLocationSearch,
-} from '../hooks/useLocationSearch';
-// eslint-disable-next-line import/first
-import type {
-  LocationSuggestion,
-  ResolvedLocationLookup,
-} from '../types';
+} from '../useLocationSearch';
 
 const mockSuggestLocations = suggestLocations as jest.MockedFunction<
   typeof suggestLocations
@@ -28,14 +28,14 @@ const mockLookupLocation = lookupLocation as jest.MockedFunction<
   typeof lookupLocation
 >;
 
-const suggestion: LocationSuggestion = {
+const suggestion: PlaceSuggestion = {
   provider: 'here',
   provider_id: 'suggestion-id',
   title: 'Da Nang International Airport',
   subtitle: 'Da Nang, Vietnam',
 };
 
-const lookup: ResolvedLocationLookup = {
+const lookup: ResolvedPlaceLookup = {
   destination: 'Duy Tan, Hoa Thuan Tay, Da Nang, Vietnam',
   destination_provider: 'here',
   destination_provider_id: 'canonical-id',
@@ -200,8 +200,8 @@ describe('useLocationSearch', () => {
   });
 
   it('aborts an older suggest request and lets only the latest request update state', async () => {
-    const first = deferred<LocationSuggestion[]>();
-    const second = deferred<LocationSuggestion[]>();
+    const first = deferred<PlaceSuggestion[]>();
+    const second = deferred<PlaceSuggestion[]>();
     const latestSuggestion = {
       ...suggestion,
       provider_id: 'latest-id',
@@ -251,29 +251,26 @@ describe('useLocationSearch', () => {
     );
     expect(selectionResult).toEqual({
       kind: 'success',
-      selection: {
-        location_mode: 'STRUCTURED',
-        location_label: suggestion.title,
-        place: {
-          provider: 'here',
-          provider_id: lookup.destination_provider_id,
-          title: suggestion.title,
-          address: lookup.destination,
-          lat: lookup.destination_lat,
-          lng: lookup.destination_lng,
-        },
+      place: {
+        provider: 'here',
+        provider_id: lookup.destination_provider_id,
+        label: suggestion.title,
+        address: lookup.destination,
+        lat: lookup.destination_lat,
+        lng: lookup.destination_lng,
+        country_code: lookup.destination_country_code,
       },
     });
     expect(
       selectionResult?.kind === 'success'
-        ? selectionResult.selection.place.provider_id
+        ? selectionResult.place.provider_id
         : undefined,
     ).not.toBe(suggestion.provider_id);
     unmount();
   });
 
   it('returns stale without a failure state when lookup is aborted by new input', async () => {
-    const pending = deferred<ResolvedLocationLookup>();
+    const pending = deferred<ResolvedPlaceLookup>();
     mockLookupLocation.mockReturnValue(pending.promise);
     const { result, unmount } = await renderHook(() => useLocationSearch());
     let lookupPromise:
@@ -305,7 +302,7 @@ describe('useLocationSearch', () => {
   });
 
   it('aborts lookup and returns stale when the picker becomes disabled', async () => {
-    const pending = deferred<ResolvedLocationLookup>();
+    const pending = deferred<ResolvedPlaceLookup>();
     mockLookupLocation.mockReturnValue(pending.promise);
     const { result, rerender, unmount } = await renderHook(
       ({ enabled }: { enabled: boolean }) =>
@@ -357,9 +354,7 @@ describe('useLocationSearch', () => {
     expect(selectionResult).toEqual({
       kind: 'failure',
       fallback: {
-        location_mode: 'MANUAL',
-        location_label: suggestion.title,
-        place: null,
+        label: suggestion.title,
         guidance: MANUAL_LOCATION_GUIDANCE,
         error: {
           kind: 'message',
@@ -373,9 +368,9 @@ describe('useLocationSearch', () => {
     expect(result.current.manualEntrySuggested).toBe(true);
     expect(
       selectionResult?.kind === 'failure'
-        ? selectionResult.fallback.place
-        : undefined,
-    ).toBeNull();
+        ? Object.keys(selectionResult.fallback)
+        : [],
+    ).not.toContain('place');
     unmount();
   });
 
@@ -401,7 +396,7 @@ describe('useLocationSearch', () => {
     expect(selectionResult?.kind).toBe('failure');
     const label =
       selectionResult?.kind === 'failure'
-        ? selectionResult.fallback.location_label
+        ? selectionResult.fallback.label
         : '';
     expect(Array.from(label)).toHaveLength(200);
     expect(label).toBe('😀'.repeat(200));
@@ -428,9 +423,7 @@ describe('useLocationSearch', () => {
         ? selectionResult.fallback
         : undefined,
     ).toMatchObject({
-      location_mode: 'MANUAL',
-      location_label: suggestion.title,
-      place: null,
+      label: suggestion.title,
     });
     expect(result.current.lookupStatus).toBe('error');
     unmount();

--- a/mobile/src/shared/location/api.ts
+++ b/mobile/src/shared/location/api.ts
@@ -1,0 +1,34 @@
+import { apiClient } from '@/shared/api/client';
+import type { PlaceSuggestion, ResolvedPlaceLookup } from './types';
+
+interface PlaceSuggestionsResponse {
+  suggestions: PlaceSuggestion[];
+}
+
+export async function suggestLocations(
+  query: string,
+  signal?: AbortSignal,
+): Promise<PlaceSuggestion[]> {
+  const { data } = await apiClient.get<PlaceSuggestionsResponse>(
+    '/location-search/suggest',
+    {
+      params: { q: query },
+      signal,
+    },
+  );
+  return data.suggestions;
+}
+
+export async function lookupLocation(
+  providerId: string,
+  signal?: AbortSignal,
+): Promise<ResolvedPlaceLookup> {
+  const { data } = await apiClient.get<ResolvedPlaceLookup>(
+    '/location-search/lookup',
+    {
+      params: { id: providerId },
+      signal,
+    },
+  );
+  return data;
+}

--- a/mobile/src/shared/location/resolvePlace.ts
+++ b/mobile/src/shared/location/resolvePlace.ts
@@ -1,0 +1,59 @@
+import type { PlaceSuggestion, ResolvedPlace, ResolvedPlaceLookup } from './types';
+
+/**
+ * The tightest backend cap across every consumer of this module (decision D5).
+ * They coincide for timeline activities and trip destinations, so a per-caller
+ * prop would be configuration with exactly one possible value.
+ */
+export const MAX_PLACE_LABEL_LENGTH = 200;
+export const MAX_PLACE_ADDRESS_LENGTH = 255;
+export const MAX_PROVIDER_ID_LENGTH = 255;
+
+/** Backend limits count characters, and an emoji is one character there too. */
+export function codePointLength(value: string): number {
+  return Array.from(value).length;
+}
+
+export function truncateCodePoints(value: string, maxLength: number): string {
+  return Array.from(value).slice(0, maxLength).join('');
+}
+
+/**
+ * Turn a suggestion plus its canonical lookup into a verified place.
+ *
+ * Returns null when the lookup carries no usable canonical id — the suggestion's
+ * own id is never a fallback, because a suggestion id is not stable enough to
+ * store. A null result is what makes the caller degrade to manual entry.
+ */
+export function resolvePlace(
+  suggestion: PlaceSuggestion,
+  lookup: ResolvedPlaceLookup,
+): ResolvedPlace | null {
+  const canonicalProviderId = lookup.destination_provider_id;
+  if (
+    typeof canonicalProviderId !== 'string' ||
+    canonicalProviderId.trim().length === 0 ||
+    codePointLength(canonicalProviderId) > MAX_PROVIDER_ID_LENGTH
+  ) {
+    return null;
+  }
+
+  return {
+    provider: 'here',
+    provider_id: canonicalProviderId,
+    label: truncateCodePoints(suggestion.title, MAX_PLACE_LABEL_LENGTH),
+    address: truncateCodePoints(
+      lookup.destination ?? suggestion.subtitle,
+      MAX_PLACE_ADDRESS_LENGTH,
+    ),
+    lat: lookup.destination_lat ?? null,
+    lng: lookup.destination_lng ?? null,
+    // Trip.destination_country_code is max_length=2, so anything else would turn
+    // an otherwise valid place into a 400. A missing optional attribute of one
+    // canonical place is not a half-populated place (decision D6).
+    country_code:
+      lookup.destination_country_code?.length === 2
+        ? lookup.destination_country_code
+        : '',
+  };
+}

--- a/mobile/src/shared/location/types.ts
+++ b/mobile/src/shared/location/types.ts
@@ -1,0 +1,40 @@
+/**
+ * Provider-neutral place search contract, shared by every feature that needs a
+ * HERE-backed place. The picker and this module know nothing about the fields a
+ * caller writes: timeline maps a ResolvedPlace onto activity location fields,
+ * trips map it onto destination_*.
+ *
+ * The caps below are the tightest backend limits across both consumers and
+ * coincide exactly (decision D5 of the issue #63 plan):
+ *   label   200 = activity.location_label = activity.place_title = trip.destination
+ *   address 255 = activity.place_address
+ *   id      255 = activity.place_provider_id = trip.destination_provider_id
+ */
+export interface PlaceSuggestion {
+  provider: 'here';
+  provider_id: string;
+  title: string;
+  subtitle: string;
+}
+
+/** Raw shape of GET /api/location-search/lookup. */
+export interface ResolvedPlaceLookup {
+  destination: string;
+  destination_provider: 'here';
+  destination_provider_id: string;
+  destination_lat: number | null;
+  destination_lng: number | null;
+  destination_country_code: string;
+}
+
+/** A verified place, already truncated to the shared caps. */
+export interface ResolvedPlace {
+  provider: 'here';
+  provider_id: string;
+  label: string;
+  address: string;
+  lat: number | null;
+  lng: number | null;
+  /** ISO 3166-1 alpha-2, or '' when the provider gave nothing usable. */
+  country_code: string;
+}

--- a/mobile/src/shared/location/useLocationSearch.ts
+++ b/mobile/src/shared/location/useLocationSearch.ts
@@ -1,15 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { type ApiError, normalizeApiError } from '@/shared/api/errors';
-import { lookupLocation, suggestLocations } from '../api';
-import { ACTIVITY_FIELD_LIMITS } from '../formModel';
-import type {
-  ActivityPlacePayload,
-  LocationSuggestion,
-} from '../types';
+import { lookupLocation, suggestLocations } from './api';
 import {
-  buildStructuredLocation,
-  type StructuredLocationValue,
-} from '../viewModel';
+  MAX_PLACE_LABEL_LENGTH,
+  MAX_PROVIDER_ID_LENGTH,
+  resolvePlace,
+  truncateCodePoints,
+} from './resolvePlace';
+import type { PlaceSuggestion, ResolvedPlace } from './types';
 
 export const LOCATION_SEARCH_DEBOUNCE_MS = 300;
 export const PLACE_SEARCH_UNAVAILABLE_MESSAGE =
@@ -25,24 +23,19 @@ export type LocationSearchStatus =
   | 'error';
 export type LocationLookupStatus = 'idle' | 'loading' | 'ready' | 'error';
 
-export interface StructuredLocationSelection extends StructuredLocationValue {
-  location_mode: 'STRUCTURED';
+/** What the caller stores when the user declines or fails verification. */
+export interface ManualPlaceEntry {
+  label: string;
 }
 
-export interface ManualLocationValue {
-  location_mode: 'MANUAL';
-  location_label: string;
-  place: null;
-}
-
-export interface SettledLocationLookupFailure extends ManualLocationValue {
+export interface PlaceLookupFailure extends ManualPlaceEntry {
   error: ApiError;
   guidance: string;
 }
 
-export type LocationLookupResult =
-  | { kind: 'success'; selection: StructuredLocationSelection }
-  | { kind: 'failure'; fallback: SettledLocationLookupFailure }
+export type PlaceLookupResult =
+  | { kind: 'success'; place: ResolvedPlace }
+  | { kind: 'failure'; fallback: PlaceLookupFailure }
   | { kind: 'stale' };
 
 interface UseLocationSearchOptions {
@@ -62,26 +55,19 @@ function isLocationSearchUnavailable(error: ApiError): boolean {
   );
 }
 
-function withinProviderIdLimit(suggestion: LocationSuggestion): boolean {
-  return (
-    Array.from(suggestion.provider_id).length <=
-    ACTIVITY_FIELD_LIMITS.place_provider_id
-  );
+function withinProviderIdLimit(suggestion: PlaceSuggestion): boolean {
+  return Array.from(suggestion.provider_id).length <= MAX_PROVIDER_ID_LENGTH;
 }
 
-function staleLookupResult(): LocationLookupResult {
+function staleLookupResult(): PlaceLookupResult {
   return { kind: 'stale' };
-}
-
-function truncateCodePoints(value: string, maxLength: number): string {
-  return Array.from(value).slice(0, maxLength).join('');
 }
 
 export function useLocationSearch({
   enabled = true,
 }: UseLocationSearchOptions = {}) {
   const [query, setQueryValue] = useState('');
-  const [suggestions, setSuggestions] = useState<LocationSuggestion[]>([]);
+  const [suggestions, setSuggestions] = useState<PlaceSuggestion[]>([]);
   const [searchStatus, setSearchStatus] =
     useState<LocationSearchStatus>('idle');
   const [searchError, setSearchError] = useState<ApiError | null>(null);
@@ -241,16 +227,11 @@ export function useLocationSearch({
 
   const commitLookupFailure = useCallback(
     (
-      suggestion: LocationSuggestion,
+      suggestion: PlaceSuggestion,
       nextError: ApiError,
-    ): LocationLookupResult => {
-      const fallback: SettledLocationLookupFailure = {
-        location_mode: 'MANUAL',
-        location_label: truncateCodePoints(
-          suggestion.title,
-          ACTIVITY_FIELD_LIMITS.location_label,
-        ),
-        place: null,
+    ): PlaceLookupResult => {
+      const fallback: PlaceLookupFailure = {
+        label: truncateCodePoints(suggestion.title, MAX_PLACE_LABEL_LENGTH),
         error: nextError,
         guidance: MANUAL_LOCATION_GUIDANCE,
       };
@@ -263,9 +244,7 @@ export function useLocationSearch({
   );
 
   const selectSuggestion = useCallback(
-    async (
-      suggestion: LocationSuggestion,
-    ): Promise<LocationLookupResult> => {
+    async (suggestion: PlaceSuggestion): Promise<PlaceLookupResult> => {
       if (!enabled || !mountedRef.current) {
         return staleLookupResult();
       }
@@ -298,8 +277,8 @@ export function useLocationSearch({
           return staleLookupResult();
         }
 
-        const value = buildStructuredLocation(suggestion, lookup);
-        if (!value) {
+        const place = resolvePlace(suggestion, lookup);
+        if (!place) {
           return commitLookupFailure(
             suggestion,
             INVALID_CANONICAL_PLACE_ERROR,
@@ -307,13 +286,7 @@ export function useLocationSearch({
         }
 
         setLookupStatus('ready');
-        return {
-          kind: 'success',
-          selection: {
-            location_mode: 'STRUCTURED',
-            ...value,
-          },
-        };
+        return { kind: 'success', place };
       } catch (caught) {
         if (
           !mountedRef.current ||
@@ -338,10 +311,8 @@ export function useLocationSearch({
   );
 
   const createManualValue = useCallback(
-    (existingLabel = ''): ManualLocationValue => ({
-      location_mode: 'MANUAL',
-      location_label: query.trim() || existingLabel,
-      place: null,
+    (existingLabel = ''): ManualPlaceEntry => ({
+      label: query.trim() || existingLabel,
     }),
     [query],
   );
@@ -361,8 +332,3 @@ export function useLocationSearch({
     createManualValue,
   };
 }
-
-export type PlacePickerValue = {
-  location_label: string;
-  place: ActivityPlacePayload | null;
-};

--- a/mobile/src/shared/media/__tests__/uploadFile.test.ts
+++ b/mobile/src/shared/media/__tests__/uploadFile.test.ts
@@ -52,4 +52,21 @@ describe('uploadFile', () => {
 
     expect(request.mock.calls[0][0].method).toBe('post');
   });
+
+  it('leaves the timeout to the client default when no override is given', async () => {
+    const request = jest.spyOn(apiClient, 'request').mockResolvedValue({ data: {} });
+
+    await uploadFile('/auth/avatar', 'avatar', file);
+
+    // Avatars are small; they must keep inheriting the 15s instance default.
+    expect(request.mock.calls[0][0].timeout).toBeUndefined();
+  });
+
+  it('passes an explicit timeout down to axios', async () => {
+    const request = jest.spyOn(apiClient, 'request').mockResolvedValue({ data: {} });
+
+    await uploadFile('/media/trip-covers', 'file', file, 'post', { timeoutMs: 120_000 });
+
+    expect(request.mock.calls[0][0].timeout).toBe(120_000);
+  });
 });

--- a/mobile/src/shared/media/uploadFile.ts
+++ b/mobile/src/shared/media/uploadFile.ts
@@ -13,22 +13,37 @@ export function buildUploadFormData(field: string, file: UploadableFile): FormDa
   return form;
 }
 
+export interface UploadFileOptions {
+  /**
+   * Only for uploads whose payload cannot finish inside the client's 15s default
+   * on a mobile connection. Omit it and the instance default applies — axios
+   * treats an undefined per-request timeout as "use the instance value".
+   */
+  timeoutMs?: number;
+}
+
 /**
  * Content-Type is deliberately left unset. Axios passes FormData through its
  * transform untouched without adding a header, and React Native's
  * XMLHttpRequest then sets `multipart/form-data; boundary=...`. Setting the
  * header by hand drops the boundary and the body becomes unparseable server-side.
+ *
+ * The timeout rides in the request config rather than in a second axios client,
+ * so an upload retried after a 401 refresh keeps it, and keeps the auth
+ * interceptors with it.
  */
 export async function uploadFile<T>(
   path: string,
   field: string,
   file: UploadableFile,
   method: 'post' | 'patch' = 'patch',
+  options: UploadFileOptions = {},
 ): Promise<T> {
   const { data } = await apiClient.request<T>({
     url: path,
     method,
     data: buildUploadFormData(field, file),
+    timeout: options.timeoutMs,
   });
   return data;
 }


### PR DESCRIPTION
Closes #63.

Brings the mobile trip create/edit forms to parity with web on the two degraded fields: the **cover image** (mobile could display one but never set it) and the **destination** (mobile submitted free text, leaving the five `destination_*` columns empty on a row the web client also writes).

Two independently revertable halves: commits 1–7 destination, 8–9 cover. Neither imports the other. No backend change.

## What changed

**Shared place picker (`src/shared/location/`)** — the HERE picker built for the timeline in #58 is promoted out of `features/timeline` and made field-agnostic. It emits a neutral `ResolvedPlace` and knows nothing about activity or trip fields; each caller owns its own mapping.

**Destination** — `features/trips/destination.ts` maps a verified place onto the six destination columns. All six always travel together: a structured value writes five columns from one lookup, a manual value clears all five. There is no third shape.

**Cover** — reuses `src/shared/media/` end to end: pick → preprocess to the backend's budget → `POST /api/media/trip-covers` → hold the returned `/media/...` URL → submit as `cover_image_url`.

## Disclosures

**Edit never clears stored coordinates.** A PATCH omits all six destination keys unless the user actually changed the destination — a partial PATCH that never mentions destination cannot clear stored coordinates. This is the one failure mode of this milestone that produces no error and no visible symptom, so it is tested first and by name: `'keeps the stored destination when only the name changes'` (`EditTripScreen.test.tsx`) asserts the payload has **none** of the six keys. **It passes**, and it was also verified live against the running backend: renaming a trip left `destination`, `destination_provider`, `destination_provider_id`, `destination_lat`, `destination_lng`, `destination_country_code` and `cover_image_url` byte-identical.

**Divergence from the issue's "timeline tests pass untouched" clause (D1).** A genuinely field-agnostic picker cannot keep the timeline-shaped callback payloads, so the issue body was edited before implementation to record this. Three timeline test files changed, and only mechanically:
- `viewModel.test.ts` — **type import path only**. Every `describe`, `it` and `expect` is byte-identical; this suite is the behaviour-preservation proof for the whole move.
- `ActivityFormScreen.test.tsx` — mock path (`../components/PlacePicker` → `@/shared/location/PlacePicker`) and the two callback payload shapes. The `expect(onChange)` / `expect(onUseManual)` assertions keep their original expected values, which is what proves the timeline still writes the same draft.
- `api.test.ts` — the two location cases moved verbatim to `src/shared/location/__tests__/api.test.ts`.

`useLocationSearch.test.tsx` and `PlacePicker.test.tsx` moved to `src/shared/location/__tests__/` with the same mechanical edits. No assertion intent, no expected value, and no behaviour changed anywhere.

**Orphaned uploads — accepted.** An upload followed by an abandoned form leaves a file in `trip-covers/` that no trip references. This matches web behaviour, the file is a single downscaled WebP, and no delete endpoint exists. No cleanup mechanism was invented.

**Covers are public media.** `PublicMediaFileAPIView` sets `authentication_classes = []` and `AllowAny`, so covers need **no** auth header — verified live (`GET` without a header returns `200 image/webp`). Trip photos and memory assets in #64/#65 are expected to behave the opposite way.

**Request/response asymmetry (D2).** `destination_lat`/`destination_lng` travel as JSON numbers on the request and come back as strings, because Django serialises `Decimal` that way. Confirmed live in both directions; commented in `types.ts`.

**`destination_country_code` (D6).** A code that is not exactly 2 characters is dropped client-side, because the column is `max_length=2` and anything longer would 400 an otherwise valid place.

## Verification

`pnpm lint` + `pnpm typecheck` + `pnpm test` from `mobile/`: **97 suites / 1116 tests pass** (baseline on `main`: 91 / 1058).

iOS Simulator QA on the existing iPhone 17 Pro Max dev build, against the local Django backend and the real HERE API — all seven journeys pass:

| # | Journey | Result |
|---|---|---|
| 1 | Create with HERE-picked destination + cover | all five `destination_*` populated, cover renders in list and on detail |
| 2 | Edit that trip, change only the name | cover and all six destination fields unchanged |
| 3 | Create with a manual destination and no cover | five fields empty/null, placeholder renders |
| 4 | Tap Create while a cover upload is in flight | submit blocked with the wait hint; no trip created |
| 5 | `ENABLE_HERE_LOCATION_SEARCH=false` | picker shows the unavailable message; manual entry still submits |
| 6 | Remove a cover on edit, save | `cover_image_url` becomes `''`; destination untouched |
| 7 | Upload the same cover 30 times | `429` renders as the throttle message at request #31 |

Journey 4 was made observable by pausing the backend container to hold the upload open. Journey 5 temporarily flipped the backend flag; the env file was restored and verified identical to its backup.

## Known trade-off in the history

Commits 1–3 are a deliberate mid-move state and do **not** typecheck in isolation; commit 4 closes it. Tasks 1–4 form one revert boundary — reverting all four restores the shipped timeline behaviour without touching anything else. Worth knowing before `git bisect` across this range.

## Not done

No map view, pin-drop, or reverse geocoding. No cover cropping UI. No cover delete endpoint or orphan cleanup. No cover on any entity other than `Trip`. No web, HERE-proxy, or backend contract changes. No Android work — iOS only, per #58/#62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
