### PR TITLE
feat(mobile): add realtime transport and notifications

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,13 +1,17 @@
 # -------- Django Core Flags --------
 DJANGO_DEBUG=1
-# For mobile/Expo Go dev on a physical device, add the Mac's LAN IP so
-# Django accepts requests from the phone's network address, e.g.
-# DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,192.168.1.23
+# For mobile/Expo Go dev on a physical device, use an HTTPS API ingress or
+# tunnel and add its hostname, e.g. api-dev.example.test. The mobile realtime
+# client intentionally rejects cleartext WebSockets to non-loopback hosts.
+# DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,api-dev.example.test
 DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
-# Include http://[::1]:3000 for IPv6 loopback — some browsers / Node DNS
-# orderings resolve `localhost` to ::1 first. Without this entry the ASGI
-# OriginValidator silently rejects WebSocket handshakes from that origin.
-CORS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,http://[::1]:3000
+# ASGI OriginValidator uses this list for WebSockets too. Browsers send the
+# web-app origin (:3000), while React Native iOS derives Origin from the API
+# socket URL (:8000). Keep both explicit; never use a wildcard or `null`.
+# For a physical device, add the exact HTTPS ingress/tunnel API origin, e.g.
+# https://api-dev.example.test. Production likewise needs both the public app
+# and API origins, e.g. https://app.example.com,https://api.example.com.
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,http://[::1]:3000,http://localhost:8000,http://127.0.0.1:8000,http://[::1]:8000
 CSRF_TRUSTED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,http://[::1]:3000
 DJANGO_SECRET_KEY=replace-with-your-own-secret-key
 # Optional, dev-only: enable explicit throttle bypass for listed emails. Keep

--- a/backend/configs/asgi.py
+++ b/backend/configs/asgi.py
@@ -15,12 +15,17 @@ from django.conf import settings  # noqa: E402
 from realtime.middleware import WebSocketAuthMiddleware  # noqa: E402
 from realtime.routing import websocket_urlpatterns  # noqa: E402
 
-application = ProtocolTypeRouter({
-    "http": django_asgi_app,
-    "websocket": OriginValidator(
-        WebSocketAuthMiddleware(
-            URLRouter(websocket_urlpatterns)
+
+def build_asgi_application() -> ProtocolTypeRouter:
+    return ProtocolTypeRouter({
+        "http": django_asgi_app,
+        "websocket": OriginValidator(
+            WebSocketAuthMiddleware(
+                URLRouter(websocket_urlpatterns)
+            ),
+            allowed_origins=settings.CORS_ALLOWED_ORIGINS,
         ),
-        allowed_origins=settings.CORS_ALLOWED_ORIGINS,
-    ),
-})
+    })
+
+
+application = build_asgi_application()

--- a/backend/configs/settings.py
+++ b/backend/configs/settings.py
@@ -36,11 +36,11 @@ def env_origins(name: str) -> tuple[str, ...]:
     if not origins:
         raise ImproperlyConfigured(f"{name} must contain at least one origin.")
 
-    for origin in origins:
+    for entry_index, origin in enumerate(origins, start=1):
         lowered_origin = origin.lower()
         if lowered_origin == "null" or "*" in origin:
             raise ImproperlyConfigured(
-                f"{name} must contain only explicit HTTP(S) origins."
+                f"{name} entry {entry_index} must be an explicit HTTP(S) origin."
             )
 
         try:
@@ -48,25 +48,26 @@ def env_origins(name: str) -> tuple[str, ...]:
             parsed = urlsplit(origin)
             hostname = parsed.hostname
             _ = parsed.port
-        except (ValidationError, ValueError) as exc:
-            raise ImproperlyConfigured(
-                f"{name} contains an invalid origin: {origin}."
-            ) from exc
-
-        if (
-            parsed.scheme not in {"http", "https"}
-            or hostname is None
-            or hostname.startswith(".")
-            or parsed.username is not None
-            or parsed.password is not None
-            or parsed.path
-            or parsed.query
-            or parsed.fragment
-            or parsed.netloc.endswith(":")
-        ):
-            raise ImproperlyConfigured(
-                f"{name} contains an invalid origin: {origin}."
+        except (ValidationError, ValueError):
+            invalid_origin = True
+        else:
+            invalid_origin = (
+                parsed.scheme not in {"http", "https"}
+                or hostname is None
+                or hostname.startswith(".")
+                or parsed.username is not None
+                or parsed.password is not None
+                or parsed.path
+                or parsed.query
+                or parsed.fragment
+                or parsed.netloc.endswith(":")
             )
+
+        if invalid_origin:
+            raise ImproperlyConfigured(
+                f"{name} entry {entry_index} must be a valid HTTP(S) origin "
+                "without credentials, path, query, or fragment."
+            ) from None
 
     return origins
 

--- a/backend/configs/settings.py
+++ b/backend/configs/settings.py
@@ -3,8 +3,10 @@ import sys
 
 from datetime import timedelta
 from pathlib import Path
+from urllib.parse import urlsplit
 
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured, ValidationError
+from django.core.validators import URLValidator
 from PIL import Image as _PILImage
 
 # Process-wide hard guard for extreme decompression bombs. Every Image.open path
@@ -14,6 +16,7 @@ _PILImage.MAX_IMAGE_PIXELS = 50_000_000
 
 
 BASE_DIR = Path(__file__).resolve().parent.parent
+_HTTP_ORIGIN_VALIDATOR = URLValidator(schemes=("http", "https"))
 
 
 def env_bool(name: str, default: bool = False) -> bool:
@@ -26,6 +29,46 @@ def env_bool(name: str, default: bool = False) -> bool:
 def env_list(name: str) -> tuple[str, ...]:
     raw = os.environ.get(name, "")
     return tuple(item.strip() for item in raw.split(",") if item.strip())
+
+
+def env_origins(name: str) -> tuple[str, ...]:
+    origins = env_list(name)
+    if not origins:
+        raise ImproperlyConfigured(f"{name} must contain at least one origin.")
+
+    for origin in origins:
+        lowered_origin = origin.lower()
+        if lowered_origin == "null" or "*" in origin:
+            raise ImproperlyConfigured(
+                f"{name} must contain only explicit HTTP(S) origins."
+            )
+
+        try:
+            _HTTP_ORIGIN_VALIDATOR(origin)
+            parsed = urlsplit(origin)
+            hostname = parsed.hostname
+            _ = parsed.port
+        except (ValidationError, ValueError) as exc:
+            raise ImproperlyConfigured(
+                f"{name} contains an invalid origin: {origin}."
+            ) from exc
+
+        if (
+            parsed.scheme not in {"http", "https"}
+            or hostname is None
+            or hostname.startswith(".")
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.path
+            or parsed.query
+            or parsed.fragment
+            or parsed.netloc.endswith(":")
+        ):
+            raise ImproperlyConfigured(
+                f"{name} contains an invalid origin: {origin}."
+            )
+
+    return origins
 
 
 def env_int(name: str, default: int) -> int:
@@ -228,7 +271,7 @@ TRIP_MEMORY_MAX_ACTIVE_PER_USER_PER_TRIP = 1
 TRIP_MEMORY_MAX_ACTIVE_PER_TRIP = 3
 
 # -------- Cross-Origin Settings --------
-CORS_ALLOWED_ORIGINS = os.environ['CORS_ALLOWED_ORIGINS'].split(',')
+CORS_ALLOWED_ORIGINS = env_origins('CORS_ALLOWED_ORIGINS')
 CSRF_TRUSTED_ORIGINS = os.environ['CSRF_TRUSTED_ORIGINS'].split(',')
 
 SESSION_COOKIE_SAMESITE = 'Lax'

--- a/backend/configs/tests.py
+++ b/backend/configs/tests.py
@@ -1,14 +1,109 @@
 import logging
 import os
+import subprocess
+import sys
 from unittest.mock import patch
 
 from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase
 
-from configs.settings import env_int, env_positive_int
+from configs.settings import env_int, env_origins, env_positive_int
 
 
 class SettingsEnvironmentTests(SimpleTestCase):
+    def test_env_origins_parses_trimmed_explicit_origins(self):
+        with patch.dict(
+            os.environ,
+            {
+                "TEST_ALLOWED_ORIGINS": (
+                    " https://app.example.com, http://127.0.0.1:8000 "
+                )
+            },
+            clear=True,
+        ):
+            self.assertEqual(
+                env_origins("TEST_ALLOWED_ORIGINS"),
+                ("https://app.example.com", "http://127.0.0.1:8000"),
+            )
+
+    def test_env_origins_rejects_missing_or_blank_allowlist(self):
+        for value in (None, "", " , "):
+            with self.subTest(value=value):
+                environment = (
+                    {} if value is None else {"TEST_ALLOWED_ORIGINS": value}
+                )
+                with patch.dict(os.environ, environment, clear=True):
+                    with self.assertRaisesMessage(
+                        ImproperlyConfigured,
+                        "TEST_ALLOWED_ORIGINS must contain at least one origin.",
+                    ):
+                        env_origins("TEST_ALLOWED_ORIGINS")
+
+    def test_env_origins_rejects_permissive_values(self):
+        for value in (
+            "*",
+            "null",
+            "https://*.example.com",
+        ):
+            with self.subTest(value=value):
+                with patch.dict(
+                    os.environ,
+                    {"TEST_ALLOWED_ORIGINS": value},
+                    clear=True,
+                ):
+                    with self.assertRaisesMessage(
+                        ImproperlyConfigured,
+                        "TEST_ALLOWED_ORIGINS must contain only explicit HTTP(S) origins.",
+                    ):
+                        env_origins("TEST_ALLOWED_ORIGINS")
+
+    def test_env_origins_rejects_non_origin_urls(self):
+        invalid_origins = (
+            "ftp://api.example.com",
+            "https://user@example.com",
+            "https://api.example.com/path",
+            "https://api.example.com?query=1",
+            "https://api.example.com#fragment",
+            "https://api.example.com:not-a-port",
+            "http://[::1",
+            "http://[]",
+            "https://bad host.example",
+            "https://example.com\\evil",
+            "https://.example.com",
+        )
+        for value in invalid_origins:
+            with self.subTest(value=value):
+                with patch.dict(
+                    os.environ,
+                    {"TEST_ALLOWED_ORIGINS": value},
+                    clear=True,
+                ):
+                    with self.assertRaisesMessage(
+                        ImproperlyConfigured,
+                        f"TEST_ALLOWED_ORIGINS contains an invalid origin: {value}.",
+                    ):
+                        env_origins("TEST_ALLOWED_ORIGINS")
+
+    def test_asgi_startup_rejects_unsafe_origin_allowlists(self):
+        cases = (
+            ("*", "must contain only explicit HTTP(S) origins"),
+            ("", "must contain at least one origin"),
+        )
+        for value, expected_error in cases:
+            with self.subTest(value=value):
+                environment = os.environ.copy()
+                environment["CORS_ALLOWED_ORIGINS"] = value
+                result = subprocess.run(
+                    [sys.executable, "-c", "import configs.asgi"],
+                    capture_output=True,
+                    check=False,
+                    env=environment,
+                    text=True,
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(expected_error, result.stderr)
+
     def test_env_int_uses_default_when_variable_is_missing(self):
         with patch.dict(os.environ, {}, clear=True):
             self.assertEqual(env_int("DB_CONN_MAX_AGE", 0), 0)

--- a/backend/configs/tests.py
+++ b/backend/configs/tests.py
@@ -53,7 +53,8 @@ class SettingsEnvironmentTests(SimpleTestCase):
                 ):
                     with self.assertRaisesMessage(
                         ImproperlyConfigured,
-                        "TEST_ALLOWED_ORIGINS must contain only explicit HTTP(S) origins.",
+                        "TEST_ALLOWED_ORIGINS entry 1 must be an explicit "
+                        "HTTP(S) origin.",
                     ):
                         env_origins("TEST_ALLOWED_ORIGINS")
 
@@ -80,13 +81,42 @@ class SettingsEnvironmentTests(SimpleTestCase):
                 ):
                     with self.assertRaisesMessage(
                         ImproperlyConfigured,
-                        f"TEST_ALLOWED_ORIGINS contains an invalid origin: {value}.",
-                    ):
+                        "TEST_ALLOWED_ORIGINS entry 1 must be a valid HTTP(S) origin",
+                    ) as raised:
                         env_origins("TEST_ALLOWED_ORIGINS")
+                self.assertNotIn(value, str(raised.exception))
+
+    def test_env_origins_redacts_invalid_values_and_discards_validation_context(self):
+        marker = "REVIEW_FAKE_SECRET_72"
+        cases = (
+            f"not-a-url-{marker}",
+            f"https://review-user:{marker}@example.com",
+        )
+
+        for value in cases:
+            with self.subTest(value=value):
+                with patch.dict(
+                    os.environ,
+                    {
+                        "TEST_ALLOWED_ORIGINS": (
+                            f"https://app.example.com,{value}"
+                        )
+                    },
+                    clear=True,
+                ):
+                    with self.assertRaisesMessage(
+                        ImproperlyConfigured,
+                        "TEST_ALLOWED_ORIGINS entry 2",
+                    ) as raised:
+                        env_origins("TEST_ALLOWED_ORIGINS")
+
+                self.assertNotIn(marker, str(raised.exception))
+                self.assertIsNone(raised.exception.__cause__)
+                self.assertIsNone(raised.exception.__context__)
 
     def test_asgi_startup_rejects_unsafe_origin_allowlists(self):
         cases = (
-            ("*", "must contain only explicit HTTP(S) origins"),
+            ("*", "entry 1 must be an explicit HTTP(S) origin"),
             ("", "must contain at least one origin"),
         )
         for value, expected_error in cases:
@@ -103,6 +133,32 @@ class SettingsEnvironmentTests(SimpleTestCase):
 
                 self.assertNotEqual(result.returncode, 0)
                 self.assertIn(expected_error, result.stderr)
+
+    def test_asgi_startup_does_not_log_invalid_origin_values(self):
+        marker = "REVIEW_FAKE_SECRET_72"
+        cases = (
+            f"not-a-url-{marker}",
+            f"https://review-user:{marker}@example.com",
+        )
+
+        for value in cases:
+            with self.subTest(value=value):
+                environment = os.environ.copy()
+                environment["CORS_ALLOWED_ORIGINS"] = value
+                result = subprocess.run(
+                    [sys.executable, "-c", "import configs.asgi"],
+                    capture_output=True,
+                    check=False,
+                    env=environment,
+                    text=True,
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    "CORS_ALLOWED_ORIGINS entry 1 must be a valid HTTP(S) origin",
+                    result.stderr,
+                )
+                self.assertNotIn(marker, result.stderr)
 
     def test_env_int_uses_default_when_variable_is_missing(self):
         with patch.dict(os.environ, {}, clear=True):

--- a/backend/realtime/tests/test_middleware.py
+++ b/backend/realtime/tests/test_middleware.py
@@ -11,6 +11,10 @@ from django.test import TransactionTestCase, override_settings
 from django.urls import re_path
 from django.utils import timezone
 
+from configs.asgi import (
+    application as production_asgi_application,
+    build_asgi_application,
+)
 from realtime.consumers import RealtimeConsumer
 from realtime.middleware import WebSocketAuthMiddleware
 from realtime.services import issue_ws_ticket
@@ -40,6 +44,35 @@ def _make_communicator(ticket=None):
     return WebsocketCommunicator(
         _build_application(),
         "ws/realtime",
+        subprotocols=subprotocols,
+    )
+
+
+def _make_configured_production_communicator(
+    ticket,
+    origin=None,
+    *,
+    allowed_origins,
+):
+    subprotocols = [settings.WS_SUBPROTOCOL, ticket]
+    with override_settings(CORS_ALLOWED_ORIGINS=allowed_origins):
+        application = build_asgi_application()
+    headers = [] if origin is None else [(b"origin", origin.encode("ascii"))]
+    return WebsocketCommunicator(
+        application,
+        "ws/realtime",
+        headers=headers,
+        subprotocols=subprotocols,
+    )
+
+
+def _make_production_communicator(ticket, origin=None):
+    subprotocols = [settings.WS_SUBPROTOCOL, ticket]
+    headers = [] if origin is None else [(b"origin", origin.encode("ascii"))]
+    return WebsocketCommunicator(
+        production_asgi_application,
+        "ws/realtime",
+        headers=headers,
         subprotocols=subprotocols,
     )
 
@@ -91,6 +124,95 @@ class WebSocketAuthMiddlewareTests(TransactionTestCase):
 
         self.assertTrue(connected)
         await communicator.disconnect()
+
+    async def test_configured_origins_reach_production_ticket_authentication(self):
+        browser_origin = "http://localhost:3000"
+        native_origin = "http://127.0.0.1:8000"
+        allowed_origins = [browser_origin, native_origin]
+
+        for index, origin in enumerate(allowed_origins):
+            with self.subTest(origin=origin):
+                user = await _create_user(email=f"allowed-origin-{index}@example.com")
+                ticket = await _issue_ws_ticket(user)
+                communicator = _make_configured_production_communicator(
+                    ticket,
+                    origin,
+                    allowed_origins=allowed_origins,
+                )
+                connected, subprotocol = await communicator.connect()
+
+                self.assertTrue(connected)
+                self.assertEqual(subprotocol, settings.WS_SUBPROTOCOL)
+                await communicator.disconnect()
+
+    async def test_missing_origin_is_rejected_without_consuming_ticket(self):
+        user = await _create_user(email="missing-origin@example.com")
+        ticket = await _issue_ws_ticket(user)
+
+        native_origin = "http://127.0.0.1:8000"
+        allowed_origins = [native_origin]
+        rejected = _make_configured_production_communicator(
+            ticket,
+            allowed_origins=allowed_origins,
+        )
+        connected, _ = await rejected.connect()
+
+        self.assertFalse(connected)
+
+        accepted = _make_configured_production_communicator(
+            ticket,
+            native_origin,
+            allowed_origins=allowed_origins,
+        )
+        connected, _ = await accepted.connect()
+        self.assertTrue(connected)
+        await accepted.send_json_to({"type": "ping"})
+        self.assertEqual(await accepted.receive_json_from(), {"type": "pong"})
+        await accepted.disconnect()
+
+    async def test_unlisted_origin_is_rejected_without_consuming_ticket(self):
+        user = await _create_user(email="rejected-origin@example.com")
+        ticket = await _issue_ws_ticket(user)
+        native_origin = "http://127.0.0.1:8000"
+
+        rejected = _make_configured_production_communicator(
+            ticket,
+            "https://untrusted.example",
+            allowed_origins=[native_origin],
+        )
+        connected, _ = await rejected.connect()
+        self.assertFalse(connected)
+
+        accepted = _make_configured_production_communicator(
+            ticket,
+            native_origin,
+            allowed_origins=[native_origin],
+        )
+        connected, _ = await accepted.connect()
+        self.assertTrue(connected)
+        await accepted.send_json_to({"type": "ping"})
+        self.assertEqual(await accepted.receive_json_from(), {"type": "pong"})
+        await accepted.disconnect()
+
+    async def test_production_asgi_stack_rejects_origin_before_consuming_ticket(self):
+        user = await _create_user(email="production-origin-stack@example.com")
+        ticket = await _issue_ws_ticket(user)
+        configured_origin = settings.CORS_ALLOWED_ORIGINS[0]
+
+        rejected = _make_production_communicator(
+            ticket,
+            "https://untrusted.example",
+        )
+        connected, _ = await rejected.connect()
+        self.assertFalse(connected)
+
+        accepted = _make_production_communicator(ticket, configured_origin)
+        connected, subprotocol = await accepted.connect()
+        self.assertTrue(connected)
+        self.assertEqual(subprotocol, settings.WS_SUBPROTOCOL)
+        await accepted.send_json_to({"type": "ping"})
+        self.assertEqual(await accepted.receive_json_from(), {"type": "pong"})
+        await accepted.disconnect()
 
     async def test_missing_ticket_closes_4001(self):
         communicator = _make_communicator(ticket=None)

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -23,6 +23,7 @@
     "expo-image-picker": "57.0.2",
     "expo-linking": "~57.0.1",
     "expo-media-library": "~57.0.3",
+    "expo-network": "~57.0.1",
     "expo-router": "~57.0.3",
     "expo-secure-store": "~57.0.0",
     "expo-splash-screen": "~57.0.2",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       expo-media-library:
         specifier: ~57.0.3
         version: 57.0.3(expo@57.0.2)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))
+      expo-network:
+        specifier: ~57.0.1
+        version: 57.0.1(expo@57.0.2)(react@19.2.3)
       expo-router:
         specifier: ~57.0.3
         version: 57.0.3(33be339587e66ea5f87a3b18ea47a8b6)
@@ -2571,6 +2574,12 @@ packages:
     resolution: {integrity: sha512-lNcA2XLKpbG/Qr3CZ6yCgzlK8oT+zwuD19QKYoRfN5ZurkVhnSA3QdTR5K32n9AxohcENYtZRtnHr2pZoG7W4w==}
     peerDependencies:
       react-native: '*'
+
+  expo-network@57.0.1:
+    resolution: {integrity: sha512-ndg+FbDDlz6XTpQ6aVuVgyvrYQwMkpcUAvZIXbwrGBbLTSWNzYC/gawYu1BAeDN7O6JTGY98GBVJBov/JH7LgQ==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
 
   expo-router@57.0.3:
     resolution: {integrity: sha512-Pm9CYn6WSyTM3pfmUJxQHkS/bzCzX1G+IJBRsXLE/MyOOWyfkM/Lu1/UiAlCyHOCuCWe2SuA5jrIE00+5qF9pQ==}
@@ -8004,6 +8013,11 @@ snapshots:
   expo-modules-jsi@57.0.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)):
     dependencies:
       react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+
+  expo-network@57.0.1(expo@57.0.2)(react@19.2.3):
+    dependencies:
+      expo: 57.0.2(@babel/core@7.29.7)(@expo/dom-webview@57.0.0)(@expo/metro-runtime@57.0.3)(expo-router@57.0.3)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      react: 19.2.3
 
   expo-router@57.0.3(33be339587e66ea5f87a3b18ea47a8b6):
     dependencies:

--- a/mobile/src/app/(tabs)/_layout.tsx
+++ b/mobile/src/app/(tabs)/_layout.tsx
@@ -1,14 +1,22 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Redirect, Tabs } from 'expo-router';
 import { useSession } from '@/features/auth/session';
-import { NotificationsProvider, useNotifications } from '@/features/notifications/application/NotificationsProvider';
+import { useNotifications } from '@/features/notifications/application/NotificationsProvider';
 import { colors } from '@/shared/theme/tokens';
 import { LoadingScreen } from '@/shared/ui/LoadingScreen';
 
 function TabsNavigator() {
-  const { unreadCount } = useNotifications();
+  const { unreadCount, lastKnownUnreadCount } = useNotifications();
   const notificationsBadge =
-    unreadCount !== null && unreadCount > 0 ? (unreadCount > 99 ? '99+' : unreadCount) : undefined;
+    unreadCount !== null
+      ? unreadCount > 0
+        ? unreadCount > 99
+          ? '99+'
+          : unreadCount
+        : undefined
+      : lastKnownUnreadCount !== null && lastKnownUnreadCount > 0
+        ? '•'
+        : undefined;
   return (
     <Tabs screenOptions={{ tabBarActiveTintColor: colors.primary, headerShown: true }}>
       <Tabs.Screen
@@ -58,9 +66,5 @@ export default function TabsLayout() {
   if (user?.requires_profile_setup) {
     return <Redirect href="/(auth)/profile-setup" />;
   }
-  return (
-    <NotificationsProvider ownerUserId={user?.id ?? null}>
-      <TabsNavigator />
-    </NotificationsProvider>
-  );
+  return <TabsNavigator />;
 }

--- a/mobile/src/app/(tabs)/_layout.tsx
+++ b/mobile/src/app/(tabs)/_layout.tsx
@@ -6,7 +6,8 @@ import { colors } from '@/shared/theme/tokens';
 import { LoadingScreen } from '@/shared/ui/LoadingScreen';
 
 function TabsNavigator() {
-  const { unreadCount, lastKnownUnreadCount } = useNotifications();
+  const { items, unreadCount, lastKnownUnreadCount } = useNotifications();
+  const hasLoadedUnread = items.some((item) => !item.is_read);
   const notificationsBadge =
     unreadCount !== null
       ? unreadCount > 0
@@ -14,7 +15,7 @@ function TabsNavigator() {
           ? '99+'
           : unreadCount
         : undefined
-      : lastKnownUnreadCount !== null && lastKnownUnreadCount > 0
+      : (lastKnownUnreadCount !== null && lastKnownUnreadCount > 0) || hasLoadedUnread
         ? '•'
         : undefined;
   return (

--- a/mobile/src/app/__tests__/_layout.test.tsx
+++ b/mobile/src/app/__tests__/_layout.test.tsx
@@ -1,4 +1,5 @@
 const mockStackScreen = jest.fn();
+const mockProviderOrder = jest.fn();
 
 jest.mock('expo-router', () => {
   const React = jest.requireActual<typeof import('react')>('react');
@@ -17,7 +18,31 @@ jest.mock('expo-router', () => {
 });
 
 jest.mock('@/features/auth/session', () => ({
-  SessionProvider: ({ children }: { children: import('react').ReactNode }) => children,
+  SessionProvider: ({ children }: { children: import('react').ReactNode }) => {
+    mockProviderOrder('session');
+    return children;
+  },
+  useSession: () => ({ user: { id: 'user-1' } }),
+}));
+
+jest.mock('@/features/realtime/application/RealtimeProvider', () => ({
+  RealtimeProvider: ({ children }: { children: import('react').ReactNode }) => {
+    mockProviderOrder('realtime');
+    return children;
+  },
+}));
+
+jest.mock('@/features/notifications/application/NotificationsProvider', () => ({
+  NotificationsProvider: ({
+    children,
+    ownerUserId,
+  }: {
+    children: import('react').ReactNode;
+    ownerUserId: string | null;
+  }) => {
+    mockProviderOrder(`notifications:${ownerUserId ?? 'none'}`);
+    return children;
+  },
 }));
 
 // eslint-disable-next-line import/first
@@ -26,6 +51,20 @@ import { render } from '@testing-library/react-native';
 import RootLayout from '../_layout';
 
 describe('RootLayout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('owns one session-scoped realtime and notifications provider above the root stack', async () => {
+    await render(<RootLayout />);
+
+    expect(mockProviderOrder.mock.calls.map(([name]) => name)).toEqual([
+      'session',
+      'realtime',
+      'notifications:user-1',
+    ]);
+  });
+
   it('registers the guarded Friends native stack', async () => {
     await render(<RootLayout />);
 

--- a/mobile/src/app/_layout.tsx
+++ b/mobile/src/app/_layout.tsx
@@ -1,16 +1,32 @@
 import { Stack } from 'expo-router';
-import { SessionProvider } from '@/features/auth/session';
+import type { PropsWithChildren } from 'react';
+import { SessionProvider, useSession } from '@/features/auth/session';
+import { NotificationsProvider } from '@/features/notifications/application/NotificationsProvider';
+import { RealtimeProvider } from '@/features/realtime/application/RealtimeProvider';
+
+function SessionBoundProviders({ children }: PropsWithChildren) {
+  const { user } = useSession();
+  return (
+    <RealtimeProvider>
+      <NotificationsProvider ownerUserId={user?.id ?? null}>
+        {children}
+      </NotificationsProvider>
+    </RealtimeProvider>
+  );
+}
 
 export default function RootLayout() {
   return (
     <SessionProvider>
-      <Stack screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="(auth)" />
-        <Stack.Screen name="(tabs)" />
-        <Stack.Screen name="trips" />
-        <Stack.Screen name="friends" />
-        <Stack.Screen name="account" />
-      </Stack>
+      <SessionBoundProviders>
+        <Stack screenOptions={{ headerShown: false }}>
+          <Stack.Screen name="(auth)" />
+          <Stack.Screen name="(tabs)" />
+          <Stack.Screen name="trips" />
+          <Stack.Screen name="friends" />
+          <Stack.Screen name="account" />
+        </Stack>
+      </SessionBoundProviders>
     </SessionProvider>
   );
 }

--- a/mobile/src/features/notifications/__tests__/NotificationRow.test.tsx
+++ b/mobile/src/features/notifications/__tests__/NotificationRow.test.tsx
@@ -42,6 +42,25 @@ describe('NotificationRow', () => {
     expect(onOpen).toHaveBeenCalledWith('notification-1', null);
   });
 
+  it('exposes the current read state once on the simple row action', async () => {
+    const { rerender } = await render(<NotificationRow {...defaultProps} notification={base} />);
+
+    const label = 'Bob sent you a friend request';
+    expect(screen.getByRole('button', { name: label }).props.accessibilityValue).toEqual({
+      text: 'Unread',
+    });
+    expect(screen.queryByLabelText('Unread')).toBeNull();
+
+    await rerender(
+      <NotificationRow {...defaultProps} notification={{ ...base, is_read: true }} />,
+    );
+
+    expect(screen.getByRole('button', { name: label }).props.accessibilityValue).toEqual({
+      text: 'Read',
+    });
+    expect(screen.queryByLabelText('Unread')).toBeNull();
+  });
+
   it('renders malformed and unknown payloads neutrally without exposing raw JSON', async () => {
     await render(
       <NotificationRow
@@ -108,6 +127,35 @@ describe('NotificationRow', () => {
     expect(screen.getByText('You joined this trip.')).toBeTruthy();
     await fireEvent.press(screen.getByRole('button', { name: 'Trip invitation to Da Lat escape' }));
     expect(onOpen).toHaveBeenLastCalledWith('notification-1', 'trip-1');
+  });
+
+  it('exposes the current read state once on the invitation row action', async () => {
+    const invitation: NotificationItem = {
+      ...base,
+      notification_type: 'TRIP_INVITATION',
+      payload: invitationPayload,
+    };
+    const { rerender } = await render(
+      <NotificationRow {...defaultProps} notification={invitation} />,
+    );
+
+    const label = 'Trip invitation to Da Lat escape';
+    expect(screen.getByRole('button', { name: label }).props.accessibilityValue).toEqual({
+      text: 'Unread',
+    });
+    expect(screen.queryByLabelText('Unread')).toBeNull();
+
+    await rerender(
+      <NotificationRow
+        {...defaultProps}
+        notification={{ ...invitation, is_read: true }}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: label }).props.accessibilityValue).toEqual({
+      text: 'Read',
+    });
+    expect(screen.queryByLabelText('Unread')).toBeNull();
   });
 
   it('keeps legacy invitation status non-actionable and displays normalized row errors', async () => {

--- a/mobile/src/features/notifications/__tests__/NotificationsProvider.test.tsx
+++ b/mobile/src/features/notifications/__tests__/NotificationsProvider.test.tsx
@@ -1,4 +1,20 @@
+const mockRealtimeListeners = new Map<string, Set<(message: unknown) => void>>();
+const mockRealtimeSubscribe = jest.fn(
+  (type: string, listener: (message: unknown) => void) => {
+    const listeners = mockRealtimeListeners.get(type) ?? new Set();
+    listeners.add(listener);
+    mockRealtimeListeners.set(type, listeners);
+    return () => {
+      listeners.delete(listener);
+      if (listeners.size === 0) {
+        mockRealtimeListeners.delete(type);
+      }
+    };
+  },
+);
+
 jest.mock('../api', () => ({
+  ...jest.requireActual('../api'),
   acceptTripInvitation: jest.fn(),
   declineTripInvitation: jest.fn(),
   getUnreadCount: jest.fn(),
@@ -7,6 +23,9 @@ jest.mock('../api', () => ({
   markNotificationRead: jest.fn(),
 }));
 jest.mock('@/features/trips/tripEvents', () => ({ publishTripEvent: jest.fn() }));
+jest.mock('@/features/realtime/application/RealtimeProvider', () => ({
+  useRealtimeTransport: () => ({ subscribe: mockRealtimeSubscribe }),
+}));
 
 // eslint-disable-next-line import/first
 import { AxiosError, AxiosHeaders } from 'axios';
@@ -90,6 +109,12 @@ function axiosErrorWith(status: number, data: unknown): AxiosError {
   });
 }
 
+function emitRealtime(message: unknown): void {
+  for (const listener of mockRealtimeListeners.get('notification') ?? []) {
+    listener(message);
+  }
+}
+
 function wrapper({ children }: PropsWithChildren) {
   return <NotificationsProvider ownerUserId="user-1">{children}</NotificationsProvider>;
 }
@@ -133,6 +158,7 @@ async function renderLoaded(items: NotificationItem[] = [notification], nextCurs
 describe('NotificationsProvider', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRealtimeListeners.clear();
     mockGetUnread.mockResolvedValue(1);
     mockMarkRead.mockResolvedValue(undefined);
     mockMarkAll.mockResolvedValue(1);
@@ -189,6 +215,344 @@ describe('NotificationsProvider', () => {
 
     await waitFor(() => expect(rendered.result.current.items[0]?.is_read).toBe(true));
     expect(mockMarkRead).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a live created notification over a stale first page and dedupes its echo', async () => {
+    const pushed = {
+      ...notification,
+      id: 'notification-pushed',
+      payload: { source: 'websocket' },
+    };
+    const rendered = await renderLoaded();
+    const staleRefresh = deferred<NotificationPage>();
+    mockList.mockReturnValueOnce(staleRefresh.promise);
+
+    let refreshPromise!: Promise<void>;
+    await act(() => {
+      refreshPromise = rendered.result.current.refreshForFocus();
+    });
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+    mockGetUnread.mockResolvedValue(2);
+
+    await act(() => {
+      emitRealtime({ type: 'notification', event: 'created', notification: pushed });
+    });
+    await waitFor(() => expect(rendered.result.current.unreadCount).toBe(2));
+    expect(rendered.result.current.items.map((item) => item.id)).toEqual([
+      'notification-pushed',
+      'notification-1',
+    ]);
+
+    await act(async () => {
+      staleRefresh.resolve(page([notification]));
+      await refreshPromise;
+    });
+    expect(rendered.result.current.items.map((item) => item.id)).toEqual([
+      'notification-pushed',
+      'notification-1',
+    ]);
+
+    await act(() => {
+      emitRealtime({
+        type: 'notification',
+        event: 'created',
+        notification: { ...pushed, payload: { source: 'duplicate-echo' } },
+      });
+    });
+    await waitFor(() =>
+      expect(rendered.result.current.items[0]?.payload).toEqual({ source: 'duplicate-echo' }),
+    );
+    expect(rendered.result.current.items).toHaveLength(2);
+    expect(rendered.result.current.unreadCount).toBe(2);
+  });
+
+  it('surfaces a created push while the first page is pending and keeps it after that request fails', async () => {
+    const pendingFirstPage = deferred<NotificationPage>();
+    mockList.mockReturnValueOnce(pendingFirstPage.promise);
+    const rendered = await renderHook(useNotifications, { wrapper });
+
+    let loadPromise!: Promise<void>;
+    await act(() => {
+      loadPromise = rendered.result.current.refreshForFocus();
+    });
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(1));
+
+    await act(() => {
+      emitRealtime({
+        type: 'notification',
+        event: 'created',
+        notification: { ...notification, id: 'notification-live-first' },
+      });
+    });
+    expect(rendered.result.current.status).toBe('ready');
+    expect(rendered.result.current.items.map((item) => item.id)).toEqual([
+      'notification-live-first',
+    ]);
+
+    await act(async () => {
+      pendingFirstPage.reject(
+        axiosErrorWith(503, { detail: 'Notifications are temporarily unavailable.' }),
+      );
+      await loadPromise;
+    });
+    expect(rendered.result.current.status).toBe('ready');
+    expect(rendered.result.current.errorSource).toBe('refresh');
+    expect(rendered.result.current.items.map((item) => item.id)).toEqual([
+      'notification-live-first',
+    ]);
+  });
+
+  it('converges when REST read succeeds before the realtime echo without double decrementing', async () => {
+    const rendered = await renderLoaded();
+    mockGetUnread.mockResolvedValue(0);
+
+    await act(async () => rendered.result.current.markRead(notification.id));
+    expect(rendered.result.current.items[0]?.is_read).toBe(true);
+    expect(rendered.result.current.unreadCount).toBe(0);
+
+    await act(() => {
+      emitRealtime({
+        type: 'notification',
+        event: 'read',
+        notification_ids: [notification.id],
+      });
+    });
+
+    await waitFor(() => expect(rendered.result.current.unreadCount).toBe(0));
+    expect(rendered.result.current.items[0]?.is_read).toBe(true);
+    expect(mockMarkRead).toHaveBeenCalledTimes(1);
+  });
+
+  it('converges when the realtime read echo arrives before REST succeeds', async () => {
+    const rendered = await renderLoaded();
+    const pendingRead = deferred<void>();
+    mockMarkRead.mockReturnValueOnce(pendingRead.promise);
+    mockGetUnread.mockResolvedValue(0);
+
+    let readPromise!: Promise<boolean>;
+    await act(() => {
+      readPromise = rendered.result.current.markRead(notification.id);
+    });
+    await waitFor(() => expect(mockMarkRead).toHaveBeenCalledTimes(1));
+
+    await act(() => {
+      emitRealtime({
+        type: 'notification',
+        event: 'read',
+        notification_ids: [notification.id],
+      });
+    });
+    await waitFor(() => expect(rendered.result.current.unreadCount).toBe(0));
+    expect(rendered.result.current.items[0]?.is_read).toBe(true);
+
+    await act(async () => {
+      pendingRead.resolve();
+      await readPromise;
+    });
+    await expect(readPromise).resolves.toBe(true);
+    expect(rendered.result.current.unreadCount).toBe(0);
+    expect(rendered.result.current.items[0]?.is_read).toBe(true);
+  });
+
+  it('invalidates the badge for an unloaded read id until the trailing count reconciles', async () => {
+    const rendered = await renderLoaded();
+    const trailingCount = deferred<number>();
+    mockGetUnread.mockReset();
+    mockGetUnread.mockReturnValueOnce(trailingCount.promise);
+
+    await act(() => {
+      emitRealtime({
+        type: 'notification',
+        event: 'read',
+        notification_ids: ['notification-not-loaded'],
+      });
+    });
+    expect(rendered.result.current.unreadCount).toBeNull();
+
+    await act(async () => {
+      trailingCount.resolve(0);
+      await trailingCount.promise;
+    });
+    await waitFor(() => expect(rendered.result.current.unreadCount).toBe(0));
+  });
+
+  it('retains the last known unread signal when an unknown-id reconciliation fails', async () => {
+    mockGetUnread.mockResolvedValue(5);
+    const rendered = await renderLoaded();
+    await waitFor(() => expect(rendered.result.current.lastKnownUnreadCount).toBe(5));
+    mockGetUnread.mockReset();
+    mockGetUnread.mockRejectedValueOnce(
+      axiosErrorWith(503, { detail: 'Notifications are temporarily unavailable.' }),
+    );
+
+    await act(() => {
+      emitRealtime({
+        type: 'notification',
+        event: 'read',
+        notification_ids: ['notification-not-loaded'],
+      });
+    });
+
+    await waitFor(() => expect(mockGetUnread).toHaveBeenCalledTimes(1));
+    expect(rendered.result.current.unreadCount).toBeNull();
+    expect(rendered.result.current.lastKnownUnreadCount).toBe(5);
+  });
+
+  it('applies read_all immediately and prevents a duplicate created event from resurrecting a row', async () => {
+    const second = { ...notification, id: 'notification-2' };
+    mockGetUnread.mockResolvedValue(2);
+    const rendered = await renderLoaded([notification, second]);
+    mockGetUnread.mockResolvedValue(0);
+
+    await act(() => {
+      emitRealtime({ type: 'notification', event: 'read_all' });
+    });
+    await waitFor(() => expect(rendered.result.current.unreadCount).toBe(0));
+    expect(rendered.result.current.items.every((item) => item.is_read)).toBe(true);
+
+    await act(() => {
+      emitRealtime({
+        type: 'notification',
+        event: 'created',
+        notification: { ...notification, payload: { duplicate: true } },
+      });
+    });
+    expect(rendered.result.current.items).toHaveLength(2);
+    expect(rendered.result.current.items.find((item) => item.id === notification.id)?.is_read).toBe(true);
+    expect(rendered.result.current.unreadCount).toBe(0);
+  });
+
+  it('does not let a REST read-all completion mark a notification created after its realtime echo', async () => {
+    const rendered = await renderLoaded();
+    const pendingMarkAll = deferred<number>();
+    mockMarkAll.mockReturnValueOnce(pendingMarkAll.promise);
+    mockGetUnread.mockResolvedValue(1);
+
+    let markAllPromise!: Promise<boolean>;
+    await act(() => {
+      markAllPromise = rendered.result.current.markAllRead();
+    });
+    await waitFor(() => expect(mockMarkAll).toHaveBeenCalledTimes(1));
+
+    await act(() => {
+      emitRealtime({ type: 'notification', event: 'read_all' });
+      emitRealtime({
+        type: 'notification',
+        event: 'created',
+        notification: { ...notification, id: 'notification-after-read-all' },
+      });
+    });
+    expect(rendered.result.current.items.find((item) => item.id === notification.id)?.is_read).toBe(true);
+    expect(
+      rendered.result.current.items.find((item) => item.id === 'notification-after-read-all')?.is_read,
+    ).toBe(false);
+
+    await act(async () => {
+      pendingMarkAll.resolve(1);
+      await markAllPromise;
+    });
+    await expect(markAllPromise).resolves.toBe(true);
+    expect(
+      rendered.result.current.items.find((item) => item.id === 'notification-after-read-all')?.is_read,
+    ).toBe(false);
+    expect(rendered.result.current.unreadCount).toBe(1);
+  });
+
+  it('clears stale read mutation errors when realtime confirms the resulting state', async () => {
+    const rendered = await renderLoaded();
+    mockMarkRead.mockRejectedValueOnce(
+      axiosErrorWith(503, { detail: 'Could not mark notification as read.' }),
+    );
+
+    await act(async () => rendered.result.current.markRead(notification.id));
+    expect(rendered.result.current.rowErrors.get(notification.id)?.message).toBe(
+      'Could not mark notification as read.',
+    );
+
+    mockGetUnread.mockResolvedValue(0);
+    await act(() => {
+      emitRealtime({
+        type: 'notification',
+        event: 'read',
+        notification_ids: [notification.id],
+      });
+    });
+    expect(rendered.result.current.rowErrors.has(notification.id)).toBe(false);
+
+    mockMarkAll.mockRejectedValueOnce(
+      axiosErrorWith(503, { detail: 'Could not mark all notifications as read.' }),
+    );
+    await act(async () => rendered.result.current.markAllRead());
+    expect(rendered.result.current.globalMutationError?.message).toBe(
+      'Could not mark all notifications as read.',
+    );
+
+    await act(() => {
+      emitRealtime({ type: 'notification', event: 'read_all' });
+    });
+    expect(rendered.result.current.globalMutationError).toBeNull();
+  });
+
+  it('does not recreate a row error when realtime confirms read before the REST request rejects', async () => {
+    const rendered = await renderLoaded();
+    const pendingRead = deferred<void>();
+    mockMarkRead.mockReturnValueOnce(pendingRead.promise);
+    mockGetUnread.mockResolvedValue(0);
+
+    let readPromise!: Promise<boolean>;
+    await act(() => {
+      readPromise = rendered.result.current.markRead(notification.id);
+    });
+    await waitFor(() => expect(mockMarkRead).toHaveBeenCalledWith(notification.id));
+
+    await act(() => {
+      emitRealtime({
+        type: 'notification',
+        event: 'read',
+        notification_ids: [notification.id],
+      });
+    });
+    expect(rendered.result.current.rowErrors.has(notification.id)).toBe(false);
+
+    await act(async () => {
+      pendingRead.reject(
+        axiosErrorWith(503, { detail: 'Could not mark notification as read.' }),
+      );
+      await readPromise;
+    });
+
+    await expect(readPromise).resolves.toBe(true);
+    expect(rendered.result.current.rowErrors.has(notification.id)).toBe(false);
+    expect(rendered.result.current.items[0]?.is_read).toBe(true);
+  });
+
+  it('does not recreate a global error when realtime confirms read-all before the REST request rejects', async () => {
+    const rendered = await renderLoaded();
+    const pendingMarkAll = deferred<number>();
+    mockMarkAll.mockReturnValueOnce(pendingMarkAll.promise);
+    mockGetUnread.mockResolvedValue(0);
+
+    let markAllPromise!: Promise<boolean>;
+    await act(() => {
+      markAllPromise = rendered.result.current.markAllRead();
+    });
+    await waitFor(() => expect(mockMarkAll).toHaveBeenCalledTimes(1));
+
+    await act(() => {
+      emitRealtime({ type: 'notification', event: 'read_all' });
+    });
+    expect(rendered.result.current.globalMutationError).toBeNull();
+
+    await act(async () => {
+      pendingMarkAll.reject(
+        axiosErrorWith(503, { detail: 'Could not mark all notifications as read.' }),
+      );
+      await markAllPromise;
+    });
+
+    await expect(markAllPromise).resolves.toBe(true);
+    expect(rendered.result.current.globalMutationError).toBeNull();
+    expect(rendered.result.current.items[0]?.is_read).toBe(true);
   });
 
   it('ignores an older unread-count response after a read reconciliation has completed', async () => {
@@ -250,6 +614,53 @@ describe('NotificationsProvider', () => {
     expect(mockPublishTripEvent).toHaveBeenCalledWith({ type: 'membershipAdded', tripId: 'trip-1' });
     expect(mockMarkRead).toHaveBeenCalledWith(invitation.id);
     expect(rendered.result.current.items[0]?.is_read).toBe(true);
+    expect(rendered.result.current.items[0]?.payload).toEqual(
+      expect.objectContaining({ invitation_status: 'ACCEPTED' }),
+    );
+  });
+
+  it('preserves a local invitation outcome when a stale created envelope arrives in flight', async () => {
+    const rendered = await renderLoaded([invitation]);
+    const pendingMarkRead = deferred<void>();
+    mockMarkRead.mockReturnValueOnce(pendingMarkRead.promise);
+    mockGetUnread.mockResolvedValue(0);
+    mockList.mockResolvedValueOnce(
+      page([
+        {
+          ...invitation,
+          is_read: true,
+          payload: { ...(invitation.payload as object), invitation_status: 'ACCEPTED' },
+        },
+      ]),
+    );
+
+    let response!: Promise<boolean>;
+    await act(() => {
+      response = rendered.result.current.respondToInvitation(
+        invitation.id,
+        'invitation-1',
+        'trip-1',
+        'accept',
+      );
+    });
+    await waitFor(() =>
+      expect(rendered.result.current.items[0]?.payload).toEqual(
+        expect.objectContaining({ invitation_status: 'ACCEPTED' }),
+      ),
+    );
+
+    await act(() => {
+      emitRealtime({ type: 'notification', event: 'created', notification: invitation });
+    });
+    expect(rendered.result.current.items[0]?.payload).toEqual(
+      expect.objectContaining({ invitation_status: 'ACCEPTED' }),
+    );
+
+    await act(async () => {
+      pendingMarkRead.resolve();
+      await response;
+    });
+    await expect(response).resolves.toBe(true);
     expect(rendered.result.current.items[0]?.payload).toEqual(
       expect.objectContaining({ invitation_status: 'ACCEPTED' }),
     );
@@ -448,6 +859,42 @@ describe('NotificationsProvider', () => {
     expect(screen.getByTestId('notification-state').props.children).not.toBe('3:1');
     await fireEvent.press(screen.getByRole('button', { name: 'Load notifications' }));
     await waitFor(() => expect(screen.getByTestId('notification-state').props.children).toBe('0:0'));
+  });
+
+  it('unsubscribes the old owner listener and fences a captured stale callback', async () => {
+    mockGetUnread.mockResolvedValue(1);
+    const rendered = await render(
+      <NotificationsProvider ownerUserId="user-1">
+        <StateProbe />
+      </NotificationsProvider>,
+    );
+    const oldListener = [...(mockRealtimeListeners.get('notification') ?? [])][0];
+    expect(oldListener).toBeDefined();
+
+    await rendered.rerender(
+      <NotificationsProvider ownerUserId="user-2">
+        <StateProbe />
+      </NotificationsProvider>,
+    );
+    expect(mockRealtimeListeners.get('notification')?.size).toBe(1);
+
+    await act(() => {
+      oldListener?.({
+        type: 'notification',
+        event: 'created',
+        notification: { ...notification, id: 'stale-owner-notification' },
+      });
+    });
+    expect(screen.getByTestId('notification-state').props.children).toBe('1:0');
+
+    await act(() => {
+      emitRealtime({
+        type: 'notification',
+        event: 'created',
+        notification: { ...notification, id: 'current-owner-notification' },
+      });
+    });
+    await waitFor(() => expect(screen.getByTestId('notification-state').props.children).toBe('1:1'));
   });
 
   it('does not finish an old owner invitation response under the new owner lifetime', async () => {

--- a/mobile/src/features/notifications/__tests__/NotificationsProvider.test.tsx
+++ b/mobile/src/features/notifications/__tests__/NotificationsProvider.test.tsx
@@ -376,6 +376,51 @@ describe('NotificationsProvider', () => {
     await waitFor(() => expect(rendered.result.current.unreadCount).toBe(0));
   });
 
+  it('invalidates zero when a pending load-more appends an unread row outside the count snapshot', async () => {
+    const loadedAfterCountStarted = {
+      ...notification,
+      id: 'notification-loaded-after-count-started',
+    };
+    const rendered = await renderLoaded([notification], 'next-cursor');
+    const pendingLoadMore = deferred<NotificationPage>();
+    const pendingCount = deferred<number>();
+    mockList.mockReturnValueOnce(pendingLoadMore.promise);
+
+    let loadMorePromise!: Promise<void>;
+    await act(() => {
+      loadMorePromise = rendered.result.current.loadMore();
+    });
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+
+    mockGetUnread.mockReset();
+    mockGetUnread.mockReturnValueOnce(pendingCount.promise);
+    await act(() => {
+      emitRealtime({
+        type: 'notification',
+        event: 'read',
+        notification_ids: ['notification-not-loaded'],
+      });
+    });
+    await waitFor(() => expect(mockGetUnread).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      pendingCount.resolve(0);
+      await pendingCount.promise;
+    });
+    await waitFor(() => expect(rendered.result.current.unreadCount).toBe(0));
+
+    await act(async () => {
+      pendingLoadMore.resolve(page([loadedAfterCountStarted]));
+      await loadMorePromise;
+    });
+
+    expect(
+      rendered.result.current.items.find(
+        (item) => item.id === loadedAfterCountStarted.id,
+      )?.is_read,
+    ).toBe(false);
+    expect(rendered.result.current.unreadCount).toBeNull();
+  });
+
   it('retains the last known unread signal when an unknown-id reconciliation fails', async () => {
     mockGetUnread.mockResolvedValue(5);
     const rendered = await renderLoaded();
@@ -422,6 +467,75 @@ describe('NotificationsProvider', () => {
     expect(rendered.result.current.unreadCount).toBe(0);
   });
 
+  it('discards stale load-more on read_all and reconciles a missed post-barrier created push', async () => {
+    const unloaded = { ...notification, id: 'notification-unloaded' };
+    const createdAfterReadAll = {
+      ...notification,
+      id: 'notification-created-after-read-all',
+    };
+    mockGetUnread.mockResolvedValue(2);
+    const rendered = await renderLoaded([notification], 'next-cursor');
+    const staleLoadMore = deferred<NotificationPage>();
+    mockList.mockReturnValueOnce(staleLoadMore.promise);
+
+    let loadMorePromise!: Promise<void>;
+    await act(() => {
+      loadMorePromise = rendered.result.current.loadMore();
+    });
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+    mockGetUnread.mockResolvedValue(1);
+    mockList.mockResolvedValueOnce(page([createdAfterReadAll]));
+
+    await act(() => {
+      emitRealtime({ type: 'notification', event: 'read_all' });
+    });
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(3));
+    await act(async () => {
+      staleLoadMore.resolve(page([unloaded, createdAfterReadAll]));
+      await loadMorePromise;
+    });
+
+    expect(rendered.result.current.items.some((item) => item.id === unloaded.id)).toBe(
+      false,
+    );
+    expect(
+      rendered.result.current.items.find(
+        (item) => item.id === createdAfterReadAll.id,
+      )?.is_read,
+    ).toBe(false);
+    await waitFor(() => expect(rendered.result.current.unreadCount).toBe(1));
+  });
+
+  it('discards a stale first page on read_all and keeps a missed post-barrier notification unread', async () => {
+    const createdAfterReadAll = {
+      ...notification,
+      id: 'notification-created-after-read-all',
+    };
+    mockGetUnread.mockResolvedValue(1);
+    const rendered = await renderLoaded();
+    const staleRefresh = deferred<NotificationPage>();
+    mockList.mockReturnValueOnce(staleRefresh.promise);
+
+    let staleRefreshPromise!: Promise<void>;
+    await act(() => {
+      staleRefreshPromise = rendered.result.current.refreshForFocus();
+    });
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+    mockList.mockResolvedValueOnce(page([createdAfterReadAll]));
+
+    await act(() => {
+      emitRealtime({ type: 'notification', event: 'read_all' });
+    });
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(3));
+    await act(async () => {
+      staleRefresh.resolve(page([notification, createdAfterReadAll]));
+      await staleRefreshPromise;
+    });
+
+    expect(rendered.result.current.items).toEqual([createdAfterReadAll]);
+    expect(rendered.result.current.items[0]?.is_read).toBe(false);
+  });
+
   it('does not let a REST read-all completion mark a notification created after its realtime echo', async () => {
     const rendered = await renderLoaded();
     const pendingMarkAll = deferred<number>();
@@ -456,6 +570,473 @@ describe('NotificationsProvider', () => {
       rendered.result.current.items.find((item) => item.id === 'notification-after-read-all')?.is_read,
     ).toBe(false);
     expect(rendered.result.current.unreadCount).toBe(1);
+  });
+
+  it('uses the REST updated count when count reconciliation fails and preserves a later created push', async () => {
+    const createdAfterRequest = {
+      ...notification,
+      id: 'notification-created-after-request',
+    };
+    mockGetUnread.mockResolvedValue(2);
+    const rendered = await renderLoaded();
+    const pendingMarkAll = deferred<number>();
+    mockMarkAll.mockReturnValueOnce(pendingMarkAll.promise);
+
+    let markAllPromise!: Promise<boolean>;
+    await act(() => {
+      markAllPromise = rendered.result.current.markAllRead();
+    });
+    await waitFor(() => expect(mockMarkAll).toHaveBeenCalledTimes(1));
+
+    mockGetUnread.mockResolvedValue(3);
+    await act(() => {
+      emitRealtime({
+        type: 'notification',
+        event: 'created',
+        notification: createdAfterRequest,
+      });
+    });
+    await waitFor(() => expect(rendered.result.current.unreadCount).toBe(3));
+
+    mockGetUnread.mockRejectedValueOnce(
+      axiosErrorWith(503, { detail: 'Count unavailable.' }),
+    );
+    mockList.mockResolvedValueOnce(
+      page([
+        createdAfterRequest,
+        { ...notification, is_read: true, read_at: '2026-08-09T02:00:00Z' },
+      ]),
+    );
+    await act(async () => {
+      pendingMarkAll.resolve(2);
+      await markAllPromise;
+    });
+
+    expect(rendered.result.current.items.find((item) => item.id === notification.id)?.is_read).toBe(true);
+    expect(
+      rendered.result.current.items.find((item) => item.id === createdAfterRequest.id)
+        ?.is_read,
+    ).toBe(false);
+    expect(rendered.result.current.unreadCount).toBe(1);
+  });
+
+  it('invalidates an ambiguous two-client read-all badge when count reconciliation fails', async () => {
+    const second = { ...notification, id: 'notification-2' };
+    const createdBetweenReadAlls = {
+      ...notification,
+      id: 'notification-created-between-read-alls',
+    };
+    mockGetUnread.mockResolvedValue(2);
+    const rendered = await renderLoaded([notification, second]);
+    const pendingMarkAll = deferred<number>();
+    mockMarkAll.mockReturnValueOnce(pendingMarkAll.promise);
+
+    let markAllPromise!: Promise<boolean>;
+    await act(() => {
+      markAllPromise = rendered.result.current.markAllRead();
+    });
+    await waitFor(() => expect(mockMarkAll).toHaveBeenCalledTimes(1));
+
+    mockGetUnread.mockResolvedValueOnce(0).mockResolvedValueOnce(1);
+    mockList.mockResolvedValueOnce(page([createdBetweenReadAlls]));
+    await act(() => {
+      emitRealtime({ type: 'notification', event: 'read_all' });
+    });
+    await waitFor(() => expect(rendered.result.current.unreadCount).toBeNull());
+    await act(() => {
+      emitRealtime({
+        type: 'notification',
+        event: 'created',
+        notification: createdBetweenReadAlls,
+      });
+    });
+    await waitFor(() => expect(rendered.result.current.unreadCount).toBe(1));
+
+    mockGetUnread.mockRejectedValueOnce(
+      axiosErrorWith(503, { detail: 'Count unavailable.' }),
+    );
+    mockList.mockResolvedValueOnce(
+      page([
+        {
+          ...createdBetweenReadAlls,
+          is_read: true,
+          read_at: '2026-08-09T02:00:00Z',
+        },
+      ]),
+    );
+    await act(async () => {
+      pendingMarkAll.resolve(1);
+      await markAllPromise;
+    });
+
+    expect(rendered.result.current.items[0]?.is_read).toBe(true);
+    expect(rendered.result.current.unreadCount).toBeNull();
+    expect(rendered.result.current.lastKnownUnreadCount).toBe(1);
+  });
+
+  it('does not subtract a positive own-echo delta from a later unread notification', async () => {
+    const createdAfterEcho = {
+      ...notification,
+      id: 'notification-created-after-own-echo',
+    };
+    mockGetUnread.mockResolvedValue(1);
+    const rendered = await renderLoaded();
+    const pendingMarkAll = deferred<number>();
+    mockMarkAll.mockReturnValueOnce(pendingMarkAll.promise);
+
+    let markAllPromise!: Promise<boolean>;
+    await act(() => {
+      markAllPromise = rendered.result.current.markAllRead();
+    });
+    await waitFor(() => expect(mockMarkAll).toHaveBeenCalledTimes(1));
+
+    mockGetUnread.mockResolvedValueOnce(0).mockResolvedValueOnce(1);
+    mockList.mockResolvedValueOnce(page([createdAfterEcho]));
+    await act(() => {
+      emitRealtime({ type: 'notification', event: 'read_all' });
+    });
+    await act(() => {
+      emitRealtime({
+        type: 'notification',
+        event: 'created',
+        notification: createdAfterEcho,
+      });
+    });
+    await waitFor(() => expect(rendered.result.current.unreadCount).toBe(1));
+
+    mockGetUnread.mockRejectedValueOnce(
+      axiosErrorWith(503, { detail: 'Count unavailable.' }),
+    );
+    mockList.mockResolvedValueOnce(page([createdAfterEcho]));
+    await act(async () => {
+      pendingMarkAll.resolve(1);
+      await markAllPromise;
+    });
+
+    expect(rendered.result.current.items[0]?.is_read).toBe(false);
+    expect(rendered.result.current.unreadCount).toBeNull();
+    expect(rendered.result.current.lastKnownUnreadCount).toBe(1);
+  });
+
+  it('invalidates an ambiguous zero delta when a post-mutation unread push was missed', async () => {
+    const createdAfterMutation = {
+      ...notification,
+      id: 'notification-created-after-mutation',
+    };
+    mockGetUnread.mockResolvedValue(1);
+    const rendered = await renderLoaded();
+    const pendingMarkAll = deferred<number>();
+    mockMarkAll.mockReturnValueOnce(pendingMarkAll.promise);
+
+    let markAllPromise!: Promise<boolean>;
+    await act(() => {
+      markAllPromise = rendered.result.current.markAllRead();
+    });
+    await waitFor(() => expect(mockMarkAll).toHaveBeenCalledTimes(1));
+
+    mockGetUnread.mockResolvedValueOnce(0);
+    mockList.mockResolvedValueOnce(page([]));
+    await act(() => {
+      emitRealtime({ type: 'notification', event: 'read_all' });
+    });
+    await waitFor(() => expect(rendered.result.current.unreadCount).toBe(0));
+
+    mockGetUnread.mockRejectedValueOnce(
+      axiosErrorWith(503, { detail: 'Count unavailable.' }),
+    );
+    mockList.mockResolvedValueOnce(page([createdAfterMutation]));
+    await act(async () => {
+      pendingMarkAll.resolve(0);
+      await markAllPromise;
+    });
+
+    expect(rendered.result.current.items).toEqual([createdAfterMutation]);
+    expect(rendered.result.current.items[0]?.is_read).toBe(false);
+    expect(rendered.result.current.unreadCount).toBeNull();
+    expect(rendered.result.current.lastKnownUnreadCount).toBe(0);
+  });
+
+  it('invalidates a non-ambiguous zero badge below the refreshed unread rows', async () => {
+    const createdAfterMutation = {
+      ...notification,
+      id: 'notification-created-after-mutation',
+    };
+    mockGetUnread.mockResolvedValue(0);
+    const rendered = await renderLoaded([notification]);
+    const pendingMarkAll = deferred<number>();
+    mockMarkAll.mockReturnValueOnce(pendingMarkAll.promise);
+
+    let markAllPromise!: Promise<boolean>;
+    await act(() => {
+      markAllPromise = rendered.result.current.markAllRead();
+    });
+    await waitFor(() => expect(mockMarkAll).toHaveBeenCalledTimes(1));
+
+    mockGetUnread.mockRejectedValueOnce(
+      axiosErrorWith(503, { detail: 'Count unavailable.' }),
+    );
+    mockList.mockResolvedValueOnce(page([createdAfterMutation]));
+    await act(async () => {
+      pendingMarkAll.resolve(0);
+      await markAllPromise;
+    });
+
+    expect(rendered.result.current.items).toEqual([createdAfterMutation]);
+    expect(rendered.result.current.items[0]?.is_read).toBe(false);
+    expect(rendered.result.current.unreadCount).toBeNull();
+    expect(rendered.result.current.lastKnownUnreadCount).toBe(0);
+  });
+
+  it('uses a trailing zero count to correct a delayed created envelope already read by mark-all', async () => {
+    const delayedCreated = {
+      ...notification,
+      id: 'notification-created-before-mark-all',
+    };
+    mockGetUnread.mockResolvedValue(1);
+    const rendered = await renderLoaded([notification]);
+    const pendingMarkAll = deferred<number>();
+    mockMarkAll.mockReturnValueOnce(pendingMarkAll.promise);
+
+    let markAllPromise!: Promise<boolean>;
+    await act(() => {
+      markAllPromise = rendered.result.current.markAllRead();
+    });
+    await waitFor(() => expect(mockMarkAll).toHaveBeenCalledTimes(1));
+
+    mockList.mockRejectedValueOnce(
+      axiosErrorWith(503, { detail: 'Notifications are temporarily unavailable.' }),
+    );
+    mockGetUnread.mockReset();
+    mockGetUnread.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
+    await act(async () => {
+      pendingMarkAll.resolve(2);
+      await markAllPromise;
+    });
+    expect(rendered.result.current.unreadCount).toBe(0);
+
+    await act(() => {
+      emitRealtime({
+        type: 'notification',
+        event: 'created',
+        notification: delayedCreated,
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        rendered.result.current.items.find((item) => item.id === delayedCreated.id)
+          ?.is_read,
+      ).toBe(true);
+      expect(rendered.result.current.unreadCount).toBe(0);
+    });
+    expect(mockGetUnread).toHaveBeenCalledTimes(2);
+  });
+
+  it('scopes zero-count outcomes to rows known when reconciliation started', async () => {
+    const rendered = await renderLoaded([notification]);
+    const pendingRead = deferred<void>();
+    const pendingCount = deferred<number>();
+    mockMarkRead.mockReturnValueOnce(pendingRead.promise);
+    mockGetUnread.mockReset();
+    mockGetUnread.mockReturnValueOnce(pendingCount.promise);
+
+    let readPromise!: Promise<boolean>;
+    await act(() => {
+      readPromise = rendered.result.current.markRead(notification.id);
+    });
+    await act(() => {
+      emitRealtime({
+        type: 'notification',
+        event: 'read',
+        notification_ids: ['notification-not-loaded'],
+      });
+    });
+    await waitFor(() => expect(mockGetUnread).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      pendingCount.resolve(0);
+      await pendingCount.promise;
+    });
+    await waitFor(() =>
+      expect(rendered.result.current.items[0]?.is_read).toBe(true),
+    );
+    await act(async () => {
+      pendingRead.reject(
+        axiosErrorWith(503, { detail: 'Could not mark notification as read.' }),
+      );
+      await readPromise;
+    });
+
+    await expect(readPromise).resolves.toBe(true);
+    expect(rendered.result.current.rowErrors.has(notification.id)).toBe(false);
+
+    const laterNotification = {
+      ...notification,
+      id: 'notification-created-after-zero-request',
+    };
+    mockGetUnread.mockRejectedValueOnce(
+      axiosErrorWith(503, { detail: 'Count unavailable.' }),
+    );
+    await act(() => {
+      emitRealtime({
+        type: 'notification',
+        event: 'created',
+        notification: laterNotification,
+      });
+    });
+    await waitFor(() =>
+      expect(
+        rendered.result.current.items.find((item) => item.id === laterNotification.id)
+          ?.is_read,
+      ).toBe(false),
+    );
+
+    mockMarkRead.mockRejectedValueOnce(
+      axiosErrorWith(503, { detail: 'Could not mark notification as read.' }),
+    );
+    let laterReadResult!: boolean;
+    await act(async () => {
+      laterReadResult = await rendered.result.current.markRead(laterNotification.id);
+    });
+
+    expect(laterReadResult).toBe(false);
+    expect(
+      rendered.result.current.rowErrors.get(laterNotification.id)?.message,
+    ).toBe('Could not mark notification as read.');
+  });
+
+  it('treats local read-all success as a newer outcome for an older read failure', async () => {
+    const rendered = await renderLoaded();
+    const pendingRead = deferred<void>();
+    mockMarkRead.mockReturnValueOnce(pendingRead.promise);
+    mockList.mockResolvedValueOnce(
+      page([{ ...notification, is_read: true, read_at: '2026-08-09T02:00:00Z' }]),
+    );
+    mockGetUnread.mockResolvedValue(0);
+
+    let readPromise!: Promise<boolean>;
+    await act(() => {
+      readPromise = rendered.result.current.markRead(notification.id);
+    });
+    await waitFor(() => expect(mockMarkRead).toHaveBeenCalledTimes(1));
+
+    await act(async () => rendered.result.current.markAllRead());
+    expect(rendered.result.current.items[0]?.is_read).toBe(true);
+
+    await act(async () => {
+      pendingRead.reject(
+        axiosErrorWith(503, { detail: 'Could not mark notification as read.' }),
+      );
+      await readPromise;
+    });
+
+    await expect(readPromise).resolves.toBe(true);
+    expect(rendered.result.current.rowErrors.has(notification.id)).toBe(false);
+  });
+
+  it('does not hide a later read failure behind an older local read-all response', async () => {
+    const createdAfterReadAll = {
+      ...notification,
+      id: 'notification-created-after-read-all',
+    };
+    mockGetUnread.mockResolvedValue(1);
+    const rendered = await renderLoaded();
+    const pendingMarkAll = deferred<number>();
+    mockMarkAll.mockReturnValueOnce(pendingMarkAll.promise);
+
+    let markAllPromise!: Promise<boolean>;
+    await act(() => {
+      markAllPromise = rendered.result.current.markAllRead();
+    });
+    await waitFor(() => expect(mockMarkAll).toHaveBeenCalledTimes(1));
+
+    mockList.mockResolvedValueOnce(page([createdAfterReadAll]));
+    await act(() => {
+      emitRealtime({ type: 'notification', event: 'read_all' });
+      emitRealtime({
+        type: 'notification',
+        event: 'created',
+        notification: createdAfterReadAll,
+      });
+    });
+    const pendingRead = deferred<void>();
+    mockMarkRead.mockReturnValueOnce(pendingRead.promise);
+    let readPromise!: Promise<boolean>;
+    await act(() => {
+      readPromise = rendered.result.current.markRead(createdAfterReadAll.id);
+    });
+    await waitFor(() => expect(mockMarkRead).toHaveBeenCalledTimes(1));
+
+    mockGetUnread.mockRejectedValueOnce(
+      axiosErrorWith(503, { detail: 'Count unavailable.' }),
+    );
+    mockList.mockResolvedValueOnce(
+      page([createdAfterReadAll]),
+    );
+    await act(async () => {
+      pendingMarkAll.resolve(1);
+      await markAllPromise;
+    });
+    await act(async () => {
+      pendingRead.reject(
+        axiosErrorWith(503, { detail: 'Could not mark notification as read.' }),
+      );
+      await readPromise;
+    });
+
+    await expect(readPromise).resolves.toBe(false);
+    expect(rendered.result.current.rowErrors.get(createdAfterReadAll.id)?.message).toBe(
+      'Could not mark notification as read.',
+    );
+    expect(rendered.result.current.unreadCount).toBeNull();
+  });
+
+  it('does not clear a later row error when an older local read-all response arrives', async () => {
+    const createdAfterReadAll = {
+      ...notification,
+      id: 'notification-created-after-read-all',
+    };
+    mockGetUnread.mockResolvedValue(1);
+    const rendered = await renderLoaded();
+    const pendingMarkAll = deferred<number>();
+    mockMarkAll.mockReturnValueOnce(pendingMarkAll.promise);
+
+    let markAllPromise!: Promise<boolean>;
+    await act(() => {
+      markAllPromise = rendered.result.current.markAllRead();
+    });
+    await waitFor(() => expect(mockMarkAll).toHaveBeenCalledTimes(1));
+
+    mockList.mockResolvedValueOnce(page([createdAfterReadAll]));
+    await act(() => {
+      emitRealtime({ type: 'notification', event: 'read_all' });
+      emitRealtime({
+        type: 'notification',
+        event: 'created',
+        notification: createdAfterReadAll,
+      });
+    });
+    mockMarkRead.mockRejectedValueOnce(
+      axiosErrorWith(503, { detail: 'Could not mark notification as read.' }),
+    );
+    await act(async () => rendered.result.current.markRead(createdAfterReadAll.id));
+    expect(
+      rendered.result.current.rowErrors.get(createdAfterReadAll.id)?.message,
+    ).toBe('Could not mark notification as read.');
+
+    mockGetUnread.mockRejectedValueOnce(
+      axiosErrorWith(503, { detail: 'Count unavailable.' }),
+    );
+    mockList.mockResolvedValueOnce(page([createdAfterReadAll]));
+    await act(async () => {
+      pendingMarkAll.resolve(1);
+      await markAllPromise;
+    });
+
+    expect(rendered.result.current.items[0]?.is_read).toBe(false);
+    expect(
+      rendered.result.current.rowErrors.get(createdAfterReadAll.id)?.message,
+    ).toBe('Could not mark notification as read.');
   });
 
   it('clears stale read mutation errors when realtime confirms the resulting state', async () => {
@@ -788,6 +1369,77 @@ describe('NotificationsProvider', () => {
 
     expect(rendered.result.current.items.every((item) => item.is_read)).toBe(true);
     expect(rendered.result.current.unreadCount).toBe(0);
+  });
+
+  it('fences a pre-mark-all first page and reconciles unloaded rows after REST succeeds', async () => {
+    const unloaded = { ...notification, id: 'notification-unloaded' };
+    mockGetUnread.mockResolvedValue(2);
+    const rendered = await renderLoaded();
+    const staleRefresh = deferred<NotificationPage>();
+    mockList.mockReturnValueOnce(staleRefresh.promise);
+
+    let refreshPromise!: Promise<void>;
+    await act(() => {
+      refreshPromise = rendered.result.current.refreshForFocus();
+    });
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+
+    mockGetUnread.mockResolvedValue(0);
+    mockList.mockResolvedValueOnce(
+      page([
+        { ...notification, is_read: true, read_at: '2026-08-09T02:00:00Z' },
+        { ...unloaded, is_read: true, read_at: '2026-08-09T02:00:00Z' },
+      ]),
+    );
+    await act(async () => rendered.result.current.markAllRead());
+    expect(mockList).toHaveBeenCalledTimes(3);
+
+    await act(async () => {
+      staleRefresh.resolve(page([notification, unloaded]));
+      await refreshPromise;
+    });
+
+    expect(rendered.result.current.items.map((item) => item.id)).toEqual([
+      notification.id,
+      unloaded.id,
+    ]);
+    expect(rendered.result.current.items.every((item) => item.is_read)).toBe(true);
+    expect(rendered.result.current.unreadCount).toBe(0);
+  });
+
+  it('fences a pre-mark-all load-more response before reconciling the first page', async () => {
+    const unloaded = { ...notification, id: 'notification-unloaded' };
+    mockGetUnread.mockResolvedValue(2);
+    const rendered = await renderLoaded([notification], 'next-cursor');
+    const staleLoadMore = deferred<NotificationPage>();
+    mockList.mockReturnValueOnce(staleLoadMore.promise);
+
+    let loadMorePromise!: Promise<void>;
+    await act(() => {
+      loadMorePromise = rendered.result.current.loadMore();
+    });
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+
+    mockGetUnread.mockResolvedValue(0);
+    mockList.mockResolvedValueOnce(
+      page([
+        { ...notification, is_read: true, read_at: '2026-08-09T02:00:00Z' },
+      ], 'fresh-cursor'),
+    );
+    await act(async () => rendered.result.current.markAllRead());
+    expect(mockList).toHaveBeenCalledTimes(3);
+
+    await act(async () => {
+      staleLoadMore.resolve(page([unloaded], null));
+      await loadMorePromise;
+    });
+
+    expect(rendered.result.current.items.map((item) => item.id)).toEqual([
+      notification.id,
+    ]);
+    expect(rendered.result.current.items[0]?.is_read).toBe(true);
+    expect(rendered.result.current.unreadCount).toBe(0);
+    expect(rendered.result.current.loadingMore).toBe(false);
   });
 
   it('reconciles both the badge and loaded list when the app returns to foreground', async () => {

--- a/mobile/src/features/notifications/__tests__/NotificationsScreen.test.tsx
+++ b/mobile/src/features/notifications/__tests__/NotificationsScreen.test.tsx
@@ -74,6 +74,7 @@ function readyContext(overrides: Partial<NotificationsContextValue> = {}): Notif
     loadingMore: false,
     hasNextPage: false,
     unreadCount: 1,
+    lastKnownUnreadCount: 1,
     markingAllRead: false,
     pendingReadIds: new Set(),
     pendingInvitationActions: new Map(),
@@ -128,6 +129,23 @@ describe('NotificationsScreen', () => {
     expect(screen.getByRole('button', { name: 'Mark all notifications as read' }).props.accessibilityState).toEqual(
       expect.objectContaining({ disabled: true }),
     );
+  });
+
+  it('keeps mark-all available from the last known signal while the exact badge is unknown', async () => {
+    mockUseNotifications.mockReturnValue(
+      readyContext({
+        unreadCount: null,
+        lastKnownUnreadCount: 3,
+        items: [{ ...notification, is_read: true }],
+      }),
+    );
+
+    await render(<NotificationsScreen />);
+
+    expect(
+      screen.getByRole('button', { name: 'Mark all notifications as read' }).props
+        .accessibilityState,
+    ).toEqual(expect.objectContaining({ disabled: false }));
   });
 
   it('delegates pull-to-refresh and guarded cursor pagination', async () => {

--- a/mobile/src/features/notifications/__tests__/TabsLayout.test.tsx
+++ b/mobile/src/features/notifications/__tests__/TabsLayout.test.tsx
@@ -1,6 +1,7 @@
 const mockUseSession = jest.fn();
 const mockUnreadCount = jest.fn();
 const mockLastKnownUnreadCount = jest.fn();
+const mockNotificationItems = jest.fn();
 const mockTabsScreen = jest.fn();
 
 jest.mock('expo-router', () => {
@@ -23,6 +24,7 @@ jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
 jest.mock('@/features/auth/session', () => ({ useSession: () => mockUseSession() }));
 jest.mock('../application/NotificationsProvider', () => ({
   useNotifications: () => ({
+    items: mockNotificationItems(),
     unreadCount: mockUnreadCount(),
     lastKnownUnreadCount: mockLastKnownUnreadCount(),
   }),
@@ -50,6 +52,7 @@ describe('TabsLayout notifications integration', () => {
       user: { id: 'user-1', requires_profile_setup: false },
     });
     mockLastKnownUnreadCount.mockReturnValue(null);
+    mockNotificationItems.mockReturnValue([]);
   });
 
   it('caps a large unread badge from the root-owned provider', async () => {
@@ -73,5 +76,23 @@ describe('TabsLayout notifications integration', () => {
     await render(<TabsLayout />);
 
     expect(notificationsOptions().tabBarBadge).toBe('•');
+  });
+
+  it('shows a degraded dot for a loaded unread row when count reconciliation is unavailable', async () => {
+    mockUnreadCount.mockReturnValue(null);
+    mockLastKnownUnreadCount.mockReturnValue(0);
+    mockNotificationItems.mockReturnValue([{ id: 'notification-1', is_read: false }]);
+    await render(<TabsLayout />);
+
+    expect(notificationsOptions().tabBarBadge).toBe('•');
+  });
+
+  it('hides the degraded badge when the unknown count has only loaded read rows', async () => {
+    mockUnreadCount.mockReturnValue(null);
+    mockLastKnownUnreadCount.mockReturnValue(0);
+    mockNotificationItems.mockReturnValue([{ id: 'notification-1', is_read: true }]);
+    await render(<TabsLayout />);
+
+    expect(notificationsOptions().tabBarBadge).toBeUndefined();
   });
 });

--- a/mobile/src/features/notifications/__tests__/TabsLayout.test.tsx
+++ b/mobile/src/features/notifications/__tests__/TabsLayout.test.tsx
@@ -1,7 +1,7 @@
 const mockUseSession = jest.fn();
 const mockUnreadCount = jest.fn();
+const mockLastKnownUnreadCount = jest.fn();
 const mockTabsScreen = jest.fn();
-const mockProviderOwner = jest.fn();
 
 jest.mock('expo-router', () => {
   const React = jest.requireActual<typeof import('react')>('react');
@@ -22,11 +22,10 @@ jest.mock('expo-router', () => {
 jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
 jest.mock('@/features/auth/session', () => ({ useSession: () => mockUseSession() }));
 jest.mock('../application/NotificationsProvider', () => ({
-  NotificationsProvider: ({ children, ownerUserId }: { children: import('react').ReactNode; ownerUserId: string }) => {
-    mockProviderOwner(ownerUserId);
-    return children;
-  },
-  useNotifications: () => ({ unreadCount: mockUnreadCount() }),
+  useNotifications: () => ({
+    unreadCount: mockUnreadCount(),
+    lastKnownUnreadCount: mockLastKnownUnreadCount(),
+  }),
 }));
 jest.mock('@/shared/ui/LoadingScreen', () => ({ LoadingScreen: () => null }));
 
@@ -50,13 +49,13 @@ describe('TabsLayout notifications integration', () => {
       status: 'signedIn',
       user: { id: 'user-1', requires_profile_setup: false },
     });
+    mockLastKnownUnreadCount.mockReturnValue(null);
   });
 
-  it('scopes the provider to the authenticated user and caps a large unread badge', async () => {
+  it('caps a large unread badge from the root-owned provider', async () => {
     mockUnreadCount.mockReturnValue(120);
     await render(<TabsLayout />);
 
-    expect(mockProviderOwner).toHaveBeenCalledWith('user-1');
     expect(notificationsOptions()).toEqual(
       expect.objectContaining({ headerShown: false, tabBarBadge: '99+' }),
     );
@@ -66,5 +65,13 @@ describe('TabsLayout notifications integration', () => {
     mockUnreadCount.mockReturnValue(count);
     await render(<TabsLayout />);
     expect(notificationsOptions().tabBarBadge).toBeUndefined();
+  });
+
+  it('shows a degraded dot when the exact count is unknown but unread work was previously known', async () => {
+    mockUnreadCount.mockReturnValue(null);
+    mockLastKnownUnreadCount.mockReturnValue(5);
+    await render(<TabsLayout />);
+
+    expect(notificationsOptions().tabBarBadge).toBe('•');
   });
 });

--- a/mobile/src/features/notifications/__tests__/realtimeEvents.test.ts
+++ b/mobile/src/features/notifications/__tests__/realtimeEvents.test.ts
@@ -1,0 +1,73 @@
+import { parseNotificationRealtimeEvent } from '../realtimeEvents';
+
+const notification = {
+  id: 'notification-1',
+  notification_type: 'FRIEND_REQUEST',
+  actor: { id: 'user-2', display_name: 'Bob', identify_tag: 'bob#ABC123' },
+  payload: { friend_request_id: 'request-1' },
+  is_read: false,
+  read_at: null,
+  created_at: '2026-08-09T01:00:00Z',
+};
+
+describe('parseNotificationRealtimeEvent', () => {
+  it('parses the exact created envelope and keeps unknown notification types forward-compatible', () => {
+    expect(
+      parseNotificationRealtimeEvent({
+        type: 'notification',
+        event: 'created',
+        notification: { ...notification, notification_type: 'FUTURE_NOTIFICATION' },
+      }),
+    ).toEqual({
+      type: 'notification',
+      event: 'created',
+      notification: { ...notification, notification_type: 'FUTURE_NOTIFICATION' },
+    });
+  });
+
+  it('parses read and read_all envelopes and removes duplicate read ids', () => {
+    expect(
+      parseNotificationRealtimeEvent({
+        type: 'notification',
+        event: 'read',
+        notification_ids: ['notification-1', 'notification-1', 'notification-2'],
+      }),
+    ).toEqual({
+      type: 'notification',
+      event: 'read',
+      notification_ids: ['notification-1', 'notification-2'],
+    });
+    expect(
+      parseNotificationRealtimeEvent({ type: 'notification', event: 'read_all' }),
+    ).toEqual({ type: 'notification', event: 'read_all' });
+  });
+
+  it.each([
+    null,
+    notification,
+    { type: 'notification', event: 'created', notification: { payload: {} } },
+    { type: 'notification', event: 'created', notification: { id: 'notification-1' } },
+    {
+      type: 'notification',
+      event: 'created',
+      notification: { ...notification, actor: { display_name: 'Missing actor id' } },
+    },
+    {
+      type: 'notification',
+      event: 'created',
+      notification: { ...notification, is_read: 'false' },
+    },
+    {
+      type: 'notification',
+      event: 'created',
+      notification: { ...notification, read_at: 123 },
+    },
+    { type: 'notification', event: 'read', notification_ids: 'notification-1' },
+    { type: 'notification', event: 'read', notification_ids: [''] },
+    { type: 'notification', event: 'read', notification_ids: ['notification-1', 2] },
+    { type: 'notification', event: 'unknown' },
+    { type: 'chat.message', event: 'created', notification },
+  ])('rejects a malformed or unrelated frame: %p', (value) => {
+    expect(parseNotificationRealtimeEvent(value)).toBeNull();
+  });
+});

--- a/mobile/src/features/notifications/__tests__/realtimeReducer.test.ts
+++ b/mobile/src/features/notifications/__tests__/realtimeReducer.test.ts
@@ -110,6 +110,7 @@ describe('notificationRealtimeReducer', () => {
       type: 'UNREAD_COUNT_RESOLVED',
       unreadCount: 3,
       requestVersion: staleRequestVersion,
+      knownItemIdsAtStart: [],
     });
     expect(state.unreadCount).toBeNull();
 
@@ -118,6 +119,7 @@ describe('notificationRealtimeReducer', () => {
       type: 'UNREAD_COUNT_RESOLVED',
       unreadCount: 3,
       requestVersion: reconcileRequestVersion,
+      knownItemIdsAtStart: [],
     });
     expect(state.unreadCount).toBe(3);
   });
@@ -160,7 +162,7 @@ describe('notificationRealtimeReducer', () => {
     expect(state.unreadCount).toBe(0);
   });
 
-  it('only applies read_all to ids known when the event arrived', () => {
+  it('does not guess the read state of an unknown row returned by a stale first page', () => {
     const known = makeNotification('known');
     const unknown = makeNotification('unknown');
     let state = createNotificationRealtimeState({ items: [known], unreadCount: 2 });
@@ -222,6 +224,52 @@ describe('notificationRealtimeReducer', () => {
     ).toBe(true);
   });
 
+  it('applies a local read-all delta only to the request snapshot ids', () => {
+    const visibleAtStart = makeNotification('visible-at-start');
+    const createdAfterStart = makeNotification('created-after-start');
+    let state = createNotificationRealtimeState({
+      items: [visibleAtStart],
+      unreadCount: 2,
+    });
+    state = receive(state, created(createdAfterStart));
+
+    state = notificationRealtimeReducer(state, {
+      type: 'LOCAL_READ_ALL_CONFIRMED',
+      notificationIds: [visibleAtStart.id],
+      updatedCount: 2,
+      countIsAmbiguous: false,
+    });
+
+    expect(
+      state.items.find((item) => item.id === visibleAtStart.id)?.is_read,
+    ).toBe(true);
+    expect(
+      state.items.find((item) => item.id === createdAfterStart.id)?.is_read,
+    ).toBe(false);
+    expect(state.unreadCount).toBe(1);
+  });
+
+  it.each([0, 1])(
+    'invalidates an ambiguous read-all delta of %s until count reconciliation',
+    (updatedCount) => {
+    const item = makeNotification('item');
+    const initial = createNotificationRealtimeState({
+      items: [item],
+      unreadCount: 1,
+    });
+
+    const next = notificationRealtimeReducer(initial, {
+      type: 'LOCAL_READ_ALL_CONFIRMED',
+      notificationIds: [item.id],
+      updatedCount,
+      countIsAmbiguous: true,
+    });
+
+    expect(next.items[0]?.is_read).toBe(true);
+    expect(next.unreadCount).toBeNull();
+    },
+  );
+
   it('does not let a stale first page drop a created push that arrived in flight', () => {
     const existing = makeNotification('existing');
     const pushed = { ...makeNotification('pushed'), payload: { source: 'websocket' } };
@@ -238,6 +286,120 @@ describe('notificationRealtimeReducer', () => {
     expect(state.items).toEqual([pushed, existing]);
   });
 
+  it('invalidates a numeric badge below the loaded unread lower bound', () => {
+    const unread = makeNotification('unread');
+    const state = notificationRealtimeReducer(
+      createNotificationRealtimeState({ unreadCount: 0 }),
+      {
+        type: 'FIRST_PAGE_RESOLVED',
+        items: [unread],
+        requestVersion: 0,
+      },
+    );
+
+    expect(state.items).toEqual([unread]);
+    expect(state.unreadCount).toBeNull();
+  });
+
+  it('turns an accepted zero count into a per-id read proof for a stale first page', () => {
+    const item = makeNotification('item');
+    let state = createNotificationRealtimeState({ items: [item], unreadCount: 1 });
+    const requestVersion = captureNotificationRealtimeVersion(state);
+
+    state = notificationRealtimeReducer(state, {
+      type: 'UNREAD_COUNT_RESOLVED',
+      unreadCount: 0,
+      requestVersion,
+      knownItemIdsAtStart: [item.id],
+    });
+
+    expect(state.items[0]?.is_read).toBe(true);
+    expect(state.unreadCount).toBe(0);
+    expect(state.version).toBe(1);
+    expect(state.overlays.readById.get(item.id)).toEqual({
+      version: 1,
+      countDelta: 0,
+    });
+
+    state = notificationRealtimeReducer(state, {
+      type: 'FIRST_PAGE_RESOLVED',
+      items: [item],
+      requestVersion,
+    });
+
+    expect(state.items[0]?.is_read).toBe(true);
+    expect(state.unreadCount).toBe(0);
+  });
+
+  it('keeps an item added after a zero-count request unread and invalidates the count', () => {
+    const known = makeNotification('known');
+    const addedDuringRequest = makeNotification('added-during-request');
+    let state = createNotificationRealtimeState({
+      items: [known],
+      unreadCount: 2,
+    });
+    const requestVersion = captureNotificationRealtimeVersion(state);
+
+    state = notificationRealtimeReducer(state, {
+      type: 'FIRST_PAGE_RESOLVED',
+      items: [addedDuringRequest, known],
+      requestVersion,
+    });
+    state = notificationRealtimeReducer(state, {
+      type: 'UNREAD_COUNT_RESOLVED',
+      unreadCount: 0,
+      requestVersion,
+      knownItemIdsAtStart: [known.id],
+    });
+
+    expect(state.items.find((item) => item.id === known.id)?.is_read).toBe(true);
+    expect(
+      state.items.find((item) => item.id === addedDuringRequest.id)?.is_read,
+    ).toBe(false);
+    expect(state.unreadCount).toBeNull();
+    expect(state.overlays.readById.has(addedDuringRequest.id)).toBe(false);
+  });
+
+  it('discards a stale zero count without publishing read proofs', () => {
+    const known = makeNotification('known');
+    let state = createNotificationRealtimeState({ items: [known], unreadCount: 1 });
+    const requestVersion = captureNotificationRealtimeVersion(state);
+    state = receive(state, created(makeNotification('created-after-request')));
+    const beforeResponse = state;
+
+    state = notificationRealtimeReducer(state, {
+      type: 'UNREAD_COUNT_RESOLVED',
+      unreadCount: 0,
+      requestVersion,
+      knownItemIdsAtStart: [known.id],
+    });
+
+    expect(state).toBe(beforeResponse);
+    expect(state.items.find((item) => item.id === known.id)?.is_read).toBe(false);
+    expect(state.overlays.readById.has(known.id)).toBe(false);
+  });
+
+  it('invalidates a positive count below the loaded unread lower bound without marking rows', () => {
+    const first = makeNotification('first');
+    const second = makeNotification('second');
+    const initial = createNotificationRealtimeState({
+      items: [first, second],
+      unreadCount: 2,
+    });
+
+    const state = notificationRealtimeReducer(initial, {
+      type: 'UNREAD_COUNT_RESOLVED',
+      unreadCount: 1,
+      requestVersion: 0,
+      knownItemIdsAtStart: [first.id, second.id],
+    });
+
+    expect(state.items).toEqual([first, second]);
+    expect(state.unreadCount).toBeNull();
+    expect(state.version).toBe(0);
+    expect(state.overlays.readById.size).toBe(0);
+  });
+
   it('discards a stale count instead of double-applying realtime badge changes', () => {
     let state = createNotificationRealtimeState({ unreadCount: 2 });
     const requestVersion = captureNotificationRealtimeVersion(state);
@@ -249,6 +411,7 @@ describe('notificationRealtimeReducer', () => {
       type: 'UNREAD_COUNT_RESOLVED',
       unreadCount: 3,
       requestVersion,
+      knownItemIdsAtStart: [],
     });
 
     expect(state.unreadCount).toBe(3);
@@ -264,6 +427,7 @@ describe('notificationRealtimeReducer', () => {
       type: 'UNREAD_COUNT_RESOLVED',
       unreadCount: 1,
       requestVersion: staleRequestVersion,
+      knownItemIdsAtStart: [],
     });
 
     expect(state.unreadCount).toBe(2);
@@ -279,6 +443,7 @@ describe('notificationRealtimeReducer', () => {
       type: 'UNREAD_COUNT_RESOLVED',
       unreadCount: 7.9,
       requestVersion,
+      knownItemIdsAtStart: [],
     });
 
     expect(state.unreadCount).toBe(7);

--- a/mobile/src/features/notifications/__tests__/realtimeReducer.test.ts
+++ b/mobile/src/features/notifications/__tests__/realtimeReducer.test.ts
@@ -1,0 +1,354 @@
+import {
+  captureNotificationRealtimeVersion,
+  createNotificationRealtimeState,
+  notificationRealtimeReducer,
+  type NotificationRealtimeState,
+} from '../application/realtimeReducer';
+import type { NotificationRealtimeEvent } from '../realtimeEvents';
+import type { NotificationItem } from '../types';
+
+function makeNotification(id: string, isRead = false): NotificationItem {
+  return {
+    id,
+    notification_type: 'FRIEND_REQUEST',
+    actor: { id: 'user-2', display_name: 'Bob', identify_tag: 'bob#ABC123' },
+    payload: {},
+    is_read: isRead,
+    read_at: isRead ? '2026-08-09T02:00:00Z' : null,
+    created_at: `2026-08-09T01:00:0${id.length}Z`,
+  };
+}
+
+function created(notification: NotificationItem): NotificationRealtimeEvent {
+  return { type: 'notification', event: 'created', notification };
+}
+
+function read(...notificationIds: string[]): NotificationRealtimeEvent {
+  return { type: 'notification', event: 'read', notification_ids: notificationIds };
+}
+
+const readAll: NotificationRealtimeEvent = { type: 'notification', event: 'read_all' };
+
+function receive(
+  state: NotificationRealtimeState,
+  event: NotificationRealtimeEvent,
+): NotificationRealtimeState {
+  return notificationRealtimeReducer(state, { type: 'REALTIME_EVENT_RECEIVED', event });
+}
+
+describe('notificationRealtimeReducer', () => {
+  it('prepends a created notification, increments a hydrated badge once, and records its version', () => {
+    const existing = makeNotification('existing');
+    const incoming = makeNotification('incoming');
+    const initial = createNotificationRealtimeState({ items: [existing], unreadCount: 2 });
+
+    const next = receive(initial, created(incoming));
+
+    expect(next.items).toEqual([incoming, existing]);
+    expect(next.unreadCount).toBe(3);
+    expect(next.version).toBe(1);
+    expect(next.overlays.createdById.get(incoming.id)).toEqual({
+      version: 1,
+      notification: incoming,
+      countDelta: 1,
+    });
+    const duplicate = receive(next, created({ ...incoming, payload: { duplicate: true } }));
+    expect(duplicate.items[0]?.payload).toEqual({ duplicate: true });
+    expect(duplicate.unreadCount).toBe(3);
+    expect(duplicate.version).toBe(1);
+  });
+
+  it('upserts a created event over a REST row, preserves read state, and does not increment the badge', () => {
+    const existing = makeNotification('existing', true);
+    const initial = createNotificationRealtimeState({ items: [existing], unreadCount: 1 });
+    const incoming = {
+      ...makeNotification('existing'),
+      actor: { id: 'user-3', display_name: 'Updated actor', identify_tag: null },
+      payload: { websocket: true },
+    };
+
+    const next = receive(initial, created(incoming));
+
+    expect(next.items).toEqual([
+      {
+        ...incoming,
+        is_read: true,
+        read_at: existing.read_at,
+      },
+    ]);
+    expect(next.unreadCount).toBe(1);
+    expect(next.overlays.createdById.get(existing.id)?.countDelta).toBe(0);
+  });
+
+  it('applies each loaded read id once and invalidates the badge for an unloaded id', () => {
+    const unread = makeNotification('unread');
+    const alreadyRead = makeNotification('already-read', true);
+    const initial = createNotificationRealtimeState({
+      items: [unread, alreadyRead],
+      unreadCount: 3,
+    });
+
+    const next = receive(initial, read(unread.id, unread.id, alreadyRead.id, 'not-loaded'));
+
+    expect(next.items.every((item) => item.is_read)).toBe(true);
+    expect(next.unreadCount).toBeNull();
+    expect(next.overlays.readById.get(unread.id)?.countDelta).toBe(-1);
+    expect(next.overlays.readById.get(alreadyRead.id)?.countDelta).toBe(0);
+    expect(next.overlays.readById.get('not-loaded')?.countDelta).toBeNull();
+    expect(receive(next, read(unread.id, alreadyRead.id, 'not-loaded'))).toBe(next);
+
+    const zero = createNotificationRealtimeState({ unreadCount: 0 });
+    expect(receive(zero, read('another-unloaded')).unreadCount).toBeNull();
+  });
+
+  it('restores an invalidated badge only from a count request started after the unknown-id read', () => {
+    let state = createNotificationRealtimeState({ unreadCount: 4 });
+    const staleRequestVersion = captureNotificationRealtimeVersion(state);
+    state = receive(state, read('not-loaded'));
+
+    state = notificationRealtimeReducer(state, {
+      type: 'UNREAD_COUNT_RESOLVED',
+      unreadCount: 3,
+      requestVersion: staleRequestVersion,
+    });
+    expect(state.unreadCount).toBeNull();
+
+    const reconcileRequestVersion = captureNotificationRealtimeVersion(state);
+    state = notificationRealtimeReducer(state, {
+      type: 'UNREAD_COUNT_RESOLVED',
+      unreadCount: 3,
+      requestVersion: reconcileRequestVersion,
+    });
+    expect(state.unreadCount).toBe(3);
+  });
+
+  it('keeps an unknown badge unknown until read_all establishes zero', () => {
+    const initial = createNotificationRealtimeState();
+    const afterCreated = receive(initial, created(makeNotification('first')));
+    const afterRead = receive(afterCreated, read('first'));
+
+    expect(afterCreated.unreadCount).toBeNull();
+    expect(afterRead.unreadCount).toBeNull();
+
+    const afterReadAll = receive(afterRead, readAll);
+    const futureCreated = receive(afterReadAll, created(makeNotification('future')));
+
+    expect(afterReadAll.unreadCount).toBe(0);
+    expect(afterReadAll.items.every((item) => item.is_read)).toBe(true);
+    expect(futureCreated.unreadCount).toBe(1);
+    expect(futureCreated.items.find((item) => item.id === 'future')?.is_read).toBe(false);
+  });
+
+  it('does not resurrect a known item when read_all happens during an in-flight request', () => {
+    const item = makeNotification('item');
+    let state = createNotificationRealtimeState({ items: [item], unreadCount: 1 });
+    state = receive(state, read(item.id));
+    const requestVersion = captureNotificationRealtimeVersion(state);
+    state = receive(state, readAll);
+    expect(state.overlays.readById.get(item.id)?.version).toBe(2);
+    state = notificationRealtimeReducer(state, {
+      type: 'FIRST_PAGE_RESOLVED',
+      items: [],
+      requestVersion,
+    });
+
+    state = receive(state, created({ ...item, payload: { duplicate: true } }));
+
+    expect(state.items).toEqual([
+      { ...item, payload: { duplicate: true }, is_read: true },
+    ]);
+    expect(state.unreadCount).toBe(0);
+  });
+
+  it('only applies read_all to ids known when the event arrived', () => {
+    const known = makeNotification('known');
+    const unknown = makeNotification('unknown');
+    let state = createNotificationRealtimeState({ items: [known], unreadCount: 2 });
+    const requestVersion = captureNotificationRealtimeVersion(state);
+
+    state = receive(state, readAll);
+    state = notificationRealtimeReducer(state, {
+      type: 'FIRST_PAGE_RESOLVED',
+      items: [unknown, known],
+      requestVersion,
+    });
+
+    expect(state.items.find((item) => item.id === known.id)?.is_read).toBe(true);
+    expect(state.items.find((item) => item.id === unknown.id)?.is_read).toBe(false);
+
+    state = receive(
+      state,
+      created({ ...unknown, payload: { source: 'delayed-created' } }),
+    );
+
+    expect(state.items.find((item) => item.id === known.id)?.is_read).toBe(true);
+    expect(state.items.find((item) => item.id === unknown.id)?.is_read).toBe(false);
+  });
+
+  it('merges created, read, and read_all overlays over a stale first page', () => {
+    const first = makeNotification('first');
+    const second = makeNotification('second');
+    let state = createNotificationRealtimeState({ items: [first, second], unreadCount: 2 });
+    const requestVersion = captureNotificationRealtimeVersion(state);
+
+    state = receive(state, read(first.id));
+    state = receive(state, created(makeNotification('before-read-all')));
+    state = receive(state, readAll);
+    state = receive(state, created(makeNotification('after-read-all')));
+
+    state = notificationRealtimeReducer(state, {
+      type: 'FIRST_PAGE_RESOLVED',
+      requestVersion,
+      items: [
+        makeNotification('after-read-all'),
+        makeNotification('before-read-all'),
+        second,
+        first,
+        first,
+      ],
+    });
+
+    expect(state.items.map((item) => item.id)).toEqual([
+      'after-read-all',
+      'before-read-all',
+      'second',
+      'first',
+    ]);
+    expect(state.items.find((item) => item.id === 'after-read-all')?.is_read).toBe(false);
+    expect(
+      state.items
+        .filter((item) => item.id !== 'after-read-all')
+        .every((item) => item.is_read),
+    ).toBe(true);
+  });
+
+  it('does not let a stale first page drop a created push that arrived in flight', () => {
+    const existing = makeNotification('existing');
+    const pushed = { ...makeNotification('pushed'), payload: { source: 'websocket' } };
+    let state = createNotificationRealtimeState({ items: [existing], unreadCount: 1 });
+    const requestVersion = captureNotificationRealtimeVersion(state);
+    state = receive(state, created(pushed));
+
+    state = notificationRealtimeReducer(state, {
+      type: 'FIRST_PAGE_RESOLVED',
+      items: [{ ...pushed, payload: { source: 'stale-rest' } }, existing],
+      requestVersion,
+    });
+
+    expect(state.items).toEqual([pushed, existing]);
+  });
+
+  it('discards a stale count instead of double-applying realtime badge changes', () => {
+    let state = createNotificationRealtimeState({ unreadCount: 2 });
+    const requestVersion = captureNotificationRealtimeVersion(state);
+
+    state = receive(state, created(makeNotification('created')));
+    expect(state.unreadCount).toBe(3);
+
+    state = notificationRealtimeReducer(state, {
+      type: 'UNREAD_COUNT_RESOLVED',
+      unreadCount: 3,
+      requestVersion,
+    });
+
+    expect(state.unreadCount).toBe(3);
+  });
+
+  it('uses the same version clock for local overrides and async response guards', () => {
+    let state = createNotificationRealtimeState({ unreadCount: 2 });
+    const staleRequestVersion = captureNotificationRealtimeVersion(state);
+
+    state = notificationRealtimeReducer(state, { type: 'LOCAL_MUTATION_RECORDED' });
+    expect(state.version).toBe(1);
+    state = notificationRealtimeReducer(state, {
+      type: 'UNREAD_COUNT_RESOLVED',
+      unreadCount: 1,
+      requestVersion: staleRequestVersion,
+    });
+
+    expect(state.unreadCount).toBe(2);
+  });
+
+  it('accepts a response started after earlier overlays as authoritative and normalizes counts', () => {
+    let state = createNotificationRealtimeState({ unreadCount: -4 });
+    expect(state.unreadCount).toBe(0);
+    state = receive(state, created(makeNotification('created')));
+    const requestVersion = captureNotificationRealtimeVersion(state);
+
+    state = notificationRealtimeReducer(state, {
+      type: 'UNREAD_COUNT_RESOLVED',
+      unreadCount: 7.9,
+      requestVersion,
+    });
+
+    expect(state.unreadCount).toBe(7);
+  });
+
+  it('preserves a known per-id read across later list merges', () => {
+    const item = makeNotification('item');
+    let state = createNotificationRealtimeState({ items: [item], unreadCount: 1 });
+    state = receive(state, read(item.id));
+    const requestVersion = captureNotificationRealtimeVersion(state);
+
+    state = notificationRealtimeReducer(state, {
+      type: 'FIRST_PAGE_RESOLVED',
+      items: [item],
+      requestVersion,
+    });
+
+    expect(state.items[0]?.is_read).toBe(true);
+    expect(state.overlays.readById.size).toBe(0);
+  });
+
+  it('compacts all overlays covered by a current first-page request', () => {
+    const item = makeNotification('item');
+    let state = createNotificationRealtimeState({ unreadCount: 1 });
+    state = receive(state, created(item));
+    state = receive(state, read(item.id));
+    state = receive(state, readAll);
+    const requestVersion = captureNotificationRealtimeVersion(state);
+
+    state = notificationRealtimeReducer(state, {
+      type: 'FIRST_PAGE_RESOLVED',
+      items: [makeNotification(item.id, true)],
+      requestVersion,
+    });
+
+    expect(state.overlays.createdById.size).toBe(0);
+    expect(state.overlays.readById.size).toBe(0);
+    expect(state.overlays.readAll).toBeNull();
+  });
+
+  it('compacts covered overlays but retains mutations newer than the request', () => {
+    const covered = makeNotification('covered');
+    const inFlight = makeNotification('in-flight');
+    const afterReadAll = makeNotification('after-read-all');
+    let state = createNotificationRealtimeState({ unreadCount: 0 });
+    state = receive(state, created(covered));
+    state = receive(state, read(covered.id));
+    const requestVersion = captureNotificationRealtimeVersion(state);
+
+    state = receive(state, created(inFlight));
+    state = receive(state, read(inFlight.id));
+    state = receive(state, readAll);
+    state = receive(state, created(afterReadAll));
+    state = notificationRealtimeReducer(state, {
+      type: 'FIRST_PAGE_RESOLVED',
+      items: [covered],
+      requestVersion,
+    });
+
+    expect([...state.overlays.createdById.keys()]).toEqual([
+      inFlight.id,
+      afterReadAll.id,
+    ]);
+    expect([...state.overlays.readById.keys()]).toEqual([
+      covered.id,
+      inFlight.id,
+    ]);
+    expect(
+      [...state.overlays.readById.values()].every((overlay) => overlay.version === 5),
+    ).toBe(true);
+    expect(state.overlays.readAll?.version).toBe(5);
+  });
+});

--- a/mobile/src/features/notifications/application/NotificationsProvider.tsx
+++ b/mobile/src/features/notifications/application/NotificationsProvider.tsx
@@ -188,21 +188,26 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
       if (!isOwnerGenerationCurrent(ownerGeneration)) {
         return;
       }
+      const loadedUnreadCount = next.items.filter((item) => !item.is_read).length;
+      const effectiveNext =
+        next.unreadCount !== null && next.unreadCount < loadedUnreadCount
+          ? { ...next, unreadCount: null }
+          : next;
       const previous = realtimeStateRef.current;
-      realtimeStateRef.current = next;
-      if (previous.items !== next.items) {
-        itemsRef.current = next.items;
-        setItems(next.items);
+      realtimeStateRef.current = effectiveNext;
+      if (previous.items !== effectiveNext.items) {
+        itemsRef.current = effectiveNext.items;
+        setItems(effectiveNext.items);
       }
-      if (previous.unreadCount !== next.unreadCount) {
-        setUnreadCount(next.unreadCount);
+      if (previous.unreadCount !== effectiveNext.unreadCount) {
+        setUnreadCount(effectiveNext.unreadCount);
       }
       if (
-        next.unreadCount !== null &&
-        lastKnownUnreadCountRef.current !== next.unreadCount
+        effectiveNext.unreadCount !== null &&
+        lastKnownUnreadCountRef.current !== effectiveNext.unreadCount
       ) {
-        lastKnownUnreadCountRef.current = next.unreadCount;
-        setLastKnownUnreadCount(next.unreadCount);
+        lastKnownUnreadCountRef.current = effectiveNext.unreadCount;
+        setLastKnownUnreadCount(effectiveNext.unreadCount);
       }
     },
     [isOwnerGenerationCurrent],
@@ -392,29 +397,50 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
       }
       const requestId = countRequestRef.current + 1;
       countRequestRef.current = requestId;
+      const requestState = realtimeStateRef.current;
       const requestVersion = captureNotificationRealtimeVersion(
-        realtimeStateRef.current,
+        requestState,
       );
+      const knownItemIdsAtStart = requestState.items.map((item) => item.id);
       try {
         const count = await getUnreadCount();
         if (
           isOwnerGenerationCurrent(ownerGeneration) &&
           requestId === countRequestRef.current
         ) {
-          commitRealtimeState(
-            notificationRealtimeReducer(realtimeStateRef.current, {
-              type: 'UNREAD_COUNT_RESOLVED',
-              unreadCount: count,
-              requestVersion,
-            }),
-            ownerGeneration,
-          );
+          const previous = realtimeStateRef.current;
+          const next = notificationRealtimeReducer(previous, {
+            type: 'UNREAD_COUNT_RESOLVED',
+            unreadCount: count,
+            requestVersion,
+            knownItemIdsAtStart,
+          });
+          if (count === 0 && next.version > previous.version) {
+            const sequence = readOutcomeSequenceRef.current + 1;
+            readOutcomeSequenceRef.current = sequence;
+            for (const notificationId of knownItemIdsAtStart) {
+              readOutcomeByIdRef.current.set(notificationId, sequence);
+              const current = overridesRef.current.get(notificationId);
+              overridesRef.current.set(notificationId, {
+                ...current,
+                isRead: true,
+                version: next.version,
+              });
+            }
+            clearResolvedReadErrors(knownItemIdsAtStart, ownerGeneration);
+          }
+          commitRealtimeState(next, ownerGeneration);
         }
       } catch {
         // Keep the last usable badge. Focus and foreground transitions retry.
       }
     },
-    [captureOwnerGeneration, commitRealtimeState, isOwnerGenerationCurrent],
+    [
+      captureOwnerGeneration,
+      clearResolvedReadErrors,
+      commitRealtimeState,
+      isOwnerGenerationCurrent,
+    ],
   );
 
   const requestRealtimeCountReconcile = useCallback(
@@ -676,21 +702,41 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
     setMarkingAllRead(true);
     setGlobalMutationError(null);
     try {
-      await markAllNotificationsRead();
+      const updatedCount = await markAllNotificationsRead();
       if (!isOwnerGenerationCurrent(ownerGeneration)) {
         return false;
       }
-      if (visibleIdsAtStart.length > 0) {
-        applyNotificationEvent(
-          {
-            type: 'notification',
-            event: 'read',
-            notification_ids: visibleIdsAtStart,
-          },
-          ownerGeneration,
-        );
+      const countIsAmbiguous =
+        readAllOutcomeSequenceRef.current > outcomeSequenceAtStart;
+      const sequence = readOutcomeSequenceRef.current + 1;
+      readOutcomeSequenceRef.current = sequence;
+      for (const notificationId of visibleIdsAtStart) {
+        readOutcomeByIdRef.current.set(notificationId, sequence);
       }
-      await reconcileUnreadCount(ownerGeneration);
+      const next = notificationRealtimeReducer(realtimeStateRef.current, {
+        type: 'LOCAL_READ_ALL_CONFIRMED',
+        notificationIds: visibleIdsAtStart,
+        updatedCount,
+        countIsAmbiguous,
+      });
+      const version = next.version;
+      for (const notificationId of visibleIdsAtStart) {
+        const current = overridesRef.current.get(notificationId);
+        overridesRef.current.set(notificationId, {
+          ...current,
+          isRead: true,
+          version,
+        });
+      }
+      commitRealtimeState(next, ownerGeneration);
+      clearResolvedReadErrors(visibleIdsAtStart, ownerGeneration);
+      await Promise.all([
+        loadFirstPage(
+          hasUsablePageRef.current ? 'silent' : 'initial',
+          ownerGeneration,
+        ),
+        reconcileUnreadCount(ownerGeneration),
+      ]);
       return isOwnerGenerationCurrent(ownerGeneration);
     } catch (caught) {
       if (!isOwnerGenerationCurrent(ownerGeneration)) {
@@ -708,9 +754,11 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
       }
     }
   }, [
-    applyNotificationEvent,
     captureOwnerGeneration,
+    clearResolvedReadErrors,
+    commitRealtimeState,
     isOwnerGenerationCurrent,
+    loadFirstPage,
     reconcileUnreadCount,
   ]);
 
@@ -840,6 +888,12 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
         return;
       }
       applyNotificationEvent(event, ownerGeneration);
+      if (event.event === 'read_all' && hasRequestedListRef.current) {
+        void loadFirstPage(
+          hasUsablePageRef.current ? 'silent' : 'initial',
+          ownerGeneration,
+        );
+      }
       requestRealtimeCountReconcile(ownerGeneration);
     });
     return unsubscribe;
@@ -847,6 +901,7 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
     applyNotificationEvent,
     captureOwnerGeneration,
     isOwnerGenerationCurrent,
+    loadFirstPage,
     requestRealtimeCountReconcile,
     subscribe,
   ]);

--- a/mobile/src/features/notifications/application/NotificationsProvider.tsx
+++ b/mobile/src/features/notifications/application/NotificationsProvider.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react';
 import { AppState, type AppStateStatus } from 'react-native';
 import { normalizeApiError, type ApiError } from '@/shared/api/errors';
+import { useRealtimeTransport } from '@/features/realtime/application/RealtimeProvider';
 import { publishTripEvent } from '@/features/trips/tripEvents';
 import {
   acceptTripInvitation,
@@ -20,6 +21,16 @@ import {
   markAllNotificationsRead,
   markNotificationRead,
 } from '../api';
+import {
+  captureNotificationRealtimeVersion,
+  createNotificationRealtimeState,
+  notificationRealtimeReducer,
+  type NotificationRealtimeState,
+} from './realtimeReducer';
+import {
+  parseNotificationRealtimeEvent,
+  type NotificationRealtimeEvent,
+} from '../realtimeEvents';
 import type {
   InvitationAction,
   InvitationStatus,
@@ -35,14 +46,12 @@ interface NotificationsProviderProps extends PropsWithChildren {
   ownerUserId: string | null;
 }
 
-interface ReadAllOverride {
-  version: number;
-}
-
 interface OwnerGeneration {
   ownerUserId: string;
   generation: number;
 }
+
+type RowErrorSource = 'read' | 'invitation';
 
 const NotificationsContext = createContext<NotificationsContextValue | null>(null);
 
@@ -68,23 +77,19 @@ function applyOverride(item: NotificationItem, override: NotificationOverride | 
 function applyResponseOverrides(
   items: NotificationItem[],
   overrides: Map<string, NotificationOverride>,
-  readAllOverride: ReadAllOverride | null,
   requestMutationVersion: number,
 ): NotificationItem[] {
   return items.map((item) => {
     const override = overrides.get(item.id);
-    let next = applyOverride(
+    return applyOverride(
       item,
       override && override.version > requestMutationVersion ? override : undefined,
     );
-    if (readAllOverride && readAllOverride.version > requestMutationVersion && !next.is_read) {
-      next = { ...next, is_read: true };
-    }
-    return next;
   });
 }
 
 function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProviderProps) {
+  const { subscribe } = useRealtimeTransport();
   const [items, setItems] = useState<NotificationItem[]>([]);
   const [status, setStatus] = useState<NotificationListStatus>('loading');
   const [error, setError] = useState<ApiError | null>(null);
@@ -93,6 +98,7 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasNextPage, setHasNextPage] = useState(false);
   const [unreadCount, setUnreadCount] = useState<number | null>(null);
+  const [lastKnownUnreadCount, setLastKnownUnreadCount] = useState<number | null>(null);
   const [markingAllRead, setMarkingAllRead] = useState(false);
   const [pendingReadIds, setPendingReadIds] = useState<ReadonlySet<string>>(new Set());
   const [pendingInvitationActions, setPendingInvitationActions] = useState<ReadonlyMap<string, InvitationAction>>(
@@ -110,12 +116,18 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
   const hasUsablePageRef = useRef(false);
   const hasRequestedListRef = useRef(false);
   const overridesRef = useRef(new Map<string, NotificationOverride>());
-  const readAllOverrideRef = useRef<ReadAllOverride | null>(null);
-  const mutationVersionRef = useRef(0);
+  const realtimeStateRef = useRef(createNotificationRealtimeState());
+  const lastKnownUnreadCountRef = useRef<number | null>(null);
   const countRequestRef = useRef(0);
+  const realtimeCountRequestedRef = useRef(false);
+  const realtimeCountRunningRef = useRef(false);
   const readLocksRef = useRef(new Set<string>());
   const markAllLockRef = useRef(false);
   const invitationLocksRef = useRef(new Map<string, InvitationAction>());
+  const rowErrorSourcesRef = useRef(new Map<string, RowErrorSource>());
+  const readOutcomeSequenceRef = useRef(0);
+  const readOutcomeByIdRef = useRef(new Map<string, number>());
+  const readAllOutcomeSequenceRef = useRef(0);
   const appStateRef = useRef<AppStateStatus>(AppState.currentState);
 
   const providerActiveRef = useRef(true);
@@ -150,27 +162,48 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
     activeOwnerUserIdRef.current = ownerUserId;
     const readLocks = readLocksRef.current;
     const invitationLocks = invitationLocksRef.current;
+    const rowErrorSources = rowErrorSourcesRef.current;
+    const readOutcomesById = readOutcomeByIdRef.current;
     return () => {
       providerActiveRef.current = false;
       ownerGenerationRef.current += 1;
       firstPageRequestRef.current += 1;
       listGenerationRef.current += 1;
       countRequestRef.current += 1;
+      realtimeCountRequestedRef.current = false;
       firstPageInFlightRef.current = null;
       loadMoreInFlightRef.current = false;
       readLocks.clear();
       markAllLockRef.current = false;
       invitationLocks.clear();
+      rowErrorSources.clear();
+      readOutcomesById.clear();
+      readOutcomeSequenceRef.current = 0;
+      readAllOutcomeSequenceRef.current = 0;
     };
   }, [ownerUserId]);
 
-  const replaceItems = useCallback(
-    (next: NotificationItem[], ownerGeneration: OwnerGeneration) => {
+  const commitRealtimeState = useCallback(
+    (next: NotificationRealtimeState, ownerGeneration: OwnerGeneration) => {
       if (!isOwnerGenerationCurrent(ownerGeneration)) {
         return;
       }
-      itemsRef.current = next;
-      setItems(next);
+      const previous = realtimeStateRef.current;
+      realtimeStateRef.current = next;
+      if (previous.items !== next.items) {
+        itemsRef.current = next.items;
+        setItems(next.items);
+      }
+      if (previous.unreadCount !== next.unreadCount) {
+        setUnreadCount(next.unreadCount);
+      }
+      if (
+        next.unreadCount !== null &&
+        lastKnownUnreadCountRef.current !== next.unreadCount
+      ) {
+        lastKnownUnreadCountRef.current = next.unreadCount;
+        setLastKnownUnreadCount(next.unreadCount);
+      }
     },
     [isOwnerGenerationCurrent],
   );
@@ -183,13 +216,107 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
       if (!isOwnerGenerationCurrent(ownerGeneration)) {
         return;
       }
-      setItems((current) => {
-        const next = update(current);
-        itemsRef.current = next;
-        return next;
+      const next = update(itemsRef.current);
+      commitRealtimeState(
+        { ...realtimeStateRef.current, items: next },
+        ownerGeneration,
+      );
+    },
+    [commitRealtimeState, isOwnerGenerationCurrent],
+  );
+
+  const clearResolvedReadErrors = useCallback(
+    (
+      notificationIds: readonly string[] | null,
+      ownerGeneration: OwnerGeneration,
+    ) => {
+      if (!isOwnerGenerationCurrent(ownerGeneration)) {
+        return;
+      }
+      const targetIds = notificationIds === null ? null : new Set(notificationIds);
+      setRowErrors((current) => {
+        let next: Map<string, ApiError> | null = null;
+        for (const [notificationId, source] of rowErrorSourcesRef.current) {
+          if (
+            source === 'read' &&
+            (targetIds === null || targetIds.has(notificationId))
+          ) {
+            next ??= new Map(current);
+            next.delete(notificationId);
+            rowErrorSourcesRef.current.delete(notificationId);
+          }
+        }
+        return next ?? current;
       });
+      if (notificationIds === null) {
+        setGlobalMutationError(null);
+      }
     },
     [isOwnerGenerationCurrent],
+  );
+
+  const applyNotificationEvent = useCallback(
+    (event: NotificationRealtimeEvent, ownerGeneration: OwnerGeneration) => {
+      if (!isOwnerGenerationCurrent(ownerGeneration)) {
+        return;
+      }
+      const effectiveEvent: NotificationRealtimeEvent =
+        event.event === 'created'
+          ? {
+              ...event,
+              notification: applyOverride(
+                event.notification,
+                overridesRef.current.get(event.notification.id),
+              ),
+            }
+          : event;
+      if (effectiveEvent.event === 'read') {
+        const sequence = readOutcomeSequenceRef.current + 1;
+        readOutcomeSequenceRef.current = sequence;
+        for (const notificationId of effectiveEvent.notification_ids) {
+          readOutcomeByIdRef.current.set(notificationId, sequence);
+        }
+      } else if (effectiveEvent.event === 'read_all') {
+        const sequence = readOutcomeSequenceRef.current + 1;
+        readOutcomeSequenceRef.current = sequence;
+        readAllOutcomeSequenceRef.current = sequence;
+      }
+      const next = notificationRealtimeReducer(realtimeStateRef.current, {
+        type: 'REALTIME_EVENT_RECEIVED',
+        event: effectiveEvent,
+      });
+      const version = next.version;
+      if (effectiveEvent.event === 'read') {
+        for (const notificationId of effectiveEvent.notification_ids) {
+          const current = overridesRef.current.get(notificationId);
+          overridesRef.current.set(notificationId, {
+            ...current,
+            isRead: true,
+            version,
+          });
+        }
+        clearResolvedReadErrors(effectiveEvent.notification_ids, ownerGeneration);
+      } else if (effectiveEvent.event === 'read_all') {
+        for (const [notificationId, readOverlay] of next.overlays.readById) {
+          if (readOverlay.version !== version) {
+            continue;
+          }
+          const current = overridesRef.current.get(notificationId);
+          overridesRef.current.set(notificationId, {
+            ...current,
+            isRead: true,
+            version,
+          });
+        }
+        clearResolvedReadErrors(null, ownerGeneration);
+      } else if (!hasUsablePageRef.current) {
+        hasUsablePageRef.current = true;
+        setStatus('ready');
+        setErrorSource((current) => current === 'initial' ? 'refresh' : current);
+      }
+      commitRealtimeState(next, ownerGeneration);
+    },
+    [clearResolvedReadErrors, commitRealtimeState, isOwnerGenerationCurrent],
   );
 
   const clearRowError = useCallback(
@@ -203,6 +330,7 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
         }
         const next = new Map(current);
         next.delete(notificationId);
+        rowErrorSourcesRef.current.delete(notificationId);
         return next;
       });
     },
@@ -210,10 +338,16 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
   );
 
   const setRowError = useCallback(
-    (notificationId: string, nextError: ApiError, ownerGeneration: OwnerGeneration) => {
+    (
+      notificationId: string,
+      nextError: ApiError,
+      source: RowErrorSource,
+      ownerGeneration: OwnerGeneration,
+    ) => {
       if (!isOwnerGenerationCurrent(ownerGeneration)) {
         return;
       }
+      rowErrorSourcesRef.current.set(notificationId, source);
       setRowErrors((current) => new Map(current).set(notificationId, nextError));
     },
     [isOwnerGenerationCurrent],
@@ -228,12 +362,15 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
       if (!isOwnerGenerationCurrent(ownerGeneration)) {
         return;
       }
-      mutationVersionRef.current += 1;
+      const clock = notificationRealtimeReducer(realtimeStateRef.current, {
+        type: 'LOCAL_MUTATION_RECORDED',
+      });
+      realtimeStateRef.current = clock;
       const current = overridesRef.current.get(notificationId);
       const override: NotificationOverride = {
         ...current,
         ...patch,
-        version: mutationVersionRef.current,
+        version: clock.version,
       };
       overridesRef.current.set(notificationId, override);
       updateItems(
@@ -255,21 +392,56 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
       }
       const requestId = countRequestRef.current + 1;
       countRequestRef.current = requestId;
-      const requestMutationVersion = mutationVersionRef.current;
+      const requestVersion = captureNotificationRealtimeVersion(
+        realtimeStateRef.current,
+      );
       try {
         const count = await getUnreadCount();
         if (
           isOwnerGenerationCurrent(ownerGeneration) &&
-          requestId === countRequestRef.current &&
-          requestMutationVersion === mutationVersionRef.current
+          requestId === countRequestRef.current
         ) {
-          setUnreadCount(count);
+          commitRealtimeState(
+            notificationRealtimeReducer(realtimeStateRef.current, {
+              type: 'UNREAD_COUNT_RESOLVED',
+              unreadCount: count,
+              requestVersion,
+            }),
+            ownerGeneration,
+          );
         }
       } catch {
         // Keep the last usable badge. Focus and foreground transitions retry.
       }
     },
-    [captureOwnerGeneration, isOwnerGenerationCurrent],
+    [captureOwnerGeneration, commitRealtimeState, isOwnerGenerationCurrent],
+  );
+
+  const requestRealtimeCountReconcile = useCallback(
+    (ownerGeneration: OwnerGeneration) => {
+      if (!isOwnerGenerationCurrent(ownerGeneration)) {
+        return;
+      }
+      realtimeCountRequestedRef.current = true;
+      if (realtimeCountRunningRef.current) {
+        return;
+      }
+      realtimeCountRunningRef.current = true;
+      void (async () => {
+        try {
+          while (
+            realtimeCountRequestedRef.current &&
+            isOwnerGenerationCurrent(ownerGeneration)
+          ) {
+            realtimeCountRequestedRef.current = false;
+            await reconcileUnreadCount(ownerGeneration);
+          }
+        } finally {
+          realtimeCountRunningRef.current = false;
+        }
+      })();
+    },
+    [isOwnerGenerationCurrent, reconcileUnreadCount],
   );
 
   const loadFirstPage = useCallback(
@@ -283,7 +455,9 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
       firstPageRequestRef.current = requestId;
       firstPageInFlightRef.current = requestId;
       listGenerationRef.current += 1;
-      const requestMutationVersion = mutationVersionRef.current;
+      const requestVersion = captureNotificationRealtimeVersion(
+        realtimeStateRef.current,
+      );
       loadMoreInFlightRef.current = false;
       setLoadingMore(false);
       setError(null);
@@ -304,15 +478,24 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
         }
         nextCursorRef.current = page.nextCursor;
         setHasNextPage(page.nextCursor !== null);
-        replaceItems(
-          applyResponseOverrides(
-            page.items,
-            overridesRef.current,
-            readAllOverrideRef.current,
-            requestMutationVersion,
-          ),
+        const responseItems = applyResponseOverrides(
+          page.items,
+          overridesRef.current,
+          requestVersion,
+        );
+        commitRealtimeState(
+          notificationRealtimeReducer(realtimeStateRef.current, {
+            type: 'FIRST_PAGE_RESOLVED',
+            items: responseItems,
+            requestVersion,
+          }),
           ownerGeneration,
         );
+        for (const [notificationId, override] of overridesRef.current) {
+          if (override.version <= requestVersion) {
+            overridesRef.current.delete(notificationId);
+          }
+        }
         hasUsablePageRef.current = true;
         setStatus('ready');
       } catch (caught) {
@@ -323,7 +506,7 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
           return;
         }
         setError(normalizeApiError(caught));
-        if (mode === 'initial' || !hasUsablePageRef.current) {
+        if (!hasUsablePageRef.current) {
           setErrorSource('initial');
           setStatus('error');
         } else {
@@ -339,7 +522,7 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
         }
       }
     },
-    [captureOwnerGeneration, isOwnerGenerationCurrent, replaceItems],
+    [captureOwnerGeneration, commitRealtimeState, isOwnerGenerationCurrent],
   );
 
   const loadMore = useCallback(async () => {
@@ -354,7 +537,9 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
       return;
     }
     const generation = listGenerationRef.current;
-    const requestMutationVersion = mutationVersionRef.current;
+    const requestVersion = captureNotificationRealtimeVersion(
+      realtimeStateRef.current,
+    );
     loadMoreInFlightRef.current = true;
     setLoadingMore(true);
     setError(null);
@@ -375,8 +560,7 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
           const additions = applyResponseOverrides(
             page.items,
             overridesRef.current,
-            readAllOverrideRef.current,
-            requestMutationVersion,
+            requestVersion,
           ).filter((item) => !seen.has(item.id));
           return [...current, ...additions];
         },
@@ -440,22 +624,29 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
       readLocksRef.current.add(notificationId);
       setPendingReadIds(new Set(readLocksRef.current));
       clearRowError(notificationId, ownerGeneration);
+      const outcomeSequenceAtStart = readOutcomeSequenceRef.current;
       try {
         await markNotificationRead(notificationId);
         if (!isOwnerGenerationCurrent(ownerGeneration)) {
           return false;
         }
-        applyLocalOverride(notificationId, { isRead: true }, ownerGeneration);
-        if (notification && !notification.is_read) {
-          setUnreadCount((current) => (current === null ? null : Math.max(0, current - 1)));
-        }
+        applyNotificationEvent(
+          { type: 'notification', event: 'read', notification_ids: [notificationId] },
+          ownerGeneration,
+        );
         await reconcileUnreadCount(ownerGeneration);
         return isOwnerGenerationCurrent(ownerGeneration);
       } catch (caught) {
         if (!isOwnerGenerationCurrent(ownerGeneration)) {
           return false;
         }
-        setRowError(notificationId, normalizeApiError(caught), ownerGeneration);
+        if (
+          (readOutcomeByIdRef.current.get(notificationId) ?? 0) > outcomeSequenceAtStart ||
+          readAllOutcomeSequenceRef.current > outcomeSequenceAtStart
+        ) {
+          return true;
+        }
+        setRowError(notificationId, normalizeApiError(caught), 'read', ownerGeneration);
         return false;
       } finally {
         readLocksRef.current.delete(notificationId);
@@ -465,7 +656,7 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
       }
     },
     [
-      applyLocalOverride,
+      applyNotificationEvent,
       captureOwnerGeneration,
       clearRowError,
       isOwnerGenerationCurrent,
@@ -479,6 +670,8 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
     if (!isOwnerGenerationCurrent(ownerGeneration) || markAllLockRef.current) {
       return false;
     }
+    const visibleIdsAtStart = itemsRef.current.map((item) => item.id);
+    const outcomeSequenceAtStart = readOutcomeSequenceRef.current;
     markAllLockRef.current = true;
     setMarkingAllRead(true);
     setGlobalMutationError(null);
@@ -487,18 +680,24 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
       if (!isOwnerGenerationCurrent(ownerGeneration)) {
         return false;
       }
-      mutationVersionRef.current += 1;
-      readAllOverrideRef.current = { version: mutationVersionRef.current };
-      updateItems(
-        (current) => current.map((item) => (item.is_read ? item : { ...item, is_read: true })),
-        ownerGeneration,
-      );
-      setUnreadCount(0);
+      if (visibleIdsAtStart.length > 0) {
+        applyNotificationEvent(
+          {
+            type: 'notification',
+            event: 'read',
+            notification_ids: visibleIdsAtStart,
+          },
+          ownerGeneration,
+        );
+      }
       await reconcileUnreadCount(ownerGeneration);
       return isOwnerGenerationCurrent(ownerGeneration);
     } catch (caught) {
       if (!isOwnerGenerationCurrent(ownerGeneration)) {
         return false;
+      }
+      if (readAllOutcomeSequenceRef.current > outcomeSequenceAtStart) {
+        return true;
       }
       setGlobalMutationError(normalizeApiError(caught));
       return false;
@@ -508,7 +707,12 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
         setMarkingAllRead(false);
       }
     }
-  }, [captureOwnerGeneration, isOwnerGenerationCurrent, reconcileUnreadCount, updateItems]);
+  }, [
+    applyNotificationEvent,
+    captureOwnerGeneration,
+    isOwnerGenerationCurrent,
+    reconcileUnreadCount,
+  ]);
 
   const respondToInvitation = useCallback(
     async (
@@ -548,21 +752,32 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
           return false;
         }
 
+        const outcomeSequenceAtStart = readOutcomeSequenceRef.current;
         try {
           await markNotificationRead(notificationId);
           if (!isOwnerGenerationCurrent(ownerGeneration)) {
             return false;
           }
-          const notification = itemsRef.current.find((item) => item.id === notificationId);
-          applyLocalOverride(notificationId, { isRead: true }, ownerGeneration);
-          if (notification && !notification.is_read) {
-            setUnreadCount((current) => (current === null ? null : Math.max(0, current - 1)));
-          }
+          applyNotificationEvent(
+            { type: 'notification', event: 'read', notification_ids: [notificationId] },
+            ownerGeneration,
+          );
         } catch (caught) {
           if (!isOwnerGenerationCurrent(ownerGeneration)) {
             return false;
           }
-          setRowError(notificationId, normalizeApiError(caught), ownerGeneration);
+          if (
+            (readOutcomeByIdRef.current.get(notificationId) ?? 0) <=
+              outcomeSequenceAtStart &&
+            readAllOutcomeSequenceRef.current <= outcomeSequenceAtStart
+          ) {
+            setRowError(
+              notificationId,
+              normalizeApiError(caught),
+              'invitation',
+              ownerGeneration,
+            );
+          }
         }
 
         if (!isOwnerGenerationCurrent(ownerGeneration)) {
@@ -578,7 +793,7 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
           return false;
         }
         const nextError = normalizeApiError(caught);
-        setRowError(notificationId, nextError, ownerGeneration);
+        setRowError(notificationId, nextError, 'invitation', ownerGeneration);
         if (nextError.status === 404 || nextError.status === 409) {
           applyLocalOverride(notificationId, { invitationStatus: null }, ownerGeneration);
           await Promise.all([
@@ -596,6 +811,7 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
     },
     [
       applyLocalOverride,
+      applyNotificationEvent,
       captureOwnerGeneration,
       clearRowError,
       isOwnerGenerationCurrent,
@@ -610,32 +826,30 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
     if (!isOwnerGenerationCurrent(ownerGeneration)) {
       return;
     }
-    let cancelled = false;
-    const requestId = countRequestRef.current + 1;
-    countRequestRef.current = requestId;
-    const requestMutationVersion = mutationVersionRef.current;
+    void reconcileUnreadCount(ownerGeneration);
+  }, [captureOwnerGeneration, isOwnerGenerationCurrent, reconcileUnreadCount]);
 
-    async function hydrateUnreadCount() {
-      try {
-        const count = await getUnreadCount();
-        if (
-          !cancelled &&
-          isOwnerGenerationCurrent(ownerGeneration) &&
-          requestId === countRequestRef.current &&
-          requestMutationVersion === mutationVersionRef.current
-        ) {
-          setUnreadCount(count);
-        }
-      } catch {
-        // Focus and foreground transitions provide the next retry.
+  useEffect(() => {
+    const unsubscribe = subscribe('notification', (message) => {
+      const event = parseNotificationRealtimeEvent(message);
+      if (!event) {
+        return;
       }
-    }
-
-    void hydrateUnreadCount();
-    return () => {
-      cancelled = true;
-    };
-  }, [captureOwnerGeneration, isOwnerGenerationCurrent]);
+      const ownerGeneration = captureOwnerGeneration();
+      if (!isOwnerGenerationCurrent(ownerGeneration)) {
+        return;
+      }
+      applyNotificationEvent(event, ownerGeneration);
+      requestRealtimeCountReconcile(ownerGeneration);
+    });
+    return unsubscribe;
+  }, [
+    applyNotificationEvent,
+    captureOwnerGeneration,
+    isOwnerGenerationCurrent,
+    requestRealtimeCountReconcile,
+    subscribe,
+  ]);
 
   useEffect(() => {
     const ownerGeneration = captureOwnerGeneration();
@@ -675,6 +889,7 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
       loadingMore,
       hasNextPage,
       unreadCount,
+      lastKnownUnreadCount,
       markingAllRead,
       pendingReadIds,
       pendingInvitationActions,
@@ -693,6 +908,7 @@ function OwnedNotificationsProvider({ children, ownerUserId }: NotificationsProv
       globalMutationError,
       hasNextPage,
       items,
+      lastKnownUnreadCount,
       loadMore,
       loadingMore,
       markAllRead,

--- a/mobile/src/features/notifications/application/realtimeReducer.ts
+++ b/mobile/src/features/notifications/application/realtimeReducer.ts
@@ -1,0 +1,351 @@
+import type { NotificationItem } from '../types';
+import type { NotificationRealtimeEvent } from '../realtimeEvents';
+
+type CreatedCountDelta = 0 | 1;
+type ReadCountDelta = -1 | 0 | null;
+
+export interface NotificationCreatedOverlay {
+  version: number;
+  notification: NotificationItem;
+  countDelta: CreatedCountDelta;
+}
+
+export interface NotificationReadOverlay {
+  version: number;
+  countDelta: ReadCountDelta;
+}
+
+export interface NotificationReadAllOverlay {
+  version: number;
+}
+
+export interface NotificationRealtimeOverlays {
+  createdById: ReadonlyMap<string, NotificationCreatedOverlay>;
+  readById: ReadonlyMap<string, NotificationReadOverlay>;
+  readAll: NotificationReadAllOverlay | null;
+}
+
+export interface NotificationRealtimeState {
+  items: NotificationItem[];
+  unreadCount: number | null;
+  /** The single mutation clock shared by realtime events and local overrides. */
+  version: number;
+  overlays: NotificationRealtimeOverlays;
+}
+
+export type NotificationRealtimeReducerAction =
+  | { type: 'REALTIME_EVENT_RECEIVED'; event: NotificationRealtimeEvent }
+  /** Advance before stamping a non-realtime local override with the returned version. */
+  | { type: 'LOCAL_MUTATION_RECORDED' }
+  | {
+      type: 'FIRST_PAGE_RESOLVED';
+      items: NotificationItem[];
+      requestVersion: number;
+    }
+  | {
+      type: 'UNREAD_COUNT_RESOLVED';
+      unreadCount: number | null;
+      requestVersion: number;
+    };
+
+interface InitialNotificationRealtimeState {
+  items?: NotificationItem[];
+  unreadCount?: number | null;
+}
+
+function normalizeUnreadCount(value: number | null | undefined): number | null {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return null;
+  }
+  return Math.max(0, Math.floor(value));
+}
+
+function normalizeRequestVersion(state: NotificationRealtimeState, value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(state.version, Math.max(0, Math.floor(value)));
+}
+
+function dedupeItems(items: NotificationItem[]): NotificationItem[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    if (seen.has(item.id)) {
+      return false;
+    }
+    seen.add(item.id);
+    return true;
+  });
+}
+
+function compactOverlayMap<T extends { version: number }>(
+  overlays: ReadonlyMap<string, T>,
+  requestVersion: number,
+): ReadonlyMap<string, T> {
+  return new Map(
+    [...overlays].filter(([, overlay]) => overlay.version > requestVersion),
+  );
+}
+
+function adjustUnreadCount(current: number | null, delta: number): number | null {
+  return current === null ? null : Math.max(0, current + delta);
+}
+
+function markItemRead(item: NotificationItem): NotificationItem {
+  return item.is_read ? item : { ...item, is_read: true };
+}
+
+function preserveReadState(
+  incoming: NotificationItem,
+  existing: NotificationItem | undefined,
+  hasReadOverride: boolean,
+): NotificationItem {
+  if (incoming.is_read || (!existing?.is_read && !hasReadOverride)) {
+    return incoming;
+  }
+  return {
+    ...incoming,
+    is_read: true,
+    read_at: existing?.read_at ?? incoming.read_at,
+  };
+}
+
+function applyCreatedEvent(
+  state: NotificationRealtimeState,
+  notification: NotificationItem,
+): NotificationRealtimeState {
+  const existingOverlay = state.overlays.createdById.get(notification.id);
+  if (existingOverlay) {
+    const existingItem = state.items.find((item) => item.id === notification.id);
+    const effectiveNotification = preserveReadState(
+      notification,
+      existingItem,
+      state.overlays.readById.has(notification.id),
+    );
+    const createdById = new Map(state.overlays.createdById);
+    createdById.set(notification.id, {
+      ...existingOverlay,
+      notification: effectiveNotification,
+    });
+    return {
+      ...state,
+      items: existingItem
+        ? state.items.map((item) =>
+            item.id === notification.id ? effectiveNotification : item,
+          )
+        : [effectiveNotification, ...state.items],
+      overlays: { ...state.overlays, createdById },
+    };
+  }
+
+  const version = state.version + 1;
+  const existingIndex = state.items.findIndex((item) => item.id === notification.id);
+  const existingItem = existingIndex >= 0 ? state.items[existingIndex] : undefined;
+  const effectiveNotification = preserveReadState(
+    notification,
+    existingItem,
+    state.overlays.readById.has(notification.id),
+  );
+  const countDelta: CreatedCountDelta = existingItem !== undefined || effectiveNotification.is_read ? 0 : 1;
+  let items = state.items;
+
+  if (!existingItem) {
+    items = [effectiveNotification, ...state.items];
+  } else {
+    items = [...state.items];
+    items[existingIndex] = effectiveNotification;
+  }
+
+  const createdById = new Map(state.overlays.createdById);
+  createdById.set(notification.id, { version, notification: effectiveNotification, countDelta });
+
+  return {
+    ...state,
+    items,
+    unreadCount: adjustUnreadCount(state.unreadCount, countDelta),
+    version,
+    overlays: { ...state.overlays, createdById },
+  };
+}
+
+function applyReadEvent(
+  state: NotificationRealtimeState,
+  notificationIds: string[],
+): NotificationRealtimeState {
+  const uniqueIds = [...new Set(notificationIds.filter((id) => id.length > 0))];
+  const newIds = uniqueIds.filter((id) => !state.overlays.readById.has(id));
+
+  if (newIds.length === 0) {
+    const staleUnreadIds = new Set(
+      uniqueIds.filter((id) => state.items.some((item) => item.id === id && !item.is_read)),
+    );
+    return staleUnreadIds.size === 0
+      ? state
+      : {
+          ...state,
+          items: state.items.map((item) =>
+            staleUnreadIds.has(item.id) ? markItemRead(item) : item,
+          ),
+        };
+  }
+
+  const version = state.version + 1;
+  const itemsById = new Map(state.items.map((item) => [item.id, item]));
+  const readById = new Map(state.overlays.readById);
+  let countDelta = 0;
+  let countBecameUnknown = false;
+
+  for (const id of newIds) {
+    const item = itemsById.get(id);
+    const itemDelta: ReadCountDelta = item ? (item.is_read ? 0 : -1) : null;
+    if (itemDelta === null) {
+      countBecameUnknown = true;
+    } else {
+      countDelta += itemDelta;
+    }
+    readById.set(id, { version, countDelta: itemDelta });
+  }
+
+  const idsToMark = new Set(newIds);
+  return {
+    ...state,
+    items: state.items.map((item) =>
+      idsToMark.has(item.id) ? markItemRead(item) : item,
+    ),
+    unreadCount: countBecameUnknown
+      ? null
+      : adjustUnreadCount(state.unreadCount, countDelta),
+    version,
+    overlays: { ...state.overlays, readById },
+  };
+}
+
+function applyReadAllEvent(state: NotificationRealtimeState): NotificationRealtimeState {
+  const version = state.version + 1;
+  const readById = new Map(state.overlays.readById);
+  const knownIds = new Set([
+    ...state.items.map((item) => item.id),
+    ...state.overlays.createdById.keys(),
+    ...state.overlays.readById.keys(),
+  ]);
+  for (const id of knownIds) {
+    readById.set(id, { version, countDelta: 0 });
+  }
+  return {
+    ...state,
+    items: state.items.map(markItemRead),
+    unreadCount: 0,
+    version,
+    overlays: { ...state.overlays, readById, readAll: { version } },
+  };
+}
+
+function applyRealtimeEvent(
+  state: NotificationRealtimeState,
+  event: NotificationRealtimeEvent,
+): NotificationRealtimeState {
+  switch (event.event) {
+    case 'created':
+      return applyCreatedEvent(state, event.notification);
+    case 'read':
+      return applyReadEvent(state, event.notification_ids);
+    case 'read_all':
+      return applyReadAllEvent(state);
+  }
+}
+
+function mergeFirstPage(
+  state: NotificationRealtimeState,
+  incomingItems: NotificationItem[],
+  rawRequestVersion: number,
+): NotificationRealtimeState {
+  const requestVersion = normalizeRequestVersion(state, rawRequestVersion);
+  let items = dedupeItems(incomingItems);
+  const createdAfterRequest = [...state.overlays.createdById.values()]
+    .filter((overlay) => overlay.version > requestVersion)
+    .sort((left, right) => left.version - right.version);
+
+  for (const overlay of createdAfterRequest) {
+    const existingIndex = items.findIndex((item) => item.id === overlay.notification.id);
+    if (existingIndex < 0) {
+      items = [overlay.notification, ...items];
+      continue;
+    }
+
+    const existing = items[existingIndex];
+    items = [...items];
+    items[existingIndex] = preserveReadState(
+      overlay.notification,
+      existing,
+      state.overlays.readById.has(overlay.notification.id),
+    );
+  }
+
+  if (state.overlays.readById.size > 0) {
+    items = items.map((item) =>
+      state.overlays.readById.has(item.id) ? markItemRead(item) : item,
+    );
+  }
+
+  return {
+    ...state,
+    items,
+    overlays: {
+      createdById: compactOverlayMap(state.overlays.createdById, requestVersion),
+      readById: compactOverlayMap(state.overlays.readById, requestVersion),
+      readAll:
+        state.overlays.readAll && state.overlays.readAll.version > requestVersion
+          ? state.overlays.readAll
+          : null,
+    },
+  };
+}
+
+function mergeUnreadCount(
+  state: NotificationRealtimeState,
+  incomingCount: number | null,
+  rawRequestVersion: number,
+): NotificationRealtimeState {
+  const requestVersion = normalizeRequestVersion(state, rawRequestVersion);
+  // A DB query can observe an in-flight mutation, so replaying deltas can double-apply it.
+  // The caller must schedule a trailing reconciliation when this stale result is discarded.
+  if (requestVersion !== state.version) {
+    return state;
+  }
+  return { ...state, unreadCount: normalizeUnreadCount(incomingCount) };
+}
+
+export function createNotificationRealtimeState(
+  initial: InitialNotificationRealtimeState = {},
+): NotificationRealtimeState {
+  return {
+    items: dedupeItems(initial.items ?? []),
+    unreadCount: normalizeUnreadCount(initial.unreadCount),
+    version: 0,
+    overlays: {
+      createdById: new Map(),
+      readById: new Map(),
+      readAll: null,
+    },
+  };
+}
+
+export function captureNotificationRealtimeVersion(state: NotificationRealtimeState): number {
+  return state.version;
+}
+
+export function notificationRealtimeReducer(
+  state: NotificationRealtimeState,
+  action: NotificationRealtimeReducerAction,
+): NotificationRealtimeState {
+  switch (action.type) {
+    case 'REALTIME_EVENT_RECEIVED':
+      return applyRealtimeEvent(state, action.event);
+    case 'LOCAL_MUTATION_RECORDED':
+      return { ...state, version: state.version + 1 };
+    case 'FIRST_PAGE_RESOLVED':
+      return mergeFirstPage(state, action.items, action.requestVersion);
+    case 'UNREAD_COUNT_RESOLVED':
+      return mergeUnreadCount(state, action.unreadCount, action.requestVersion);
+  }
+}

--- a/mobile/src/features/notifications/application/realtimeReducer.ts
+++ b/mobile/src/features/notifications/application/realtimeReducer.ts
@@ -43,9 +43,16 @@ export type NotificationRealtimeReducerAction =
       requestVersion: number;
     }
   | {
+      type: 'LOCAL_READ_ALL_CONFIRMED';
+      notificationIds: string[];
+      updatedCount: number;
+      countIsAmbiguous: boolean;
+    }
+  | {
       type: 'UNREAD_COUNT_RESOLVED';
       unreadCount: number | null;
       requestVersion: number;
+      knownItemIdsAtStart: string[];
     };
 
 interface InitialNotificationRealtimeState {
@@ -286,10 +293,16 @@ function mergeFirstPage(
       state.overlays.readById.has(item.id) ? markItemRead(item) : item,
     );
   }
+  const loadedUnreadCount = items.filter((item) => !item.is_read).length;
+  const unreadCount =
+    state.unreadCount !== null && state.unreadCount < loadedUnreadCount
+      ? null
+      : state.unreadCount;
 
   return {
     ...state,
     items,
+    unreadCount,
     overlays: {
       createdById: compactOverlayMap(state.overlays.createdById, requestVersion),
       readById: compactOverlayMap(state.overlays.readById, requestVersion),
@@ -301,10 +314,39 @@ function mergeFirstPage(
   };
 }
 
+function applyLocalReadAllConfirmation(
+  state: NotificationRealtimeState,
+  notificationIds: string[],
+  rawUpdatedCount: number,
+  countIsAmbiguous: boolean,
+): NotificationRealtimeState {
+  const updatedCount = Number.isFinite(rawUpdatedCount)
+    ? Math.max(0, Math.floor(rawUpdatedCount))
+    : 0;
+  const version = state.version + 1;
+  const readById = new Map(state.overlays.readById);
+  const idsToMark = new Set(notificationIds);
+  for (const notificationId of idsToMark) {
+    readById.set(notificationId, { version, countDelta: 0 });
+  }
+  return {
+    ...state,
+    items: state.items.map((item) =>
+      idsToMark.has(item.id) ? markItemRead(item) : item,
+    ),
+    unreadCount: countIsAmbiguous
+      ? null
+      : adjustUnreadCount(state.unreadCount, -updatedCount),
+    version,
+    overlays: { ...state.overlays, readById },
+  };
+}
+
 function mergeUnreadCount(
   state: NotificationRealtimeState,
   incomingCount: number | null,
   rawRequestVersion: number,
+  knownItemIdsAtStart: string[],
 ): NotificationRealtimeState {
   const requestVersion = normalizeRequestVersion(state, rawRequestVersion);
   // A DB query can observe an in-flight mutation, so replaying deltas can double-apply it.
@@ -312,7 +354,40 @@ function mergeUnreadCount(
   if (requestVersion !== state.version) {
     return state;
   }
-  return { ...state, unreadCount: normalizeUnreadCount(incomingCount) };
+  const unreadCount = normalizeUnreadCount(incomingCount);
+  if (unreadCount !== 0) {
+    const loadedUnreadCount = state.items.filter((item) => !item.is_read).length;
+    return {
+      ...state,
+      unreadCount:
+        unreadCount !== null && unreadCount < loadedUnreadCount
+          ? null
+          : unreadCount,
+    };
+  }
+
+  // Zero is monotonic read authority only for rows known before the count query.
+  // A first-page response can add a newer row without advancing this clock.
+  const version = state.version + 1;
+  const idsToMark = new Set(
+    knownItemIdsAtStart.filter((notificationId) => notificationId.length > 0),
+  );
+  const readById = new Map(state.overlays.readById);
+  for (const notificationId of idsToMark) {
+    readById.set(notificationId, { version, countDelta: 0 });
+  }
+  const items = state.items.map((item) =>
+    idsToMark.has(item.id) ? markItemRead(item) : item,
+  );
+  const loadedUnreadCount = items.filter((item) => !item.is_read).length;
+
+  return {
+    ...state,
+    items,
+    unreadCount: loadedUnreadCount > 0 ? null : 0,
+    version,
+    overlays: { ...state.overlays, readById },
+  };
 }
 
 export function createNotificationRealtimeState(
@@ -345,7 +420,19 @@ export function notificationRealtimeReducer(
       return { ...state, version: state.version + 1 };
     case 'FIRST_PAGE_RESOLVED':
       return mergeFirstPage(state, action.items, action.requestVersion);
+    case 'LOCAL_READ_ALL_CONFIRMED':
+      return applyLocalReadAllConfirmation(
+        state,
+        action.notificationIds,
+        action.updatedCount,
+        action.countIsAmbiguous,
+      );
     case 'UNREAD_COUNT_RESOLVED':
-      return mergeUnreadCount(state, action.unreadCount, action.requestVersion);
+      return mergeUnreadCount(
+        state,
+        action.unreadCount,
+        action.requestVersion,
+        action.knownItemIdsAtStart,
+      );
   }
 }

--- a/mobile/src/features/notifications/components/NotificationRow.tsx
+++ b/mobile/src/features/notifications/components/NotificationRow.tsx
@@ -106,6 +106,7 @@ export const NotificationRow = memo(function NotificationRow({
     <Pressable
       accessibilityRole="button"
       accessibilityLabel={presentation.title}
+      accessibilityValue={{ text: notification.is_read ? 'Read' : 'Unread' }}
       accessibilityState={{ busy: readPending }}
       disabled={readPending}
       onPress={open}
@@ -116,7 +117,7 @@ export const NotificationRow = memo(function NotificationRow({
       ]}
     >
       <View style={styles.titleRow}>
-        {!notification.is_read ? <View accessibilityLabel="Unread" style={styles.unreadDot} /> : null}
+        {!notification.is_read ? <View accessible={false} style={styles.unreadDot} /> : null}
         <Text style={styles.title}>{presentation.title}</Text>
         {readPending ? <ActivityIndicator size="small" color={colors.primary} /> : null}
       </View>

--- a/mobile/src/features/notifications/components/TripInvitationNotificationRow.tsx
+++ b/mobile/src/features/notifications/components/TripInvitationNotificationRow.tsx
@@ -103,13 +103,14 @@ export const TripInvitationNotificationRow = memo(function TripInvitationNotific
       <Pressable
         accessibilityRole="button"
         accessibilityLabel={`Trip invitation to ${invitation.trip_name}`}
+        accessibilityValue={{ text: isRead ? 'Read' : 'Unread' }}
         accessibilityState={{ busy: readPending }}
         disabled={readPending}
         onPress={open}
         style={({ pressed }) => [styles.content, pressed && !readPending ? styles.pressed : null]}
       >
         <View style={styles.titleRow}>
-          {!isRead ? <View accessibilityLabel="Unread" style={styles.unreadDot} /> : null}
+          {!isRead ? <View accessible={false} style={styles.unreadDot} /> : null}
           <Text style={styles.title}>
             <Text style={styles.actor}>{actorName}</Text> invited you to a trip
           </Text>

--- a/mobile/src/features/notifications/realtimeEvents.ts
+++ b/mobile/src/features/notifications/realtimeEvents.ts
@@ -1,0 +1,103 @@
+import { normalizeNotification } from './api';
+import type { NotificationItem } from './types';
+
+export interface NotificationCreatedRealtimeEvent {
+  type: 'notification';
+  event: 'created';
+  notification: NotificationItem;
+}
+
+export interface NotificationReadRealtimeEvent {
+  type: 'notification';
+  event: 'read';
+  notification_ids: string[];
+}
+
+export interface NotificationReadAllRealtimeEvent {
+  type: 'notification';
+  event: 'read_all';
+}
+
+export type NotificationRealtimeEvent =
+  | NotificationCreatedRealtimeEvent
+  | NotificationReadRealtimeEvent
+  | NotificationReadAllRealtimeEvent;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isNotificationActor(value: unknown): boolean {
+  if (value === null) {
+    return true;
+  }
+  return Boolean(
+    isRecord(value) &&
+      typeof value.id === 'string' &&
+      typeof value.display_name === 'string' &&
+      (value.identify_tag === null || typeof value.identify_tag === 'string'),
+  );
+}
+
+function hasCreatedNotificationShape(value: unknown): value is Record<string, unknown> {
+  return Boolean(
+    isRecord(value) &&
+      typeof value.id === 'string' &&
+      value.id.length > 0 &&
+      typeof value.notification_type === 'string' &&
+      value.notification_type.length > 0 &&
+      isNotificationActor(value.actor) &&
+      Object.prototype.hasOwnProperty.call(value, 'payload') &&
+      typeof value.is_read === 'boolean' &&
+      (value.read_at === null || typeof value.read_at === 'string') &&
+      typeof value.created_at === 'string' &&
+      value.created_at.length > 0,
+  );
+}
+
+function normalizeNotificationIds(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const uniqueIds: string[] = [];
+  const seen = new Set<string>();
+  for (const rawId of value) {
+    if (typeof rawId !== 'string' || rawId.length === 0) {
+      return null;
+    }
+    if (!seen.has(rawId)) {
+      seen.add(rawId);
+      uniqueIds.push(rawId);
+    }
+  }
+  return uniqueIds;
+}
+
+export function parseNotificationRealtimeEvent(value: unknown): NotificationRealtimeEvent | null {
+  if (!isRecord(value) || value.type !== 'notification') {
+    return null;
+  }
+
+  switch (value.event) {
+    case 'created': {
+      if (!hasCreatedNotificationShape(value.notification)) {
+        return null;
+      }
+      const notification = normalizeNotification(value.notification);
+      return notification
+        ? { type: 'notification', event: 'created', notification }
+        : null;
+    }
+    case 'read': {
+      const notificationIds = normalizeNotificationIds(value.notification_ids);
+      return notificationIds
+        ? { type: 'notification', event: 'read', notification_ids: notificationIds }
+        : null;
+    }
+    case 'read_all':
+      return { type: 'notification', event: 'read_all' };
+    default:
+      return null;
+  }
+}

--- a/mobile/src/features/notifications/screens/NotificationsScreen.tsx
+++ b/mobile/src/features/notifications/screens/NotificationsScreen.tsx
@@ -23,6 +23,7 @@ export function NotificationsScreen() {
     loadingMore,
     hasNextPage,
     unreadCount,
+    lastKnownUnreadCount,
     markingAllRead,
     pendingReadIds,
     pendingInvitationActions,
@@ -43,8 +44,10 @@ export function NotificationsScreen() {
   );
 
   const hasUnread = useMemo(
-    () => (unreadCount ?? 0) > 0 || items.some((item) => !item.is_read),
-    [items, unreadCount],
+    () =>
+      (unreadCount ?? lastKnownUnreadCount ?? 0) > 0 ||
+      items.some((item) => !item.is_read),
+    [items, lastKnownUnreadCount, unreadCount],
   );
 
   const openNotification = useCallback(

--- a/mobile/src/features/notifications/types.ts
+++ b/mobile/src/features/notifications/types.ts
@@ -96,6 +96,8 @@ export interface NotificationsContextValue {
   loadingMore: boolean;
   hasNextPage: boolean;
   unreadCount: number | null;
+  /** Last authoritative count, retained only for degraded badge affordances while `unreadCount` is unknown. */
+  lastKnownUnreadCount: number | null;
   markingAllRead: boolean;
   pendingReadIds: ReadonlySet<string>;
   pendingInvitationActions: ReadonlyMap<string, InvitationAction>;

--- a/mobile/src/features/realtime/__tests__/RealtimeProvider.test.tsx
+++ b/mobile/src/features/realtime/__tests__/RealtimeProvider.test.tsx
@@ -1,0 +1,82 @@
+import { useEffect } from 'react';
+import { act, render, waitFor } from '@testing-library/react-native';
+import {
+  RealtimeProvider,
+  useRealtimeSnapshot,
+  useRealtimeTransport,
+} from '../application/RealtimeProvider';
+import type { RealtimeSnapshot, RealtimeTransport } from '../types';
+import {
+  FakeAppStateObserver,
+  FakeAuthSource,
+  FakeManager,
+  FakeNetworkObserver,
+  flushPromises,
+} from '../testing/fakes';
+
+const auth = {
+  phase: 'active' as const,
+  sessionGeneration: 1,
+  credentialRevision: 0,
+  publishedCredentialRevision: 0,
+  access: 'access',
+};
+
+describe('RealtimeProvider', () => {
+  it('keeps transport commands stable while publishing snapshot changes separately', async () => {
+    const manager = new FakeManager();
+    const authSource = new FakeAuthSource(auth);
+    const appState = new FakeAppStateObserver('active');
+    const network = new FakeNetworkObserver({
+      availability: 'unknown',
+      type: null,
+    });
+    const transports: RealtimeTransport[] = [];
+    const snapshots: RealtimeSnapshot[] = [];
+
+    function TransportProbe() {
+      const transport = useRealtimeTransport();
+      useEffect(() => {
+        transports.push(transport);
+      }, [transport]);
+      return null;
+    }
+
+    function SnapshotProbe() {
+      const snapshot = useRealtimeSnapshot();
+      useEffect(() => {
+        snapshots.push(snapshot);
+      }, [snapshot]);
+      return null;
+    }
+
+    const view = await render(
+      <RealtimeProvider
+        manager={manager}
+        authSource={authSource}
+        appStateObserver={appState}
+        networkObserver={network}
+      >
+        <TransportProbe />
+        <SnapshotProbe />
+      </RealtimeProvider>,
+    );
+    await act(async () => {
+      manager.emitSnapshot({ status: 'connected', connectionEpoch: 1 });
+    });
+
+    expect(transports).toHaveLength(1);
+    await waitFor(() => {
+      expect(snapshots.at(-1)).toEqual({ status: 'connected', connectionEpoch: 1 });
+    });
+
+    await view.unmount();
+    await flushPromises();
+    expect(manager.events.indexOf('unsubscribeSnapshot')).toBeLessThan(
+      manager.events.indexOf('disconnect:unmount'),
+    );
+    expect(manager.events.indexOf('disconnect:unmount')).toBeLessThan(
+      manager.events.indexOf('destroy'),
+    );
+  });
+});

--- a/mobile/src/features/realtime/__tests__/RealtimeRuntimeController.test.ts
+++ b/mobile/src/features/realtime/__tests__/RealtimeRuntimeController.test.ts
@@ -1,0 +1,160 @@
+import type {
+  ConnectivitySnapshot,
+  PublishedAuthLifecycleSnapshot,
+  RealtimeAppState,
+} from '../types';
+import { RealtimeRuntimeController } from '../application/RealtimeRuntimeController';
+import {
+  deferred,
+  FakeAppStateObserver,
+  FakeAuthSource,
+  FakeManager,
+  FakeNetworkObserver,
+  flushPromises,
+} from '../testing/fakes';
+
+const ACTIVE_AUTH: PublishedAuthLifecycleSnapshot = {
+  phase: 'active',
+  sessionGeneration: 1,
+  credentialRevision: 0,
+  publishedCredentialRevision: 0,
+  access: 'access-0',
+};
+
+function makeHarness(
+  authSnapshot: PublishedAuthLifecycleSnapshot = ACTIVE_AUTH,
+  appState: RealtimeAppState = 'active',
+  networkSnapshot: ConnectivitySnapshot = {
+    availability: 'unknown',
+    type: null,
+  },
+) {
+  const manager = new FakeManager();
+  const auth = new FakeAuthSource(authSnapshot);
+  const app = new FakeAppStateObserver(appState);
+  const network = new FakeNetworkObserver(networkSnapshot);
+  const controller = new RealtimeRuntimeController({ manager, auth, appState: app, network });
+  return { manager, auth, app, network, controller };
+}
+
+describe('RealtimeRuntimeController', () => {
+  it('connects only when active credentials have actually been published', async () => {
+    const value = makeHarness({
+      ...ACTIVE_AUTH,
+      credentialRevision: 1,
+      publishedCredentialRevision: 0,
+      access: 'old-access',
+    });
+
+    value.controller.start();
+    await flushPromises();
+    expect(value.manager.connectCalls).toHaveLength(0);
+    expect(value.manager.disconnectCalls).toContain('auth');
+
+    value.auth.emit({
+      ...ACTIVE_AUTH,
+      credentialRevision: 1,
+      publishedCredentialRevision: 1,
+      access: 'rotated-access',
+    });
+    expect(value.manager.connectCalls).toContainEqual({
+      sessionGeneration: 1,
+      credentialRevision: 1,
+    });
+  });
+
+  it('disconnects synchronously at credential rotation and reconnects after publication', async () => {
+    const value = makeHarness();
+    value.controller.start();
+    await flushPromises();
+    const connectsBeforeRotation = value.manager.connectCalls.length;
+
+    value.auth.emit({
+      ...ACTIVE_AUTH,
+      credentialRevision: 1,
+      publishedCredentialRevision: 0,
+      access: 'access-0',
+    });
+    expect(value.manager.disconnectCalls.at(-1)).toBe('auth');
+    expect(value.manager.connectCalls).toHaveLength(connectsBeforeRotation);
+
+    value.auth.emit({
+      ...ACTIVE_AUTH,
+      credentialRevision: 1,
+      publishedCredentialRevision: 1,
+      access: 'access-1',
+    });
+    expect(value.manager.connectCalls.at(-1)).toEqual({
+      sessionGeneration: 1,
+      credentialRevision: 1,
+    });
+  });
+
+  it('disconnects and reconnects across background and confirmed offline transitions', async () => {
+    const value = makeHarness();
+    value.controller.start();
+    await flushPromises();
+
+    value.app.emit('inactive');
+    expect(value.manager.disconnectCalls.at(-1)).toBe('background');
+    value.app.emit('active');
+    expect(value.manager.connectCalls.at(-1)).toEqual({
+      sessionGeneration: 1,
+      credentialRevision: 0,
+    });
+
+    value.network.emit({ availability: 'offline', type: null });
+    expect(value.manager.disconnectCalls.at(-1)).toBe('offline');
+    const beforeOnline = value.manager.connectCalls.length;
+    value.network.emit({ availability: 'online', type: 'WIFI' });
+    expect(value.manager.connectCalls).toHaveLength(beforeOnline + 1);
+  });
+
+  it('restarts once for a real online network handoff and dedupes identical observations', async () => {
+    const value = makeHarness(ACTIVE_AUTH, 'active', {
+      availability: 'online',
+      type: 'WIFI',
+    });
+    value.controller.start();
+    await flushPromises();
+
+    value.network.emit({ availability: 'online', type: 'WIFI' });
+    expect(value.manager.restartCalls).toHaveLength(0);
+    value.network.emit({ availability: 'online', type: 'CELLULAR' });
+    value.network.emit({ availability: 'online', type: 'CELLULAR' });
+    expect(value.manager.restartCalls).toEqual([
+      { sessionGeneration: 1, credentialRevision: 0 },
+    ]);
+  });
+
+  it('ignores a stale initial network read after a newer listener event', async () => {
+    const value = makeHarness();
+    const initial = deferred<ConnectivitySnapshot>();
+    value.network.currentResult = initial.promise;
+    value.controller.start();
+    value.network.emit({ availability: 'online', type: 'WIFI' });
+    const disconnectsBeforeStaleRead = value.manager.disconnectCalls.length;
+
+    initial.resolve({ availability: 'offline', type: null });
+    await flushPromises();
+    expect(value.manager.disconnectCalls).toHaveLength(disconnectsBeforeStaleRead);
+  });
+
+  it('unsubscribes every source and ignores events after stop', async () => {
+    const value = makeHarness();
+    value.controller.start();
+    await flushPromises();
+    value.controller.stop();
+    const callsAfterStop = value.manager.connectCalls.length;
+
+    expect(value.auth.listenerCount).toBe(0);
+    expect(value.app.listenerCount).toBe(0);
+    expect(value.network.listenerCount).toBe(0);
+    expect(value.manager.disconnectCalls.at(-1)).toBe('unmount');
+
+    value.auth.emit(ACTIVE_AUTH);
+    value.app.emit('active');
+    value.network.emit({ availability: 'online', type: 'WIFI' });
+    expect(value.manager.connectCalls).toHaveLength(callsAfterStop);
+  });
+});

--- a/mobile/src/features/realtime/__tests__/WebSocketManager.test.ts
+++ b/mobile/src/features/realtime/__tests__/WebSocketManager.test.ts
@@ -1,0 +1,481 @@
+import type { RealtimeOwner } from '../types';
+import { TicketRequestError } from '../infrastructure/ticket-api';
+import {
+  REALTIME_TIMING,
+  WebSocketManager,
+  type WebSocketManagerDependencies,
+} from '../infrastructure/WebSocketManager';
+import {
+  deferred,
+  FakeSocketFactory,
+  FakeTicketApi,
+  flushPromises,
+  jestScheduler,
+} from '../testing/fakes';
+
+const OWNER_A: RealtimeOwner = {
+  sessionGeneration: 1,
+  credentialRevision: 0,
+};
+const OWNER_B: RealtimeOwner = {
+  sessionGeneration: 3,
+  credentialRevision: 0,
+};
+
+interface Harness {
+  manager: WebSocketManager;
+  tickets: FakeTicketApi;
+  sockets: FakeSocketFactory;
+  owner: { current: RealtimeOwner | null };
+  dependencies: WebSocketManagerDependencies;
+}
+
+function sameOwner(left: RealtimeOwner | null, right: RealtimeOwner): boolean {
+  return (
+    left?.sessionGeneration === right.sessionGeneration &&
+    left.credentialRevision === right.credentialRevision
+  );
+}
+
+function makeHarness(overrides: Partial<WebSocketManagerDependencies> = {}): Harness {
+  const tickets = new FakeTicketApi();
+  const sockets = new FakeSocketFactory();
+  const owner = { current: OWNER_A as RealtimeOwner | null };
+  const dependencies: WebSocketManagerDependencies = {
+    ticketApi: tickets,
+    socketFactory: sockets.create,
+    resolveUrl: () => 'ws://localhost:8000/ws/realtime',
+    isOwnerCurrent: (candidate) => sameOwner(owner.current, candidate),
+    scheduler: jestScheduler,
+    random: () => 0,
+    ...overrides,
+  };
+  return {
+    manager: new WebSocketManager(dependencies),
+    tickets,
+    sockets,
+    owner,
+    dependencies,
+  };
+}
+
+describe('WebSocketManager', () => {
+  const managers: WebSocketManager[] = [];
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    for (const manager of managers.splice(0)) manager.destroy();
+    jest.useRealTimers();
+  });
+
+  function harness(overrides: Partial<WebSocketManagerDependencies> = {}): Harness {
+    const value = makeHarness(overrides);
+    managers.push(value.manager);
+    return value;
+  }
+
+  async function connectOpen(value: Harness) {
+    value.manager.connect(OWNER_A);
+    await flushPromises();
+    const socket = value.sockets.sockets[0];
+    expect(socket).toBeDefined();
+    socket.open();
+    return socket;
+  }
+
+  it('validates URL before consuming a ticket', async () => {
+    const value = harness({
+      resolveUrl: () => {
+        throw new Error('invalid cleartext configuration');
+      },
+    });
+
+    value.manager.connect(OWNER_A);
+    await flushPromises();
+
+    expect(value.tickets.issueCalls).toBe(0);
+    expect(value.manager.getSnapshot().status).toBe('disconnected');
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('connects single-flight with the required subprotocol and increments epoch only on open', async () => {
+    const value = harness();
+    const snapshots = jest.fn();
+    value.manager.subscribeSnapshot(snapshots);
+
+    value.manager.connect(OWNER_A);
+    value.manager.connect(OWNER_A);
+    await flushPromises();
+
+    expect(value.tickets.issueCalls).toBe(1);
+    expect(value.sockets.calls).toEqual([
+      {
+        url: 'ws://localhost:8000/ws/realtime',
+        protocols: ['goplan.realtime.v1', 'ticket-1'],
+      },
+    ]);
+    expect(value.manager.getSnapshot()).toEqual({
+      status: 'connecting',
+      connectionEpoch: 0,
+    });
+
+    value.sockets.sockets[0].open();
+    expect(value.manager.getSnapshot()).toEqual({
+      status: 'connected',
+      connectionEpoch: 1,
+    });
+    expect(snapshots).toHaveBeenLastCalledWith({
+      status: 'connected',
+      connectionEpoch: 1,
+    });
+  });
+
+  it('bounds a stuck opening socket and enters bootstrap then backoff recovery', async () => {
+    const value = harness();
+
+    value.manager.connect(OWNER_A);
+    await flushPromises();
+    const first = value.sockets.sockets[0];
+
+    await jest.advanceTimersByTimeAsync(REALTIME_TIMING.openTimeoutMs - 1);
+    expect(first.closeCalls).toHaveLength(0);
+    expect(value.tickets.issueCalls).toBe(1);
+
+    await jest.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    expect(first.closeCalls).toHaveLength(1);
+    expect(value.tickets.issueCalls).toBe(2);
+    expect(value.manager.getSnapshot().status).toBe('reconnecting');
+
+    const bootstrap = value.sockets.sockets[1];
+    await jest.advanceTimersByTimeAsync(REALTIME_TIMING.openTimeoutMs);
+    await flushPromises();
+    expect(bootstrap.closeCalls).toHaveLength(1);
+    expect(value.tickets.issueCalls).toBe(2);
+
+    await jest.advanceTimersByTimeAsync(999);
+    expect(value.tickets.issueCalls).toBe(2);
+    await jest.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    expect(value.tickets.issueCalls).toBe(3);
+  });
+
+  it('does not let a cleared stale timeout kill a replacement or opened socket', async () => {
+    const openTimeoutCallbacks: (() => void)[] = [];
+    const value = harness({
+      scheduler: {
+        ...jestScheduler,
+        setTimeout: (callback, delayMs) => {
+          if (delayMs === REALTIME_TIMING.openTimeoutMs) {
+            openTimeoutCallbacks.push(callback);
+          }
+          return jestScheduler.setTimeout(callback, delayMs);
+        },
+      },
+    });
+
+    value.manager.connect(OWNER_A);
+    await flushPromises();
+    const stale = value.sockets.sockets[0];
+    expect(openTimeoutCallbacks).toHaveLength(1);
+
+    value.manager.restart(OWNER_A);
+    await flushPromises();
+    const replacement = value.sockets.sockets[1];
+    expect(openTimeoutCallbacks).toHaveLength(2);
+
+    openTimeoutCallbacks[0]?.();
+    expect(replacement.closeCalls).toHaveLength(0);
+    expect(value.tickets.issueCalls).toBe(2);
+
+    replacement.open();
+    openTimeoutCallbacks[1]?.();
+    expect(value.manager.getSnapshot()).toEqual({
+      status: 'connected',
+      connectionEpoch: 1,
+    });
+    expect(replacement.closeCalls).toHaveLength(0);
+    expect(value.tickets.issueCalls).toBe(2);
+    expect(stale.closeCalls).toHaveLength(1);
+  });
+
+  it.each(['disconnect', 'destroy'] as const)(
+    'clears a pending open timeout on %s',
+    async (action) => {
+      const value = harness();
+      value.manager.connect(OWNER_A);
+      await flushPromises();
+      const socket = value.sockets.sockets[0];
+      expect(jest.getTimerCount()).toBe(1);
+
+      if (action === 'disconnect') {
+        value.manager.disconnect('background');
+      } else {
+        value.manager.destroy();
+      }
+
+      expect(socket.closeCalls).toHaveLength(1);
+      expect(jest.getTimerCount()).toBe(0);
+      await jest.advanceTimersByTimeAsync(REALTIME_TIMING.openTimeoutMs);
+      await flushPromises();
+      expect(value.tickets.issueCalls).toBe(1);
+      expect(value.manager.getSnapshot().status).toBe('disconnected');
+    },
+  );
+
+  it.each(['auth message', 'close'] as const)(
+    'clears a pending open timeout on a terminal pre-open %s',
+    async (eventKind) => {
+      const value = harness();
+      value.manager.connect(OWNER_A);
+      await flushPromises();
+      const socket = value.sockets.sockets[0];
+      expect(jest.getTimerCount()).toBe(1);
+
+      if (eventKind === 'auth message') {
+        socket.message(JSON.stringify({ type: 'auth_error', code: 'auth_failed' }));
+      } else {
+        socket.serverClose(4001);
+      }
+      await flushPromises();
+
+      expect(jest.getTimerCount()).toBe(0);
+      await jest.advanceTimersByTimeAsync(REALTIME_TIMING.openTimeoutMs);
+      expect(value.tickets.issueCalls).toBe(1);
+      expect(value.manager.getSnapshot().status).toBe('disconnected');
+    },
+  );
+
+  it('fences a deferred ticket from an older auth generation', async () => {
+    const value = harness();
+    const ticketA = deferred<string>();
+    const ticketB = deferred<string>();
+    value.tickets.issueSteps.push(() => ticketA.promise, () => ticketB.promise);
+
+    value.manager.connect(OWNER_A);
+    value.owner.current = OWNER_B;
+    value.manager.disconnect('auth');
+    value.manager.connect(OWNER_B);
+
+    ticketA.resolve('stale-a');
+    await flushPromises();
+    expect(value.sockets.sockets).toHaveLength(0);
+
+    ticketB.resolve('current-b');
+    await flushPromises();
+    expect(value.sockets.calls[0]?.protocols).toEqual([
+      'goplan.realtime.v1',
+      'current-b',
+    ]);
+  });
+
+  it('ignores callbacks from a socket invalidated by restart', async () => {
+    const value = harness();
+    value.manager.connect(OWNER_A);
+    await flushPromises();
+    const stale = value.sockets.sockets[0];
+
+    value.manager.restart(OWNER_A);
+    await flushPromises();
+    const current = value.sockets.sockets[1];
+    stale.open();
+    stale.message(JSON.stringify({ type: 'notification', event: 'read_all' }));
+    expect(value.manager.getSnapshot().connectionEpoch).toBe(0);
+
+    current.open();
+    expect(value.manager.getSnapshot().connectionEpoch).toBe(1);
+    expect(stale.closeCalls).toHaveLength(1);
+  });
+
+  it('routes envelopes losslessly to multiple exact and wildcard listeners', async () => {
+    const value = harness();
+    const socket = await connectOpen(value);
+    const first = jest.fn();
+    const second = jest.fn();
+    const all = jest.fn();
+    const unsubscribeFirst = value.manager.subscribe('chat.ai_typing_started', first);
+    value.manager.subscribe('chat.ai_typing_started', second);
+    value.manager.subscribeAll(all);
+    const message = {
+      type: 'chat.ai_typing_started',
+      trip_id: 'trip-1',
+      interaction_id: 'interaction-1',
+      requested_by_user_id: null,
+      future_field: { untouched: true },
+    };
+
+    socket.message(JSON.stringify(message));
+    expect(first).toHaveBeenCalledWith(message);
+    expect(second).toHaveBeenCalledWith(message);
+    expect(all).toHaveBeenCalledWith(message);
+
+    unsubscribeFirst();
+    socket.message(JSON.stringify(message));
+    socket.message('{bad json');
+    socket.message(JSON.stringify({ event: 'missing-type' }));
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(2);
+    expect(all).toHaveBeenCalledTimes(2);
+  });
+
+  it('sends only on an open socket', async () => {
+    const value = harness();
+    expect(value.manager.send({ type: 'chat.subscribe', trip_id: 'trip-1' })).toBe(false);
+    const socket = await connectOpen(value);
+
+    expect(value.manager.send({ type: 'chat.subscribe', trip_id: 'trip-1' })).toBe(true);
+    expect(socket.sent).toEqual([
+      JSON.stringify({ type: 'chat.subscribe', trip_id: 'trip-1' }),
+    ]);
+  });
+
+  it('waits for pong without resetting the timeout on the next heartbeat tick', async () => {
+    const value = harness();
+    const socket = await connectOpen(value);
+
+    await jest.advanceTimersByTimeAsync(REALTIME_TIMING.heartbeatIntervalMs);
+    expect(socket.sent).toEqual([JSON.stringify({ type: 'ping' })]);
+    await jest.advanceTimersByTimeAsync(REALTIME_TIMING.heartbeatIntervalMs);
+    expect(socket.sent).toHaveLength(1);
+    await jest.advanceTimersByTimeAsync(
+      REALTIME_TIMING.heartbeatTimeoutMs - REALTIME_TIMING.heartbeatIntervalMs,
+    );
+    await flushPromises();
+
+    expect(socket.closeCalls).toHaveLength(1);
+    expect(value.tickets.issueCalls).toBe(2);
+  });
+
+  it('clears the heartbeat timeout on pong and sends the next heartbeat', async () => {
+    const value = harness();
+    const socket = await connectOpen(value);
+
+    await jest.advanceTimersByTimeAsync(REALTIME_TIMING.heartbeatIntervalMs);
+    socket.message(JSON.stringify({ type: 'pong' }));
+    await jest.advanceTimersByTimeAsync(REALTIME_TIMING.heartbeatIntervalMs);
+
+    expect(socket.sent).toHaveLength(2);
+  });
+
+  it('uses one immediate network-close bootstrap before exponential backoff', async () => {
+    const value = harness();
+    const first = await connectOpen(value);
+
+    first.serverClose();
+    await flushPromises();
+    expect(value.tickets.issueCalls).toBe(2);
+    const bootstrapSocket = value.sockets.sockets[1];
+    bootstrapSocket.serverClose();
+
+    await jest.advanceTimersByTimeAsync(999);
+    expect(value.tickets.issueCalls).toBe(2);
+    await jest.advanceTimersByTimeAsync(1);
+    expect(value.tickets.issueCalls).toBe(3);
+  });
+
+  it('caps exponential backoff and stops after ten attempts', async () => {
+    const value = harness();
+    value.tickets.defaultIssue = () =>
+      Promise.reject(new TicketRequestError('transient'));
+    const delays = [1_000, 2_000, 4_000, 8_000, 16_000, 30_000, 30_000, 30_000, 30_000, 30_000];
+
+    value.manager.connect(OWNER_A);
+    await flushPromises();
+    for (const [index, delay] of delays.entries()) {
+      await jest.advanceTimersByTimeAsync(delay);
+      await flushPromises();
+      expect(value.tickets.issueCalls).toBe(index + 2);
+    }
+
+    expect(value.manager.getSnapshot().status).toBe('disconnected');
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('honours throttling without burning a reconnect attempt', async () => {
+    const value = harness();
+    value.tickets.issueSteps.push(
+      () => Promise.reject(new TicketRequestError('throttled', 42_000)),
+      () => Promise.reject(new TicketRequestError('transient')),
+      () => Promise.resolve('after-backoff'),
+    );
+
+    value.manager.connect(OWNER_A);
+    await flushPromises();
+    await jest.advanceTimersByTimeAsync(41_999);
+    expect(value.tickets.issueCalls).toBe(1);
+    await jest.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    expect(value.tickets.issueCalls).toBe(2);
+
+    await jest.advanceTimersByTimeAsync(999);
+    expect(value.tickets.issueCalls).toBe(2);
+    await jest.advanceTimersByTimeAsync(1);
+    expect(value.tickets.issueCalls).toBe(3);
+  });
+
+  it('caps the final throttled delay including jitter at 300 seconds', async () => {
+    const value = harness({ random: () => 1 });
+    value.tickets.issueSteps.push(
+      () => Promise.reject(new TicketRequestError('throttled', 300_000)),
+      () => Promise.resolve('capped'),
+    );
+
+    value.manager.connect(OWNER_A);
+    await flushPromises();
+    await jest.advanceTimersByTimeAsync(299_999);
+    expect(value.tickets.issueCalls).toBe(1);
+    await jest.advanceTimersByTimeAsync(1);
+    expect(value.tickets.issueCalls).toBe(2);
+  });
+
+  it.each([
+    ['envelope', (socket: { message(data: unknown): void }) => socket.message(JSON.stringify({ type: 'auth_error', code: 'token_expired' }))],
+    ['close code', (socket: { serverClose(code: number): void }) => socket.serverClose(4002)],
+  ])('uses refreshed-ticket recovery for token expiry via %s', async (_label, expire) => {
+    const value = harness();
+    const socket = await connectOpen(value);
+
+    expire(socket);
+    await flushPromises();
+
+    expect(value.tickets.refreshCalls).toBe(1);
+    expect(value.sockets.calls[1]?.protocols[1]).toBe('refresh-1');
+  });
+
+  it.each([
+    ['envelope', (socket: { message(data: unknown): void }) => socket.message(JSON.stringify({ type: 'auth_error', code: 'auth_failed' }))],
+    ['close code', (socket: { serverClose(code: number): void }) => socket.serverClose(4001)],
+  ])('hard-stops auth failure via %s', async (_label, fail) => {
+    const value = harness();
+    const socket = await connectOpen(value);
+
+    fail(socket);
+    value.manager.connect(OWNER_A);
+    await flushPromises();
+
+    expect(value.manager.getSnapshot().status).toBe('disconnected');
+    expect(value.tickets.issueCalls).toBe(1);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('disconnect cancels timers and destroy clears listeners', async () => {
+    const value = harness();
+    const listener = jest.fn();
+    value.manager.subscribe('notification', listener);
+    const socket = await connectOpen(value);
+    await jest.advanceTimersByTimeAsync(REALTIME_TIMING.heartbeatIntervalMs);
+
+    value.manager.disconnect('background');
+    socket.message(JSON.stringify({ type: 'notification', event: 'created' }));
+    expect(jest.getTimerCount()).toBe(0);
+    expect(listener).not.toHaveBeenCalled();
+
+    value.manager.destroy();
+    value.manager.connect(OWNER_A);
+    await flushPromises();
+    expect(value.tickets.issueCalls).toBe(1);
+  });
+});

--- a/mobile/src/features/realtime/__tests__/WebSocketManager.test.ts
+++ b/mobile/src/features/realtime/__tests__/WebSocketManager.test.ts
@@ -445,6 +445,71 @@ describe('WebSocketManager', () => {
     expect(value.sockets.calls[1]?.protocols[1]).toBe('refresh-1');
   });
 
+  it('retries a throttled refreshed-ticket request through the refresh endpoint', async () => {
+    const value = harness();
+    value.tickets.refreshSteps.push(
+      () => Promise.reject(new TicketRequestError('throttled', 42_000)),
+      () => Promise.resolve('refreshed-after-throttle'),
+    );
+    const socket = await connectOpen(value);
+
+    socket.message(JSON.stringify({ type: 'auth_error', code: 'token_expired' }));
+    await flushPromises();
+
+    expect(value.tickets.issueCalls).toBe(1);
+    expect(value.tickets.refreshCalls).toBe(1);
+    await jest.advanceTimersByTimeAsync(41_999);
+    expect(value.tickets.refreshCalls).toBe(1);
+
+    await jest.advanceTimersByTimeAsync(1);
+    await flushPromises();
+
+    expect(value.tickets.issueCalls).toBe(1);
+    expect(value.tickets.refreshCalls).toBe(2);
+    expect(value.sockets.calls[1]?.protocols[1]).toBe('refreshed-after-throttle');
+  });
+
+  it('retries a transient refreshed-ticket failure through the refresh endpoint', async () => {
+    const value = harness();
+    value.tickets.refreshSteps.push(
+      () => Promise.reject(new TicketRequestError('transient')),
+      () => Promise.resolve('refreshed-after-backoff'),
+    );
+    const socket = await connectOpen(value);
+
+    socket.serverClose(4002);
+    await flushPromises();
+
+    expect(value.tickets.issueCalls).toBe(1);
+    expect(value.tickets.refreshCalls).toBe(1);
+    await jest.advanceTimersByTimeAsync(999);
+    expect(value.tickets.refreshCalls).toBe(1);
+
+    await jest.advanceTimersByTimeAsync(1);
+    await flushPromises();
+
+    expect(value.tickets.issueCalls).toBe(1);
+    expect(value.tickets.refreshCalls).toBe(2);
+    expect(value.sockets.calls[1]?.protocols[1]).toBe('refreshed-after-backoff');
+  });
+
+  it('hard-stops when refreshed-ticket recovery receives a hard auth failure', async () => {
+    const value = harness();
+    value.tickets.refreshSteps.push(
+      () => Promise.reject(new TicketRequestError('hardAuth')),
+    );
+    const socket = await connectOpen(value);
+
+    socket.serverClose(4002);
+    await flushPromises();
+    value.manager.connect(OWNER_A);
+
+    expect(value.tickets.issueCalls).toBe(1);
+    expect(value.tickets.refreshCalls).toBe(1);
+    expect(value.manager.getSnapshot().status).toBe('disconnected');
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
   it.each([
     ['envelope', (socket: { message(data: unknown): void }) => socket.message(JSON.stringify({ type: 'auth_error', code: 'auth_failed' }))],
     ['close code', (socket: { serverClose(code: number): void }) => socket.serverClose(4001)],

--- a/mobile/src/features/realtime/__tests__/expo-network-observer.test.ts
+++ b/mobile/src/features/realtime/__tests__/expo-network-observer.test.ts
@@ -1,0 +1,89 @@
+import * as Network from 'expo-network';
+import {
+  expoNetworkObserver,
+  normalizeNetworkState,
+} from '../infrastructure/expo-network-observer';
+
+describe('normalizeNetworkState', () => {
+  it('treats NONE as offline', () => {
+    expect(
+      normalizeNetworkState({
+        type: Network.NetworkStateType.NONE,
+        isConnected: false,
+        isInternetReachable: false,
+      }),
+    ).toEqual({ availability: 'offline', type: null });
+  });
+
+  it.each([
+    { type: Network.NetworkStateType.UNKNOWN, isConnected: false },
+    { isConnected: false, isInternetReachable: false },
+  ])('does not interpret indeterminate false fields as offline', (state) => {
+    expect(normalizeNetworkState(state)).toEqual({
+      availability: 'unknown',
+      type: null,
+    });
+  });
+
+  it('uses explicit false on a known network as offline', () => {
+    expect(
+      normalizeNetworkState({
+        type: Network.NetworkStateType.WIFI,
+        isConnected: true,
+        isInternetReachable: false,
+      }),
+    ).toEqual({ availability: 'offline', type: null });
+  });
+
+  it('preserves known online network types for handoff detection', () => {
+    expect(
+      normalizeNetworkState({
+        type: Network.NetworkStateType.CELLULAR,
+        isConnected: true,
+        isInternetReachable: true,
+      }),
+    ).toEqual({ availability: 'online', type: 'CELLULAR' });
+  });
+});
+
+describe('expoNetworkObserver', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('normalizes current state and removes its native listener', async () => {
+    jest.spyOn(Network, 'getNetworkStateAsync').mockResolvedValue({
+      type: Network.NetworkStateType.WIFI,
+      isConnected: true,
+      isInternetReachable: true,
+    });
+    const nativeListener: {
+      current: ((state: Network.NetworkState) => void) | null;
+    } = { current: null };
+    const remove = jest.fn();
+    jest.spyOn(Network, 'addNetworkStateListener').mockImplementation((listener) => {
+      nativeListener.current = listener;
+      return { remove };
+    });
+    const listener = jest.fn();
+
+    await expect(expoNetworkObserver.getCurrent()).resolves.toEqual({
+      availability: 'online',
+      type: 'WIFI',
+    });
+    const unsubscribe = expoNetworkObserver.subscribe(listener);
+    if (nativeListener.current === null) {
+      throw new Error('Native listener was not registered.');
+    }
+    nativeListener.current({
+      type: Network.NetworkStateType.CELLULAR,
+      isConnected: true,
+      isInternetReachable: true,
+    });
+    expect(listener).toHaveBeenCalledWith({
+      availability: 'online',
+      type: 'CELLULAR',
+    });
+
+    unsubscribe();
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/src/features/realtime/__tests__/ticket-api.test.ts
+++ b/mobile/src/features/realtime/__tests__/ticket-api.test.ts
@@ -1,0 +1,77 @@
+import { apiClient } from '@/shared/api/client';
+import {
+  parseRetryAfterMs,
+  realtimeTicketApi,
+} from '../infrastructure/ticket-api';
+
+describe('realtimeTicketApi', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('uses the direct-Django ticket endpoints and returns validated tickets', async () => {
+    const post = jest
+      .spyOn(apiClient, 'post')
+      .mockResolvedValueOnce({ data: { ticket: 'issue-ticket' } })
+      .mockResolvedValueOnce({ data: { ticket: 'refresh-ticket' } });
+
+    await expect(realtimeTicketApi.issue()).resolves.toBe('issue-ticket');
+    await expect(realtimeTicketApi.refresh()).resolves.toBe('refresh-ticket');
+    expect(post).toHaveBeenNthCalledWith(1, '/realtime/ws-ticket');
+    expect(post).toHaveBeenNthCalledWith(2, '/realtime/ws-ticket/refresh');
+  });
+
+  it.each([null, {}, { ticket: '' }, { ticket: 7 }])(
+    'rejects malformed successful payload %p',
+    async (data) => {
+      jest.spyOn(apiClient, 'post').mockResolvedValue({ data });
+      await expect(realtimeTicketApi.issue()).rejects.toMatchObject({
+        kind: 'transient',
+      });
+    },
+  );
+
+  it.each([
+    [401, 'hardAuth'],
+    [403, 'hardAuth'],
+    [500, 'transient'],
+  ])('classifies HTTP %s as %s', async (status, kind) => {
+    jest.spyOn(apiClient, 'post').mockRejectedValue({
+      isAxiosError: true,
+      response: { status, headers: {} },
+    });
+    await expect(realtimeTicketApi.issue()).rejects.toMatchObject({ kind });
+  });
+
+  it('preserves parsed Retry-After on throttling', async () => {
+    jest.spyOn(apiClient, 'post').mockRejectedValue({
+      isAxiosError: true,
+      response: { status: 429, headers: { 'retry-after': '42' } },
+    });
+    await expect(realtimeTicketApi.issue()).rejects.toEqual(
+      expect.objectContaining({
+        kind: 'throttled',
+        retryAfterMs: 42_000,
+      }),
+    );
+  });
+});
+
+describe('parseRetryAfterMs', () => {
+  const now = Date.parse('2026-08-09T00:00:00.000Z');
+
+  it('supports delta-seconds and HTTP-date', () => {
+    expect(parseRetryAfterMs('17', now)).toBe(17_000);
+    expect(parseRetryAfterMs('Sun, 09 Aug 2026 00:00:42 GMT', now)).toBe(42_000);
+  });
+
+  it.each([
+    '0',
+    '-1',
+    '17junk',
+    'invalid',
+    'Sat, 08 Aug 2026 23:59:59 GMT',
+  ])('rejects invalid or past value %s', (value) => {
+    expect(parseRetryAfterMs(value, now)).toBeNull();
+  });
+});

--- a/mobile/src/features/realtime/__tests__/ws-url.test.ts
+++ b/mobile/src/features/realtime/__tests__/ws-url.test.ts
@@ -1,0 +1,22 @@
+import { resolveRealtimeWebSocketUrl } from '../infrastructure/ws-url';
+
+describe('resolveRealtimeWebSocketUrl', () => {
+  it.each([
+    ['http://localhost:8000', 'ws://localhost:8000/ws/realtime'],
+    ['http://127.0.0.1:8000/', 'ws://127.0.0.1:8000/ws/realtime'],
+    ['http://dev.localhost:8000/api', 'ws://dev.localhost:8000/ws/realtime'],
+    ['https://api.example.com', 'wss://api.example.com/ws/realtime'],
+    ['https://api.example.com/root?old=1#hash', 'wss://api.example.com/ws/realtime'],
+  ])('derives the realtime endpoint from %s', (input, expected) => {
+    expect(resolveRealtimeWebSocketUrl(input)).toBe(expected);
+  });
+
+  it.each([
+    'http://api.example.com',
+    'ftp://api.example.com',
+    'not a url',
+    'https://user:secret@api.example.com',
+  ])('rejects unsafe or invalid server root %s', (input) => {
+    expect(() => resolveRealtimeWebSocketUrl(input)).toThrow();
+  });
+});

--- a/mobile/src/features/realtime/application/RealtimeProvider.tsx
+++ b/mobile/src/features/realtime/application/RealtimeProvider.tsx
@@ -1,0 +1,114 @@
+import {
+  createContext,
+  type PropsWithChildren,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  getAuthSnapshot,
+  subscribeAuthLifecycle,
+} from '@/shared/api/authSessionLifecycle';
+import type {
+  AppStateObserver,
+  AuthLifecycleSource,
+  NetworkObserver,
+  RealtimeManager,
+  RealtimeSnapshot,
+  RealtimeTransport,
+} from '../types';
+import { nativeAppStateObserver } from '../infrastructure/app-state-observer';
+import { expoNetworkObserver } from '../infrastructure/expo-network-observer';
+import { createDefaultWebSocketManager } from '../infrastructure/WebSocketManager';
+import { RealtimeRuntimeController } from './RealtimeRuntimeController';
+
+const RealtimeTransportContext = createContext<RealtimeTransport | null>(null);
+const RealtimeSnapshotContext = createContext<RealtimeSnapshot | null>(null);
+
+const nativeAuthLifecycleSource: AuthLifecycleSource = {
+  getSnapshot: getAuthSnapshot,
+  subscribe: subscribeAuthLifecycle,
+};
+
+export interface RealtimeProviderProps extends PropsWithChildren {
+  manager?: RealtimeManager;
+  authSource?: AuthLifecycleSource;
+  appStateObserver?: AppStateObserver;
+  networkObserver?: NetworkObserver;
+}
+
+export function RealtimeProvider({
+  children,
+  manager: injectedManager,
+  authSource = nativeAuthLifecycleSource,
+  appStateObserver = nativeAppStateObserver,
+  networkObserver = expoNetworkObserver,
+}: RealtimeProviderProps) {
+  const [manager] = useState<RealtimeManager>(
+    () => injectedManager ?? createDefaultWebSocketManager(),
+  );
+  const [snapshot, setSnapshot] = useState<RealtimeSnapshot>(() =>
+    manager.getSnapshot(),
+  );
+  const runtimeGenerationRef = useRef(0);
+
+  useEffect(() => {
+    runtimeGenerationRef.current += 1;
+    const runtimeGeneration = runtimeGenerationRef.current;
+    const unsubscribeSnapshot = manager.subscribeSnapshot(setSnapshot);
+    const controller = new RealtimeRuntimeController({
+      manager,
+      auth: authSource,
+      appState: appStateObserver,
+      network: networkObserver,
+    });
+    controller.start();
+    return () => {
+      // Stop React delivery first, then invalidate transport work. Deferring
+      // destroy by one microtask keeps React Strict Mode's effect replay usable;
+      // a replacement effect advances the generation and cancels destruction.
+      unsubscribeSnapshot();
+      controller.stop();
+      void Promise.resolve().then(() => {
+        if (runtimeGenerationRef.current === runtimeGeneration) {
+          manager.destroy();
+        }
+      });
+    };
+  }, [appStateObserver, authSource, manager, networkObserver]);
+
+  const transport = useMemo<RealtimeTransport>(
+    () => ({
+      send: (message) => manager.send(message),
+      subscribe: (type, listener) => manager.subscribe(type, listener),
+      subscribeAll: (listener) => manager.subscribeAll(listener),
+    }),
+    [manager],
+  );
+
+  return (
+    <RealtimeTransportContext.Provider value={transport}>
+      <RealtimeSnapshotContext.Provider value={snapshot}>
+        {children}
+      </RealtimeSnapshotContext.Provider>
+    </RealtimeTransportContext.Provider>
+  );
+}
+
+export function useRealtimeTransport(): RealtimeTransport {
+  const context = useContext(RealtimeTransportContext);
+  if (!context) {
+    throw new Error('useRealtimeTransport must be used within RealtimeProvider');
+  }
+  return context;
+}
+
+export function useRealtimeSnapshot(): RealtimeSnapshot {
+  const context = useContext(RealtimeSnapshotContext);
+  if (!context) {
+    throw new Error('useRealtimeSnapshot must be used within RealtimeProvider');
+  }
+  return context;
+}

--- a/mobile/src/features/realtime/application/RealtimeRuntimeController.ts
+++ b/mobile/src/features/realtime/application/RealtimeRuntimeController.ts
@@ -1,0 +1,172 @@
+import type {
+  AppStateObserver,
+  AuthLifecycleSource,
+  ConnectivitySnapshot,
+  NetworkObserver,
+  PublishedAuthLifecycleSnapshot,
+  RealtimeDisconnectReason,
+  RealtimeManager,
+  RealtimeOwner,
+} from '../types';
+
+export interface RealtimeRuntimeControllerDependencies {
+  manager: RealtimeManager;
+  auth: AuthLifecycleSource;
+  appState: AppStateObserver;
+  network: NetworkObserver;
+}
+
+function ownerFromAuth(
+  snapshot: PublishedAuthLifecycleSnapshot,
+): RealtimeOwner | null {
+  if (
+    snapshot.phase !== 'active' ||
+    snapshot.access === null ||
+    snapshot.publishedCredentialRevision === null ||
+    snapshot.publishedCredentialRevision !== snapshot.credentialRevision
+  ) {
+    return null;
+  }
+  return {
+    sessionGeneration: snapshot.sessionGeneration,
+    credentialRevision: snapshot.credentialRevision,
+  };
+}
+
+function sameConnectivity(
+  left: ConnectivitySnapshot,
+  right: ConnectivitySnapshot,
+): boolean {
+  return left.availability === right.availability && left.type === right.type;
+}
+
+export class RealtimeRuntimeController {
+  private authSnapshot: PublishedAuthLifecycleSnapshot | null = null;
+  private appIsActive = false;
+  private connectivity: ConnectivitySnapshot = {
+    availability: 'unknown',
+    type: null,
+  };
+  private lastKnownOnlineType: string | null = null;
+  private networkObservationVersion = 0;
+  private started = false;
+  private unsubscribers: (() => void)[] = [];
+
+  constructor(private readonly dependencies: RealtimeRuntimeControllerDependencies) {}
+
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+
+    this.unsubscribers = [
+      this.dependencies.auth.subscribe((snapshot) => this.applyAuth(snapshot)),
+      this.dependencies.appState.subscribe((state) => this.applyAppState(state)),
+      this.dependencies.network.subscribe((snapshot) => {
+        this.networkObservationVersion += 1;
+        this.applyConnectivity(snapshot);
+      }),
+    ];
+
+    // Subscribe first, then perform atomic reads so a transition between setup
+    // and the initial snapshot cannot be missed.
+    this.applyAuth(this.dependencies.auth.getSnapshot());
+    this.applyAppState(this.dependencies.appState.getCurrent());
+
+    const requestVersion = this.networkObservationVersion;
+    void this.dependencies.network
+      .getCurrent()
+      .then((snapshot) => {
+        if (
+          this.started &&
+          requestVersion === this.networkObservationVersion
+        ) {
+          this.applyConnectivity(snapshot);
+        }
+      })
+      .catch(() => {
+        // Unknown remains eligible; heartbeat is the fallback for observer errors.
+      });
+  }
+
+  stop(): void {
+    if (!this.started) return;
+    this.started = false;
+    this.networkObservationVersion += 1;
+    for (const unsubscribe of this.unsubscribers.splice(0)) {
+      unsubscribe();
+    }
+    this.dependencies.manager.disconnect('unmount');
+  }
+
+  private applyAuth(snapshot: PublishedAuthLifecycleSnapshot): void {
+    if (!this.started) return;
+    this.authSnapshot = snapshot;
+    this.synchronize();
+  }
+
+  private applyAppState(state: 'active' | 'inactive'): void {
+    if (!this.started) return;
+    const nextActive = state === 'active';
+    if (this.appIsActive === nextActive) return;
+    this.appIsActive = nextActive;
+    this.synchronize();
+  }
+
+  private applyConnectivity(snapshot: ConnectivitySnapshot): void {
+    if (!this.started || sameConnectivity(this.connectivity, snapshot)) return;
+
+    const wasOffline = this.connectivity.availability === 'offline';
+    let networkHandoff = false;
+
+    if (snapshot.availability === 'offline') {
+      this.lastKnownOnlineType = null;
+    } else if (snapshot.availability === 'online' && snapshot.type !== null) {
+      networkHandoff =
+        !wasOffline &&
+        this.lastKnownOnlineType !== null &&
+        this.lastKnownOnlineType !== snapshot.type;
+      this.lastKnownOnlineType = snapshot.type;
+    }
+
+    this.connectivity = snapshot;
+    this.synchronize(networkHandoff);
+  }
+
+  private synchronize(networkHandoff = false): void {
+    const blocked = this.blockReason();
+    if (blocked !== null) {
+      this.dependencies.manager.disconnect(blocked);
+      return;
+    }
+
+    const auth = this.authSnapshot;
+    if (auth === null) {
+      this.dependencies.manager.disconnect('auth');
+      return;
+    }
+    const owner = ownerFromAuth(auth);
+    if (owner === null) {
+      this.dependencies.manager.disconnect('auth');
+      return;
+    }
+
+    if (networkHandoff) {
+      this.dependencies.manager.restart(owner);
+    } else {
+      this.dependencies.manager.connect(owner);
+    }
+  }
+
+  private blockReason(): RealtimeDisconnectReason | null {
+    if (ownerFromAuthOrNull(this.authSnapshot) === null) return 'auth';
+    if (!this.appIsActive) return 'background';
+    if (this.connectivity.availability === 'offline') return 'offline';
+    return null;
+  }
+}
+
+function ownerFromAuthOrNull(
+  snapshot: PublishedAuthLifecycleSnapshot | null,
+): RealtimeOwner | null {
+  return snapshot === null ? null : ownerFromAuth(snapshot);
+}

--- a/mobile/src/features/realtime/infrastructure/WebSocketManager.ts
+++ b/mobile/src/features/realtime/infrastructure/WebSocketManager.ts
@@ -1,0 +1,657 @@
+import { isAuthTicketCurrent } from '@/shared/api/authSessionLifecycle';
+import {
+  type RealtimeEnvelope,
+  type RealtimeManager,
+  type RealtimeMessageListener,
+  type RealtimeOwner,
+  type RealtimeSnapshot,
+  type RealtimeSnapshotListener,
+} from '../types';
+import { realtimeTicketApi, TicketRequestError, type TicketApi } from './ticket-api';
+import { resolveRealtimeWebSocketUrl } from './ws-url';
+
+const WS_SUBPROTOCOL = 'goplan.realtime.v1';
+const SOCKET_CONNECTING = 0;
+const SOCKET_OPEN = 1;
+
+export const REALTIME_TIMING = {
+  openTimeoutMs: 30_000,
+  heartbeatIntervalMs: 25_000,
+  heartbeatTimeoutMs: 30_000,
+  maxReconnectAttempts: 10,
+  maxBackoffMs: 30_000,
+  throttleFallbackMs: 30_000,
+  throttleMaxMs: 300_000,
+  jitterMaxMs: 1_000,
+} as const;
+
+interface SocketOpenTimeout {
+  handle: TimerHandle | null;
+  socket: RealtimeSocket;
+}
+
+export interface RealtimeSocket {
+  readonly readyState: number;
+  onopen: (() => void) | null;
+  onmessage: ((event: { data: unknown }) => void) | null;
+  onclose: ((event: { code: number }) => void) | null;
+  onerror: (() => void) | null;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+}
+
+export type RealtimeSocketFactory = (
+  url: string,
+  protocols: string[],
+) => RealtimeSocket;
+
+type TimerHandle = ReturnType<typeof setTimeout>;
+
+export interface RealtimeScheduler {
+  setTimeout(callback: () => void, delayMs: number): TimerHandle;
+  clearTimeout(handle: TimerHandle): void;
+  setInterval(callback: () => void, delayMs: number): TimerHandle;
+  clearInterval(handle: TimerHandle): void;
+}
+
+export interface WebSocketManagerDependencies {
+  ticketApi: TicketApi;
+  socketFactory: RealtimeSocketFactory;
+  resolveUrl: () => string;
+  isOwnerCurrent: (owner: RealtimeOwner) => boolean;
+  scheduler: RealtimeScheduler;
+  random: () => number;
+}
+
+class NativeRealtimeSocket implements RealtimeSocket {
+  private readonly socket: WebSocket;
+
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onclose: ((event: { code: number }) => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(url: string, protocols: string[]) {
+    this.socket = new WebSocket(url, protocols);
+    this.socket.onopen = () => this.onopen?.();
+    this.socket.onmessage = (event) => this.onmessage?.({ data: event.data });
+    this.socket.onclose = (event) => this.onclose?.({ code: event.code });
+    this.socket.onerror = () => this.onerror?.();
+  }
+
+  get readyState(): number {
+    return this.socket.readyState;
+  }
+
+  send(data: string): void {
+    this.socket.send(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.socket.close(code, reason);
+  }
+}
+
+const nativeScheduler: RealtimeScheduler = {
+  setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+  clearTimeout: (handle) => clearTimeout(handle),
+  setInterval: (callback, delayMs) => setInterval(callback, delayMs),
+  clearInterval: (handle) => clearInterval(handle),
+};
+
+function sameOwner(left: RealtimeOwner | null, right: RealtimeOwner): boolean {
+  return (
+    left !== null &&
+    left.sessionGeneration === right.sessionGeneration &&
+    left.credentialRevision === right.credentialRevision
+  );
+}
+
+function copyOwner(owner: RealtimeOwner): RealtimeOwner {
+  return {
+    sessionGeneration: owner.sessionGeneration,
+    credentialRevision: owner.credentialRevision,
+  };
+}
+
+function isRealtimeEnvelope(value: unknown): value is RealtimeEnvelope {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    'type' in value &&
+    typeof value.type === 'string' &&
+    value.type.length > 0
+  );
+}
+
+function authErrorCode(message: RealtimeEnvelope): string | null {
+  return typeof message.code === 'string' ? message.code : null;
+}
+
+export class WebSocketManager implements RealtimeManager {
+  private socket: RealtimeSocket | null = null;
+  private snapshot: RealtimeSnapshot = {
+    status: 'disconnected',
+    connectionEpoch: 0,
+  };
+  private currentOwner: RealtimeOwner | null = null;
+  private hardStoppedOwner: RealtimeOwner | null = null;
+  private connectRequestId = 0;
+  private isConnecting = false;
+  private reconnectAttempt = 0;
+  private reconnectBootstrapUsed = false;
+  private reconnectTimer: TimerHandle | null = null;
+  private openTimeout: SocketOpenTimeout | null = null;
+  private heartbeatTimer: TimerHandle | null = null;
+  private heartbeatTimeoutTimer: TimerHandle | null = null;
+  private awaitingPong = false;
+  private destroyed = false;
+
+  private readonly messageListeners = new Map<string, Set<RealtimeMessageListener>>();
+  private readonly allMessageListeners = new Set<RealtimeMessageListener>();
+  private readonly snapshotListeners = new Set<RealtimeSnapshotListener>();
+
+  constructor(private readonly dependencies: WebSocketManagerDependencies) {}
+
+  connect(owner: RealtimeOwner): void {
+    if (!this.canUseOwner(owner)) return;
+    if (!sameOwner(this.currentOwner, owner)) {
+      this.invalidateWork(true);
+      this.currentOwner = copyOwner(owner);
+      this.hardStoppedOwner = null;
+    }
+    if (
+      this.isConnecting ||
+      this.reconnectTimer !== null ||
+      this.socket?.readyState === SOCKET_OPEN ||
+      this.socket?.readyState === SOCKET_CONNECTING
+    ) {
+      return;
+    }
+
+    const status = this.snapshot.connectionEpoch > 0 ? 'reconnecting' : 'connecting';
+    this.beginTicketRequest(owner, 'issue', status);
+  }
+
+  restart(owner: RealtimeOwner): void {
+    if (!this.canUseOwner(owner)) return;
+    this.invalidateWork(true);
+    this.currentOwner = copyOwner(owner);
+    this.hardStoppedOwner = null;
+    this.beginTicketRequest(owner, 'issue', 'reconnecting');
+  }
+
+  disconnect(_reason: 'auth' | 'background' | 'offline' | 'unmount'): void {
+    if (this.destroyed) return;
+    this.invalidateWork(true);
+    this.currentOwner = null;
+    this.setStatus('disconnected');
+  }
+
+  send(message: RealtimeEnvelope): boolean {
+    if (this.socket?.readyState !== SOCKET_OPEN) return false;
+    try {
+      this.socket.send(JSON.stringify(message));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  subscribe(type: string, listener: RealtimeMessageListener): () => void {
+    let listeners = this.messageListeners.get(type);
+    if (!listeners) {
+      listeners = new Set();
+      this.messageListeners.set(type, listeners);
+    }
+    listeners.add(listener);
+    return () => {
+      listeners?.delete(listener);
+      if (listeners?.size === 0) {
+        this.messageListeners.delete(type);
+      }
+    };
+  }
+
+  subscribeAll(listener: RealtimeMessageListener): () => void {
+    this.allMessageListeners.add(listener);
+    return () => this.allMessageListeners.delete(listener);
+  }
+
+  subscribeSnapshot(listener: RealtimeSnapshotListener): () => void {
+    this.snapshotListeners.add(listener);
+    return () => this.snapshotListeners.delete(listener);
+  }
+
+  getSnapshot(): RealtimeSnapshot {
+    return this.snapshot;
+  }
+
+  destroy(): void {
+    if (this.destroyed) return;
+    this.disconnect('unmount');
+    this.destroyed = true;
+    this.messageListeners.clear();
+    this.allMessageListeners.clear();
+    this.snapshotListeners.clear();
+  }
+
+  private canUseOwner(owner: RealtimeOwner): boolean {
+    return (
+      !this.destroyed &&
+      this.dependencies.isOwnerCurrent(owner) &&
+      !sameOwner(this.hardStoppedOwner, owner)
+    );
+  }
+
+  private beginTicketRequest(
+    owner: RealtimeOwner,
+    requestKind: 'issue' | 'refresh',
+    status: 'connecting' | 'reconnecting',
+  ): void {
+    if (!this.canUseOwner(owner) || !sameOwner(this.currentOwner, owner)) return;
+
+    let url: string;
+    try {
+      // Configuration is deterministic and must be validated before consuming a
+      // single-use, throttled ticket.
+      url = this.dependencies.resolveUrl();
+    } catch {
+      this.invalidateWork(true);
+      this.currentOwner = copyOwner(owner);
+      this.setStatus('disconnected');
+      return;
+    }
+
+    this.clearReconnectTimer();
+    const requestId = ++this.connectRequestId;
+    this.isConnecting = true;
+    this.setStatus(status);
+    void this.fetchTicket(url, owner, requestId, requestKind);
+  }
+
+  private async fetchTicket(
+    url: string,
+    owner: RealtimeOwner,
+    requestId: number,
+    requestKind: 'issue' | 'refresh',
+  ): Promise<void> {
+    try {
+      const ticket =
+        requestKind === 'refresh'
+          ? await this.dependencies.ticketApi.refresh()
+          : await this.dependencies.ticketApi.issue();
+      if (!this.isAttemptCurrent(owner, requestId)) return;
+      this.openSocket(url, ticket, owner, requestId);
+    } catch (error) {
+      if (!this.isAttemptCurrent(owner, requestId)) return;
+      this.isConnecting = false;
+      this.handleTicketFailure(owner, error);
+    }
+  }
+
+  private openSocket(
+    url: string,
+    ticket: string,
+    owner: RealtimeOwner,
+    requestId: number,
+  ): void {
+    if (!this.isAttemptCurrent(owner, requestId)) return;
+
+    let socket: RealtimeSocket;
+    try {
+      socket = this.dependencies.socketFactory(url, [WS_SUBPROTOCOL, ticket]);
+    } catch {
+      this.isConnecting = false;
+      this.scheduleReconnect(owner);
+      return;
+    }
+
+    this.socket = socket;
+    let authHandled = false;
+    this.startOpenTimeout(socket, owner, requestId);
+
+    socket.onopen = () => {
+      this.clearOpenTimeout(socket);
+      if (!this.isActiveSocket(socket, owner, requestId)) {
+        this.detachSocket(socket, true);
+        return;
+      }
+      this.isConnecting = false;
+      this.clearReconnectTimer();
+      this.reconnectAttempt = 0;
+      this.reconnectBootstrapUsed = false;
+      this.markConnected();
+      this.startHeartbeat(socket, owner, requestId);
+    };
+
+    socket.onmessage = (event) => {
+      if (!this.isActiveSocket(socket, owner, requestId)) return;
+      const message = this.parseMessage(event.data);
+      if (!message) return;
+
+      if (message.type === 'auth_error') {
+        this.clearOpenTimeout(socket);
+        authHandled = true;
+        this.detachSocket(socket, true);
+        this.stopHeartbeat();
+        if (authErrorCode(message) === 'token_expired') {
+          this.beginTicketRequest(owner, 'refresh', 'reconnecting');
+        } else {
+          this.hardStop(owner);
+        }
+        return;
+      }
+
+      if (message.type === 'pong') {
+        this.clearHeartbeatTimeout();
+        return;
+      }
+
+      this.emit(message);
+    };
+
+    socket.onclose = (event) => {
+      this.clearOpenTimeout(socket);
+      if (authHandled || !this.isActiveSocket(socket, owner, requestId)) return;
+      this.detachSocket(socket, false);
+      this.isConnecting = false;
+      this.stopHeartbeat();
+
+      if (event.code === 4002) {
+        this.beginTicketRequest(owner, 'refresh', 'reconnecting');
+      } else if (event.code === 4001) {
+        this.hardStop(owner);
+      } else {
+        this.handleNetworkClose(owner);
+      }
+    };
+
+    socket.onerror = () => {
+      // React Native reports a close after an error. The close code owns recovery.
+    };
+  }
+
+  private startOpenTimeout(
+    socket: RealtimeSocket,
+    owner: RealtimeOwner,
+    requestId: number,
+  ): void {
+    this.clearOpenTimeout();
+    const timeout: SocketOpenTimeout = { handle: null, socket };
+    this.openTimeout = timeout;
+    timeout.handle = this.dependencies.scheduler.setTimeout(() => {
+      if (this.openTimeout !== timeout) return;
+      this.openTimeout = null;
+      if (
+        !this.isConnecting ||
+        socket.readyState !== SOCKET_CONNECTING ||
+        !this.isActiveSocket(socket, owner, requestId)
+      ) {
+        return;
+      }
+      this.detachSocket(socket, true);
+      this.isConnecting = false;
+      this.stopHeartbeat();
+      this.handleNetworkClose(owner);
+    }, REALTIME_TIMING.openTimeoutMs);
+  }
+
+  private clearOpenTimeout(socket?: RealtimeSocket): void {
+    const timeout = this.openTimeout;
+    if (timeout === null || (socket && timeout.socket !== socket)) return;
+    this.openTimeout = null;
+    if (timeout.handle !== null) {
+      this.dependencies.scheduler.clearTimeout(timeout.handle);
+    }
+  }
+
+  private parseMessage(raw: unknown): RealtimeEnvelope | null {
+    if (typeof raw !== 'string') return null;
+    try {
+      const value: unknown = JSON.parse(raw);
+      return isRealtimeEnvelope(value) ? value : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private handleTicketFailure(owner: RealtimeOwner, error: unknown): void {
+    if (error instanceof TicketRequestError) {
+      if (error.kind === 'hardAuth') {
+        this.hardStop(owner);
+        return;
+      }
+      if (error.kind === 'throttled') {
+        this.scheduleThrottledReconnect(owner, error.retryAfterMs);
+        return;
+      }
+    }
+    this.scheduleReconnect(owner);
+  }
+
+  private handleNetworkClose(owner: RealtimeOwner): void {
+    if (!this.reconnectBootstrapUsed) {
+      this.reconnectBootstrapUsed = true;
+      this.beginTicketRequest(owner, 'issue', 'reconnecting');
+      return;
+    }
+    this.scheduleReconnect(owner);
+  }
+
+  private scheduleReconnect(owner: RealtimeOwner): void {
+    if (!this.canUseOwner(owner) || !sameOwner(this.currentOwner, owner)) return;
+    if (this.reconnectAttempt >= REALTIME_TIMING.maxReconnectAttempts) {
+      this.isConnecting = false;
+      this.setStatus('disconnected');
+      return;
+    }
+
+    const baseDelay = Math.min(
+      1_000 * 2 ** this.reconnectAttempt,
+      REALTIME_TIMING.maxBackoffMs,
+    );
+    this.reconnectAttempt += 1;
+    this.scheduleRetry(owner, baseDelay + this.jitterMs());
+  }
+
+  private scheduleThrottledReconnect(
+    owner: RealtimeOwner,
+    retryAfterMs: number | null,
+  ): void {
+    const requestedDelay = retryAfterMs ?? REALTIME_TIMING.throttleFallbackMs;
+    const delay = Math.min(
+      requestedDelay + this.jitterMs(),
+      REALTIME_TIMING.throttleMaxMs,
+    );
+    this.scheduleRetry(owner, delay);
+  }
+
+  private scheduleRetry(owner: RealtimeOwner, delayMs: number): void {
+    if (!this.canUseOwner(owner) || !sameOwner(this.currentOwner, owner)) return;
+    this.clearReconnectTimer();
+    this.isConnecting = false;
+    this.setStatus('reconnecting');
+    this.reconnectTimer = this.dependencies.scheduler.setTimeout(() => {
+      this.reconnectTimer = null;
+      this.beginTicketRequest(owner, 'issue', 'reconnecting');
+    }, delayMs);
+  }
+
+  private jitterMs(): number {
+    return Math.max(0, Math.min(1, this.dependencies.random())) * REALTIME_TIMING.jitterMaxMs;
+  }
+
+  private startHeartbeat(
+    socket: RealtimeSocket,
+    owner: RealtimeOwner,
+    requestId: number,
+  ): void {
+    this.stopHeartbeat();
+    this.heartbeatTimer = this.dependencies.scheduler.setInterval(() => {
+      if (
+        this.awaitingPong ||
+        !this.isActiveSocket(socket, owner, requestId) ||
+        socket.readyState !== SOCKET_OPEN
+      ) {
+        return;
+      }
+      try {
+        socket.send(JSON.stringify({ type: 'ping' }));
+      } catch {
+        this.failActiveSocket(socket, owner, requestId);
+        return;
+      }
+      this.awaitingPong = true;
+      this.heartbeatTimeoutTimer = this.dependencies.scheduler.setTimeout(() => {
+        this.heartbeatTimeoutTimer = null;
+        this.failActiveSocket(socket, owner, requestId);
+      }, REALTIME_TIMING.heartbeatTimeoutMs);
+    }, REALTIME_TIMING.heartbeatIntervalMs);
+  }
+
+  private failActiveSocket(
+    socket: RealtimeSocket,
+    owner: RealtimeOwner,
+    requestId: number,
+  ): void {
+    if (!this.isActiveSocket(socket, owner, requestId)) return;
+    this.detachSocket(socket, true);
+    this.isConnecting = false;
+    this.stopHeartbeat();
+    this.handleNetworkClose(owner);
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer !== null) {
+      this.dependencies.scheduler.clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+    this.clearHeartbeatTimeout();
+  }
+
+  private clearHeartbeatTimeout(): void {
+    if (this.heartbeatTimeoutTimer !== null) {
+      this.dependencies.scheduler.clearTimeout(this.heartbeatTimeoutTimer);
+      this.heartbeatTimeoutTimer = null;
+    }
+    this.awaitingPong = false;
+  }
+
+  private hardStop(owner: RealtimeOwner): void {
+    this.hardStoppedOwner = copyOwner(owner);
+    this.invalidateWork(true);
+    this.currentOwner = copyOwner(owner);
+    this.setStatus('disconnected');
+  }
+
+  private invalidateWork(resetAttempts: boolean): void {
+    this.connectRequestId += 1;
+    this.isConnecting = false;
+    this.clearReconnectTimer();
+    this.clearOpenTimeout();
+    this.stopHeartbeat();
+    if (this.socket !== null) {
+      this.detachSocket(this.socket, true);
+    }
+    if (resetAttempts) {
+      this.reconnectAttempt = 0;
+      this.reconnectBootstrapUsed = false;
+    }
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer !== null) {
+      this.dependencies.scheduler.clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  private detachSocket(socket: RealtimeSocket, shouldClose: boolean): void {
+    this.clearOpenTimeout(socket);
+    if (this.socket === socket) {
+      this.socket = null;
+    }
+    socket.onopen = null;
+    socket.onmessage = null;
+    socket.onclose = null;
+    socket.onerror = null;
+    if (
+      shouldClose &&
+      (socket.readyState === SOCKET_OPEN || socket.readyState === SOCKET_CONNECTING)
+    ) {
+      try {
+        socket.close(1000, 'Realtime connection replaced');
+      } catch {
+        // The reference is already invalidated; native close failure is non-fatal.
+      }
+    }
+  }
+
+  private isAttemptCurrent(owner: RealtimeOwner, requestId: number): boolean {
+    return (
+      requestId === this.connectRequestId &&
+      sameOwner(this.currentOwner, owner) &&
+      this.canUseOwner(owner)
+    );
+  }
+
+  private isActiveSocket(
+    socket: RealtimeSocket,
+    owner: RealtimeOwner,
+    requestId: number,
+  ): boolean {
+    return this.socket === socket && this.isAttemptCurrent(owner, requestId);
+  }
+
+  private markConnected(): void {
+    this.snapshot = {
+      status: 'connected',
+      connectionEpoch: this.snapshot.connectionEpoch + 1,
+    };
+    this.emitSnapshot();
+  }
+
+  private setStatus(status: RealtimeSnapshot['status']): void {
+    if (this.snapshot.status === status) return;
+    this.snapshot = { ...this.snapshot, status };
+    this.emitSnapshot();
+  }
+
+  private emitSnapshot(): void {
+    for (const listener of Array.from(this.snapshotListeners)) {
+      try {
+        listener(this.snapshot);
+      } catch {
+        // One UI observer must not prevent the remaining observers from updating.
+      }
+    }
+  }
+
+  private emit(message: RealtimeEnvelope): void {
+    const listeners = this.messageListeners.get(message.type);
+    const targets = [
+      ...(listeners ? Array.from(listeners) : []),
+      ...Array.from(this.allMessageListeners),
+    ];
+    for (const listener of targets) {
+      try {
+        listener(message);
+      } catch {
+        // Domain listeners are isolated from the transport and from each other.
+      }
+    }
+  }
+}
+
+export function createDefaultWebSocketManager(): WebSocketManager {
+  return new WebSocketManager({
+    ticketApi: realtimeTicketApi,
+    socketFactory: (url, protocols) => new NativeRealtimeSocket(url, protocols),
+    resolveUrl: resolveRealtimeWebSocketUrl,
+    isOwnerCurrent: isAuthTicketCurrent,
+    scheduler: nativeScheduler,
+    random: Math.random,
+  });
+}

--- a/mobile/src/features/realtime/infrastructure/WebSocketManager.ts
+++ b/mobile/src/features/realtime/infrastructure/WebSocketManager.ts
@@ -46,6 +46,7 @@ export type RealtimeSocketFactory = (
 ) => RealtimeSocket;
 
 type TimerHandle = ReturnType<typeof setTimeout>;
+type TicketRequestKind = 'issue' | 'refresh';
 
 export interface RealtimeScheduler {
   setTimeout(callback: () => void, delayMs: number): TimerHandle;
@@ -247,7 +248,7 @@ export class WebSocketManager implements RealtimeManager {
 
   private beginTicketRequest(
     owner: RealtimeOwner,
-    requestKind: 'issue' | 'refresh',
+    requestKind: TicketRequestKind,
     status: 'connecting' | 'reconnecting',
   ): void {
     if (!this.canUseOwner(owner) || !sameOwner(this.currentOwner, owner)) return;
@@ -275,7 +276,7 @@ export class WebSocketManager implements RealtimeManager {
     url: string,
     owner: RealtimeOwner,
     requestId: number,
-    requestKind: 'issue' | 'refresh',
+    requestKind: TicketRequestKind,
   ): Promise<void> {
     try {
       const ticket =
@@ -287,7 +288,7 @@ export class WebSocketManager implements RealtimeManager {
     } catch (error) {
       if (!this.isAttemptCurrent(owner, requestId)) return;
       this.isConnecting = false;
-      this.handleTicketFailure(owner, error);
+      this.handleTicketFailure(owner, requestKind, error);
     }
   }
 
@@ -304,7 +305,7 @@ export class WebSocketManager implements RealtimeManager {
       socket = this.dependencies.socketFactory(url, [WS_SUBPROTOCOL, ticket]);
     } catch {
       this.isConnecting = false;
-      this.scheduleReconnect(owner);
+      this.scheduleReconnect(owner, 'issue');
       return;
     }
 
@@ -417,18 +418,22 @@ export class WebSocketManager implements RealtimeManager {
     }
   }
 
-  private handleTicketFailure(owner: RealtimeOwner, error: unknown): void {
+  private handleTicketFailure(
+    owner: RealtimeOwner,
+    requestKind: TicketRequestKind,
+    error: unknown,
+  ): void {
     if (error instanceof TicketRequestError) {
       if (error.kind === 'hardAuth') {
         this.hardStop(owner);
         return;
       }
       if (error.kind === 'throttled') {
-        this.scheduleThrottledReconnect(owner, error.retryAfterMs);
+        this.scheduleThrottledReconnect(owner, requestKind, error.retryAfterMs);
         return;
       }
     }
-    this.scheduleReconnect(owner);
+    this.scheduleReconnect(owner, requestKind);
   }
 
   private handleNetworkClose(owner: RealtimeOwner): void {
@@ -437,10 +442,13 @@ export class WebSocketManager implements RealtimeManager {
       this.beginTicketRequest(owner, 'issue', 'reconnecting');
       return;
     }
-    this.scheduleReconnect(owner);
+    this.scheduleReconnect(owner, 'issue');
   }
 
-  private scheduleReconnect(owner: RealtimeOwner): void {
+  private scheduleReconnect(
+    owner: RealtimeOwner,
+    requestKind: TicketRequestKind,
+  ): void {
     if (!this.canUseOwner(owner) || !sameOwner(this.currentOwner, owner)) return;
     if (this.reconnectAttempt >= REALTIME_TIMING.maxReconnectAttempts) {
       this.isConnecting = false;
@@ -453,11 +461,12 @@ export class WebSocketManager implements RealtimeManager {
       REALTIME_TIMING.maxBackoffMs,
     );
     this.reconnectAttempt += 1;
-    this.scheduleRetry(owner, baseDelay + this.jitterMs());
+    this.scheduleRetry(owner, requestKind, baseDelay + this.jitterMs());
   }
 
   private scheduleThrottledReconnect(
     owner: RealtimeOwner,
+    requestKind: TicketRequestKind,
     retryAfterMs: number | null,
   ): void {
     const requestedDelay = retryAfterMs ?? REALTIME_TIMING.throttleFallbackMs;
@@ -465,17 +474,21 @@ export class WebSocketManager implements RealtimeManager {
       requestedDelay + this.jitterMs(),
       REALTIME_TIMING.throttleMaxMs,
     );
-    this.scheduleRetry(owner, delay);
+    this.scheduleRetry(owner, requestKind, delay);
   }
 
-  private scheduleRetry(owner: RealtimeOwner, delayMs: number): void {
+  private scheduleRetry(
+    owner: RealtimeOwner,
+    requestKind: TicketRequestKind,
+    delayMs: number,
+  ): void {
     if (!this.canUseOwner(owner) || !sameOwner(this.currentOwner, owner)) return;
     this.clearReconnectTimer();
     this.isConnecting = false;
     this.setStatus('reconnecting');
     this.reconnectTimer = this.dependencies.scheduler.setTimeout(() => {
       this.reconnectTimer = null;
-      this.beginTicketRequest(owner, 'issue', 'reconnecting');
+      this.beginTicketRequest(owner, requestKind, 'reconnecting');
     }, delayMs);
   }
 

--- a/mobile/src/features/realtime/infrastructure/app-state-observer.ts
+++ b/mobile/src/features/realtime/infrastructure/app-state-observer.ts
@@ -1,0 +1,18 @@
+import { AppState } from 'react-native';
+import type { AppStateObserver, RealtimeAppState } from '../types';
+
+function normalizeAppState(state: string): RealtimeAppState {
+  return state === 'active' ? 'active' : 'inactive';
+}
+
+export const nativeAppStateObserver: AppStateObserver = {
+  getCurrent() {
+    return normalizeAppState(AppState.currentState);
+  },
+  subscribe(listener) {
+    const subscription = AppState.addEventListener('change', (state) => {
+      listener(normalizeAppState(state));
+    });
+    return () => subscription.remove();
+  },
+};

--- a/mobile/src/features/realtime/infrastructure/expo-network-observer.ts
+++ b/mobile/src/features/realtime/infrastructure/expo-network-observer.ts
@@ -1,0 +1,49 @@
+import * as Network from 'expo-network';
+import type { ConnectivitySnapshot, NetworkObserver } from '../types';
+
+function normalizedType(type: Network.NetworkStateType | undefined): string | null {
+  if (
+    type === undefined ||
+    type === Network.NetworkStateType.NONE ||
+    type === Network.NetworkStateType.UNKNOWN
+  ) {
+    return null;
+  }
+  return type;
+}
+
+export function normalizeNetworkState(
+  state: Network.NetworkState,
+): ConnectivitySnapshot {
+  if (state.type === Network.NetworkStateType.NONE) {
+    return { availability: 'offline', type: null };
+  }
+
+  const type = normalizedType(state.type);
+  if (
+    type !== null &&
+    (state.isConnected === false || state.isInternetReachable === false)
+  ) {
+    return { availability: 'offline', type: null };
+  }
+
+  if (state.isConnected === true || state.isInternetReachable === true) {
+    return { availability: 'online', type };
+  }
+
+  // Expo reports UNKNOWN + false on some indeterminate states. The issue
+  // contract deliberately keeps that eligible for heartbeat-based recovery.
+  return { availability: 'unknown', type };
+}
+
+export const expoNetworkObserver: NetworkObserver = {
+  async getCurrent() {
+    return normalizeNetworkState(await Network.getNetworkStateAsync());
+  },
+  subscribe(listener) {
+    const subscription = Network.addNetworkStateListener((state) => {
+      listener(normalizeNetworkState(state));
+    });
+    return () => subscription.remove();
+  },
+};

--- a/mobile/src/features/realtime/infrastructure/ticket-api.ts
+++ b/mobile/src/features/realtime/infrastructure/ticket-api.ts
@@ -1,0 +1,85 @@
+import { isAxiosError } from 'axios';
+import { apiClient } from '@/shared/api/client';
+
+export type TicketRequestErrorKind = 'hardAuth' | 'throttled' | 'transient';
+
+export class TicketRequestError extends Error {
+  readonly kind: TicketRequestErrorKind;
+  readonly retryAfterMs: number | null;
+
+  constructor(kind: TicketRequestErrorKind, retryAfterMs: number | null = null) {
+    super('Realtime ticket request failed.');
+    this.name = 'TicketRequestError';
+    this.kind = kind;
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+export interface TicketApi {
+  issue(): Promise<string>;
+  refresh(): Promise<string>;
+}
+
+export function parseRetryAfterMs(
+  value: unknown,
+  nowMs: number = Date.now(),
+): number | null {
+  const normalized = typeof value === 'string' ? value.trim() : String(value);
+  if (/^\d+$/.test(normalized)) {
+    const seconds = Number(normalized);
+    return Number.isSafeInteger(seconds) && seconds > 0 ? seconds * 1_000 : null;
+  }
+
+  const retryAtMs = Date.parse(normalized);
+  if (!Number.isFinite(retryAtMs) || retryAtMs <= nowMs) return null;
+  return retryAtMs - nowMs;
+}
+
+function classifyTicketError(error: unknown): TicketRequestError {
+  if (!isAxiosError(error)) {
+    return new TicketRequestError('transient');
+  }
+
+  const status = error.response?.status;
+  if (status === 401 || status === 403) {
+    return new TicketRequestError('hardAuth');
+  }
+  if (status === 429) {
+    return new TicketRequestError(
+      'throttled',
+      parseRetryAfterMs(error.response?.headers?.['retry-after']),
+    );
+  }
+  return new TicketRequestError('transient');
+}
+
+function parseTicketResponse(value: unknown): string {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    Array.isArray(value) ||
+    !('ticket' in value) ||
+    typeof value.ticket !== 'string' ||
+    value.ticket.length === 0
+  ) {
+    throw new TicketRequestError('transient');
+  }
+  return value.ticket;
+}
+
+async function requestTicket(path: string): Promise<string> {
+  try {
+    const response = await apiClient.post<unknown>(path);
+    return parseTicketResponse(response.data);
+  } catch (error) {
+    if (error instanceof TicketRequestError) {
+      throw error;
+    }
+    throw classifyTicketError(error);
+  }
+}
+
+export const realtimeTicketApi: TicketApi = {
+  issue: () => requestTicket('/realtime/ws-ticket'),
+  refresh: () => requestTicket('/realtime/ws-ticket/refresh'),
+};

--- a/mobile/src/features/realtime/infrastructure/ws-url.ts
+++ b/mobile/src/features/realtime/infrastructure/ws-url.ts
@@ -1,0 +1,39 @@
+import { getServerRootUrl } from '@/shared/api/base-url';
+
+function isLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return (
+    normalized === 'localhost' ||
+    normalized === '127.0.0.1' ||
+    normalized === '::1' ||
+    normalized === '[::1]' ||
+    normalized.endsWith('.localhost')
+  );
+}
+
+export function resolveRealtimeWebSocketUrl(
+  serverRoot: string = getServerRootUrl(),
+): string {
+  let url: URL;
+  try {
+    url = new URL(serverRoot);
+  } catch {
+    throw new Error('EXPO_PUBLIC_API_URL must be a valid HTTP(S) URL.');
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('EXPO_PUBLIC_API_URL must use http or https.');
+  }
+  if (url.username || url.password) {
+    throw new Error('EXPO_PUBLIC_API_URL must not contain credentials.');
+  }
+  if (url.protocol === 'http:' && !isLoopbackHost(url.hostname)) {
+    throw new Error('Cleartext WebSocket connections are allowed only for local development.');
+  }
+
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  url.pathname = '/ws/realtime';
+  url.search = '';
+  url.hash = '';
+  return url.toString();
+}

--- a/mobile/src/features/realtime/testing/fakes.ts
+++ b/mobile/src/features/realtime/testing/fakes.ts
@@ -1,0 +1,259 @@
+import type {
+  AppStateObserver,
+  AuthLifecycleSource,
+  ConnectivitySnapshot,
+  NetworkObserver,
+  PublishedAuthLifecycleSnapshot,
+  RealtimeAppState,
+  RealtimeDisconnectReason,
+  RealtimeEnvelope,
+  RealtimeManager,
+  RealtimeMessageListener,
+  RealtimeOwner,
+  RealtimeSnapshot,
+  RealtimeSnapshotListener,
+} from '../types';
+import type { TicketApi } from '../infrastructure/ticket-api';
+import type {
+  RealtimeScheduler,
+  RealtimeSocket,
+  RealtimeSocketFactory,
+} from '../infrastructure/WebSocketManager';
+
+export interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+}
+
+export function deferred<T>(): Deferred<T> {
+  let resolvePromise: (value: T) => void = () => undefined;
+  let rejectPromise: (error: unknown) => void = () => undefined;
+  const promise = new Promise<T>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  return { promise, resolve: resolvePromise, reject: rejectPromise };
+}
+
+export async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+type TicketStep = () => Promise<string>;
+
+export class FakeTicketApi implements TicketApi {
+  issueCalls = 0;
+  refreshCalls = 0;
+  issueSteps: TicketStep[] = [];
+  refreshSteps: TicketStep[] = [];
+  defaultIssue: TicketStep = () => Promise.resolve(`ticket-${this.issueCalls}`);
+  defaultRefresh: TicketStep = () => Promise.resolve(`refresh-${this.refreshCalls}`);
+
+  issue(): Promise<string> {
+    this.issueCalls += 1;
+    return (this.issueSteps.shift() ?? this.defaultIssue)();
+  }
+
+  refresh(): Promise<string> {
+    this.refreshCalls += 1;
+    return (this.refreshSteps.shift() ?? this.defaultRefresh)();
+  }
+}
+
+export class FakeSocket implements RealtimeSocket {
+  private state = 0;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onclose: ((event: { code: number }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  readonly sent: string[] = [];
+  readonly closeCalls: { code?: number; reason?: string }[] = [];
+
+  get readyState(): number {
+    return this.state;
+  }
+
+  open(): void {
+    this.state = 1;
+    this.onopen?.();
+  }
+
+  message(data: unknown): void {
+    this.onmessage?.({ data });
+  }
+
+  serverClose(code = 1006): void {
+    this.state = 3;
+    this.onclose?.({ code });
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closeCalls.push({ code, reason });
+    this.state = 3;
+  }
+}
+
+export class FakeSocketFactory {
+  readonly sockets: FakeSocket[] = [];
+  readonly calls: { url: string; protocols: string[] }[] = [];
+
+  readonly create: RealtimeSocketFactory = (url, protocols) => {
+    this.calls.push({ url, protocols: [...protocols] });
+    const socket = new FakeSocket();
+    this.sockets.push(socket);
+    return socket;
+  };
+}
+
+export const jestScheduler: RealtimeScheduler = {
+  setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+  clearTimeout: (handle) => clearTimeout(handle),
+  setInterval: (callback, delayMs) => setInterval(callback, delayMs),
+  clearInterval: (handle) => clearInterval(handle),
+};
+
+export class FakeManager implements RealtimeManager {
+  readonly connectCalls: RealtimeOwner[] = [];
+  readonly restartCalls: RealtimeOwner[] = [];
+  readonly disconnectCalls: RealtimeDisconnectReason[] = [];
+  readonly events: string[] = [];
+  private snapshot: RealtimeSnapshot = {
+    status: 'disconnected',
+    connectionEpoch: 0,
+  };
+  private readonly snapshotListeners = new Set<RealtimeSnapshotListener>();
+
+  connect(owner: RealtimeOwner): void {
+    this.connectCalls.push({ ...owner });
+    this.events.push('connect');
+  }
+
+  restart(owner: RealtimeOwner): void {
+    this.restartCalls.push({ ...owner });
+    this.events.push('restart');
+  }
+
+  disconnect(reason: RealtimeDisconnectReason): void {
+    this.disconnectCalls.push(reason);
+    this.events.push(`disconnect:${reason}`);
+  }
+
+  send(_message: RealtimeEnvelope): boolean {
+    return false;
+  }
+
+  subscribe(_type: string, _listener: RealtimeMessageListener): () => void {
+    return () => undefined;
+  }
+
+  subscribeAll(_listener: RealtimeMessageListener): () => void {
+    return () => undefined;
+  }
+
+  subscribeSnapshot(listener: RealtimeSnapshotListener): () => void {
+    this.snapshotListeners.add(listener);
+    this.events.push('subscribeSnapshot');
+    return () => {
+      this.snapshotListeners.delete(listener);
+      this.events.push('unsubscribeSnapshot');
+    };
+  }
+
+  getSnapshot(): RealtimeSnapshot {
+    return this.snapshot;
+  }
+
+  emitSnapshot(snapshot: RealtimeSnapshot): void {
+    this.snapshot = snapshot;
+    for (const listener of this.snapshotListeners) listener(snapshot);
+  }
+
+  destroy(): void {
+    this.events.push('destroy');
+    this.snapshotListeners.clear();
+  }
+}
+
+export class FakeAuthSource implements AuthLifecycleSource {
+  private readonly listeners = new Set<
+    (snapshot: PublishedAuthLifecycleSnapshot) => void
+  >();
+
+  constructor(public snapshot: PublishedAuthLifecycleSnapshot) {}
+
+  getSnapshot(): PublishedAuthLifecycleSnapshot {
+    return this.snapshot;
+  }
+
+  subscribe(
+    listener: (snapshot: PublishedAuthLifecycleSnapshot) => void,
+  ): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  emit(snapshot: PublishedAuthLifecycleSnapshot): void {
+    this.snapshot = snapshot;
+    for (const listener of this.listeners) listener(snapshot);
+  }
+
+  get listenerCount(): number {
+    return this.listeners.size;
+  }
+}
+
+export class FakeAppStateObserver implements AppStateObserver {
+  private readonly listeners = new Set<(state: RealtimeAppState) => void>();
+
+  constructor(public state: RealtimeAppState) {}
+
+  getCurrent(): RealtimeAppState {
+    return this.state;
+  }
+
+  subscribe(listener: (state: RealtimeAppState) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  emit(state: RealtimeAppState): void {
+    this.state = state;
+    for (const listener of this.listeners) listener(state);
+  }
+
+  get listenerCount(): number {
+    return this.listeners.size;
+  }
+}
+
+export class FakeNetworkObserver implements NetworkObserver {
+  private readonly listeners = new Set<(snapshot: ConnectivitySnapshot) => void>();
+  currentResult: Promise<ConnectivitySnapshot>;
+
+  constructor(snapshot: ConnectivitySnapshot) {
+    this.currentResult = Promise.resolve(snapshot);
+  }
+
+  getCurrent(): Promise<ConnectivitySnapshot> {
+    return this.currentResult;
+  }
+
+  subscribe(listener: (snapshot: ConnectivitySnapshot) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  emit(snapshot: ConnectivitySnapshot): void {
+    for (const listener of this.listeners) listener(snapshot);
+  }
+
+  get listenerCount(): number {
+    return this.listeners.size;
+  }
+}

--- a/mobile/src/features/realtime/types.ts
+++ b/mobile/src/features/realtime/types.ts
@@ -1,0 +1,76 @@
+import type {
+  AuthLifecycleSnapshot,
+  AuthTicket,
+} from '@/shared/api/authSessionLifecycle';
+
+export type RealtimeStatus =
+  | 'disconnected'
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting';
+
+export interface RealtimeEnvelope {
+  type: string;
+  [key: string]: unknown;
+}
+
+export type RealtimeOwner = AuthTicket;
+
+export interface RealtimeSnapshot {
+  status: RealtimeStatus;
+  connectionEpoch: number;
+}
+
+export interface PublishedAuthLifecycleSnapshot extends AuthLifecycleSnapshot {
+  publishedCredentialRevision: number | null;
+}
+
+export type RealtimeMessageListener = (message: RealtimeEnvelope) => void;
+export type RealtimeSnapshotListener = (snapshot: RealtimeSnapshot) => void;
+
+export interface RealtimeTransport {
+  send(message: RealtimeEnvelope): boolean;
+  subscribe(type: string, listener: RealtimeMessageListener): () => void;
+  subscribeAll(listener: RealtimeMessageListener): () => void;
+}
+
+export interface RealtimeManager extends RealtimeTransport {
+  connect(owner: RealtimeOwner): void;
+  restart(owner: RealtimeOwner): void;
+  disconnect(reason: RealtimeDisconnectReason): void;
+  subscribeSnapshot(listener: RealtimeSnapshotListener): () => void;
+  getSnapshot(): RealtimeSnapshot;
+  destroy(): void;
+}
+
+export type RealtimeDisconnectReason =
+  | 'auth'
+  | 'background'
+  | 'offline'
+  | 'unmount';
+
+export type ConnectivityAvailability = 'unknown' | 'offline' | 'online';
+
+export interface ConnectivitySnapshot {
+  availability: ConnectivityAvailability;
+  type: string | null;
+}
+
+export interface NetworkObserver {
+  getCurrent(): Promise<ConnectivitySnapshot>;
+  subscribe(listener: (snapshot: ConnectivitySnapshot) => void): () => void;
+}
+
+export type RealtimeAppState = 'active' | 'inactive';
+
+export interface AppStateObserver {
+  getCurrent(): RealtimeAppState;
+  subscribe(listener: (state: RealtimeAppState) => void): () => void;
+}
+
+export interface AuthLifecycleSource {
+  getSnapshot(): PublishedAuthLifecycleSnapshot;
+  subscribe(
+    listener: (snapshot: PublishedAuthLifecycleSnapshot) => void,
+  ): () => void;
+}

--- a/mobile/src/shared/api/__tests__/authSessionLifecycle.test.ts
+++ b/mobile/src/shared/api/__tests__/authSessionLifecycle.test.ts
@@ -75,12 +75,24 @@ describe('auth session lifecycle', () => {
     expect(openingA).toEqual({ sessionGeneration: 1, credentialRevision: 0 });
     await setRefreshToken('refresh-a');
     publishAuthPair(openingA, { access: 'access-a', refresh: 'refresh-a' });
+    expect(getAuthSnapshot()).toMatchObject({
+      access: 'access-a',
+      publishedCredentialRevision: 0,
+    });
     activateAuthSession(openingA);
 
     const closing = requestAuthSessionClose('user');
-    expect(getAuthSnapshot()).toMatchObject({ phase: 'closing', sessionGeneration: 2 });
+    expect(getAuthSnapshot()).toMatchObject({
+      phase: 'closing',
+      sessionGeneration: 2,
+      publishedCredentialRevision: null,
+    });
     await closing;
-    expect(getAuthSnapshot()).toMatchObject({ phase: 'signedOut', sessionGeneration: 2 });
+    expect(getAuthSnapshot()).toMatchObject({
+      phase: 'signedOut',
+      sessionGeneration: 2,
+      publishedCredentialRevision: null,
+    });
 
     const openingB = await beginAuthSessionOpening();
     expect(openingB).toEqual({ sessionGeneration: 3, credentialRevision: 0 });
@@ -258,9 +270,18 @@ describe('auth session lifecycle', () => {
     const rotatedTicket = beginAuthCredentialRotation(ticket, rotatedPair);
 
     expect(rotatedTicket).toEqual({ sessionGeneration: 1, credentialRevision: 1 });
+    expect(getAuthSnapshot()).toMatchObject({
+      credentialRevision: 1,
+      access: 'access-a',
+      publishedCredentialRevision: 0,
+    });
     expect(oldRefresh?.recordCandidate({ access: 'stale-access', refresh: 'stale-refresh' })).toBe(false);
     expect(rotatedTicket && publishAuthPair(rotatedTicket, rotatedPair)).toBe(true);
-    expect(getAuthSnapshot()).toMatchObject({ credentialRevision: 1, access: 'rotated-access' });
+    expect(getAuthSnapshot()).toMatchObject({
+      credentialRevision: 1,
+      access: 'rotated-access',
+      publishedCredentialRevision: 1,
+    });
     oldRefresh?.finish();
   });
 

--- a/mobile/src/shared/api/authSessionLifecycle.ts
+++ b/mobile/src/shared/api/authSessionLifecycle.ts
@@ -15,6 +15,11 @@ export interface AuthPair {
 export interface AuthLifecycleSnapshot extends AuthTicket {
   phase: AuthPhase;
   access: string | null;
+  /**
+   * Revision that owns `access`. It deliberately lags `credentialRevision`
+   * while a rotated refresh token is being persisted.
+   */
+  publishedCredentialRevision: number | null;
 }
 
 export type AuthCloseReason =
@@ -69,6 +74,7 @@ let phase: AuthPhase = 'signedOut';
 let sessionGeneration = 0;
 let credentialRevision = 0;
 let publishedAccess: string | null = null;
+let publishedCredentialRevision: number | null = null;
 let activePair: PairCandidate | null = null;
 let latestCandidate: PairCandidate | null = null;
 let closingSource: AuthTicket | null = null;
@@ -103,8 +109,15 @@ function sourceTicketIsCurrent(ticket: AuthTicket): boolean {
   return phase === 'closing' && closingSource !== null && sameTicket(ticket, closingSource);
 }
 
-function setPublishedAccess(access: string | null): void {
+function setPublishedAccess(
+  access: string | null,
+  revision: number | null,
+): void {
+  if ((access === null) !== (revision === null)) {
+    throw new Error('Published access and credential revision must move atomically.');
+  }
   publishedAccess = access;
+  publishedCredentialRevision = revision;
   setAccessToken(access);
 }
 
@@ -152,6 +165,7 @@ export function getAuthSnapshot(): AuthLifecycleSnapshot {
     sessionGeneration,
     credentialRevision,
     access: publishedAccess,
+    publishedCredentialRevision,
   };
 }
 
@@ -204,6 +218,7 @@ export async function beginAuthSessionOpening(): Promise<AuthTicket> {
   credentialRevision = 0;
   phase = 'opening';
   publishedAccess = null;
+  publishedCredentialRevision = null;
   activePair = null;
   latestCandidate = null;
   closingSource = null;
@@ -297,7 +312,7 @@ export function publishAuthPair(ticket: AuthTicket, pair: AuthPair): boolean {
   const candidate = makeCandidate(ticket, pair);
   activePair = candidate;
   latestCandidate = newerCandidate(latestCandidate, candidate);
-  setPublishedAccess(pair.access);
+  setPublishedAccess(pair.access, ticket.credentialRevision);
   publishLifecycle();
   return true;
 }
@@ -385,7 +400,7 @@ export function requestAuthSessionClose(reason: AuthCloseReason): Promise<void> 
   closingHandoff = newerCandidate(activePair, latestCandidate);
   phase = 'closing';
   sessionGeneration = context.closingGeneration;
-  setPublishedAccess(null);
+  setPublishedAccess(null, null);
   try {
     effectsAtStart?.onClosing?.(context);
   } catch {
@@ -434,6 +449,7 @@ export function requestAuthSessionClose(reason: AuthCloseReason): Promise<void> 
     closingHandoff = null;
     closingSource = null;
     publishedAccess = null;
+    publishedCredentialRevision = null;
     phase = 'signedOut';
     publishLifecycle();
 
@@ -452,6 +468,7 @@ export function __resetAuthSessionLifecycleForTests(): void {
   sessionGeneration = 0;
   credentialRevision = 0;
   publishedAccess = null;
+  publishedCredentialRevision = null;
   activePair = null;
   latestCandidate = null;
   closingSource = null;


### PR DESCRIPTION
## Summary

Implements issue #66 PR 1 (Sub-issues 5.1–5.3):

- add a session- and credential-revision-bound mobile WebSocket transport using single-use subprotocol tickets;
- handle app lifecycle, network observations, bounded open/heartbeat timeouts, reconnect backoff, and `429 Retry-After` without consuming reconnect attempts;
- synchronize notification `created`, `read`, and `read_all` events with REST pagination/count reconciliation;
- keep degraded badge/mark-all affordances safe when an unloaded notification makes the exact unread count unknown;
- mount one realtime and notifications provider above the root stack;
- validate Django's Origin allowlist at settings load, document the explicit native API origin, and regression-test the real ASGI stack.

This is the first of two sequential #66 PRs. Trip chat remains in PR 2, which will be stacked on this branch and retargeted to `main` only after this PR merges.

## Contract and security decisions

- Mobile connects directly to Django ASGI at `/ws/realtime`.
- Authentication remains `Sec-WebSocket-Protocol: goplan.realtime.v1, <single-use-ticket>`; no token is placed in a URL.
- `OriginValidator` remains fail-closed. Settings reject an empty allowlist, `*`, `null`, wildcard hosts, credentials, paths, and malformed origins before Daphne can start.
- The env template lists browser and Simulator API origins explicitly. Physical-device development uses an explicitly allowlisted HTTPS ingress/tunnel because mobile rejects cleartext non-loopback WebSockets.
- Socket/ticket work is fenced by `{sessionGeneration, credentialRevision}`. A rotated access token is not eligible until its published revision matches.
- REST list/count responses share the same mutation clock as realtime/local overlays; stale responses cannot resurrect rows, read state, invitation outcomes, or badge counts.

## Verification

- `podman compose exec -T backend python manage.py test realtime` — 23 passed
- `podman compose exec -T backend python manage.py test configs.tests.SettingsEnvironmentTests` — 16 passed
- ASGI startup smoke tests with blank and wildcard Origin allowlists — both failed closed with `ImproperlyConfigured`
- `pnpm lint` — passed
- `pnpm typecheck` — passed
- `pnpm test --runInBand` — 137 suites / 1,779 tests passed
- `pnpm prebuild:ios` — passed; Expo Network 57.0.1 pods generated
- `pnpm rebuild:sim` — native build/install/launch passed on iPhone 17 Pro Max (iOS 26.3)
- `git diff --check` — passed

## iOS Simulator QA

- login, relaunch/session restore, background/foreground reconnect, logout, and immediate socket teardown;
- live notification creation plus remote-client `read` and `read_all`, with Read/Unread accessibility values;
- backend black-hole long enough to trigger heartbeat timeout, followed by successful reconnect;
- real ticket endpoint `429`, followed by one `Retry-After` retry and successful reconnect;
- initial handshake failure reproduced and fixed: native API Origin was rejected before ticket authentication; the configured API origin now reaches `CONNECT`.

iOS Simulator has no Airplane Mode/Wi-Fi controls and shares the Mac network stack. Offline/online and Wi-Fi/cellular transitions are therefore covered deterministically with injected `expo-network` tests; physical-device network handoff is outside this PR gate unless explicitly requested.

## Review gates

- independent architecture/security review;
- independent functionality/race review;
- independent mobile UI/UX/accessibility review;
- all validated findings fixed and re-reviewed before opening this PR as ready.

Release handoff: when `main` is merged into `production`, retain the production-only env documentation and set the production example to both `https://app.example.com` and the public HTTPS API/WebSocket origin.

Part of #66.
