### PR TITLE
feat(chat): add GoPlanAI mobile experience

### DIFF
--- a/backend/ai/agent/display.py
+++ b/backend/ai/agent/display.py
@@ -36,8 +36,29 @@ STATUS_LABELS = {
     "CANCELLED": "Cancelled",
 }
 
+TIMELINE_REVIEW_META_LABELS = {
+    "Assigned member",
+    "Booking reference",
+    "Contact name",
+    "Contact phone",
+    "Custom type",
+    "External link",
+    "Location note",
+    "Meeting point",
+    "Note",
+    "Reminders",
+}
+
 
 def _activity_payload(payload: dict) -> dict:
+    resolved_data = payload.get("resolved_data")
+    if isinstance(resolved_data, dict):
+        return resolved_data
+    data = payload.get("data")
+    return data if isinstance(data, dict) else payload
+
+
+def _activity_patch_payload(payload: dict) -> dict:
     data = payload.get("data")
     return data if isinstance(data, dict) else payload
 
@@ -106,10 +127,17 @@ def _has_positive_amount(value) -> bool:
 
 
 def _location_label(payload: dict) -> str | None:
+    place = payload.get("place")
+    if payload.get("location_mode") == "STRUCTURED":
+        if not isinstance(place, dict):
+            return None
+        return _non_empty_string(place, "title") or _non_empty_string(
+            place,
+            "address",
+        )
     label = _non_empty_string(payload, "location_label")
     if label:
         return label
-    place = payload.get("place")
     if not isinstance(place, dict):
         return None
     title = _non_empty_string(place, "title")
@@ -157,10 +185,99 @@ def _activity_meta(payload: dict) -> list[dict]:
     return meta
 
 
-def _build_timeline_activity(*, payload: dict, trip_context: dict, tone: str) -> dict:
+def _timeline_review_meta(
+    *,
+    payload: dict,
+    activity_payload: dict,
+    trip_context: dict,
+    tone: str,
+) -> list[dict]:
+    meta = []
+    target_title = _non_empty_string(payload, "target_title")
+    if tone == "update" and target_title:
+        meta.append({"label": "Target", "value": target_title})
+
+    section_label = _non_empty_string(payload, "section_label")
+    section_date = _non_empty_string(payload, "section_date")
+    if section_label and section_date:
+        meta.append({"label": "Date", "value": f"{section_label} · {section_date}"})
+    elif section_date or section_label:
+        meta.append({"label": "Date", "value": section_date or section_label})
+
+    time_label = _fmt_time_range(
+        activity_payload.get("start_time"),
+        activity_payload.get("end_time"),
+        trip_context.get("timezone", "UTC"),
+        activity_payload.get("time_mode"),
+    )
+    meta.append({"label": "Time", "value": time_label or "Not set"})
+
+    location_label = _location_label(activity_payload)
+    if location_label:
+        location_value = location_label
+    else:
+        patch_payload = _activity_patch_payload(payload)
+        location_changed = any(
+            field in patch_payload
+            for field in ("location_mode", "location_label", "place")
+        )
+        location_value = "Cleared" if tone == "update" and location_changed else "Not set"
+    meta.append({"label": "Location", "value": location_value})
+
+    custom_type_label = _non_empty_string(activity_payload, "custom_type_label")
+    system_type = _non_empty_string(activity_payload, "system_type")
+    if custom_type_label:
+        type_label = custom_type_label
+    elif system_type:
+        type_label = SYSTEM_TYPE_LABELS.get(system_type, system_type)
+    else:
+        type_label = "Not set"
+    meta.append({"label": "Type", "value": type_label})
+
+    assignee_label = _non_empty_string(activity_payload, "assignee_label")
+    assignee_scope = _non_empty_string(activity_payload, "assignee_scope")
+    meta.append(
+        {
+            "label": "Assignee",
+            "value": (
+                assignee_label
+                or ASSIGNEE_LABELS.get(assignee_scope or "NONE", "Unassigned")
+            ),
+        }
+    )
+
+    review_meta = payload.get("review_meta")
+    if isinstance(review_meta, list):
+        for row in review_meta:
+            if not isinstance(row, dict):
+                continue
+            label = row.get("label")
+            value = row.get("value")
+            if (
+                label in TIMELINE_REVIEW_META_LABELS
+                and isinstance(value, str)
+                and value.strip()
+            ):
+                meta.append({"label": label, "value": value})
+    else:
+        # Preserve the standalone display-builder contract. Authoritative
+        # presentation callers always supply review_meta, including an empty
+        # list, so only legacy/direct callers use this safe text allowlist.
+        meta.extend(_activity_meta(activity_payload))
+    return meta
+
+
+def _build_timeline_activity(
+    *,
+    payload: dict,
+    trip_context: dict,
+    tone: str,
+    include_review_context: bool = True,
+) -> dict:
     activity_payload = _activity_payload(payload)
     tz = trip_context.get("timezone", "UTC")
-    system_label = SYSTEM_TYPE_LABELS.get(
+    custom_type_label = _non_empty_string(activity_payload, "custom_type_label")
+    system_label = custom_type_label or SYSTEM_TYPE_LABELS.get(
         activity_payload.get("system_type", ""),
         "Activity",
     )
@@ -176,18 +293,32 @@ def _build_timeline_activity(*, payload: dict, trip_context: dict, tone: str) ->
     location_label = _location_label(activity_payload)
     if location_label:
         chips.append({"icon": "map-pin", "label": location_label})
-    assignee = ASSIGNEE_LABELS.get(
-        activity_payload.get("assignee_scope", "GROUP"),
-        "Whole group",
+    assignee = _non_empty_string(activity_payload, "assignee_label") or (
+        ASSIGNEE_LABELS.get(
+            activity_payload.get("assignee_scope", "GROUP"),
+            "Whole group",
+        )
     )
     chips.append({"icon": "users", "label": assignee})
+    meta = (
+        _timeline_review_meta(
+            payload=payload,
+            activity_payload=activity_payload,
+            trip_context=trip_context,
+            tone=tone,
+        )
+        if include_review_context
+        else []
+    )
+    if not include_review_context:
+        meta.extend(_activity_meta(activity_payload))
     return {
         "icon": "activity",
         "tone": tone,
         "kicker": f"Activity · {system_label}",
         "title": activity_payload.get("title", ""),
         "chips": chips,
-        "meta": _activity_meta(activity_payload),
+        "meta": meta,
     }
 
 
@@ -204,6 +335,15 @@ def _build_timeline_update(payload: dict, trip_context: dict) -> dict:
         payload=payload,
         trip_context=trip_context,
         tone="update",
+    )
+
+
+def _build_timeline_status(payload: dict, trip_context: dict) -> dict:
+    return _build_timeline_activity(
+        payload=payload,
+        trip_context=trip_context,
+        tone="update",
+        include_review_context=False,
     )
 
 
@@ -340,7 +480,7 @@ DISPLAY_BUILDERS: dict[str, Callable[[dict, dict], dict]] = {
     "timeline.activity.create": _build_timeline_create,
     "timeline.activity.update": _build_timeline_update,
     "timeline.activity.delete": _build_timeline_delete,
-    "timeline.activity.status.update": _build_timeline_update,
+    "timeline.activity.status.update": _build_timeline_status,
     "expense.create": _build_expense_create,
     "expense.update": _build_expense_update,
     "expense.delete": _build_expense_delete,

--- a/backend/ai/agent/draft_fields.py
+++ b/backend/ai/agent/draft_fields.py
@@ -8,6 +8,7 @@ from ai.agent.presets import presets_for
 MISSING_FIELD_DEFINITIONS = {
     "activity_id": {"label": "Activity"},
     "amount": {"label": "Amount", "type": "money"},
+    "assignee_user_id": {"label": "Assigned member"},
     "collector_id": {"label": "Collector", "type": "select"},
     "contributions": {"label": "Contributions", "type": "json"},
     "custom_type_id": {"label": "Custom activity type", "type": "select"},
@@ -120,6 +121,7 @@ def build_missing_fields_for_action(
     action_type: str,
     payload: dict,
     missing: Iterable[str],
+    trip_id=None,
 ) -> list[dict]:
     missing_names = list(dict.fromkeys(missing))
     if action_type != AI_ACTION_TIMELINE_ACTIVITY_CREATE:
@@ -131,16 +133,20 @@ def build_missing_fields_for_action(
         time_mode=str(data.get("time_mode") or ""),
         missing=missing_names,
         system_type=data.get("system_type"),
+        trip_id=trip_id,
     )
 
 
 # -------- Section Context Resolver --------
 
-def _resolve_section_context(section_id) -> dict:
+def _resolve_section_context(section_id, *, trip_id=None) -> dict:
     from trips.models import TimelineSection
 
     try:
-        section = TimelineSection.objects.select_related("trip").get(pk=section_id)
+        sections = TimelineSection.objects.select_related("trip")
+        if trip_id is not None:
+            sections = sections.filter(trip_id=trip_id)
+        section = sections.get(pk=section_id)
     except (TimelineSection.DoesNotExist, ValueError, TypeError):
         return {}
     sections = list(
@@ -167,6 +173,7 @@ def build_missing_fields_for_create_activity(
     time_mode: str,
     missing: list[str],
     system_type: str | None = None,
+    trip_id=None,
 ) -> list[dict]:
     """Build missing_fields list for a timeline.activity.create draft,
     pairing start_time/end_time into a synthetic time_range field with
@@ -176,7 +183,7 @@ def build_missing_fields_for_create_activity(
     fields: list[dict] = []
 
     if time_mode == "TIME_RANGE" and {"start_time", "end_time"} <= missing_set:
-        section_ctx = _resolve_section_context(section_id)
+        section_ctx = _resolve_section_context(section_id, trip_id=trip_id)
         fields.append({
             "name": "time_range",
             "label": "Time",

--- a/backend/ai/agent/draft_mutations.py
+++ b/backend/ai/agent/draft_mutations.py
@@ -46,7 +46,8 @@ from ai.chat_changes import (
     mark_ai_response_message_changed,
 )
 from ai.models import AIActionDraft, AIActionDraftStatus
-from trips.models import Trip, TripMember
+from trips.models import Trip, TripMember, TripStatus
+from trips.services import TripTerminalError
 
 
 class AIActionDraftPatchFieldNotAllowedError(Exception):
@@ -196,6 +197,11 @@ def _touch_response_message(*, draft: AIActionDraft, locked_trip: Trip) -> None:
     )
 
 
+def _ensure_locked_trip_allows_draft_mutation(locked_trip: Trip) -> None:
+    if locked_trip.status in {TripStatus.COMPLETED, TripStatus.CANCELLED}:
+        raise TripTerminalError("Completed or cancelled trips are read-only.")
+
+
 def _expire_draft(*, draft: AIActionDraft, locked_trip: Trip) -> None:
     draft.status = AIActionDraftStatus.EXPIRED
     draft.save(update_fields=["status", "updated_at"])
@@ -228,6 +234,7 @@ def patch_action_draft(
             locked_trip=locked_trip,
             actor=actor,
         )
+        _ensure_locked_trip_allows_draft_mutation(locked_trip)
         draft = (
             AIActionDraft.objects.select_for_update(of=("self",))
             .select_related("response_message")
@@ -412,6 +419,15 @@ def cancel_action_draft(*, draft_id, trip_id, actor) -> AIActionDraft:
             .get(pk=draft_id, trip_id=trip_id)
         )
 
+        if draft.status in {
+            AIActionDraftStatus.CONFIRMED,
+            AIActionDraftStatus.CANCELLED,
+            AIActionDraftStatus.EXPIRED,
+            AIActionDraftStatus.FAILED,
+        }:
+            return draft
+        _ensure_locked_trip_allows_draft_mutation(locked_trip)
+
         if (
             draft.status in {
                 AIActionDraftStatus.NEEDS_INFO,
@@ -421,13 +437,6 @@ def cancel_action_draft(*, draft_id, trip_id, actor) -> AIActionDraft:
         ):
             _expire_draft(draft=draft, locked_trip=locked_trip)
             expired = True
-        elif draft.status in {
-            AIActionDraftStatus.CONFIRMED,
-            AIActionDraftStatus.CANCELLED,
-            AIActionDraftStatus.EXPIRED,
-            AIActionDraftStatus.FAILED,
-        }:
-            return draft
         elif not can_cancel_action_draft(draft, viewer=actor):
             raise AIActionDraftForbiddenError("You cannot cancel this draft.")
         else:

--- a/backend/ai/agent/draft_mutations.py
+++ b/backend/ai/agent/draft_mutations.py
@@ -85,19 +85,32 @@ def _apply_draft_patch_payload(draft: AIActionDraft, patch_payload: dict) -> dic
         AI_ACTION_TIMELINE_ACTIVITY_UPDATE,
     }:
         existing_data = next_payload.get("data")
-        data = dict(existing_data) if isinstance(existing_data, dict) else {}
+        legacy_data = {
+            key: next_payload.pop(key)
+            for key in tuple(next_payload)
+            if key in TIMELINE_ACTIVITY_DATA_FIELDS
+        }
+        data = {
+            **legacy_data,
+            **(dict(existing_data) if isinstance(existing_data, dict) else {}),
+        }
         data_overridden = False
         for key, value in patch_payload.items():
             if key == "data":
-                if isinstance(value, dict):
-                    data.update(value)
-                else:
-                    next_payload["data"] = value
-                    data_overridden = True
-            elif key in TIMELINE_ACTIVITY_DATA_FIELDS:
+                continue
+            if key in TIMELINE_ACTIVITY_DATA_FIELDS:
                 data[key] = value
             else:
                 next_payload[key] = value
+        if "data" in patch_payload:
+            nested_patch = patch_payload["data"]
+            if isinstance(nested_patch, dict):
+                # The canonical wrapper wins when a legacy client submits both
+                # representations, independent of JSON object key order.
+                data.update(nested_patch)
+            else:
+                next_payload["data"] = nested_patch
+                data_overridden = True
         if not data_overridden:
             next_payload["data"] = data
         return next_payload
@@ -257,9 +270,6 @@ def patch_action_draft(
             if not patch_payload:
                 return draft
 
-            if next_payload == draft.payload:
-                return draft
-
             expense_currency_changed = (
                 draft.action_type == AI_ACTION_EXPENSE_CREATE
                 and next_payload.get("currency_code")
@@ -270,6 +280,9 @@ def patch_action_draft(
                 # for input while the trip currency changes, so restamp the
                 # locked authoritative value on every explicit edit.
                 next_payload["currency_code"] = locked_trip.currency_code
+
+            if next_payload == draft.payload:
+                return draft
 
             timeline_create_result = plan_timeline_create_draft(
                 action_type=draft.action_type,

--- a/backend/ai/agent/draft_mutations.py
+++ b/backend/ai/agent/draft_mutations.py
@@ -4,20 +4,28 @@ from django.db import transaction
 from django.utils import timezone
 
 from ai.action_types import (
+    AI_ACTION_EXPENSE_CREATE,
     AI_ACTION_TIMELINE_ACTIVITY_CREATE,
     AI_ACTION_TIMELINE_ACTIVITY_UPDATE,
 )
-from ai.agent.display import build_display
 from ai.agent.draft_fields import (
     build_missing_fields_for_action,
     normalize_missing_fields,
     normalize_missing_field_names,
 )
+from ai.agent.draft_presentation import build_action_draft_presentation
+from ai.agent.timeline_draft_validation import (
+    plan_timeline_create_draft,
+    plan_timeline_update_draft,
+)
 from ai.agent.drafts import (
     can_cancel_action_draft,
     can_edit_action_draft,
 )
-from ai.agent.draft_validation import validate_action_draft_patch_payload
+from ai.agent.draft_validation import (
+    AIActionDraftFieldValidationError,
+    validate_action_draft_patch_payload,
+)
 from ai.agent.executor import (
     AIActionDraftExpiredError,
     AIActionDraftForbiddenError,
@@ -123,7 +131,12 @@ def _disallowed_patch_fields(draft: AIActionDraft, patch_payload: dict) -> list[
     )
 
 
-def _refresh_missing_fields(draft: AIActionDraft, payload: dict) -> list[dict]:
+def _refresh_missing_fields(
+    draft: AIActionDraft,
+    payload: dict,
+    *,
+    currency_code: str,
+) -> list[dict]:
     current_missing_names = normalize_missing_field_names(
         draft.missing_fields,
         strict=False,
@@ -132,11 +145,13 @@ def _refresh_missing_fields(draft: AIActionDraft, payload: dict) -> list[dict]:
         action_type=draft.action_type,
         payload=payload,
         provider_missing_names=current_missing_names,
+        currency_code=currency_code,
     )
     return build_missing_fields_for_action(
         action_type=draft.action_type,
         payload=payload,
         missing=missing_names,
+        trip_id=draft.trip_id,
     )
 
 
@@ -172,6 +187,18 @@ def _expire_draft(*, draft: AIActionDraft, locked_trip: Trip) -> None:
     _touch_response_message(draft=draft, locked_trip=locked_trip)
 
 
+def _timeline_activity_preconditions(activity) -> dict:
+    return {
+        "target": {
+            "type": "timeline_activity",
+            "id": str(activity.id),
+            "updated_at": activity.updated_at.isoformat(),
+            "title": activity.title,
+            "status": activity.status,
+        }
+    }
+
+
 def patch_action_draft(
     *,
     draft_id,
@@ -194,6 +221,7 @@ def patch_action_draft(
         validate_action_draft_patch_payload(
             draft=draft,
             patch_payload=patch_payload,
+            currency_code=locked_trip.currency_code,
         )
 
         if (
@@ -224,37 +252,108 @@ def patch_action_draft(
             if next_payload == draft.payload:
                 return draft
 
-            still_missing = _refresh_missing_fields(draft, next_payload)
-            try:
-                next_preconditions = (
-                    build_backend_preconditions(
-                        action_type=draft.action_type,
-                        trip_id=draft.trip_id,
-                        payload=next_payload,
-                        required=not still_missing,
-                    )
-                    if action_requires_stale_precondition(draft.action_type)
-                    else {}
+            expense_currency_changed = (
+                draft.action_type == AI_ACTION_EXPENSE_CREATE
+                and next_payload.get("currency_code")
+                != locked_trip.currency_code
+            )
+            if draft.action_type == AI_ACTION_EXPENSE_CREATE:
+                # Expense persistence is trip-currency-only. A draft can wait
+                # for input while the trip currency changes, so restamp the
+                # locked authoritative value on every explicit edit.
+                next_payload["currency_code"] = locked_trip.currency_code
+
+            timeline_create_result = plan_timeline_create_draft(
+                action_type=draft.action_type,
+                trip=locked_trip,
+                payload=next_payload,
+                lock_section=True,
+            )
+            patched_field_names = set(patch_payload)
+            nested_patch = patch_payload.get("data")
+            if isinstance(nested_patch, dict):
+                patched_field_names.update(nested_patch)
+            blocking_create_errors = {
+                field: message
+                for field, message
+                in timeline_create_result.blocking_field_errors.items()
+                if field in patched_field_names
+            }
+            if blocking_create_errors:
+                raise AIActionDraftFieldValidationError(
+                    blocking_create_errors
                 )
+            next_payload = timeline_create_result.payload
+
+            timeline_result = plan_timeline_update_draft(
+                action_type=draft.action_type,
+                trip=locked_trip,
+                payload=next_payload,
+                lock_target=True,
+            )
+            if timeline_result.field_errors:
+                raise AIActionDraftFieldValidationError(
+                    timeline_result.field_errors
+                )
+            next_payload = timeline_result.payload
+
+            still_missing = _refresh_missing_fields(
+                draft,
+                next_payload,
+                currency_code=locked_trip.currency_code,
+            )
+            existing_missing_names = set(
+                normalize_missing_field_names(still_missing, strict=False)
+            )
+            create_planner_missing = [
+                field
+                for field in timeline_create_result.field_errors
+                if field not in existing_missing_names
+            ]
+            if create_planner_missing:
+                still_missing.extend(
+                    build_missing_fields_for_action(
+                        action_type=draft.action_type,
+                        payload=next_payload,
+                        missing=create_planner_missing,
+                        trip_id=draft.trip_id,
+                    )
+                )
+            try:
+                if timeline_result.activity is not None:
+                    next_preconditions = _timeline_activity_preconditions(
+                        timeline_result.activity
+                    )
+                else:
+                    next_preconditions = (
+                        build_backend_preconditions(
+                            action_type=draft.action_type,
+                            trip_id=draft.trip_id,
+                            payload=next_payload,
+                            required=not still_missing,
+                        )
+                        if action_requires_stale_precondition(draft.action_type)
+                        else {}
+                    )
             except ValueError as exc:
                 raise AIActionDraftTargetNotFoundError(
                     "Draft target could not be resolved."
                 ) from exc
-            draft.payload = next_payload
-            draft.preview = _build_patch_preview(
+            next_preview, next_display = build_action_draft_presentation(
                 action_type=draft.action_type,
                 payload=next_payload,
-            )
-            if not still_missing:
-                trip_context = {
-                    "timezone": locked_trip.timezone,
-                    "currency_code": locked_trip.currency_code,
-                }
-                draft.display = build_display(
+                trip=locked_trip,
+                preview_base=_build_patch_preview(
                     action_type=draft.action_type,
                     payload=next_payload,
-                    trip_context=trip_context,
-                )
+                ),
+                timeline_plan=timeline_result.plan,
+                timeline_create_plan=timeline_create_result.plan,
+            )
+            draft.payload = next_payload
+            draft.preview = next_preview
+            if not still_missing or expense_currency_changed:
+                draft.display = next_display
             draft.missing_fields = still_missing
             draft.preconditions = next_preconditions
             if not still_missing:

--- a/backend/ai/agent/draft_presentation.py
+++ b/backend/ai/agent/draft_presentation.py
@@ -1,0 +1,489 @@
+from __future__ import annotations
+
+from datetime import date, time
+
+from django.core.exceptions import ValidationError
+from django.utils.dateparse import parse_date
+
+from ai.action_types import (
+    AI_ACTION_TIMELINE_ACTIVITY_CREATE,
+    AI_ACTION_TIMELINE_ACTIVITY_UPDATE,
+)
+from ai.agent.display import build_display
+from trips.models import (
+    MemberStatus,
+    TimelineActivity,
+    TimelineActivityAssigneeScope,
+    TimelineActivityTimeMode,
+    TimelineCustomType,
+    TimelineLocationMode,
+    TimelineSection,
+    Trip,
+    TripMember,
+)
+from trips.services import (
+    TimelineActivityCreatePlan,
+    TimelineActivityPatchPlan,
+)
+
+TIMELINE_PRESENTATION_ACTIONS = {
+    AI_ACTION_TIMELINE_ACTIVITY_CREATE,
+    AI_ACTION_TIMELINE_ACTIVITY_UPDATE,
+}
+
+
+def _clock_value(value) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, time):
+        return value.replace(microsecond=0).isoformat()
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def _safe_place(value) -> dict | None:
+    if not isinstance(value, dict):
+        return None
+    place = {
+        key: text.strip()
+        for key in ("title", "address")
+        if isinstance((text := value.get(key)), str) and text.strip()
+    }
+    return place or None
+
+
+def _safe_preview_patch_data(data: dict) -> dict:
+    safe = {
+        key: value
+        for key, value in data.items()
+        if key not in {"custom_type_id", "assignee_user_id"}
+    }
+    if "place" in safe:
+        safe["place"] = _safe_place(safe["place"])
+    return safe
+
+
+def _activity_place(activity: TimelineActivity) -> dict | None:
+    if (
+        activity.location_mode != TimelineLocationMode.STRUCTURED
+        or not activity.place_provider_id
+    ):
+        return None
+    return {
+        key: value
+        for key, value in {
+            "title": activity.place_title,
+            "address": activity.place_address,
+        }.items()
+        if value
+    }
+
+
+def _user_label(user) -> str | None:
+    if user is None:
+        return None
+    return user.display_name or user.identify_tag or None
+
+
+def _safe_final_data(data: dict) -> dict:
+    safe = {
+        key: value
+        for key, value in data.items()
+        if key
+        in {
+            "title",
+            "system_type",
+            "custom_type_label",
+            "time_mode",
+            "start_time",
+            "end_time",
+            "assignee_scope",
+            "assignee_label",
+            "location_mode",
+            "location_label",
+            "location_note",
+            "note",
+            "meeting_point",
+            "contact_name",
+            "contact_phone",
+            "booking_reference",
+            "external_link",
+            "reminder_offsets_minutes",
+        }
+    }
+    safe["start_time"] = _clock_value(safe.get("start_time"))
+    safe["end_time"] = _clock_value(safe.get("end_time"))
+    safe["place"] = _safe_place(data.get("place"))
+    return safe
+
+
+def _activity_snapshot(activity: TimelineActivity) -> dict:
+    return _safe_final_data({
+        "title": activity.title,
+        "system_type": activity.system_type,
+        "custom_type_label": (
+            activity.custom_type.name
+            if activity.custom_type_id is not None
+            else None
+        ),
+        "time_mode": activity.time_mode,
+        "start_time": activity.start_time,
+        "end_time": activity.end_time,
+        "assignee_scope": activity.assignee_scope,
+        "assignee_label": _user_label(activity.assignee_user),
+        "location_mode": activity.location_mode,
+        "location_label": activity.location_label,
+        "place": _activity_place(activity),
+        "location_note": activity.location_note,
+        "note": activity.note,
+        "meeting_point": activity.meeting_point,
+        "contact_name": activity.contact_name,
+        "contact_phone": activity.contact_phone,
+        "booking_reference": activity.booking_reference,
+        "external_link": activity.external_link,
+    })
+
+
+def _create_snapshot(
+    *,
+    trip: Trip,
+    data: dict,
+    timeline_create_plan: TimelineActivityCreatePlan | None,
+) -> dict:
+    if timeline_create_plan is not None:
+        return _safe_final_data(timeline_create_plan.final_data)
+
+    custom_type = None
+    custom_type_id = data.get("custom_type_id")
+    if custom_type_id:
+        custom_type = TimelineCustomType.objects.filter(
+            pk=custom_type_id,
+            trip=trip,
+            is_active=True,
+        ).first()
+
+    assignee = None
+    if (
+        data.get("assignee_scope") == TimelineActivityAssigneeScope.USER
+        and data.get("assignee_user_id")
+    ):
+        membership = (
+            TripMember.objects.select_related("user")
+            .filter(
+                trip=trip,
+                user_id=data["assignee_user_id"],
+                status=MemberStatus.ACTIVE,
+            )
+            .first()
+        )
+        assignee = membership.user if membership is not None else None
+
+    time_mode = data.get("time_mode")
+    clears_time = time_mode in {
+        TimelineActivityTimeMode.ALL_DAY,
+        TimelineActivityTimeMode.FLEXIBLE,
+    }
+    location_mode = data.get("location_mode", TimelineLocationMode.MANUAL)
+    return _safe_final_data({
+        "title": data.get("title", ""),
+        "system_type": "" if custom_type is not None else data.get("system_type", ""),
+        "custom_type_label": custom_type.name if custom_type is not None else None,
+        "time_mode": time_mode,
+        "start_time": None if clears_time else data.get("start_time"),
+        "end_time": None if clears_time else data.get("end_time"),
+        "assignee_scope": data.get("assignee_scope", "EVERYONE"),
+        "assignee_label": _user_label(assignee),
+        "location_mode": location_mode,
+        "location_label": data.get("location_label", ""),
+        "place": (
+            data.get("place")
+            if location_mode == TimelineLocationMode.STRUCTURED
+            else None
+        ),
+        "location_note": data.get("location_note", ""),
+        "note": data.get("note", ""),
+        "meeting_point": data.get("meeting_point", ""),
+        "contact_name": data.get("contact_name", ""),
+        "contact_phone": data.get("contact_phone", ""),
+        "booking_reference": data.get("booking_reference", ""),
+        "external_link": data.get("external_link", ""),
+        "reminder_offsets_minutes": data.get("reminder_offsets_minutes", []),
+    })
+
+
+def _resolved_update_snapshot(activity: TimelineActivity, data: dict) -> dict:
+    resolved = _activity_snapshot(activity)
+    for field in (
+        "title",
+        "system_type",
+        "time_mode",
+        "start_time",
+        "end_time",
+        "assignee_scope",
+        "location_mode",
+        "location_label",
+    ):
+        if field in data:
+            value = data[field]
+            resolved[field] = (
+                _clock_value(value)
+                if field in {"start_time", "end_time"}
+                else value
+            )
+
+    if resolved.get("time_mode") in {
+        TimelineActivityTimeMode.ALL_DAY,
+        TimelineActivityTimeMode.FLEXIBLE,
+    }:
+        resolved["start_time"] = None
+        resolved["end_time"] = None
+
+    if "place" in data:
+        resolved["place"] = _safe_place(data.get("place"))
+    elif (
+        "location_mode" in data
+        and data["location_mode"] == TimelineLocationMode.MANUAL
+    ):
+        resolved["place"] = None
+    return resolved
+
+
+def _reminder_label(offset: int) -> str:
+    if offset % 10080 == 0:
+        count = offset // 10080
+        unit = "week" if count == 1 else "weeks"
+    elif offset % 1440 == 0:
+        count = offset // 1440
+        unit = "day" if count == 1 else "days"
+    elif offset % 60 == 0:
+        count = offset // 60
+        unit = "hour" if count == 1 else "hours"
+    else:
+        count = offset
+        unit = "minute" if count == 1 else "minutes"
+    return f"{count} {unit} before"
+
+
+def _review_value(value) -> str | None:
+    if value is None or value == []:
+        return "Cleared"
+    if isinstance(value, str):
+        return value if value.strip() else "Cleared"
+    return None
+
+
+def _hidden_review_meta(
+    *,
+    data: dict,
+    resolved_data: dict,
+) -> list[dict]:
+    meta = []
+    custom_type_label = resolved_data.get("custom_type_label")
+    if "custom_type_id" in data:
+        if data.get("custom_type_id") is None:
+            meta.append({"label": "Custom type", "value": "Cleared"})
+        elif isinstance(custom_type_label, str) and custom_type_label.strip():
+            meta.append(
+                {"label": "Custom type", "value": custom_type_label.strip()}
+            )
+
+    if "assignee_user_id" in data:
+        assignee_label = resolved_data.get("assignee_label")
+        if data.get("assignee_user_id") is None:
+            meta.append({"label": "Assigned member", "value": "Cleared"})
+        elif isinstance(assignee_label, str) and assignee_label.strip():
+            meta.append(
+                {"label": "Assigned member", "value": assignee_label.strip()}
+            )
+
+    for field, label in (
+        ("booking_reference", "Booking reference"),
+        ("contact_name", "Contact name"),
+        ("contact_phone", "Contact phone"),
+        ("external_link", "External link"),
+        ("location_note", "Location note"),
+        ("meeting_point", "Meeting point"),
+        ("note", "Note"),
+    ):
+        if field not in data:
+            continue
+        value = _review_value(data[field])
+        if value is not None:
+            meta.append({"label": label, "value": value})
+
+    if "reminder_offsets_minutes" in data:
+        offsets = data.get("reminder_offsets_minutes")
+        if not offsets:
+            value = "Cleared"
+        elif isinstance(offsets, list) and all(
+            isinstance(offset, int) and not isinstance(offset, bool)
+            for offset in offsets
+        ):
+            value = " · ".join(_reminder_label(offset) for offset in offsets)
+        else:
+            value = None
+        if value is not None:
+            meta.append({"label": "Reminders", "value": value})
+    return meta
+
+
+def _section_label_for_date(*, trip: Trip, section_date: date) -> str:
+    if trip.start_date:
+        return f"Day {(section_date - trip.start_date).days + 1}"
+    return section_date.isoformat()
+
+
+def _create_section_context(
+    *,
+    trip: Trip,
+    payload: dict,
+    timeline_create_plan: TimelineActivityCreatePlan | None,
+) -> dict:
+    if (
+        timeline_create_plan is not None
+        and timeline_create_plan.section is not None
+    ):
+        section = timeline_create_plan.section
+        return {
+            "section_label": section.label,
+            "section_date": section.section_date.isoformat(),
+        }
+
+    section_id = payload.get("section_id")
+    if section_id:
+        try:
+            section = TimelineSection.objects.get(pk=section_id, trip=trip)
+        except (
+            TimelineSection.DoesNotExist,
+            TypeError,
+            ValueError,
+            ValidationError,
+        ):
+            return {}
+        return {
+            "section_label": section.label,
+            "section_date": section.section_date.isoformat(),
+        }
+
+    raw_date = payload.get("section_date")
+    section_date = raw_date if isinstance(raw_date, date) else parse_date(str(raw_date))
+    if section_date is None:
+        return {}
+    section = TimelineSection.objects.filter(
+        trip=trip,
+        section_date=section_date,
+    ).first()
+    return {
+        "section_label": (
+            section.label
+            if section is not None
+            else _section_label_for_date(trip=trip, section_date=section_date)
+        ),
+        "section_date": section_date.isoformat(),
+    }
+
+
+def _update_context(
+    *,
+    trip: Trip,
+    payload: dict,
+    timeline_plan: TimelineActivityPatchPlan | None,
+) -> dict:
+    try:
+        activity = TimelineActivity.objects.select_related(
+            "section",
+            "custom_type",
+            "assignee_user",
+        ).get(
+            pk=payload.get("activity_id"),
+            trip=trip,
+        )
+    except (
+        TimelineActivity.DoesNotExist,
+        TypeError,
+        ValueError,
+        ValidationError,
+    ):
+        return {}
+    data = payload.get("data")
+    patch_data = data if isinstance(data, dict) else {}
+    resolved_data = (
+        _safe_final_data(timeline_plan.final_data)
+        if timeline_plan is not None
+        else _resolved_update_snapshot(activity, patch_data)
+    )
+    return {
+        "target_title": activity.title,
+        "section_label": activity.section.label,
+        "section_date": activity.section.section_date.isoformat(),
+        "resolved_data": resolved_data,
+        "review_meta": _hidden_review_meta(
+            data=patch_data,
+            resolved_data=resolved_data,
+        ),
+    }
+
+
+def build_action_draft_presentation(
+    *,
+    action_type: str,
+    payload: dict,
+    trip: Trip,
+    preview_base: dict | None = None,
+    timeline_plan: TimelineActivityPatchPlan | None = None,
+    timeline_create_plan: TimelineActivityCreatePlan | None = None,
+) -> tuple[dict, dict]:
+    """Build additive, display-only context without changing execution payloads."""
+    preview = dict(payload if preview_base is None else preview_base)
+    display_payload = dict(payload)
+
+    if action_type in TIMELINE_PRESENTATION_ACTIONS:
+        data = payload.get("data")
+        if isinstance(data, dict):
+            # Presentation is human-facing. Keep executor-only identifiers and
+            # coordinates in the persisted payload, never in the review envelope.
+            preview.pop("custom_type_id", None)
+            preview.pop("assignee_user_id", None)
+            if "place" in preview:
+                preview["place"] = _safe_place(preview["place"])
+            preview["data"] = _safe_preview_patch_data(data)
+
+        if action_type == AI_ACTION_TIMELINE_ACTIVITY_CREATE:
+            preview.pop("section_id", None)
+            context = _create_section_context(
+                trip=trip,
+                payload=payload,
+                timeline_create_plan=timeline_create_plan,
+            )
+            if isinstance(data, dict):
+                resolved_data = _create_snapshot(
+                    trip=trip,
+                    data=data,
+                    timeline_create_plan=timeline_create_plan,
+                )
+                context["resolved_data"] = resolved_data
+                context["review_meta"] = _hidden_review_meta(
+                    data=data,
+                    resolved_data=resolved_data,
+                )
+        else:
+            context = _update_context(
+                trip=trip,
+                payload=payload,
+                timeline_plan=timeline_plan,
+            )
+
+        preview.update(context)
+        display_payload.update(context)
+
+    trip_context = {
+        "timezone": trip.timezone,
+        "currency_code": trip.currency_code,
+    }
+    display = build_display(
+        action_type=action_type,
+        payload=display_payload,
+        trip_context=trip_context,
+    )
+    return preview, display

--- a/backend/ai/agent/draft_validation.py
+++ b/backend/ai/agent/draft_validation.py
@@ -2,6 +2,15 @@ from __future__ import annotations
 
 from pydantic import ValidationError as PydanticValidationError
 
+from ai.action_types import (
+    AI_ACTION_EXPENSE_CONTRIBUTION_SET,
+    AI_ACTION_EXPENSE_CREATE,
+    AI_ACTION_EXPENSE_UPDATE,
+)
+from ai.agent.payload_validation import (
+    EXPENSE_CONTRIBUTION_AMOUNT_FIELDS,
+    currency_amount_validation_error,
+)
 from ai.agent.schemas import (
     ConfirmTransferReceivedArgs,
     CreateExpenseArgs,
@@ -65,10 +74,85 @@ def _field_errors_from_pydantic(
     return errors
 
 
+def _append_currency_amount_field_error(
+    errors: dict[str, str],
+    *,
+    path: str,
+    value,
+    currency_code: str,
+    allow_zero: bool,
+) -> None:
+    error = currency_amount_validation_error(
+        value,
+        currency_code=currency_code,
+        allow_zero=allow_zero,
+    )
+    if error:
+        errors[path] = error
+
+
+def _expense_contribution_currency_field_errors(
+    patch_payload: dict,
+    *,
+    currency_code: str,
+) -> dict[str, str]:
+    errors: dict[str, str] = {}
+
+    for field in EXPENSE_CONTRIBUTION_AMOUNT_FIELDS:
+        if field in patch_payload:
+            _append_currency_amount_field_error(
+                errors,
+                path=field,
+                value=patch_payload[field],
+                currency_code=currency_code,
+                allow_zero=True,
+            )
+
+    contributions = patch_payload.get("contributions")
+    if isinstance(contributions, list):
+        for index, contribution in enumerate(contributions):
+            if not isinstance(contribution, dict) or "amount" not in contribution:
+                continue
+            _append_currency_amount_field_error(
+                errors,
+                path=f"contributions.{index}.amount",
+                value=contribution["amount"],
+                currency_code=currency_code,
+                allow_zero=True,
+            )
+
+    member_contributions = patch_payload.get("member_contributions")
+    if isinstance(member_contributions, dict):
+        for member_id, contribution in member_contributions.items():
+            base_path = f"member_contributions.{member_id}"
+            if not isinstance(contribution, dict):
+                _append_currency_amount_field_error(
+                    errors,
+                    path=base_path,
+                    value=contribution,
+                    currency_code=currency_code,
+                    allow_zero=True,
+                )
+                continue
+            for field in EXPENSE_CONTRIBUTION_AMOUNT_FIELDS:
+                if field not in contribution:
+                    continue
+                _append_currency_amount_field_error(
+                    errors,
+                    path=f"{base_path}.{field}",
+                    value=contribution[field],
+                    currency_code=currency_code,
+                    allow_zero=True,
+                )
+
+    return errors
+
+
 def validate_action_draft_patch_payload(
     *,
     draft: AIActionDraft,
     patch_payload: dict,
+    currency_code: str,
 ) -> None:
     """Validate patch fields against the action schema without changing wire behavior."""
     schema = SCHEMA_BY_ACTION.get(draft.action_type)
@@ -84,7 +168,12 @@ def validate_action_draft_patch_payload(
     if not non_blank_patch:
         return
 
-    merged_payload = {**(draft.payload or {}), **non_blank_patch}
+    merged_payload = dict(draft.payload or {})
+    if draft.action_type == AI_ACTION_EXPENSE_CREATE:
+        # Validate against the locked current trip currency, not a snapshot
+        # captured while this draft was waiting for user input.
+        merged_payload["currency_code"] = currency_code
+    merged_payload.update(non_blank_patch)
     try:
         schema.model_validate(merged_payload)
     except PydanticValidationError as exc:
@@ -94,3 +183,26 @@ def validate_action_draft_patch_payload(
         )
         if field_errors:
             raise AIActionDraftFieldValidationError(field_errors) from exc
+
+    currency_field_errors: dict[str, str] = {}
+    if (
+        draft.action_type in {AI_ACTION_EXPENSE_CREATE, AI_ACTION_EXPENSE_UPDATE}
+        and "total_amount" in non_blank_patch
+    ):
+        _append_currency_amount_field_error(
+            currency_field_errors,
+            path="total_amount",
+            value=non_blank_patch["total_amount"],
+            currency_code=currency_code,
+            allow_zero=False,
+        )
+    elif draft.action_type == AI_ACTION_EXPENSE_CONTRIBUTION_SET:
+        currency_field_errors.update(
+            _expense_contribution_currency_field_errors(
+                non_blank_patch,
+                currency_code=currency_code,
+            )
+        )
+
+    if currency_field_errors:
+        raise AIActionDraftFieldValidationError(currency_field_errors)

--- a/backend/ai/agent/drafts.py
+++ b/backend/ai/agent/drafts.py
@@ -4,9 +4,13 @@ from datetime import timedelta
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.db import transaction
 from django.utils import timezone
 
 from ai.action_types import (
+    AI_ACTION_EXPENSE_CREATE,
+    AI_ACTION_TIMELINE_ACTIVITY_CREATE,
+    AI_ACTION_TIMELINE_ACTIVITY_UPDATE,
     AI_ACTION_SETTLEMENT_TRANSFER_CONFIRM_RECEIVED,
     AI_CONFIRMATION_CAPTAIN,
     AI_CONFIRMATION_TIMELINE_ACTIVITY_STATUS,
@@ -17,12 +21,17 @@ from ai.action_types import (
     TRANSFER_PAYER_ACTIONS,
     TRANSFER_RECIPIENT_ACTIONS,
 )
-from ai.agent.display import build_display
 from ai.agent.draft_fields import (
     build_missing_fields_for_action,
     normalize_missing_fields,
+    normalize_missing_field_names,
 )
+from ai.agent.draft_presentation import build_action_draft_presentation
 from ai.agent.payload_validation import missing_payload_field_names
+from ai.agent.timeline_draft_validation import (
+    plan_timeline_create_draft,
+    plan_timeline_update_draft,
+)
 from ai.models import AIActionDraft, AIActionDraftStatus
 from expenses.models import SettlementStatus, SettlementTransfer
 from trips.models import (
@@ -35,6 +44,7 @@ from trips.models import (
     TimelineLocationMode,
     TimelineSection,
     TimelineSystemType,
+    Trip,
     TripMember,
     TripRole,
     TripStatus,
@@ -82,55 +92,108 @@ def create_action_draft(
     """Persist a single AIActionDraft row from a tool handler."""
     from ai.lifecycle import summarize_draft  # avoid circular import at module level
 
-    if missing_fields is None:
-        missing_names = missing_payload_field_names(
+    with transaction.atomic():
+        # Keep the global AI/chat mutation order at Trip -> draft. The caller's
+        # Trip instance may be stale while a worker is preparing provider output.
+        locked_trip = Trip.objects.select_for_update().get(pk=trip.pk)
+        payload = dict(payload)
+        if action_type == AI_ACTION_EXPENSE_CREATE:
+            # Expense persistence is trip-currency-only. Resolve provider input
+            # before validation/display so confirmation restates the actual write.
+            payload["currency_code"] = locked_trip.currency_code
+
+        timeline_create_result = plan_timeline_create_draft(
             action_type=action_type,
+            trip=locked_trip,
             payload=payload,
+            lock_section=action_type == AI_ACTION_TIMELINE_ACTIVITY_CREATE,
         )
-        missing = build_missing_fields_for_action(
+        payload = timeline_create_result.payload
+        timeline_result = plan_timeline_update_draft(
             action_type=action_type,
+            trip=locked_trip,
             payload=payload,
-            missing=missing_names,
+            lock_target=action_type == AI_ACTION_TIMELINE_ACTIVITY_UPDATE,
         )
-    else:
-        missing = missing_fields
-    effective_status = status or (
-        AIActionDraftStatus.NEEDS_INFO if missing else AIActionDraftStatus.READY
-    )
-    expires_at = timezone.now() + timedelta(
-        seconds=settings.GOPLAN_AI_ACTION_DRAFT_TTL_SECONDS
-    )
-    trip_context = {
-        "timezone": trip.timezone,
-        "currency_code": trip.currency_code,
-    }
-    return AIActionDraft.objects.create(
-        trip=trip,
-        interaction=interaction,
-        response_message=response_message,
-        requested_by=interaction.requested_by,
-        action_type=action_type,
-        status=effective_status,
-        payload=payload,
-        preview=payload,
-        display=build_display(
+        payload = timeline_result.payload
+        timeline_field_errors = {
+            **timeline_create_result.field_errors,
+            **timeline_result.field_errors,
+        }
+
+        if missing_fields is None:
+            missing_names = missing_payload_field_names(
+                action_type=action_type,
+                payload=payload,
+                currency_code=locked_trip.currency_code,
+            )
+            missing_names = list(
+                dict.fromkeys(
+                    [*missing_names, *timeline_field_errors.keys()]
+                )
+            )
+            missing = build_missing_fields_for_action(
+                action_type=action_type,
+                payload=payload,
+                missing=missing_names,
+                trip_id=locked_trip.id,
+            )
+        else:
+            missing = list(missing_fields)
+            existing_missing_names = set(
+                normalize_missing_field_names(missing, strict=False)
+            )
+            planner_missing_names = [
+                name
+                for name in timeline_field_errors
+                if name not in existing_missing_names
+            ]
+            if planner_missing_names:
+                missing.extend(
+                    build_missing_fields_for_action(
+                        action_type=action_type,
+                        payload=payload,
+                        missing=planner_missing_names,
+                        trip_id=locked_trip.id,
+                    )
+                )
+        if missing and status in {None, AIActionDraftStatus.READY}:
+            effective_status = AIActionDraftStatus.NEEDS_INFO
+        else:
+            effective_status = status or AIActionDraftStatus.READY
+        expires_at = timezone.now() + timedelta(
+            seconds=settings.GOPLAN_AI_ACTION_DRAFT_TTL_SECONDS
+        )
+        preview, display = build_action_draft_presentation(
             action_type=action_type,
             payload=payload,
-            trip_context=trip_context,
-        ),
-        summary=summarize_draft(
+            trip=locked_trip,
+            timeline_plan=timeline_result.plan,
+            timeline_create_plan=timeline_create_result.plan,
+        )
+        return AIActionDraft.objects.create(
+            trip=locked_trip,
+            interaction=interaction,
+            response_message=response_message,
+            requested_by=interaction.requested_by,
             action_type=action_type,
-            payload=payload,
             status=effective_status,
-        ),
-        missing_fields=missing,
-        preconditions=preconditions or {},
-        required_confirmation=(
-            required_confirmation
-            or required_confirmation_for_action_type(action_type)
-        ),
-        expires_at=expires_at,
-    )
+            payload=payload,
+            preview=preview,
+            display=display,
+            summary=summarize_draft(
+                action_type=action_type,
+                payload=payload,
+                status=effective_status,
+            ),
+            missing_fields=missing,
+            preconditions=preconditions or {},
+            required_confirmation=(
+                required_confirmation
+                or required_confirmation_for_action_type(action_type)
+            ),
+            expires_at=expires_at,
+        )
 
 
 def _effective_draft_status(draft: AIActionDraft) -> str:
@@ -274,7 +337,7 @@ def _active_member_options(*, trip_id) -> list[dict]:
             TripMember.objects
             .select_related("user")
             .filter(trip_id=trip_id, status=MemberStatus.ACTIVE)
-            .order_by("role", "created_at")
+            .order_by("role", "joined_at")
         )
     ]
 

--- a/backend/ai/agent/executor.py
+++ b/backend/ai/agent/executor.py
@@ -22,6 +22,10 @@ from ai.action_types import (
     AI_ACTION_TIMELINE_ACTIVITY_UPDATE,
 )
 from ai.agent.drafts import can_confirm_action_draft
+from ai.agent.timeline_draft_validation import (
+    plan_timeline_create_draft,
+    plan_timeline_update_draft,
+)
 from ai.agent.payload_validation import (
     TIMELINE_ACTIVITY_DATA_FIELDS,
     missing_payload_field_names,
@@ -99,7 +103,7 @@ def _check_object_precondition(*, current_updated_at, expected_updated_at) -> No
         )
 
 
-def _check_preconditions(draft: AIActionDraft) -> None:
+def _check_preconditions(draft: AIActionDraft):
     expected_target = expected_precondition_target(
         action_type=draft.action_type,
         payload=draft.payload,
@@ -135,13 +139,18 @@ def _check_preconditions(draft: AIActionDraft) -> None:
             current_updated_at=expense.updated_at,
             expected_updated_at=expected_updated_at,
         )
-        return
+        return expense
 
     if target_type == "timeline_activity":
         try:
-            activity = TimelineActivity.objects.select_for_update().get(
-                pk=expected_target.target_id,
-                trip_id=draft.trip_id,
+            activity = (
+                TimelineActivity.objects.select_for_update(of=("self",))
+                .select_related("section", "custom_type", "assignee_user")
+                .prefetch_related("reminders")
+                .get(
+                    pk=expected_target.target_id,
+                    trip_id=draft.trip_id,
+                )
             )
         except TimelineActivity.DoesNotExist as exc:
             raise AIActionDraftStaleError("Draft target no longer exists.") from exc
@@ -149,15 +158,24 @@ def _check_preconditions(draft: AIActionDraft) -> None:
             current_updated_at=activity.updated_at,
             expected_updated_at=expected_updated_at,
         )
-        return
+        return activity
 
     raise AIActionDraftStaleError("Draft target precondition is unsupported.")
 
 
 def _validate_action_payload_ready(draft: AIActionDraft) -> None:
+    if draft.action_type == AI_ACTION_EXPENSE_CREATE:
+        payload_currency = str(draft.payload.get("currency_code") or "").upper()
+        trip_currency = str(draft.trip.currency_code).upper()
+        if payload_currency and payload_currency != trip_currency:
+            raise AIActionDraftNotReadyError(
+                "Draft currency does not match the trip currency."
+            )
+
     missing_names = missing_payload_field_names(
         action_type=draft.action_type,
         payload=draft.payload,
+        currency_code=draft.trip.currency_code,
     )
     if missing_names:
         raise AIActionDraftNotReadyError(
@@ -658,18 +676,46 @@ def confirm_action_draft(*, draft_id, trip_id, actor) -> AIActionDraft:
                     locked_trip=locked_trip,
                 )
         else:
+            original_payload = draft.payload
             normalized_payload = _normalized_timeline_activity_payload(
                 action_type=draft.action_type,
                 payload=draft.payload,
             )
-            payload_normalized = normalized_payload != draft.payload
-            if payload_normalized:
+            if normalized_payload != draft.payload:
                 draft.payload = normalized_payload
             _validate_action_payload_ready(draft)
             if not can_confirm_action_draft(draft, viewer=actor):
                 raise AIActionDraftForbiddenError("You cannot confirm this draft.")
 
-            _check_preconditions(draft)
+            locked_target = _check_preconditions(draft)
+            timeline_create_result = plan_timeline_create_draft(
+                action_type=draft.action_type,
+                trip=locked_trip,
+                payload=draft.payload,
+                lock_section=True,
+            )
+            if timeline_create_result.field_errors:
+                first_error = next(
+                    iter(timeline_create_result.field_errors.values())
+                )
+                raise AIActionDraftNotReadyError(first_error)
+            draft.payload = timeline_create_result.payload
+            timeline_result = plan_timeline_update_draft(
+                action_type=draft.action_type,
+                trip=locked_trip,
+                payload=draft.payload,
+                lock_target=False,
+                activity=(
+                    locked_target
+                    if isinstance(locked_target, TimelineActivity)
+                    else None
+                ),
+            )
+            if timeline_result.field_errors:
+                first_error = next(iter(timeline_result.field_errors.values()))
+                raise AIActionDraftNotReadyError(first_error)
+            draft.payload = timeline_result.payload
+            payload_normalized = draft.payload != original_payload
             result = _execute(draft, actor=actor)
             draft.status = AIActionDraftStatus.CONFIRMED
             draft.confirmed_by = actor

--- a/backend/ai/agent/executor.py
+++ b/backend/ai/agent/executor.py
@@ -53,9 +53,11 @@ from trips.models import (
     TimelineSection,
     Trip,
     TripMember,
+    TripStatus,
 )
 from trips.services import (
     TimelineSectionDateConflictError,
+    TripTerminalError,
     create_timeline_activity,
     create_timeline_day,
     delete_timeline_activity,
@@ -620,6 +622,8 @@ def mark_action_draft_failed(
             )
         except AIActionDraft.DoesNotExist:
             return None
+        if locked_trip.status in {TripStatus.COMPLETED, TripStatus.CANCELLED}:
+            return draft
         if draft.status != AIActionDraftStatus.READY:
             return draft
         draft.status = AIActionDraftStatus.FAILED
@@ -664,6 +668,8 @@ def confirm_action_draft(*, draft_id, trip_id, actor) -> AIActionDraft:
         draft.trip = locked_trip
         if draft.status == AIActionDraftStatus.CONFIRMED:
             return draft
+        if locked_trip.status in {TripStatus.COMPLETED, TripStatus.CANCELLED}:
+            raise TripTerminalError("Completed or cancelled trips are read-only.")
         if draft.status != AIActionDraftStatus.READY:
             raise AIActionDraftNotReadyError("Draft is not ready.")
         if draft.expires_at <= timezone.now():

--- a/backend/ai/agent/payload_validation.py
+++ b/backend/ai/agent/payload_validation.py
@@ -16,6 +16,11 @@ from ai.action_types import (
     AI_ACTION_TIMELINE_ACTIVITY_STATUS_UPDATE,
     AI_ACTION_TIMELINE_ACTIVITY_UPDATE,
 )
+from expenses.services import (
+    ExpenseServiceError,
+    normalize_currency_amount,
+    normalize_non_negative_currency_amount,
+)
 from trips.models import (
     TimelineActivityStatus,
     TimelineActivityTimeMode,
@@ -143,7 +148,49 @@ def _append_once(names: list[str], field: str) -> None:
         names.append(field)
 
 
-def _is_invalid_money_value(value, *, allow_zero: bool = False) -> bool:
+def currency_amount_validation_error(
+    value,
+    *,
+    currency_code: str,
+    allow_zero: bool = False,
+) -> str | None:
+    """Return the expense-domain error for a currency-incompatible amount."""
+    if is_missing_value(value):
+        return None
+    try:
+        amount = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return "Enter a valid amount."
+    if not amount.is_finite():
+        return "Enter a valid amount."
+
+    normalize = (
+        normalize_non_negative_currency_amount
+        if allow_zero
+        else normalize_currency_amount
+    )
+    try:
+        normalize(amount, currency_code)
+    except ExpenseServiceError as exc:
+        return str(exc)
+    return None
+
+
+def _is_invalid_money_value(
+    value,
+    *,
+    allow_zero: bool = False,
+    currency_code: str | None = None,
+) -> bool:
+    if currency_code:
+        return (
+            currency_amount_validation_error(
+                value,
+                currency_code=currency_code,
+                allow_zero=allow_zero,
+            )
+            is not None
+        )
     if is_missing_value(value):
         return False
     try:
@@ -161,17 +208,30 @@ def _append_invalid_money_field(
     field: str,
     *,
     allow_zero: bool = False,
+    currency_code: str | None = None,
 ) -> None:
     if field in payload and _is_invalid_money_value(
         payload.get(field),
         allow_zero=allow_zero,
+        currency_code=currency_code,
     ):
         _append_once(names, field)
 
 
-def _append_invalid_contribution_amounts(names: list[str], payload: dict) -> None:
+def _append_invalid_contribution_amounts(
+    names: list[str],
+    payload: dict,
+    *,
+    currency_code: str | None = None,
+) -> None:
     for field in EXPENSE_CONTRIBUTION_AMOUNT_FIELDS:
-        _append_invalid_money_field(names, payload, field, allow_zero=True)
+        _append_invalid_money_field(
+            names,
+            payload,
+            field,
+            allow_zero=True,
+            currency_code=currency_code,
+        )
 
     contributions = payload.get("contributions")
     if isinstance(contributions, list):
@@ -182,6 +242,7 @@ def _append_invalid_contribution_amounts(names: list[str], payload: dict) -> Non
                 _is_invalid_money_value(
                     contribution.get(field),
                     allow_zero=True,
+                    currency_code=currency_code,
                 )
                 for field in EXPENSE_CONTRIBUTION_AMOUNT_FIELDS
                 if field in contribution
@@ -192,13 +253,18 @@ def _append_invalid_contribution_amounts(names: list[str], payload: dict) -> Non
     if isinstance(member_contributions, dict):
         for contribution in member_contributions.values():
             if not isinstance(contribution, dict):
-                if _is_invalid_money_value(contribution, allow_zero=True):
+                if _is_invalid_money_value(
+                    contribution,
+                    allow_zero=True,
+                    currency_code=currency_code,
+                ):
                     _append_once(names, "amount")
                 continue
             if any(
                 _is_invalid_money_value(
                     contribution.get(field),
                     allow_zero=True,
+                    currency_code=currency_code,
                 )
                 for field in EXPENSE_CONTRIBUTION_AMOUNT_FIELDS
                 if field in contribution
@@ -206,35 +272,59 @@ def _append_invalid_contribution_amounts(names: list[str], payload: dict) -> Non
                 _append_once(names, "amount")
 
 
-def _has_valid_contribution_amount(payload: dict) -> bool:
+def _has_valid_contribution_amount(
+    payload: dict,
+    *,
+    currency_code: str | None = None,
+) -> bool:
     for field in EXPENSE_CONTRIBUTION_AMOUNT_FIELDS:
         if field not in payload:
             continue
         value = payload.get(field)
         if is_missing_value(value):
             continue
-        return not _is_invalid_money_value(value, allow_zero=True)
+        return not _is_invalid_money_value(
+            value,
+            allow_zero=True,
+            currency_code=currency_code,
+        )
     return False
 
 
-def _has_valid_member_contribution_amount(value) -> bool:
+def _has_valid_member_contribution_amount(
+    value,
+    *,
+    currency_code: str | None = None,
+) -> bool:
     if isinstance(value, dict):
-        return _has_valid_contribution_amount(value)
+        return _has_valid_contribution_amount(
+            value,
+            currency_code=currency_code,
+        )
     if is_missing_value(value):
         return False
-    return not _is_invalid_money_value(value, allow_zero=True)
+    return not _is_invalid_money_value(
+        value,
+        allow_zero=True,
+        currency_code=currency_code,
+    )
 
 
 def _append_invalid_explicit_contribution_payloads(
     names: list[str],
     payload: dict,
+    *,
+    currency_code: str | None = None,
 ) -> None:
     contributions = payload.get("contributions")
     if isinstance(contributions, list) and contributions:
         has_invalid_item = any(
             not isinstance(contribution, dict)
             or not _has_any_value(contribution, EXPENSE_CONTRIBUTION_USER_FIELDS)
-            or not _has_valid_contribution_amount(contribution)
+            or not _has_valid_contribution_amount(
+                contribution,
+                currency_code=currency_code,
+            )
             for contribution in contributions
         )
         if has_invalid_item:
@@ -244,7 +334,10 @@ def _append_invalid_explicit_contribution_payloads(
     if isinstance(member_contributions, dict) and member_contributions:
         has_invalid_item = any(
             is_missing_value(member_id)
-            or not _has_valid_member_contribution_amount(contribution)
+            or not _has_valid_member_contribution_amount(
+                contribution,
+                currency_code=currency_code,
+            )
             for member_id, contribution in member_contributions.items()
         )
         if has_invalid_item:
@@ -375,6 +468,7 @@ def missing_payload_field_names(
     action_type: str,
     payload: dict,
     provider_missing_names: list[str] | None = None,
+    currency_code: str | None = None,
 ) -> list[str]:
     provider_missing_names = provider_missing_names or []
 
@@ -386,7 +480,12 @@ def missing_payload_field_names(
         )
         _require_field(names, payload, "title")
         _require_field(names, payload, "total_amount")
-        _append_invalid_money_field(names, payload, "total_amount")
+        _append_invalid_money_field(
+            names,
+            payload,
+            "total_amount",
+            currency_code=currency_code,
+        )
         return names
 
     if action_type == AI_ACTION_EXPENSE_UPDATE:
@@ -398,7 +497,12 @@ def missing_payload_field_names(
         _require_field(names, payload, "expense_id")
         if not _has_any_expense_update_field(payload):
             _append_once(names, "title")
-        _append_invalid_money_field(names, payload, "total_amount")
+        _append_invalid_money_field(
+            names,
+            payload,
+            "total_amount",
+            currency_code=currency_code,
+        )
         return names
 
     if action_type == AI_ACTION_EXPENSE_DELETE:
@@ -426,13 +530,21 @@ def missing_payload_field_names(
         _require_field(names, payload, "expense_id")
         has_explicit_contributions = _has_explicit_contributions(payload)
         if has_explicit_contributions:
-            _append_invalid_explicit_contribution_payloads(names, payload)
+            _append_invalid_explicit_contribution_payloads(
+                names,
+                payload,
+                currency_code=currency_code,
+            )
         elif not _should_mark_all_participants_paid(payload):
             if not _has_any_value(payload, EXPENSE_CONTRIBUTION_USER_FIELDS):
                 names.append("user_id")
             if not _has_any_value(payload, EXPENSE_CONTRIBUTION_AMOUNT_FIELDS):
                 names.append("amount")
-        _append_invalid_contribution_amounts(names, payload)
+        _append_invalid_contribution_amounts(
+            names,
+            payload,
+            currency_code=currency_code,
+        )
         return list(dict.fromkeys(names))
 
     if action_type == AI_ACTION_TIMELINE_ACTIVITY_CREATE:

--- a/backend/ai/agent/timeline_draft_validation.py
+++ b/backend/ai/agent/timeline_draft_validation.py
@@ -18,9 +18,11 @@ from trips.services import (
     TimelineInvalidAssigneeError,
     TimelineInvalidCustomTypeError,
     TimelineSectionNotFoundError,
+    normalize_timeline_activity_input,
     plan_timeline_activity_create,
     plan_timeline_activity_patch,
     resolve_timeline_activity_create_references,
+    timeline_json_value,
 )
 
 
@@ -114,9 +116,14 @@ def plan_timeline_create_draft(
             blocking_field_errors={"data": "Activity data must be an object."},
         )
 
+    normalized_data = normalize_timeline_activity_input(data)
+    normalized_payload = {
+        **payload,
+        "data": timeline_json_value(normalized_data),
+    }
     missing_names = missing_payload_field_names(
         action_type=action_type,
-        payload=payload,
+        payload=normalized_payload,
         currency_code=trip.currency_code,
     )
     field_errors = {
@@ -138,7 +145,7 @@ def plan_timeline_create_draft(
         try:
             references = resolve_timeline_activity_create_references(
                 trip=trip,
-                data=data,
+                data=normalized_data,
                 section_id=section_id,
                 lock_section=lock_section,
                 require_section=not has_section_date,
@@ -156,7 +163,7 @@ def plan_timeline_create_draft(
 
     if field_errors:
         return TimelineDraftCreateResult(
-            payload=payload,
+            payload=normalized_payload,
             plan=None,
             field_errors=field_errors,
             blocking_field_errors=blocking_field_errors,
@@ -165,7 +172,7 @@ def plan_timeline_create_draft(
     try:
         plan = plan_timeline_activity_create(
             trip=trip,
-            data=data,
+            data=normalized_data,
             section_id=section_id,
             section=(references.section if references is not None else None),
             lock_section=False,
@@ -202,7 +209,7 @@ def plan_timeline_create_draft(
             blocking_field_errors={"assignee_user_id": str(exc)},
         )
 
-    canonical_payload = {**payload, "data": plan.data}
+    canonical_payload = {**normalized_payload, "data": plan.data}
     if plan.section is not None:
         canonical_payload["section_id"] = str(plan.section.id)
     return TimelineDraftCreateResult(

--- a/backend/ai/agent/timeline_draft_validation.py
+++ b/backend/ai/agent/timeline_draft_validation.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from rest_framework import serializers as drf_serializers
+
+from ai.action_types import (
+    AI_ACTION_TIMELINE_ACTIVITY_CREATE,
+    AI_ACTION_TIMELINE_ACTIVITY_UPDATE,
+)
+from ai.agent.payload_validation import missing_payload_field_names
+from trips.models import TimelineActivity, TimelineActivityTimeMode, Trip
+from trips.services import (
+    TimelineActivityCreatePlan,
+    TimelineActivityNotFoundError,
+    TimelineActivityPatchPlan,
+    TimelineInvalidAssigneeError,
+    TimelineInvalidCustomTypeError,
+    TimelineSectionNotFoundError,
+    plan_timeline_activity_create,
+    plan_timeline_activity_patch,
+    resolve_timeline_activity_create_references,
+)
+
+
+@dataclass(frozen=True)
+class TimelineDraftCreateResult:
+    payload: dict
+    plan: TimelineActivityCreatePlan | None
+    field_errors: dict[str, str]
+    blocking_field_errors: dict[str, str]
+
+
+@dataclass(frozen=True)
+class TimelineDraftPatchResult:
+    payload: dict
+    activity: TimelineActivity | None
+    plan: TimelineActivityPatchPlan | None
+    field_errors: dict[str, str]
+
+
+def _first_error_text(value) -> str:
+    if isinstance(value, dict):
+        for nested in value.values():
+            return _first_error_text(nested)
+    if isinstance(value, (list, tuple)):
+        for nested in value:
+            return _first_error_text(nested)
+    return str(value)
+
+
+def _drf_field_errors(detail) -> dict[str, str]:
+    if not isinstance(detail, dict):
+        return {"data": _first_error_text(detail)}
+    errors: dict[str, str] = {}
+    for raw_field, value in detail.items():
+        field = str(raw_field)
+        if field == "non_field_errors":
+            field = "data"
+        errors[field] = _first_error_text(value)
+    return errors
+
+
+def _complete_time_range_errors(
+    *,
+    activity: TimelineActivity,
+    data: dict,
+    errors: dict[str, str],
+) -> dict[str, str]:
+    final_time_mode = data.get("time_mode", activity.time_mode)
+    if final_time_mode != TimelineActivityTimeMode.TIME_RANGE:
+        return errors
+    final_start_time = data.get("start_time", activity.start_time)
+    final_end_time = data.get("end_time", activity.end_time)
+    completed = dict(errors)
+    if final_start_time is None:
+        completed.setdefault("start_time", "This field is required.")
+    if final_end_time is None:
+        completed.setdefault("end_time", "This field is required.")
+    return completed
+
+
+def _activity_queryset(*, lock_target: bool):
+    queryset = TimelineActivity.objects.select_related(
+        "section",
+        "custom_type",
+        "assignee_user",
+    ).prefetch_related("reminders")
+    return queryset.select_for_update(of=("self",)) if lock_target else queryset
+
+
+def plan_timeline_create_draft(
+    *,
+    action_type: str,
+    trip: Trip,
+    payload: dict,
+    lock_section: bool,
+) -> TimelineDraftCreateResult:
+    if action_type != AI_ACTION_TIMELINE_ACTIVITY_CREATE:
+        return TimelineDraftCreateResult(
+            payload=payload,
+            plan=None,
+            field_errors={},
+            blocking_field_errors={},
+        )
+
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        return TimelineDraftCreateResult(
+            payload=payload,
+            plan=None,
+            field_errors={"data": "Activity data must be an object."},
+            blocking_field_errors={"data": "Activity data must be an object."},
+        )
+
+    missing_names = missing_payload_field_names(
+        action_type=action_type,
+        payload=payload,
+        currency_code=trip.currency_code,
+    )
+    field_errors = {
+        name: "This field is required or invalid."
+        for name in missing_names
+    }
+    blocking_field_errors = {}
+    section_id = payload.get("section_id")
+    has_section_date = bool(payload.get("section_date"))
+    references = None
+    has_section_id = (
+        bool(str(section_id).strip())
+        if section_id is not None
+        else False
+    )
+    if not has_section_id and not has_section_date:
+        field_errors.setdefault("section_id", "Timeline day is required.")
+    else:
+        try:
+            references = resolve_timeline_activity_create_references(
+                trip=trip,
+                data=data,
+                section_id=section_id,
+                lock_section=lock_section,
+                require_section=not has_section_date,
+            )
+        except TimelineSectionNotFoundError:
+            message = "Timeline day could not be resolved."
+            field_errors["section_id"] = message
+            blocking_field_errors["section_id"] = message
+        except TimelineInvalidCustomTypeError as exc:
+            field_errors["custom_type_id"] = str(exc)
+            blocking_field_errors["custom_type_id"] = str(exc)
+        except TimelineInvalidAssigneeError as exc:
+            field_errors["assignee_user_id"] = str(exc)
+            blocking_field_errors["assignee_user_id"] = str(exc)
+
+    if field_errors:
+        return TimelineDraftCreateResult(
+            payload=payload,
+            plan=None,
+            field_errors=field_errors,
+            blocking_field_errors=blocking_field_errors,
+        )
+
+    try:
+        plan = plan_timeline_activity_create(
+            trip=trip,
+            data=data,
+            section_id=section_id,
+            section=(references.section if references is not None else None),
+            lock_section=False,
+            require_section=not has_section_date,
+        )
+    except drf_serializers.ValidationError as exc:
+        return TimelineDraftCreateResult(
+            payload=payload,
+            plan=None,
+            field_errors=_drf_field_errors(exc.detail),
+            blocking_field_errors=_drf_field_errors(exc.detail),
+        )
+    except TimelineSectionNotFoundError:
+        return TimelineDraftCreateResult(
+            payload=payload,
+            plan=None,
+            field_errors={"section_id": "Timeline day could not be resolved."},
+            blocking_field_errors={
+                "section_id": "Timeline day could not be resolved."
+            },
+        )
+    except TimelineInvalidCustomTypeError as exc:
+        return TimelineDraftCreateResult(
+            payload=payload,
+            plan=None,
+            field_errors={"custom_type_id": str(exc)},
+            blocking_field_errors={"custom_type_id": str(exc)},
+        )
+    except TimelineInvalidAssigneeError as exc:
+        return TimelineDraftCreateResult(
+            payload=payload,
+            plan=None,
+            field_errors={"assignee_user_id": str(exc)},
+            blocking_field_errors={"assignee_user_id": str(exc)},
+        )
+
+    canonical_payload = {**payload, "data": plan.data}
+    if plan.section is not None:
+        canonical_payload["section_id"] = str(plan.section.id)
+    return TimelineDraftCreateResult(
+        payload=canonical_payload,
+        plan=plan,
+        field_errors={},
+        blocking_field_errors={},
+    )
+
+
+def plan_timeline_update_draft(
+    *,
+    action_type: str,
+    trip: Trip,
+    payload: dict,
+    lock_target: bool,
+    activity: TimelineActivity | None = None,
+) -> TimelineDraftPatchResult:
+    if action_type != AI_ACTION_TIMELINE_ACTIVITY_UPDATE:
+        return TimelineDraftPatchResult(
+            payload=payload,
+            activity=None,
+            plan=None,
+            field_errors={},
+        )
+
+    if activity is None:
+        try:
+            activity = _activity_queryset(lock_target=lock_target).get(
+                pk=payload.get("activity_id"),
+                trip=trip,
+            )
+        except (
+            TimelineActivity.DoesNotExist,
+            TypeError,
+            ValueError,
+            DjangoValidationError,
+        ):
+            return TimelineDraftPatchResult(
+                payload=payload,
+                activity=None,
+                plan=None,
+                field_errors={"activity_id": "Activity could not be resolved."},
+            )
+
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        return TimelineDraftPatchResult(
+            payload=payload,
+            activity=activity,
+            plan=None,
+            field_errors={"data": "Activity patch must be an object."},
+        )
+
+    try:
+        plan = plan_timeline_activity_patch(
+            trip=trip,
+            activity=activity,
+            data=data,
+        )
+    except drf_serializers.ValidationError as exc:
+        field_errors = _complete_time_range_errors(
+            activity=activity,
+            data=data,
+            errors=_drf_field_errors(exc.detail),
+        )
+        return TimelineDraftPatchResult(
+            payload=payload,
+            activity=activity,
+            plan=None,
+            field_errors=field_errors,
+        )
+    except TimelineInvalidCustomTypeError as exc:
+        return TimelineDraftPatchResult(
+            payload=payload,
+            activity=activity,
+            plan=None,
+            field_errors={"custom_type_id": str(exc)},
+        )
+    except TimelineInvalidAssigneeError as exc:
+        return TimelineDraftPatchResult(
+            payload=payload,
+            activity=activity,
+            plan=None,
+            field_errors={"assignee_user_id": str(exc)},
+        )
+    except TimelineActivityNotFoundError:
+        return TimelineDraftPatchResult(
+            payload=payload,
+            activity=None,
+            plan=None,
+            field_errors={"activity_id": "Activity could not be resolved."},
+        )
+
+    return TimelineDraftPatchResult(
+        payload={**payload, "data": plan.data},
+        activity=activity,
+        plan=plan,
+        field_errors={},
+    )

--- a/backend/ai/tests/test_action_drafts.py
+++ b/backend/ai/tests/test_action_drafts.py
@@ -106,6 +106,36 @@ class AIActionDraftModelTests(TestCase):
 
 
 class AIActionDraftPayloadTests(AIActionDraftModelTests):
+    def test_partial_timeline_create_keeps_json_safe_clock_until_complete(self):
+        section = self.trip.timeline_sections.order_by("section_date").first()
+
+        draft = create_action_draft(
+            trip=self.trip,
+            interaction=self.interaction,
+            response_message=self.response_message,
+            action_type="timeline.activity.create",
+            payload={
+                "section_id": str(section.id),
+                "data": {
+                    "title": "Museum visit",
+                    "system_type": "SIGHTSEEING",
+                    "time_mode": "TIME_RANGE",
+                    "start_time": "2026-04-20T08:00:00+07:00",
+                },
+            },
+        )
+
+        draft.refresh_from_db()
+        self.assertEqual(draft.status, AIActionDraftStatus.NEEDS_INFO)
+        self.assertEqual(
+            draft.payload["data"]["start_time"],
+            "08:00:00",
+        )
+        self.assertEqual(
+            {field["name"] for field in draft.missing_fields},
+            {"end_time"},
+        )
+
     def test_captain_can_confirm_captain_managed_draft(self):
         draft = AIActionDraft.objects.create(
             trip=self.trip,
@@ -768,7 +798,11 @@ class AIActionDraftPatchTests(APITestCase, AIActionDraftModelTests):
         push_chat_message,
     ):
         draft = self._create_patch_draft(
-            payload={"title": "Lunch", "total_amount": "500000"},
+            payload={
+                "title": "Lunch",
+                "total_amount": "500000",
+                "currency_code": self.trip.currency_code,
+            },
         )
 
         self._assert_patch_request_is_a_true_noop(
@@ -1009,6 +1043,59 @@ class AIActionDraftPatchTests(APITestCase, AIActionDraftModelTests):
         self.assertEqual(confirmed.status, AIActionDraftStatus.CONFIRMED)
         self.assertEqual(expense.total_amount, Decimal("25.50"))
         self.assertEqual(expense.currency_code, "USD")
+
+    @patch("ai.chat_changes.push_chat_message")
+    def test_same_amount_patch_after_currency_change_restamps_and_revalidates(
+        self,
+        push_chat_message,
+    ):
+        from trips.models import Trip
+
+        draft = create_action_draft(
+            trip=self.trip,
+            interaction=self.interaction,
+            response_message=self.response_message,
+            action_type="expense.create",
+            payload={
+                "title": "Lunch",
+                "currency_code": "VND",
+                "total_amount": "25.50",
+            },
+        )
+        self.assertEqual(draft.status, AIActionDraftStatus.NEEDS_INFO)
+        self.assertEqual(draft.payload["currency_code"], "VND")
+        self.assertEqual(draft.payload["total_amount"], "25.50")
+        self.assertIn(
+            "total_amount",
+            {field["name"] for field in draft.missing_fields},
+        )
+        Trip.objects.filter(pk=self.trip.pk).update(currency_code="USD")
+        self.client.force_authenticate(self.user)
+
+        with self.captureOnCommitCallbacks(execute=False) as callbacks:
+            response = self.client.patch(
+                f"/api/trips/{self.trip.id}/ai/action-drafts/{draft.id}",
+                {"payload": {"total_amount": "25.50"}},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["draft"]["status"], AIActionDraftStatus.READY)
+        self.assertEqual(response.data["draft"]["preview"]["currency_code"], "USD")
+        self.assertEqual(response.data["draft"]["display"]["hero"]["currency"], "USD")
+        draft.refresh_from_db()
+        self.trip.refresh_from_db()
+        self.response_message.refresh_from_db()
+        self.assertEqual(draft.status, AIActionDraftStatus.READY)
+        self.assertEqual(draft.payload["currency_code"], "USD")
+        self.assertEqual(draft.payload["total_amount"], "25.50")
+        self.assertEqual(draft.preview["currency_code"], "USD")
+        self.assertEqual(draft.display["hero"]["currency"], "USD")
+        self.assertEqual(draft.missing_fields, [])
+        self.assertEqual(self.trip.chat_change_sequence, 1)
+        self.assertEqual(self.response_message.change_sequence, 1)
+        self.assertEqual(len(callbacks), 1)
+        push_chat_message.assert_not_called()
 
     @patch("ai.chat_changes.push_chat_message")
     def test_currency_change_patch_rejects_amount_invalid_for_current_trip(
@@ -2301,6 +2388,106 @@ class AIActionDraftPatchFieldValidationTests(APITestCase, AIActionDraftModelTest
         )
 
         self.assertEqual(res.status_code, 200)
+        draft.refresh_from_db()
+        self.assertEqual(
+            draft.status,
+            AIActionDraftStatus.READY,
+            {"missing_fields": draft.missing_fields, "payload": draft.payload},
+        )
+        self.assertEqual(draft.missing_fields, [])
+        self.assertNotIn("title", draft.payload)
+        self.assertNotIn("system_type", draft.payload)
+        self.assertNotIn("time_mode", draft.payload)
+        self.assertEqual(draft.payload["data"]["title"], "Museum Visit")
+        self.assertEqual(draft.payload["data"]["system_type"], "SIGHTSEEING")
+        self.assertEqual(draft.payload["data"]["time_mode"], "TIME_RANGE")
+        self.assertEqual(draft.payload["data"]["start_time"], "08:00:00")
+        self.assertEqual(draft.payload["data"]["end_time"], "10:00:00")
+
+    def test_nested_timeline_fields_take_precedence_over_legacy_top_level_fields(self):
+        draft = self._create_needs_info_activity_draft()
+        draft.payload["data"] = {
+            "title": "Canonical museum visit",
+            "system_type": "FOOD",
+            "time_mode": "TIME_RANGE",
+        }
+        draft.save(update_fields=["payload", "updated_at"])
+        self.client.force_authenticate(self.user)
+
+        res = self.client.patch(
+            f"/api/trips/{self.trip.id}/ai/action-drafts/{draft.id}",
+            data={"payload": {"start_time": "08:00", "end_time": "10:00"}},
+            format="json",
+        )
+
+        self.assertEqual(res.status_code, 200)
+        draft.refresh_from_db()
+        self.assertEqual(draft.status, AIActionDraftStatus.READY)
+        self.assertEqual(draft.missing_fields, [])
+        self.assertNotIn("title", draft.payload)
+        self.assertNotIn("system_type", draft.payload)
+        self.assertNotIn("time_mode", draft.payload)
+        self.assertEqual(
+            draft.payload["data"]["title"],
+            "Canonical museum visit",
+        )
+        self.assertEqual(draft.payload["data"]["system_type"], "FOOD")
+        self.assertEqual(draft.payload["data"]["time_mode"], "TIME_RANGE")
+
+    def test_incoming_nested_timeline_fields_win_independent_of_json_key_order(self):
+        section = self.trip.timeline_sections.order_by("section_date").first()
+        patch_payloads = (
+            {
+                "title": "Legacy leaf title",
+                "data": {"title": "Canonical nested title"},
+            },
+            {
+                "data": {"title": "Canonical nested title"},
+                "title": "Legacy leaf title",
+            },
+        )
+        self.client.force_authenticate(self.user)
+
+        for patch_payload in patch_payloads:
+            with self.subTest(keys=tuple(patch_payload)):
+                draft = AIActionDraft.objects.create(
+                    trip=self.trip,
+                    interaction=self.interaction,
+                    response_message=self.response_message,
+                    requested_by=self.user,
+                    action_type="timeline.activity.create",
+                    status=AIActionDraftStatus.NEEDS_INFO,
+                    required_confirmation=AI_CONFIRMATION_CAPTAIN,
+                    payload={
+                        "section_id": str(section.id),
+                        "data": {
+                            "system_type": "SIGHTSEEING",
+                            "time_mode": "FLEXIBLE",
+                        },
+                    },
+                    preview={},
+                    missing_fields=[
+                        {"name": "title", "label": "Title"},
+                        {"name": "data", "label": "Activity details"},
+                    ],
+                    preconditions={},
+                    expires_at=timezone.now() + timedelta(hours=24),
+                )
+
+                response = self.client.patch(
+                    f"/api/trips/{self.trip.id}/ai/action-drafts/{draft.id}",
+                    data={"payload": patch_payload},
+                    format="json",
+                )
+
+                self.assertEqual(response.status_code, 200)
+                draft.refresh_from_db()
+                self.assertEqual(draft.status, AIActionDraftStatus.READY)
+                self.assertEqual(
+                    draft.payload["data"]["title"],
+                    "Canonical nested title",
+                )
+                self.assertNotIn("title", draft.payload)
 
     def test_patch_synthetic_time_range_updates_nested_payload(self):
         section = self.trip.timeline_sections.order_by("section_date").first()

--- a/backend/ai/tests/test_action_drafts.py
+++ b/backend/ai/tests/test_action_drafts.py
@@ -641,6 +641,68 @@ class AIActionDraftPatchTests(APITestCase, AIActionDraftModelTests):
             expires_at=expires_at or timezone.now() + timedelta(hours=24),
         )
 
+    def _create_contribution_patch_draft(self, *, missing_field):
+        return AIActionDraft.objects.create(
+            trip=self.trip,
+            interaction=self.interaction,
+            response_message=self.response_message,
+            requested_by=self.user,
+            action_type="expense.contribution.set",
+            status=AIActionDraftStatus.NEEDS_INFO,
+            required_confirmation=AI_CONFIRMATION_CAPTAIN,
+            payload={"expense_id": str(uuid4())},
+            preview={"title": "Record contribution"},
+            missing_fields=[
+                {"name": missing_field, "label": "Contribution amount"}
+            ],
+            preconditions={},
+            expires_at=timezone.now() + timedelta(hours=24),
+        )
+
+    def _assert_field_validation_patch_preserves_snapshot(
+        self,
+        *,
+        draft,
+        patch_payload,
+        expected_field_errors,
+        push_chat_message,
+    ):
+        self.client.force_authenticate(self.user)
+        original_payload = draft.payload
+        draft_updated_at = draft.updated_at
+        message_updated_at = self.response_message.updated_at
+        original_trip_sequence = self.trip.chat_change_sequence
+        original_message_sequence = self.response_message.change_sequence
+
+        with self.captureOnCommitCallbacks(execute=False) as callbacks:
+            response = self.client.patch(
+                f"/api/trips/{self.trip.id}/ai/action-drafts/{draft.id}",
+                {"payload": patch_payload},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["error_code"], "FIELD_VALIDATION_FAILED")
+        self.assertEqual(response.data["field_errors"], expected_field_errors)
+        self.assertEqual(
+            response.data["draft"]["status"],
+            AIActionDraftStatus.NEEDS_INFO,
+        )
+        draft.refresh_from_db()
+        self.response_message.refresh_from_db()
+        self.trip.refresh_from_db()
+        self.assertEqual(draft.status, AIActionDraftStatus.NEEDS_INFO)
+        self.assertEqual(draft.payload, original_payload)
+        self.assertEqual(draft.updated_at, draft_updated_at)
+        self.assertEqual(self.response_message.updated_at, message_updated_at)
+        self.assertEqual(
+            self.response_message.change_sequence,
+            original_message_sequence,
+        )
+        self.assertEqual(self.trip.chat_change_sequence, original_trip_sequence)
+        self.assertEqual(callbacks, [])
+        push_chat_message.assert_not_called()
+
     def _assert_patch_request_is_a_true_noop(
         self,
         *,
@@ -886,6 +948,315 @@ class AIActionDraftPatchTests(APITestCase, AIActionDraftModelTests):
         self.assertEqual(response.data["draft"]["preview"]["total_amount"], "500000")
         self.assertEqual(draft.missing_fields, [])
 
+    @patch("ai.chat_changes.push_chat_message")
+    def test_currency_change_patch_restamps_ready_expense_and_confirms(
+        self,
+        push_chat_message,
+    ):
+        from ai.agent.executor import confirm_action_draft
+        from expenses.models import Expense
+        from trips.models import Trip
+
+        draft = create_action_draft(
+            trip=self.trip,
+            interaction=self.interaction,
+            response_message=self.response_message,
+            action_type="expense.create",
+            payload={
+                "title": "Lunch",
+                "currency_code": "VND",
+            },
+        )
+        self.assertEqual(draft.status, AIActionDraftStatus.NEEDS_INFO)
+        self.assertEqual(draft.payload["currency_code"], "VND")
+        self.assertNotIn("hero", draft.display)
+        Trip.objects.filter(pk=self.trip.pk).update(currency_code="USD")
+        self.client.force_authenticate(self.user)
+
+        with self.captureOnCommitCallbacks(execute=False) as callbacks:
+            response = self.client.patch(
+                f"/api/trips/{self.trip.id}/ai/action-drafts/{draft.id}",
+                {"payload": {"total_amount": "25.50"}},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(set(response.data), {"draft"})
+        self.assertEqual(response.data["draft"]["status"], AIActionDraftStatus.READY)
+        self.assertEqual(response.data["draft"]["preview"]["currency_code"], "USD")
+        self.assertEqual(
+            response.data["draft"]["display"]["hero"]["currency"],
+            "USD",
+        )
+        draft.refresh_from_db()
+        self.trip.refresh_from_db()
+        self.response_message.refresh_from_db()
+        self.assertEqual(draft.status, AIActionDraftStatus.READY)
+        self.assertEqual(draft.payload["currency_code"], "USD")
+        self.assertEqual(draft.preview["currency_code"], "USD")
+        self.assertEqual(draft.display["hero"]["currency"], "USD")
+        self.assertEqual(self.trip.chat_change_sequence, 1)
+        self.assertEqual(self.response_message.change_sequence, 1)
+        self.assertEqual(len(callbacks), 1)
+        push_chat_message.assert_not_called()
+
+        confirmed = confirm_action_draft(
+            draft_id=draft.id,
+            trip_id=self.trip.id,
+            actor=self.user,
+        )
+        expense = Expense.objects.get(pk=confirmed.result["object_id"])
+        self.assertEqual(confirmed.status, AIActionDraftStatus.CONFIRMED)
+        self.assertEqual(expense.total_amount, Decimal("25.50"))
+        self.assertEqual(expense.currency_code, "USD")
+
+    @patch("ai.chat_changes.push_chat_message")
+    def test_currency_change_patch_rejects_amount_invalid_for_current_trip(
+        self,
+        push_chat_message,
+    ):
+        from trips.models import Trip
+
+        self.trip.currency_code = "USD"
+        self.trip.save(update_fields=["currency_code", "updated_at"])
+        draft = create_action_draft(
+            trip=self.trip,
+            interaction=self.interaction,
+            response_message=self.response_message,
+            action_type="expense.create",
+            payload={"title": "Lunch"},
+        )
+        self.assertEqual(draft.payload["currency_code"], "USD")
+        Trip.objects.filter(pk=self.trip.pk).update(currency_code="VND")
+
+        self._assert_field_validation_patch_preserves_snapshot(
+            draft=draft,
+            patch_payload={"total_amount": "25.50"},
+            expected_field_errors={
+                "total_amount": (
+                    "Amount has too many decimal places for this currency."
+                )
+            },
+            push_chat_message=push_chat_message,
+        )
+        self.assertEqual(draft.payload["currency_code"], "USD")
+
+    @patch("ai.chat_changes.push_chat_message")
+    def test_empty_patch_after_currency_change_remains_true_noop(
+        self,
+        push_chat_message,
+    ):
+        from trips.models import Trip
+
+        draft = create_action_draft(
+            trip=self.trip,
+            interaction=self.interaction,
+            response_message=self.response_message,
+            action_type="expense.create",
+            payload={"title": "Lunch"},
+        )
+        original_display = draft.display
+        self.assertEqual(draft.payload["currency_code"], "VND")
+        Trip.objects.filter(pk=self.trip.pk).update(currency_code="USD")
+
+        self._assert_patch_request_is_a_true_noop(
+            request_data={"payload": {}},
+            draft=draft,
+            push_chat_message=push_chat_message,
+        )
+        self.assertEqual(draft.payload["currency_code"], "VND")
+        self.assertEqual(draft.display, original_display)
+
+    @patch("ai.chat_changes.push_chat_message")
+    def test_patch_rejects_fractional_vnd_amount_without_mutating_draft(
+        self,
+        push_chat_message,
+    ):
+        self.assertEqual(self.trip.currency_code, "VND")
+        self.client.force_authenticate(self.user)
+        draft = self._create_patch_draft()
+        original_payload = draft.payload
+        draft_updated_at = draft.updated_at
+        message_updated_at = self.response_message.updated_at
+        original_trip_sequence = self.trip.chat_change_sequence
+        original_message_sequence = self.response_message.change_sequence
+
+        with self.captureOnCommitCallbacks(execute=False) as callbacks:
+            response = self.client.patch(
+                f"/api/trips/{self.trip.id}/ai/action-drafts/{draft.id}",
+                {"payload": {"total_amount": "25.50"}},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["error_code"], "FIELD_VALIDATION_FAILED")
+        self.assertEqual(
+            response.data["field_errors"],
+            {
+                "total_amount": (
+                    "Amount has too many decimal places for this currency."
+                )
+            },
+        )
+        self.assertEqual(
+            response.data["draft"]["status"],
+            AIActionDraftStatus.NEEDS_INFO,
+        )
+        draft.refresh_from_db()
+        self.response_message.refresh_from_db()
+        self.trip.refresh_from_db()
+        self.assertEqual(draft.status, AIActionDraftStatus.NEEDS_INFO)
+        self.assertEqual(draft.payload, original_payload)
+        self.assertEqual(draft.updated_at, draft_updated_at)
+        self.assertEqual(self.response_message.updated_at, message_updated_at)
+        self.assertEqual(
+            self.response_message.change_sequence,
+            original_message_sequence,
+        )
+        self.assertEqual(self.trip.chat_change_sequence, original_trip_sequence)
+        self.assertEqual(callbacks, [])
+        push_chat_message.assert_not_called()
+
+    @patch("ai.chat_changes.push_chat_message")
+    def test_patch_rejects_fractional_vnd_for_every_contribution_shape(
+        self,
+        push_chat_message,
+    ):
+        amount_error = "Amount has too many decimal places for this currency."
+        member_id = str(self.user.id)
+        cases = (
+            ("amount", {"amount": "25.50"}, "amount"),
+            ("paid_amount", {"paid_amount": "25.50"}, "paid_amount"),
+            (
+                "contribution_amount",
+                {"contribution_amount": "25.50"},
+                "contribution_amount",
+            ),
+            (
+                "contributions",
+                {
+                    "contributions": [
+                        {"user_id": member_id, "amount": "25.50"}
+                    ]
+                },
+                "contributions.0.amount",
+            ),
+            (
+                "member_contributions",
+                {"member_contributions": {member_id: "25.50"}},
+                f"member_contributions.{member_id}",
+            ),
+            *(
+                (
+                    "member_contributions",
+                    {
+                        "member_contributions": {
+                            member_id: {field: "25.50"}
+                        }
+                    },
+                    f"member_contributions.{member_id}.{field}",
+                )
+                for field in ("amount", "paid_amount", "contribution_amount")
+            ),
+        )
+
+        for missing_field, patch_payload, error_path in cases:
+            with self.subTest(error_path=error_path):
+                draft = self._create_contribution_patch_draft(
+                    missing_field=missing_field,
+                )
+                self._assert_field_validation_patch_preserves_snapshot(
+                    draft=draft,
+                    patch_payload=patch_payload,
+                    expected_field_errors={error_path: amount_error},
+                    push_chat_message=push_chat_message,
+                )
+
+    def test_patch_accepts_max_decimalfield_amount_for_usd(self):
+        self.trip.currency_code = "USD"
+        self.trip.save(update_fields=["currency_code", "updated_at"])
+        self.client.force_authenticate(self.user)
+        draft = self._create_patch_draft()
+
+        response = self.client.patch(
+            f"/api/trips/{self.trip.id}/ai/action-drafts/{draft.id}",
+            {"payload": {"total_amount": "999999999999.99"}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        draft.refresh_from_db()
+        self.assertEqual(draft.status, AIActionDraftStatus.READY)
+        self.assertEqual(draft.payload["total_amount"], "999999999999.99")
+        self.assertEqual(draft.missing_fields, [])
+
+    @patch("ai.chat_changes.push_chat_message")
+    def test_patch_rejects_decimalfield_overflow_without_mutation(
+        self,
+        push_chat_message,
+    ):
+        self.trip.currency_code = "USD"
+        self.trip.save(update_fields=["currency_code", "updated_at"])
+        draft = self._create_patch_draft()
+
+        self._assert_field_validation_patch_preserves_snapshot(
+            draft=draft,
+            patch_payload={"total_amount": "1000000000000.00"},
+            expected_field_errors={
+                "total_amount": (
+                    "Amount must have no more than 12 digits before the decimal point."
+                )
+            },
+            push_chat_message=push_chat_message,
+        )
+
+    @patch("ai.chat_changes.push_chat_message")
+    def test_patch_rejects_contribution_decimalfield_overflow_without_mutation(
+        self,
+        push_chat_message,
+    ):
+        self.trip.currency_code = "USD"
+        self.trip.save(update_fields=["currency_code", "updated_at"])
+        draft = self._create_contribution_patch_draft(
+            missing_field="contributions",
+        )
+
+        self._assert_field_validation_patch_preserves_snapshot(
+            draft=draft,
+            patch_payload={
+                "contributions": [
+                    {
+                        "user_id": str(self.user.id),
+                        "amount": "1000000000000.00",
+                    }
+                ]
+            },
+            expected_field_errors={
+                "contributions.0.amount": (
+                    "Amount must have no more than 12 digits before the decimal point."
+                )
+            },
+            push_chat_message=push_chat_message,
+        )
+
+    def test_patch_accepts_two_decimal_amount_for_usd(self):
+        self.trip.currency_code = "USD"
+        self.trip.save(update_fields=["currency_code", "updated_at"])
+        self.client.force_authenticate(self.user)
+        draft = self._create_patch_draft()
+
+        response = self.client.patch(
+            f"/api/trips/{self.trip.id}/ai/action-drafts/{draft.id}",
+            {"payload": {"total_amount": "25.50"}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        draft.refresh_from_db()
+        self.assertEqual(draft.status, AIActionDraftStatus.READY)
+        self.assertEqual(draft.payload["total_amount"], "25.50")
+        self.assertEqual(draft.missing_fields, [])
+
     def test_patch_missing_target_identity_field_is_rejected(self):
         self.client.force_authenticate(self.user)
         draft = AIActionDraft.objects.create(
@@ -1036,6 +1407,138 @@ class AIActionDraftPatchTests(APITestCase, AIActionDraftModelTests):
         self.assertEqual(draft.status, AIActionDraftStatus.READY)
         self.assertEqual(draft.payload["data"]["title"], "Museum")
         self.assertNotIn("title", draft.payload)
+        self.assertEqual(
+            response.data["draft"]["preview"]["data"],
+            {
+                "time_mode": "FLEXIBLE",
+                "system_type": "SIGHTSEEING",
+                "title": "Museum",
+            },
+        )
+        self.assertEqual(
+            response.data["draft"]["preview"]["section_label"],
+            section.label,
+        )
+        self.assertEqual(
+            response.data["draft"]["preview"]["section_date"],
+            section.section_date.isoformat(),
+        )
+        self.assertEqual(
+            response.data["draft"]["preview"]["resolved_data"]["title"],
+            "Museum",
+        )
+
+    def test_patch_timeline_create_rejects_untrusted_trip_scoped_references(self):
+        from trips.models import TimelineCustomType
+
+        self.client.force_authenticate(self.user)
+        section = self.trip.timeline_sections.order_by("section_date").first()
+        other_trip = create_trip(
+            captain=self.user,
+            name="Patch Foreign Trip",
+            destination="Hue",
+            start_date="2026-08-01",
+            end_date="2026-08-02",
+        )
+        foreign_section = other_trip.timeline_sections.order_by("section_date").first()
+        foreign_custom = TimelineCustomType.objects.create(
+            trip=other_trip,
+            name="Foreign patch custom",
+            normalized_name="foreign-patch-custom",
+            created_by=self.user,
+        )
+        left_assignee = create_completed_user(
+            "agent-patch-left@example.com",
+            "agentpatchleft",
+            "AID006",
+        )
+        TripMember.objects.create(
+            trip=self.trip,
+            user=left_assignee,
+            role=TripRole.MEMBER,
+            status=MemberStatus.LEFT,
+        )
+
+        cases = (
+            (
+                "section_id",
+                {
+                    "data": {
+                        "title": "Foreign day",
+                        "time_mode": "FLEXIBLE",
+                        "system_type": "SIGHTSEEING",
+                    }
+                },
+                str(foreign_section.id),
+            ),
+            (
+                "custom_type_id",
+                {
+                    "section_id": str(section.id),
+                    "data": {
+                        "title": "Foreign custom",
+                        "time_mode": "FLEXIBLE",
+                    },
+                },
+                str(foreign_custom.id),
+            ),
+            (
+                "assignee_user_id",
+                {
+                    "section_id": str(section.id),
+                    "data": {
+                        "title": "Inactive assignee",
+                        "time_mode": "FLEXIBLE",
+                        "system_type": "SIGHTSEEING",
+                        "assignee_scope": "USER",
+                    },
+                },
+                str(left_assignee.id),
+            ),
+        )
+
+        for field_name, payload, invalid_value in cases:
+            with self.subTest(field_name=field_name):
+                draft = AIActionDraft.objects.create(
+                    trip=self.trip,
+                    interaction=self.interaction,
+                    response_message=self.response_message,
+                    requested_by=self.user,
+                    action_type="timeline.activity.create",
+                    status=AIActionDraftStatus.NEEDS_INFO,
+                    required_confirmation="CAPTAIN",
+                    payload=payload,
+                    preview={"title": payload.get("data", {}).get("title", "")},
+                    missing_fields=[
+                        {"name": field_name, "label": field_name}
+                    ],
+                    preconditions={},
+                    expires_at=timezone.now() + timedelta(hours=24),
+                )
+                original_payload = draft.payload
+
+                response = self.client.patch(
+                    f"/api/trips/{self.trip.id}/ai/action-drafts/{draft.id}",
+                    {"payload": {field_name: invalid_value}},
+                    format="json",
+                )
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(
+                    response.data["error_code"],
+                    "FIELD_VALIDATION_FAILED",
+                )
+                self.assertIn(field_name, response.data["field_errors"])
+                draft.refresh_from_db()
+                self.assertEqual(draft.status, AIActionDraftStatus.NEEDS_INFO)
+                self.assertEqual(draft.payload, original_payload)
+                review_wire = str(
+                    {
+                        "preview": response.data["draft"]["preview"],
+                        "display": response.data["draft"]["display"],
+                    }
+                )
+                self.assertNotIn(invalid_value, review_wire)
 
     def test_patch_timeline_update_missing_data_object_updates_nested_payload(self):
         self.client.force_authenticate(self.user)
@@ -1044,6 +1547,7 @@ class AIActionDraftPatchTests(APITestCase, AIActionDraftModelTests):
             trip=self.trip,
             title="Old Museum",
             time_mode="FLEXIBLE",
+            system_type="SIGHTSEEING",
             position=0,
         )
         draft = AIActionDraft.objects.create(
@@ -1078,6 +1582,22 @@ class AIActionDraftPatchTests(APITestCase, AIActionDraftModelTests):
         self.assertEqual(draft.status, AIActionDraftStatus.READY)
         self.assertEqual(draft.payload["data"], {"title": "Museum"})
         self.assertEqual(response.data["draft"]["preview"]["title"], "Museum")
+        self.assertEqual(
+            response.data["draft"]["preview"]["data"],
+            {"title": "Museum"},
+        )
+        self.assertEqual(
+            response.data["draft"]["preview"]["target_title"],
+            "Old Museum",
+        )
+        self.assertEqual(
+            response.data["draft"]["preview"]["resolved_data"]["title"],
+            "Museum",
+        )
+        self.assertEqual(
+            response.data["draft"]["display"]["meta"][0],
+            {"label": "Target", "value": "Old Museum"},
+        )
 
     def test_assignee_patches_timeline_status_missing_info(self):
         member = create_completed_user(
@@ -1220,6 +1740,64 @@ class AIActionDraftPatchFieldValidationTests(APITestCase, AIActionDraftModelTest
             set(res.data),
             {"detail", "error_code", "field_errors", "draft"},
         )
+
+    @patch("ai.chat_changes.push_chat_message")
+    def test_target_merged_validation_rejects_invalid_patch_without_side_effects(
+        self,
+        push_chat_message,
+    ):
+        section = self.trip.timeline_sections.order_by("section_date").first()
+        activity = section.activities.create(
+            trip=self.trip,
+            title="Flexible target",
+            time_mode="FLEXIBLE",
+            system_type="SIGHTSEEING",
+            position=0,
+        )
+        draft = AIActionDraft.objects.create(
+            trip=self.trip,
+            interaction=self.interaction,
+            response_message=self.response_message,
+            requested_by=self.user,
+            action_type="timeline.activity.update",
+            status=AIActionDraftStatus.NEEDS_INFO,
+            required_confirmation="CAPTAIN",
+            payload={"activity_id": str(activity.id), "data": {}},
+            preview={"title": activity.title},
+            missing_fields=[{"name": "time_mode", "label": "Time mode"}],
+            preconditions={},
+            expires_at=timezone.now() + timedelta(hours=24),
+        )
+        original_payload = draft.payload
+        original_updated_at = draft.updated_at
+        original_trip_sequence = self.trip.chat_change_sequence
+        original_message_sequence = self.response_message.change_sequence
+        self.client.force_authenticate(self.user)
+
+        with self.captureOnCommitCallbacks(execute=False) as callbacks:
+            response = self.client.patch(
+                f"/api/trips/{self.trip.id}/ai/action-drafts/{draft.id}",
+                {"payload": {"time_mode": "TIME_RANGE"}},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["error_code"], "FIELD_VALIDATION_FAILED")
+        self.assertIn("start_time", response.data["field_errors"])
+        self.assertIn("end_time", response.data["field_errors"])
+        draft.refresh_from_db()
+        self.trip.refresh_from_db()
+        self.response_message.refresh_from_db()
+        self.assertEqual(draft.status, AIActionDraftStatus.NEEDS_INFO)
+        self.assertEqual(draft.payload, original_payload)
+        self.assertEqual(draft.updated_at, original_updated_at)
+        self.assertEqual(self.trip.chat_change_sequence, original_trip_sequence)
+        self.assertEqual(
+            self.response_message.change_sequence,
+            original_message_sequence,
+        )
+        self.assertEqual(callbacks, [])
+        push_chat_message.assert_not_called()
 
     def test_field_validation_precedes_expiry_without_mutating_snapshot(self):
         draft = self._create_needs_info_activity_draft()
@@ -1402,8 +1980,8 @@ class AIActionDraftPatchFieldValidationTests(APITestCase, AIActionDraftModelTest
         self.assertEqual(res.status_code, 200)
         draft.refresh_from_db()
         self.assertEqual(draft.status, AIActionDraftStatus.READY)
-        self.assertEqual(draft.payload["data"]["start_time"], "08:30")
-        self.assertEqual(draft.payload["data"]["end_time"], "10:00")
+        self.assertEqual(draft.payload["data"]["start_time"], "08:30:00")
+        self.assertEqual(draft.payload["data"]["end_time"], "10:00:00")
         self.assertEqual(draft.missing_fields, [])
 
 

--- a/backend/ai/tests/test_action_drafts.py
+++ b/backend/ai/tests/test_action_drafts.py
@@ -37,6 +37,7 @@ from trips.models import (
     TimelineActivityStatus,
     TripMember,
     TripRole,
+    TripStatus,
 )
 from trips.services import create_trip
 
@@ -393,6 +394,137 @@ class AIActionDraftAPITests(APITestCase, AIActionDraftModelTests):
     def _cancel_url(self, draft_id):
         return f"/api/trips/{self.trip.id}/ai/action-drafts/{draft_id}/cancel"
 
+    def _request_draft_route(self, operation, *, trip_id, draft_id):
+        detail_url = f"/api/trips/{trip_id}/ai/action-drafts/{draft_id}"
+        if operation == "get":
+            return self.client.get(detail_url)
+        if operation == "patch":
+            return self.client.patch(
+                detail_url,
+                {"payload": {}},
+                format="json",
+            )
+        return self.client.post(f"{detail_url}/{operation}")
+
+    @patch("ai.chat_changes.push_chat_message")
+    def test_draft_routes_preserve_trip_not_found_access_authority(
+        self,
+        push_chat_message,
+    ):
+        draft = AIActionDraft.objects.create(
+            trip=self.trip,
+            interaction=self.interaction,
+            response_message=self.response_message,
+            requested_by=self.user,
+            action_type="expense.create",
+            status=AIActionDraftStatus.READY,
+            required_confirmation="CAPTAIN",
+            payload={"title": "Dinner"},
+            preview={"title": "Dinner"},
+            missing_fields=[],
+            preconditions={},
+            expires_at=timezone.now() + timedelta(hours=24),
+        )
+        outsider = create_completed_user(
+            "draft-route-outsider@example.com",
+            "draftrouteoutsider",
+            "DRO001",
+        )
+        draft_snapshot = AIActionDraft.objects.filter(pk=draft.id).values().get()
+        self.response_message.refresh_from_db()
+        self.trip.refresh_from_db()
+        message_updated_at = self.response_message.updated_at
+        message_sequence = self.response_message.change_sequence
+        trip_sequence = self.trip.chat_change_sequence
+        self.client.force_authenticate(outsider)
+
+        access_cases = {
+            "nonmember": self.trip.id,
+            "missing_trip": uuid4(),
+        }
+        for access_case, trip_id in access_cases.items():
+            for operation in ("get", "patch", "cancel", "confirm"):
+                with self.subTest(
+                    access_case=access_case,
+                    operation=operation,
+                ):
+                    with self.captureOnCommitCallbacks(execute=False) as callbacks:
+                        response = self._request_draft_route(
+                            operation,
+                            trip_id=trip_id,
+                            draft_id=draft.id,
+                        )
+
+                    self.assertEqual(response.status_code, 404)
+                    self.assertEqual(
+                        response.data,
+                        {
+                            "detail": "Trip not found.",
+                            "error_code": "TRIP_NOT_FOUND",
+                        },
+                    )
+                    self.assertEqual(
+                        AIActionDraft.objects.filter(pk=draft.id).values().get(),
+                        draft_snapshot,
+                    )
+                    self.response_message.refresh_from_db()
+                    self.trip.refresh_from_db()
+                    self.assertEqual(
+                        self.response_message.updated_at,
+                        message_updated_at,
+                    )
+                    self.assertEqual(
+                        self.response_message.change_sequence,
+                        message_sequence,
+                    )
+                    self.assertEqual(self.trip.chat_change_sequence, trip_sequence)
+                    self.assertEqual(callbacks, [])
+                    push_chat_message.assert_not_called()
+
+    @patch("ai.chat_changes.push_chat_message")
+    def test_draft_routes_keep_missing_draft_contract_for_active_member(
+        self,
+        push_chat_message,
+    ):
+        self.client.force_authenticate(self.user)
+        missing_draft_id = uuid4()
+        self.response_message.refresh_from_db()
+        self.trip.refresh_from_db()
+        message_updated_at = self.response_message.updated_at
+        message_sequence = self.response_message.change_sequence
+        trip_sequence = self.trip.chat_change_sequence
+
+        for operation in ("get", "patch", "cancel", "confirm"):
+            with self.subTest(operation=operation):
+                with self.captureOnCommitCallbacks(execute=False) as callbacks:
+                    response = self._request_draft_route(
+                        operation,
+                        trip_id=self.trip.id,
+                        draft_id=missing_draft_id,
+                    )
+
+                self.assertEqual(response.status_code, 404)
+                self.assertEqual(
+                    response.data,
+                    {
+                        "detail": "Draft not found.",
+                        "error_code": "AI_DRAFT_NOT_FOUND",
+                    },
+                )
+                self.assertFalse(
+                    AIActionDraft.objects.filter(pk=missing_draft_id).exists()
+                )
+                self.response_message.refresh_from_db()
+                self.trip.refresh_from_db()
+                self.assertEqual(self.response_message.updated_at, message_updated_at)
+                self.assertEqual(
+                    self.response_message.change_sequence,
+                    message_sequence,
+                )
+                self.assertEqual(self.trip.chat_change_sequence, trip_sequence)
+                self.assertEqual(callbacks, [])
+                push_chat_message.assert_not_called()
+
     def test_action_draft_detail_exposes_display_and_summary(self):
         self.client.force_authenticate(self.user)
         display_value = {
@@ -472,6 +604,224 @@ class AIActionDraftAPITests(APITestCase, AIActionDraftModelTests):
         draft.refresh_from_db()
         self.assertEqual(draft.status, AIActionDraftStatus.CANCELLED)
         self.assertEqual(draft.cancelled_by_id, self.user.id)
+
+    @patch("ai.chat_changes.push_chat_message")
+    def test_terminal_trip_rejects_cancel_without_mutating_draft(
+        self,
+        push_chat_message,
+    ):
+        self.client.force_authenticate(self.user)
+        draft = AIActionDraft.objects.create(
+            trip=self.trip,
+            interaction=self.interaction,
+            response_message=self.response_message,
+            requested_by=self.user,
+            action_type="expense.create",
+            status=AIActionDraftStatus.READY,
+            required_confirmation="CAPTAIN",
+            payload={"title": "Dinner"},
+            preview={"title": "Dinner"},
+            missing_fields=[],
+            preconditions={},
+            expires_at=timezone.now() + timedelta(hours=24),
+        )
+
+        for terminal_status in (TripStatus.COMPLETED, TripStatus.CANCELLED):
+            with self.subTest(trip_status=terminal_status):
+                self.trip.status = terminal_status
+                self.trip.save(update_fields=["status"])
+                draft.refresh_from_db()
+                self.response_message.refresh_from_db()
+                self.trip.refresh_from_db()
+                draft_updated_at = draft.updated_at
+                message_updated_at = self.response_message.updated_at
+                trip_sequence = self.trip.chat_change_sequence
+                message_sequence = self.response_message.change_sequence
+
+                with self.captureOnCommitCallbacks(execute=False) as callbacks:
+                    response = self.client.post(self._cancel_url(draft.id))
+
+                self.assertEqual(response.status_code, 409)
+                self.assertEqual(
+                    response.data,
+                    {
+                        "detail": "Completed or cancelled trips are read-only.",
+                        "error_code": "TRIP_TERMINAL",
+                    },
+                )
+                draft.refresh_from_db()
+                self.response_message.refresh_from_db()
+                self.trip.refresh_from_db()
+                self.assertEqual(draft.status, AIActionDraftStatus.READY)
+                self.assertIsNone(draft.cancelled_by_id)
+                self.assertIsNone(draft.cancelled_at)
+                self.assertEqual(draft.updated_at, draft_updated_at)
+                self.assertEqual(self.response_message.updated_at, message_updated_at)
+                self.assertEqual(self.trip.chat_change_sequence, trip_sequence)
+                self.assertEqual(
+                    self.response_message.change_sequence,
+                    message_sequence,
+                )
+                self.assertEqual(callbacks, [])
+                push_chat_message.assert_not_called()
+
+    @patch("ai.chat_changes.push_chat_message")
+    def test_terminal_trip_keeps_final_cancel_replays_idempotent(
+        self,
+        push_chat_message,
+    ):
+        self.client.force_authenticate(self.user)
+        final_status_fields = {
+            AIActionDraftStatus.CONFIRMED: {
+                "confirmed_by": self.user,
+                "confirmed_at": timezone.now(),
+                "result": {"object_type": "expense", "object_id": "existing"},
+            },
+            AIActionDraftStatus.CANCELLED: {
+                "cancelled_by": self.user,
+                "cancelled_at": timezone.now(),
+            },
+            AIActionDraftStatus.EXPIRED: {},
+            AIActionDraftStatus.FAILED: {
+                "error_code": "AI_DRAFT_STALE",
+                "error_detail": "Target changed.",
+            },
+        }
+
+        for terminal_status in (TripStatus.COMPLETED, TripStatus.CANCELLED):
+            for draft_status, status_fields in final_status_fields.items():
+                with self.subTest(
+                    trip_status=terminal_status,
+                    draft_status=draft_status,
+                ):
+                    self.trip.status = terminal_status
+                    self.trip.save(update_fields=["status"])
+                    draft = AIActionDraft.objects.create(
+                        trip=self.trip,
+                        interaction=self.interaction,
+                        response_message=self.response_message,
+                        requested_by=self.user,
+                        action_type="expense.create",
+                        status=draft_status,
+                        required_confirmation="CAPTAIN",
+                        payload={"title": "Dinner"},
+                        preview={"title": "Dinner"},
+                        missing_fields=[],
+                        preconditions={},
+                        expires_at=timezone.now() + timedelta(hours=24),
+                        **status_fields,
+                    )
+                    draft_snapshot = AIActionDraft.objects.filter(pk=draft.id).values(
+                        "status",
+                        "result",
+                        "error_code",
+                        "error_detail",
+                        "confirmed_by_id",
+                        "confirmed_at",
+                        "cancelled_by_id",
+                        "cancelled_at",
+                        "updated_at",
+                    ).get()
+                    self.response_message.refresh_from_db()
+                    self.trip.refresh_from_db()
+                    message_updated_at = self.response_message.updated_at
+                    message_sequence = self.response_message.change_sequence
+                    trip_sequence = self.trip.chat_change_sequence
+                    expected_response = {
+                        "draft": build_action_draft_payload(
+                            draft,
+                            viewer=self.user,
+                        )
+                    }
+                    push_chat_message.reset_mock()
+
+                    with self.captureOnCommitCallbacks(execute=False) as callbacks:
+                        response = self.client.post(self._cancel_url(draft.id))
+
+                    self.assertEqual(response.status_code, 200)
+                    self.assertEqual(response.data, expected_response)
+                    self.assertEqual(
+                        AIActionDraft.objects.filter(pk=draft.id).values(
+                            "status",
+                            "result",
+                            "error_code",
+                            "error_detail",
+                            "confirmed_by_id",
+                            "confirmed_at",
+                            "cancelled_by_id",
+                            "cancelled_at",
+                            "updated_at",
+                        ).get(),
+                        draft_snapshot,
+                    )
+                    self.response_message.refresh_from_db()
+                    self.trip.refresh_from_db()
+                    self.assertEqual(self.response_message.updated_at, message_updated_at)
+                    self.assertEqual(
+                        self.response_message.change_sequence,
+                        message_sequence,
+                    )
+                    self.assertEqual(self.trip.chat_change_sequence, trip_sequence)
+                    self.assertEqual(callbacks, [])
+                    push_chat_message.assert_not_called()
+
+    @patch("ai.chat_changes.push_chat_message")
+    def test_terminal_final_cancel_replay_still_requires_active_membership(
+        self,
+        push_chat_message,
+    ):
+        outsider = create_completed_user(
+            "draft-cancel-outsider@example.com",
+            "draftcanceloutsider",
+            "DCO001",
+        )
+        self.trip.status = TripStatus.COMPLETED
+        self.trip.save(update_fields=["status"])
+        draft = AIActionDraft.objects.create(
+            trip=self.trip,
+            interaction=self.interaction,
+            response_message=self.response_message,
+            requested_by=self.user,
+            action_type="expense.create",
+            status=AIActionDraftStatus.CANCELLED,
+            required_confirmation="CAPTAIN",
+            payload={"title": "Dinner"},
+            preview={"title": "Dinner"},
+            missing_fields=[],
+            preconditions={},
+            expires_at=timezone.now() + timedelta(hours=24),
+            cancelled_by=self.user,
+            cancelled_at=timezone.now(),
+        )
+        draft_updated_at = draft.updated_at
+        self.response_message.refresh_from_db()
+        self.trip.refresh_from_db()
+        message_updated_at = self.response_message.updated_at
+        message_sequence = self.response_message.change_sequence
+        trip_sequence = self.trip.chat_change_sequence
+        self.client.force_authenticate(outsider)
+
+        with self.captureOnCommitCallbacks(execute=False) as callbacks:
+            response = self.client.post(self._cancel_url(draft.id))
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(
+            response.data,
+            {
+                "detail": "Trip not found.",
+                "error_code": "TRIP_NOT_FOUND",
+            },
+        )
+        draft.refresh_from_db()
+        self.response_message.refresh_from_db()
+        self.trip.refresh_from_db()
+        self.assertEqual(draft.status, AIActionDraftStatus.CANCELLED)
+        self.assertEqual(draft.updated_at, draft_updated_at)
+        self.assertEqual(self.response_message.updated_at, message_updated_at)
+        self.assertEqual(self.response_message.change_sequence, message_sequence)
+        self.assertEqual(self.trip.chat_change_sequence, trip_sequence)
+        self.assertEqual(callbacks, [])
+        push_chat_message.assert_not_called()
 
     @patch("ai.chat_changes.push_chat_message")
     def test_cancel_expired_draft_marks_expired_and_returns_conflict(self, push_chat_message):
@@ -771,6 +1121,57 @@ class AIActionDraftPatchTests(APITestCase, AIActionDraftModelTests):
         self.assertEqual(self.trip.chat_change_sequence, original_trip_sequence)
         self.assertEqual(callbacks, [])
         push_chat_message.assert_not_called()
+
+    @patch("ai.chat_changes.push_chat_message")
+    def test_terminal_trip_rejects_patch_without_mutating_draft(
+        self,
+        push_chat_message,
+    ):
+        self.client.force_authenticate(self.user)
+        draft = self._create_patch_draft()
+
+        for terminal_status in (TripStatus.COMPLETED, TripStatus.CANCELLED):
+            with self.subTest(trip_status=terminal_status):
+                self.trip.status = terminal_status
+                self.trip.save(update_fields=["status"])
+                draft.refresh_from_db()
+                self.response_message.refresh_from_db()
+                self.trip.refresh_from_db()
+                original_payload = dict(draft.payload)
+                draft_updated_at = draft.updated_at
+                message_updated_at = self.response_message.updated_at
+                trip_sequence = self.trip.chat_change_sequence
+                message_sequence = self.response_message.change_sequence
+
+                with self.captureOnCommitCallbacks(execute=False) as callbacks:
+                    response = self.client.patch(
+                        f"/api/trips/{self.trip.id}/ai/action-drafts/{draft.id}",
+                        {"payload": {"total_amount": "500000"}},
+                        format="json",
+                    )
+
+                self.assertEqual(response.status_code, 409)
+                self.assertEqual(
+                    response.data,
+                    {
+                        "detail": "Completed or cancelled trips are read-only.",
+                        "error_code": "TRIP_TERMINAL",
+                    },
+                )
+                draft.refresh_from_db()
+                self.response_message.refresh_from_db()
+                self.trip.refresh_from_db()
+                self.assertEqual(draft.status, AIActionDraftStatus.NEEDS_INFO)
+                self.assertEqual(draft.payload, original_payload)
+                self.assertEqual(draft.updated_at, draft_updated_at)
+                self.assertEqual(self.response_message.updated_at, message_updated_at)
+                self.assertEqual(self.trip.chat_change_sequence, trip_sequence)
+                self.assertEqual(
+                    self.response_message.change_sequence,
+                    message_sequence,
+                )
+                self.assertEqual(callbacks, [])
+                push_chat_message.assert_not_called()
 
     @patch("ai.chat_changes.push_chat_message")
     def test_patch_with_absent_payload_is_a_true_noop(self, push_chat_message):

--- a/backend/ai/tests/test_action_executor.py
+++ b/backend/ai/tests/test_action_executor.py
@@ -20,6 +20,7 @@ from ai.agent.executor import (
     AIActionDraftStaleError,
     _check_preconditions,
     confirm_action_draft,
+    mark_action_draft_failed,
 )
 from ai.models import (
     AIActionDraft,
@@ -41,6 +42,7 @@ from trips.models import (
     Trip,
     TripMember,
     TripRole,
+    TripStatus,
 )
 from trips.services import create_trip
 
@@ -111,6 +113,45 @@ class ActionExecutorTests(TestCase):
                 "updated_at": expense.updated_at.isoformat(),
             }
         }
+
+    @patch("ai.chat_changes.push_chat_message")
+    def test_terminal_trip_skips_failure_bookkeeping(self, push_chat_message):
+        draft = self._expense_create_draft()
+
+        for terminal_status in (TripStatus.COMPLETED, TripStatus.CANCELLED):
+            with self.subTest(trip_status=terminal_status):
+                self.trip.status = terminal_status
+                self.trip.save(update_fields=["status"])
+                draft.refresh_from_db()
+                self.response.refresh_from_db()
+                self.trip.refresh_from_db()
+                draft_updated_at = draft.updated_at
+                response_updated_at = self.response.updated_at
+                trip_sequence = self.trip.chat_change_sequence
+                response_sequence = self.response.change_sequence
+
+                with self.captureOnCommitCallbacks(execute=False) as callbacks:
+                    returned = mark_action_draft_failed(
+                        draft_id=draft.id,
+                        trip_id=self.trip.id,
+                        error_code="AI_DRAFT_STALE",
+                        error_detail="Target changed.",
+                    )
+
+                self.assertIsNotNone(returned)
+                self.assertEqual(returned.status, AIActionDraftStatus.READY)
+                draft.refresh_from_db()
+                self.response.refresh_from_db()
+                self.trip.refresh_from_db()
+                self.assertEqual(draft.status, AIActionDraftStatus.READY)
+                self.assertEqual(draft.error_code, "")
+                self.assertEqual(draft.error_detail, "")
+                self.assertEqual(draft.updated_at, draft_updated_at)
+                self.assertEqual(self.response.updated_at, response_updated_at)
+                self.assertEqual(self.trip.chat_change_sequence, trip_sequence)
+                self.assertEqual(self.response.change_sequence, response_sequence)
+                self.assertEqual(callbacks, [])
+                push_chat_message.assert_not_called()
 
     def test_confirm_expense_create_executes_once(self):
         draft = self._expense_create_draft()
@@ -1333,6 +1374,76 @@ class ActionDraftConfirmAPITests(APITestCase):
 
     def _confirm_url(self, draft_id):
         return f"/api/trips/{self.trip.id}/ai/action-drafts/{draft_id}/confirm"
+
+    @patch("ai.chat_changes.push_chat_message")
+    def test_terminal_trip_rejects_confirm_without_mutating_draft(
+        self,
+        push_chat_message,
+    ):
+        self.client.force_authenticate(self.captain)
+        draft = AIActionDraft.objects.create(
+            trip=self.trip,
+            interaction=self.interaction,
+            response_message=self.response,
+            requested_by=self.captain,
+            action_type="expense.create",
+            status=AIActionDraftStatus.READY,
+            required_confirmation=AI_CONFIRMATION_CAPTAIN,
+            payload={"title": "Dinner", "total_amount": "1200000"},
+            preview={"title": "Dinner"},
+            missing_fields=[],
+            preconditions={},
+            expires_at=timezone.now() + timedelta(hours=24),
+        )
+
+        for terminal_status in (TripStatus.COMPLETED, TripStatus.CANCELLED):
+            for expired in (False, True):
+                with self.subTest(
+                    trip_status=terminal_status,
+                    expired=expired,
+                ):
+                    self.trip.status = terminal_status
+                    self.trip.save(update_fields=["status"])
+                    draft.expires_at = timezone.now() + (
+                        -timedelta(seconds=1)
+                        if expired
+                        else timedelta(hours=24)
+                    )
+                    draft.save(update_fields=["expires_at"])
+                    draft.refresh_from_db()
+                    self.response.refresh_from_db()
+                    self.trip.refresh_from_db()
+                    draft_updated_at = draft.updated_at
+                    response_updated_at = self.response.updated_at
+                    trip_sequence = self.trip.chat_change_sequence
+                    response_sequence = self.response.change_sequence
+
+                    with self.captureOnCommitCallbacks(execute=False) as callbacks:
+                        response = self.client.post(self._confirm_url(draft.id))
+
+                    self.assertEqual(response.status_code, 409)
+                    self.assertEqual(
+                        response.data,
+                        {
+                            "detail": "Completed or cancelled trips are read-only.",
+                            "error_code": "TRIP_TERMINAL",
+                        },
+                    )
+                    draft.refresh_from_db()
+                    self.response.refresh_from_db()
+                    self.trip.refresh_from_db()
+                    self.assertEqual(draft.status, AIActionDraftStatus.READY)
+                    self.assertIsNone(draft.confirmed_by_id)
+                    self.assertIsNone(draft.confirmed_at)
+                    self.assertEqual(draft.result, {})
+                    self.assertEqual(draft.error_code, "")
+                    self.assertEqual(draft.error_detail, "")
+                    self.assertEqual(draft.updated_at, draft_updated_at)
+                    self.assertEqual(self.response.updated_at, response_updated_at)
+                    self.assertEqual(self.trip.chat_change_sequence, trip_sequence)
+                    self.assertEqual(self.response.change_sequence, response_sequence)
+                    self.assertEqual(callbacks, [])
+                    push_chat_message.assert_not_called()
 
     @patch("ai.chat_changes.push_chat_message")
     @patch(

--- a/backend/ai/tests/test_action_executor.py
+++ b/backend/ai/tests/test_action_executor.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date, time, timedelta
 from decimal import Decimal
 from unittest.mock import patch
 from uuid import uuid4
@@ -125,6 +125,44 @@ class ActionExecutorTests(TestCase):
         self.assertEqual(Expense.objects.count(), 1)
         self.assertEqual(confirmed.result["object_type"], "expense")
 
+    def test_confirm_expense_create_rejects_legacy_currency_mismatch(self):
+        draft = self._expense_create_draft()
+        draft.payload = {**draft.payload, "currency_code": "USD"}
+        draft.save(update_fields=["payload", "updated_at"])
+
+        with self.assertRaisesMessage(
+            AIActionDraftNotReadyError,
+            "Draft currency does not match the trip currency.",
+        ):
+            confirm_action_draft(
+                draft_id=draft.id,
+                trip_id=self.trip.id,
+                actor=self.captain,
+            )
+
+        draft.refresh_from_db()
+        self.assertEqual(draft.status, AIActionDraftStatus.READY)
+        self.assertFalse(Expense.objects.exists())
+
+    def test_confirm_expense_create_rejects_legacy_invalid_amount(self):
+        draft = self._expense_create_draft()
+        draft.payload = {**draft.payload, "total_amount": "25.50"}
+        draft.save(update_fields=["payload", "updated_at"])
+
+        with self.assertRaisesMessage(
+            AIActionDraftNotReadyError,
+            "Draft is missing required field: total_amount.",
+        ):
+            confirm_action_draft(
+                draft_id=draft.id,
+                trip_id=self.trip.id,
+                actor=self.captain,
+            )
+
+        draft.refresh_from_db()
+        self.assertEqual(draft.status, AIActionDraftStatus.READY)
+        self.assertFalse(Expense.objects.exists())
+
     def test_confirm_expense_contribution_set_accepts_batch_contributions(self):
         member = create_completed_user(
             "exec-batch-member@example.com",
@@ -180,6 +218,51 @@ class ActionExecutorTests(TestCase):
         self.assertEqual(contributions[member.id], Decimal("600000"))
         self.assertEqual(confirmed.result["object_type"], "expense_contribution_batch")
         self.assertEqual(confirmed.result["updated_count"], 2)
+
+    def test_confirm_contribution_rejects_legacy_decimalfield_overflow(self):
+        expense = create_expense(
+            trip_id=self.trip.id,
+            actor=self.captain,
+            title="Dinner",
+            total_amount=Decimal("1200000"),
+            collector=self.captain,
+        )
+        draft = AIActionDraft.objects.create(
+            trip=self.trip,
+            interaction=self.interaction,
+            response_message=self.response,
+            requested_by=self.captain,
+            action_type="expense.contribution.set",
+            status=AIActionDraftStatus.READY,
+            required_confirmation=AI_CONFIRMATION_CAPTAIN,
+            payload={
+                "expense_id": str(expense.id),
+                "contributions": [
+                    {
+                        "user_id": str(self.captain.id),
+                        "amount": "1000000000000",
+                    }
+                ],
+            },
+            preview={"summary": "Captain paid"},
+            missing_fields=[],
+            preconditions=self._expense_preconditions(expense),
+            expires_at=timezone.now() + timedelta(hours=24),
+        )
+
+        with self.assertRaisesMessage(
+            AIActionDraftNotReadyError,
+            "Draft is missing required field: contributions.",
+        ):
+            confirm_action_draft(
+                draft_id=draft.id,
+                trip_id=self.trip.id,
+                actor=self.captain,
+            )
+
+        draft.refresh_from_db()
+        self.assertEqual(draft.status, AIActionDraftStatus.READY)
+        self.assertFalse(ExpenseContribution.objects.exists())
 
     def test_confirm_expense_contribution_set_accepts_member_contributions_map(self):
         member = create_completed_user(
@@ -671,6 +754,103 @@ class ActionExecutorTests(TestCase):
                 actor=self.captain,
             )
 
+    def test_confirm_rejects_invalid_target_merged_timeline_patch_without_mutation(self):
+        section = self.trip.timeline_sections.order_by("section_date").first()
+        activity = section.activities.create(
+            trip=self.trip,
+            title="Merged clock target",
+            time_mode=TimelineActivityTimeMode.TIME_RANGE,
+            start_time=time(10, 0),
+            end_time=time(11, 0),
+            system_type=TimelineSystemType.SIGHTSEEING,
+        )
+        draft = AIActionDraft.objects.create(
+            trip=self.trip,
+            interaction=self.interaction,
+            response_message=self.response,
+            requested_by=self.captain,
+            action_type="timeline.activity.update",
+            status=AIActionDraftStatus.READY,
+            required_confirmation=AI_CONFIRMATION_CAPTAIN,
+            payload={
+                "activity_id": str(activity.id),
+                "data": {"end_time": "09:00:00"},
+            },
+            preview={"title": activity.title},
+            missing_fields=[],
+            preconditions={
+                "target": {
+                    "type": "timeline_activity",
+                    "id": str(activity.id),
+                    "updated_at": activity.updated_at.isoformat(),
+                }
+            },
+            expires_at=timezone.now() + timedelta(hours=24),
+        )
+        original_trip_sequence = self.trip.chat_change_sequence
+        original_message_sequence = self.response.change_sequence
+
+        with self.assertRaises(AIActionDraftNotReadyError):
+            confirm_action_draft(
+                draft_id=draft.id,
+                trip_id=self.trip.id,
+                actor=self.captain,
+            )
+
+        activity.refresh_from_db()
+        draft.refresh_from_db()
+        self.trip.refresh_from_db()
+        self.response.refresh_from_db()
+        self.assertEqual(activity.start_time, time(10, 0))
+        self.assertEqual(activity.end_time, time(11, 0))
+        self.assertEqual(draft.status, AIActionDraftStatus.READY)
+        self.assertEqual(self.trip.chat_change_sequence, original_trip_sequence)
+        self.assertEqual(self.response.change_sequence, original_message_sequence)
+
+    def test_stale_precondition_precedes_invalid_target_merged_timeline_patch(self):
+        section = self.trip.timeline_sections.order_by("section_date").first()
+        activity = section.activities.create(
+            trip=self.trip,
+            title="Stale merged target",
+            time_mode=TimelineActivityTimeMode.TIME_RANGE,
+            start_time=time(10, 0),
+            end_time=time(11, 0),
+            system_type=TimelineSystemType.SIGHTSEEING,
+        )
+        stale_updated_at = activity.updated_at.isoformat()
+        activity.title = "Changed elsewhere"
+        activity.save(update_fields=["title", "updated_at"])
+        draft = AIActionDraft.objects.create(
+            trip=self.trip,
+            interaction=self.interaction,
+            response_message=self.response,
+            requested_by=self.captain,
+            action_type="timeline.activity.update",
+            status=AIActionDraftStatus.READY,
+            required_confirmation=AI_CONFIRMATION_CAPTAIN,
+            payload={
+                "activity_id": str(activity.id),
+                "data": {"end_time": "09:00:00"},
+            },
+            preview={"title": "Stale merged target"},
+            missing_fields=[],
+            preconditions={
+                "target": {
+                    "type": "timeline_activity",
+                    "id": str(activity.id),
+                    "updated_at": stale_updated_at,
+                }
+            },
+            expires_at=timezone.now() + timedelta(hours=24),
+        )
+
+        with self.assertRaises(AIActionDraftStaleError):
+            confirm_action_draft(
+                draft_id=draft.id,
+                trip_id=self.trip.id,
+                actor=self.captain,
+            )
+
     def test_confirm_timeline_activity_create_uses_timeline_service(self):
         section = self.trip.timeline_sections.order_by("section_date").first()
         draft = AIActionDraft.objects.create(
@@ -705,6 +885,118 @@ class ActionExecutorTests(TestCase):
         self.assertEqual(confirmed.status, AIActionDraftStatus.CONFIRMED)
         self.assertEqual(TimelineActivity.objects.count(), 1)
         self.assertEqual(confirmed.result["object_type"], "timeline_activity")
+
+    def test_confirm_timeline_activity_create_rejects_legacy_untrusted_references(self):
+        from trips.models import TimelineCustomType
+
+        section = self.trip.timeline_sections.order_by("section_date").first()
+        other_trip = create_trip(
+            captain=self.captain,
+            name="Executor Foreign Trip",
+            destination="Hue",
+            start_date="2026-08-01",
+            end_date="2026-08-02",
+        )
+        foreign_section = other_trip.timeline_sections.order_by("section_date").first()
+        foreign_custom = TimelineCustomType.objects.create(
+            trip=other_trip,
+            name="Executor foreign custom",
+            normalized_name="executor-foreign-custom",
+            created_by=self.captain,
+        )
+        left_assignee = create_completed_user(
+            "exec-left-assignee@example.com",
+            "execleftassignee",
+            "EXE002",
+        )
+        TripMember.objects.create(
+            trip=self.trip,
+            user=left_assignee,
+            role=TripRole.MEMBER,
+            status=MemberStatus.LEFT,
+        )
+
+        cases = (
+            {
+                "section_id": str(uuid4()),
+                "data": {
+                    "title": "Missing section",
+                    "time_mode": "FLEXIBLE",
+                    "system_type": "SIGHTSEEING",
+                },
+            },
+            {
+                "section_id": str(foreign_section.id),
+                "data": {
+                    "title": "Foreign section",
+                    "time_mode": "FLEXIBLE",
+                    "system_type": "SIGHTSEEING",
+                },
+            },
+            {
+                "section_id": str(section.id),
+                "data": {
+                    "title": "Foreign custom",
+                    "time_mode": "FLEXIBLE",
+                    "custom_type_id": str(foreign_custom.id),
+                },
+            },
+            {
+                "section_id": str(section.id),
+                "data": {
+                    "title": "Inactive assignee",
+                    "time_mode": "FLEXIBLE",
+                    "system_type": "SIGHTSEEING",
+                    "assignee_scope": "USER",
+                    "assignee_user_id": str(left_assignee.id),
+                },
+            },
+        )
+        original_trip_sequence = self.trip.chat_change_sequence
+        original_message_sequence = self.response.change_sequence
+
+        for payload in cases:
+            with self.subTest(title=payload["data"]["title"]):
+                draft = AIActionDraft.objects.create(
+                    trip=self.trip,
+                    interaction=self.interaction,
+                    response_message=self.response,
+                    requested_by=self.captain,
+                    action_type="timeline.activity.create",
+                    status=AIActionDraftStatus.READY,
+                    required_confirmation=AI_CONFIRMATION_CAPTAIN,
+                    payload=payload,
+                    preview={"title": payload["data"]["title"]},
+                    missing_fields=[],
+                    preconditions={},
+                    expires_at=timezone.now() + timedelta(hours=24),
+                )
+
+                with self.assertRaises(AIActionDraftNotReadyError):
+                    confirm_action_draft(
+                        draft_id=draft.id,
+                        trip_id=self.trip.id,
+                        actor=self.captain,
+                    )
+
+                draft.refresh_from_db()
+                self.trip.refresh_from_db()
+                self.response.refresh_from_db()
+                self.assertEqual(draft.status, AIActionDraftStatus.READY)
+                self.assertFalse(
+                    TimelineActivity.objects.filter(
+                        trip=self.trip,
+                        title=payload["data"]["title"],
+                    ).exists()
+                )
+                self.assertEqual(
+                    self.trip.chat_change_sequence,
+                    original_trip_sequence,
+                )
+                self.assertEqual(
+                    self.response.change_sequence,
+                    original_message_sequence,
+                )
 
     def test_confirm_timeline_activity_create_creates_missing_section_date(self):
         trip = create_trip(

--- a/backend/ai/tests/test_agent_runner.py
+++ b/backend/ai/tests/test_agent_runner.py
@@ -201,7 +201,10 @@ class RunnerTests(TestCase):
         self.assertIsNone(result.error_code)
         draft = AIActionDraft.objects.get(interaction=self.interaction)
         self.assertEqual(draft.status, AIActionDraftStatus.NEEDS_INFO)
-        self.assertEqual(draft.payload, {"title": "Lunch"})
+        self.assertEqual(
+            draft.payload,
+            {"title": "Lunch", "currency_code": "VND"},
+        )
         self.assertEqual(
             draft.missing_fields,
             [{"name": "total_amount", "label": "Amount", "type": "money"}],
@@ -227,7 +230,10 @@ class RunnerTests(TestCase):
         draft = AIActionDraft.objects.get(interaction=self.interaction)
         self.assertEqual(draft.action_type, "expense.create")
         self.assertEqual(draft.status, AIActionDraftStatus.NEEDS_INFO)
-        self.assertEqual(draft.payload, {"title": "Lunch QA"})
+        self.assertEqual(
+            draft.payload,
+            {"title": "Lunch QA", "currency_code": "VND"},
+        )
         self.assertEqual(
             draft.missing_fields,
             [{"name": "total_amount", "label": "Amount", "type": "money"}],

--- a/backend/ai/tests/test_agent_tools.py
+++ b/backend/ai/tests/test_agent_tools.py
@@ -1,4 +1,7 @@
-from datetime import date, timedelta
+import os
+import subprocess
+import sys
+from datetime import date, time, timedelta
 from decimal import Decimal
 from uuid import uuid4
 
@@ -6,6 +9,29 @@ from django.test import SimpleTestCase, TestCase
 from django.utils import timezone
 
 from ai.agent.tools import TOOLS, openai_tool_params, resolve_tool
+
+
+class AIAgentImportSmokeTests(SimpleTestCase):
+    def test_chat_services_and_action_drafts_import_in_clean_process(self):
+        environment = os.environ.copy()
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import django; "
+                    "django.setup(); "
+                    "import chat.services; "
+                    "import ai.agent.drafts"
+                ),
+            ],
+            capture_output=True,
+            check=False,
+            env=environment,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
 
 
 class ToolRegistryTests(SimpleTestCase):
@@ -68,7 +94,7 @@ class ToolHandlerTests(TestCase):
 
     def test_create_timeline_activity_persists_draft(self):
         from ai.agent import handlers, schemas
-        from ai.models import AIActionDraft
+        from ai.models import AIActionDraft, AIActionDraftStatus
 
         section_id = uuid4()
         result = handlers.create_timeline_activity(
@@ -84,6 +110,11 @@ class ToolHandlerTests(TestCase):
         )
         self.assertIsInstance(result.draft, AIActionDraft)
         self.assertEqual(result.draft.action_type, "timeline.activity.create")
+        self.assertEqual(result.draft.status, AIActionDraftStatus.NEEDS_INFO)
+        self.assertIn(
+            "section_id",
+            {field["name"] for field in result.draft.missing_fields},
+        )
         self.assertEqual(
             result.draft.payload,
             {
@@ -97,6 +128,57 @@ class ToolHandlerTests(TestCase):
             },
         )
         self.assertEqual(result.draft.display["icon"], "activity")
+        self.assertNotIn("section_label", result.draft.preview)
+        self.assertNotIn("section_date", result.draft.preview)
+        self.assertNotIn(
+            "Date",
+            {row["label"]: row["value"] for row in result.draft.display["meta"]},
+        )
+        review_wire = str(
+            {
+                "preview": result.draft.preview,
+                "display": result.draft.display,
+            }
+        )
+        self.assertNotIn(str(section_id), review_wire)
+
+    def test_create_timeline_activity_resolves_section_context_for_review(self):
+        from ai.agent import handlers, schemas
+
+        section = self.trip.timeline_sections.order_by("section_date").first()
+        result = handlers.create_timeline_activity(
+            trip=self.trip,
+            interaction=self.interaction,
+            actor=self.user,
+            args=schemas.CreateTimelineActivityArgs(
+                section_id=section.id,
+                title="Sunset walk",
+                system_type="SIGHTSEEING",
+                time_mode="TIME_RANGE",
+                start_time=time(18, 0),
+                end_time=time(20, 0),
+                location_label="Da Nang beach",
+            ),
+        )
+
+        draft = result.draft
+        self.assertEqual(draft.preview["section_label"], section.label)
+        self.assertEqual(
+            draft.preview["section_date"],
+            section.section_date.isoformat(),
+        )
+        self.assertEqual(draft.preview["resolved_data"]["title"], "Sunset walk")
+        self.assertEqual(
+            draft.preview["resolved_data"]["start_time"],
+            "18:00:00",
+        )
+        meta = {row["label"]: row["value"] for row in draft.display["meta"]}
+        self.assertEqual(
+            meta["Date"],
+            f"{section.label} · {section.section_date.isoformat()}",
+        )
+        self.assertEqual(meta["Time"], "18:00 – 20:00")
+        self.assertEqual(meta["Location"], "Da Nang beach")
 
     def test_create_timeline_activity_persists_section_date_for_uncreated_day(self):
         from ai.agent import handlers, schemas
@@ -200,6 +282,621 @@ class ToolHandlerTests(TestCase):
             },
         )
 
+    def test_update_timeline_activity_resolves_target_and_end_time_only(self):
+        from ai.agent import handlers, schemas
+
+        section = self.trip.timeline_sections.order_by("section_date").first()
+        activity = section.activities.create(
+            trip=self.trip,
+            title="Old stop",
+            time_mode="TIME_RANGE",
+            start_time=time(8, 0),
+            end_time=time(9, 0),
+            system_type="SIGHTSEEING",
+            location_label="Old Quarter",
+        )
+
+        result = handlers.update_timeline_activity(
+            trip=self.trip,
+            interaction=self.interaction,
+            actor=self.user,
+            args=schemas.UpdateTimelineActivityArgs(
+                activity_id=activity.id,
+                end_time=time(10, 0),
+            ),
+        )
+
+        draft = result.draft
+        self.assertEqual(
+            draft.payload,
+            {
+                "activity_id": str(activity.id),
+                "data": {"end_time": "10:00:00"},
+            },
+        )
+        self.assertEqual(draft.preview["data"], {"end_time": "10:00:00"})
+        self.assertEqual(draft.preview["target_title"], "Old stop")
+        self.assertEqual(draft.preview["section_label"], section.label)
+        self.assertEqual(
+            draft.preview["resolved_data"]["start_time"],
+            "08:00:00",
+        )
+        self.assertEqual(
+            draft.preview["resolved_data"]["end_time"],
+            "10:00:00",
+        )
+        meta = {row["label"]: row["value"] for row in draft.display["meta"]}
+        self.assertEqual(draft.display["title"], "Old stop")
+        self.assertEqual(meta["Target"], "Old stop")
+        self.assertEqual(meta["Time"], "08:00 – 10:00")
+        self.assertEqual(meta["Location"], "Old Quarter")
+
+    def test_update_timeline_activity_distinguishes_missing_and_cleared_location(self):
+        from ai.agent import handlers, schemas
+
+        section = self.trip.timeline_sections.order_by("section_date").first()
+        activity = section.activities.create(
+            trip=self.trip,
+            title="Cafe stop",
+            time_mode="FLEXIBLE",
+            system_type="FOOD",
+            location_label="Riverside Cafe",
+        )
+
+        preserved = handlers.update_timeline_activity(
+            trip=self.trip,
+            interaction=self.interaction,
+            actor=self.user,
+            args=schemas.UpdateTimelineActivityArgs(
+                activity_id=activity.id,
+                note="Bring cash",
+            ),
+        ).draft
+        cleared = handlers.update_timeline_activity(
+            trip=self.trip,
+            interaction=self.interaction,
+            actor=self.user,
+            args=schemas.UpdateTimelineActivityArgs(
+                activity_id=activity.id,
+                location_label="",
+            ),
+        ).draft
+
+        preserved_meta = {
+            row["label"]: row["value"] for row in preserved.display["meta"]
+        }
+        cleared_meta = {
+            row["label"]: row["value"] for row in cleared.display["meta"]
+        }
+        self.assertNotIn("location_label", preserved.payload["data"])
+        self.assertEqual(
+            preserved.preview["resolved_data"]["location_label"],
+            "Riverside Cafe",
+        )
+        self.assertEqual(preserved_meta["Location"], "Riverside Cafe")
+        self.assertIn("location_label", cleared.payload["data"])
+        self.assertEqual(cleared.payload["data"]["location_label"], "")
+        self.assertEqual(cleared.preview["resolved_data"]["location_label"], "")
+        self.assertEqual(cleared_meta["Location"], "Cleared")
+
+    def test_update_timeline_activity_all_day_clears_stale_clock_range_in_review(self):
+        from ai.agent import handlers, schemas
+
+        section = self.trip.timeline_sections.order_by("section_date").first()
+        activity = section.activities.create(
+            trip=self.trip,
+            title="Museum",
+            time_mode="TIME_RANGE",
+            start_time=time(8, 0),
+            end_time=time(10, 0),
+            system_type="SIGHTSEEING",
+        )
+
+        draft = handlers.update_timeline_activity(
+            trip=self.trip,
+            interaction=self.interaction,
+            actor=self.user,
+            args=schemas.UpdateTimelineActivityArgs(
+                activity_id=activity.id,
+                time_mode="ALL_DAY",
+            ),
+        ).draft
+
+        resolved = draft.preview["resolved_data"]
+        self.assertEqual(resolved["time_mode"], "ALL_DAY")
+        self.assertIsNone(resolved["start_time"])
+        self.assertIsNone(resolved["end_time"])
+        meta = {row["label"]: row["value"] for row in draft.display["meta"]}
+        self.assertEqual(meta["Time"], "All day")
+
+    def test_create_timeline_activity_reviews_all_hidden_editable_fields(self):
+        from ai.agent import handlers, schemas
+        from test_helpers import create_completed_user
+        from trips.models import (
+            MemberStatus,
+            TimelineCustomType,
+            TripMember,
+            TripRole,
+        )
+
+        section = self.trip.timeline_sections.order_by("section_date").first()
+        custom_type = TimelineCustomType.objects.create(
+            trip=self.trip,
+            name="Photo walk",
+            normalized_name="photo-walk",
+            created_by=self.user,
+        )
+        assignee = create_completed_user(
+            "tool-hidden-assignee@example.com",
+            "toolhidden",
+            "TH002",
+        )
+        TripMember.objects.create(
+            trip=self.trip,
+            user=assignee,
+            role=TripRole.MEMBER,
+            status=MemberStatus.ACTIVE,
+        )
+
+        draft = handlers.create_timeline_activity(
+            trip=self.trip,
+            interaction=self.interaction,
+            actor=self.user,
+            args=schemas.CreateTimelineActivityArgs(
+                section_id=section.id,
+                title="Hidden detail review",
+                custom_type_id=custom_type.id,
+                time_mode="AT_TIME",
+                start_time=time(9, 0),
+                assignee_scope="USER",
+                assignee_user_id=assignee.id,
+                booking_reference="BK-42",
+                contact_name="Lan",
+                contact_phone="+84 123",
+                external_link="https://example.com/booking",
+                location_note="Use the east entrance",
+                meeting_point="Hotel lobby",
+                note="Bring water",
+                reminder_offsets_minutes=[1440, 30],
+            ),
+        ).draft
+
+        meta = {row["label"]: row["value"] for row in draft.display["meta"]}
+        self.assertEqual(meta["Custom type"], "Photo walk")
+        self.assertEqual(meta["Assignee"], assignee.display_name)
+        self.assertEqual(meta["Booking reference"], "BK-42")
+        self.assertEqual(meta["Contact name"], "Lan")
+        self.assertEqual(meta["Contact phone"], "+84 123")
+        self.assertEqual(meta["External link"], "https://example.com/booking")
+        self.assertEqual(meta["Location note"], "Use the east entrance")
+        self.assertEqual(meta["Meeting point"], "Hotel lobby")
+        self.assertEqual(meta["Note"], "Bring water")
+        self.assertEqual(meta["Reminders"], "1 day before · 30 minutes before")
+        review_wire = str({"preview": draft.preview, "display": draft.display})
+        self.assertNotIn(str(section.id), review_wire)
+        self.assertNotIn(str(custom_type.id), review_wire)
+        self.assertNotIn(str(assignee.id), review_wire)
+
+    def test_create_timeline_activity_rejects_untrusted_trip_scoped_references(self):
+        from ai.agent.drafts import create_action_draft
+        from ai.models import AIActionDraftStatus
+        from test_helpers import create_completed_user
+        from trips.models import (
+            MemberStatus,
+            TimelineCustomType,
+            TripMember,
+            TripRole,
+        )
+        from trips.services import create_trip
+
+        other_captain = create_completed_user(
+            "tool-other-captain@example.com",
+            "toolothercaptain",
+            "TH004",
+        )
+        other_trip = create_trip(
+            captain=other_captain,
+            name="Other Tool Trip",
+            destination="Hue",
+            start_date="2026-08-01",
+            end_date="2026-08-02",
+        )
+        local_section = self.trip.timeline_sections.order_by("section_date").first()
+        foreign_section = other_trip.timeline_sections.order_by("section_date").first()
+        foreign_custom = TimelineCustomType.objects.create(
+            trip=other_trip,
+            name="Foreign custom",
+            normalized_name="foreign-custom",
+            created_by=other_captain,
+        )
+        inactive_custom = TimelineCustomType.objects.create(
+            trip=self.trip,
+            name="Inactive custom",
+            normalized_name="inactive-custom",
+            is_active=False,
+            created_by=self.user,
+        )
+        inactive_assignee = create_completed_user(
+            "tool-left-assignee@example.com",
+            "toolleftassignee",
+            "TH005",
+        )
+        TripMember.objects.create(
+            trip=self.trip,
+            user=inactive_assignee,
+            role=TripRole.MEMBER,
+            status=MemberStatus.LEFT,
+        )
+        foreign_assignee = create_completed_user(
+            "tool-foreign-assignee@example.com",
+            "toolforeignassignee",
+            "TH006",
+        )
+        removed_assignee = create_completed_user(
+            "tool-removed-assignee@example.com",
+            "toolremovedassignee",
+            "TH007",
+        )
+        TripMember.objects.create(
+            trip=self.trip,
+            user=removed_assignee,
+            role=TripRole.MEMBER,
+            status=MemberStatus.REMOVED,
+        )
+
+        cases = (
+            (
+                "missing section",
+                {"section_id": str(uuid4())},
+                {"section_id"},
+            ),
+            (
+                "foreign section",
+                {
+                    "section_id": str(foreign_section.id),
+                    "data": {
+                        "title": "Foreign timeline day",
+                        "time_mode": "TIME_RANGE",
+                        "system_type": "SIGHTSEEING",
+                    },
+                },
+                {"section_id"},
+            ),
+            (
+                "foreign custom type",
+                {
+                    "section_id": str(local_section.id),
+                    "data": {
+                        "title": "Foreign custom",
+                        "time_mode": "FLEXIBLE",
+                        "custom_type_id": str(foreign_custom.id),
+                    },
+                },
+                {"custom_type_id"},
+            ),
+            (
+                "inactive custom type",
+                {
+                    "section_id": str(local_section.id),
+                    "data": {
+                        "title": "Inactive custom",
+                        "time_mode": "FLEXIBLE",
+                        "custom_type_id": str(inactive_custom.id),
+                    },
+                },
+                {"custom_type_id"},
+            ),
+            (
+                "left assignee",
+                {
+                    "section_id": str(local_section.id),
+                    "data": {
+                        "title": "Inactive assignee",
+                        "time_mode": "FLEXIBLE",
+                        "system_type": "SIGHTSEEING",
+                        "assignee_scope": "USER",
+                        "assignee_user_id": str(inactive_assignee.id),
+                    },
+                },
+                {"assignee_user_id"},
+            ),
+            (
+                "foreign assignee",
+                {
+                    "section_id": str(local_section.id),
+                    "data": {
+                        "title": "Foreign assignee",
+                        "time_mode": "FLEXIBLE",
+                        "system_type": "SIGHTSEEING",
+                        "assignee_scope": "USER",
+                        "assignee_user_id": str(foreign_assignee.id),
+                    },
+                },
+                {"assignee_user_id"},
+            ),
+            (
+                "removed assignee",
+                {
+                    "section_id": str(local_section.id),
+                    "data": {
+                        "title": "Removed assignee",
+                        "time_mode": "FLEXIBLE",
+                        "system_type": "SIGHTSEEING",
+                        "assignee_scope": "USER",
+                        "assignee_user_id": str(removed_assignee.id),
+                    },
+                },
+                {"assignee_user_id"},
+            ),
+        )
+
+        base_payload = {
+            "data": {
+                "title": "Untrusted reference",
+                "time_mode": "FLEXIBLE",
+                "system_type": "SIGHTSEEING",
+            }
+        }
+        for label, overrides, expected_missing in cases:
+            with self.subTest(label=label):
+                payload = {
+                    **base_payload,
+                    **overrides,
+                }
+                draft = create_action_draft(
+                    trip=self.trip,
+                    interaction=self.interaction,
+                    action_type="timeline.activity.create",
+                    payload=payload,
+                )
+                self.assertEqual(draft.status, AIActionDraftStatus.NEEDS_INFO)
+                self.assertTrue(
+                    expected_missing
+                    <= {field["name"] for field in draft.missing_fields}
+                )
+                untrusted_ids = (
+                    str(foreign_section.id),
+                    str(foreign_custom.id),
+                    str(inactive_custom.id),
+                    str(inactive_assignee.id),
+                    str(foreign_assignee.id),
+                    str(removed_assignee.id),
+                )
+                review_wire = str(
+                    {
+                        "preview": draft.preview,
+                        "display": draft.display,
+                        "missing_fields": draft.missing_fields,
+                    }
+                )
+                for untrusted_id in untrusted_ids:
+                    self.assertNotIn(untrusted_id, review_wire)
+
+    def test_update_timeline_activity_reviews_explicit_clears_not_missing_fields(self):
+        from ai.agent import handlers, schemas
+
+        section = self.trip.timeline_sections.order_by("section_date").first()
+        activity = section.activities.create(
+            trip=self.trip,
+            title="Clear hidden details",
+            time_mode="FLEXIBLE",
+            system_type="SIGHTSEEING",
+            booking_reference="KEEP-ME",
+            contact_name="Old name",
+            contact_phone="Old phone",
+            external_link="https://example.com/old",
+            location_note="Old location note",
+            meeting_point="Old point",
+            note="Old note",
+        )
+
+        draft = handlers.update_timeline_activity(
+            trip=self.trip,
+            interaction=self.interaction,
+            actor=self.user,
+            args=schemas.UpdateTimelineActivityArgs(
+                activity_id=activity.id,
+                contact_name="",
+                contact_phone="",
+                external_link="",
+                location_note="",
+                meeting_point="",
+                note="",
+                reminder_offsets_minutes=[],
+            ),
+        ).draft
+
+        meta = {row["label"]: row["value"] for row in draft.display["meta"]}
+        for label in (
+            "Contact name",
+            "Contact phone",
+            "External link",
+            "Location note",
+            "Meeting point",
+            "Note",
+            "Reminders",
+        ):
+            self.assertEqual(meta[label], "Cleared")
+        self.assertNotIn("Booking reference", meta)
+        self.assertNotIn("booking_reference", draft.payload["data"])
+
+    def test_update_timeline_activity_reviews_structured_place_and_custom_type_transition(self):
+        from ai.agent import handlers, schemas
+        from trips.models import TimelineCustomType
+
+        section = self.trip.timeline_sections.order_by("section_date").first()
+        activity = section.activities.create(
+            trip=self.trip,
+            title="Old manual stop",
+            time_mode="FLEXIBLE",
+            system_type="SIGHTSEEING",
+            location_mode="MANUAL",
+            location_label="Old manual label",
+        )
+        custom_type = TimelineCustomType.objects.create(
+            trip=self.trip,
+            name="Workshop",
+            normalized_name="workshop",
+            created_by=self.user,
+        )
+
+        draft = handlers.update_timeline_activity(
+            trip=self.trip,
+            interaction=self.interaction,
+            actor=self.user,
+            args=schemas.UpdateTimelineActivityArgs(
+                activity_id=activity.id,
+                custom_type_id=custom_type.id,
+                location_mode="STRUCTURED",
+                place=schemas.PlaceArgs(
+                    provider="google",
+                    provider_id="place-123",
+                    title="New structured venue",
+                    address="1 River Road",
+                    lat="16.054407",
+                    lng="108.202164",
+                ),
+            ),
+        ).draft
+
+        resolved = draft.preview["resolved_data"]
+        meta = {row["label"]: row["value"] for row in draft.display["meta"]}
+        self.assertEqual(resolved["system_type"], "")
+        self.assertEqual(resolved["custom_type_label"], "Workshop")
+        self.assertEqual(meta["Location"], "New structured venue")
+        self.assertEqual(meta["Custom type"], "Workshop")
+        review_wire = str({"preview": draft.preview, "display": draft.display})
+        self.assertNotIn("place-123", review_wire)
+        self.assertNotIn("16.054407", review_wire)
+        self.assertNotIn("108.202164", review_wire)
+
+    def test_update_timeline_activity_invalid_merged_states_never_become_ready(self):
+        from ai.agent.drafts import create_action_draft
+        from ai.models import AIActionDraftStatus
+        from test_helpers import create_completed_user
+        from trips.models import (
+            MemberStatus,
+            TimelineActivityAssigneeScope,
+            TimelineCustomType,
+            TripMember,
+            TripRole,
+        )
+
+        section = self.trip.timeline_sections.order_by("section_date").first()
+        activity = section.activities.create(
+            trip=self.trip,
+            title="Planner target",
+            time_mode="FLEXIBLE",
+            system_type="SIGHTSEEING",
+            location_mode="MANUAL",
+            assignee_scope=TimelineActivityAssigneeScope.NONE,
+        )
+        inactive_custom = TimelineCustomType.objects.create(
+            trip=self.trip,
+            name="Inactive",
+            normalized_name="inactive",
+            is_active=False,
+            created_by=self.user,
+        )
+        inactive_user = create_completed_user(
+            "tool-inactive-assignee@example.com",
+            "toolinactive",
+            "TH003",
+        )
+        TripMember.objects.create(
+            trip=self.trip,
+            user=inactive_user,
+            role=TripRole.MEMBER,
+            status=MemberStatus.LEFT,
+        )
+        cases = (
+            ("time range without clocks", {"time_mode": "TIME_RANGE"}),
+            (
+                "structured without place",
+                {"location_mode": "STRUCTURED"},
+            ),
+            (
+                "place while manual",
+                {
+                    "place": {
+                        "provider": "google",
+                        "provider_id": "hidden",
+                        "title": "Venue",
+                    }
+                },
+            ),
+            ("empty system type", {"system_type": ""}),
+            (
+                "simultaneous system and custom",
+                {
+                    "system_type": "FOOD",
+                    "custom_type_id": str(inactive_custom.id),
+                },
+            ),
+            (
+                "assignee on non-user scope",
+                {"assignee_user_id": str(inactive_user.id)},
+            ),
+            (
+                "reminders while flexible",
+                {"reminder_offsets_minutes": [30]},
+            ),
+            (
+                "inactive custom type",
+                {"custom_type_id": str(inactive_custom.id)},
+            ),
+            (
+                "inactive assignee",
+                {
+                    "assignee_scope": "USER",
+                    "assignee_user_id": str(inactive_user.id),
+                },
+            ),
+        )
+
+        for label, data in cases:
+            with self.subTest(label=label):
+                draft = create_action_draft(
+                    trip=self.trip,
+                    interaction=self.interaction,
+                    action_type="timeline.activity.update",
+                    payload={
+                        "activity_id": str(activity.id),
+                        "data": data,
+                    },
+                )
+                self.assertEqual(draft.status, AIActionDraftStatus.NEEDS_INFO)
+
+    def test_update_timeline_activity_canonicalizes_at_time_end_clear(self):
+        from ai.agent.drafts import create_action_draft
+        from ai.models import AIActionDraftStatus
+
+        section = self.trip.timeline_sections.order_by("section_date").first()
+        activity = section.activities.create(
+            trip=self.trip,
+            title="Clock transition",
+            time_mode="TIME_RANGE",
+            start_time=time(8, 0),
+            end_time=time(10, 0),
+            system_type="SIGHTSEEING",
+        )
+
+        draft = create_action_draft(
+            trip=self.trip,
+            interaction=self.interaction,
+            action_type="timeline.activity.update",
+            payload={
+                "activity_id": str(activity.id),
+                "data": {"time_mode": "AT_TIME"},
+            },
+        )
+
+        self.assertEqual(draft.status, AIActionDraftStatus.READY)
+        self.assertIn("end_time", draft.payload["data"])
+        self.assertIsNone(draft.payload["data"]["end_time"])
+        self.assertEqual(draft.preview["resolved_data"]["time_mode"], "AT_TIME")
+        self.assertIsNone(draft.preview["resolved_data"]["end_time"])
+
     def test_update_expense_persists_description_and_collector(self):
         from ai.agent import handlers, schemas
         from expenses.services import create_expense
@@ -232,6 +929,132 @@ class ToolHandlerTests(TestCase):
                 "description": "Updated description",
                 "collector_id": str(self.user.id),
             },
+        )
+
+    def test_create_expense_keeps_fractional_vnd_draft_needs_info(self):
+        from ai.agent import handlers, schemas
+        from ai.models import AIActionDraftStatus
+
+        self.assertEqual(self.trip.currency_code, "VND")
+        result = handlers.create_expense(
+            trip=self.trip,
+            interaction=self.interaction,
+            actor=self.user,
+            args=schemas.CreateExpenseArgs(
+                title="Coffee",
+                total_amount=Decimal("25.50"),
+                currency_code="USD",
+            ),
+        )
+
+        self.assertEqual(result.draft.status, AIActionDraftStatus.NEEDS_INFO)
+        self.assertEqual(result.draft.payload["currency_code"], "VND")
+        self.assertEqual(result.draft.display["hero"]["currency"], "VND")
+        self.assertEqual(
+            [field["name"] for field in result.draft.missing_fields],
+            ["total_amount"],
+        )
+
+    def test_create_expense_uses_trip_currency_from_draft_through_confirmation(self):
+        from ai.agent import handlers, schemas
+        from ai.agent.executor import confirm_action_draft
+        from ai.models import AIActionDraftStatus
+        from expenses.models import Expense
+
+        self.assertEqual(self.trip.currency_code, "VND")
+        result = handlers.create_expense(
+            trip=self.trip,
+            interaction=self.interaction,
+            actor=self.user,
+            args=schemas.CreateExpenseArgs(
+                title="Coffee",
+                total_amount=Decimal("100"),
+                currency_code="USD",
+            ),
+        )
+
+        draft = result.draft
+        self.assertEqual(draft.status, AIActionDraftStatus.READY)
+        self.assertEqual(draft.payload["currency_code"], "VND")
+        self.assertEqual(draft.display["hero"]["currency"], "VND")
+
+        confirmed = confirm_action_draft(
+            draft_id=draft.id,
+            trip_id=self.trip.id,
+            actor=self.user,
+        )
+
+        expense = Expense.objects.get(pk=confirmed.result["object_id"])
+        self.assertEqual(confirmed.status, AIActionDraftStatus.CONFIRMED)
+        self.assertEqual(expense.total_amount, Decimal("100"))
+        self.assertEqual(expense.currency_code, "VND")
+
+    def test_create_expense_accepts_two_decimal_amount_for_usd_trip(self):
+        from ai.agent import handlers, schemas
+        from ai.models import AIActionDraftStatus
+
+        self.trip.currency_code = "USD"
+        self.trip.save(update_fields=["currency_code", "updated_at"])
+        result = handlers.create_expense(
+            trip=self.trip,
+            interaction=self.interaction,
+            actor=self.user,
+            args=schemas.CreateExpenseArgs(
+                title="Coffee",
+                total_amount=Decimal("25.50"),
+                currency_code="USD",
+            ),
+        )
+
+        self.assertEqual(result.draft.status, AIActionDraftStatus.READY)
+        self.assertEqual(result.draft.missing_fields, [])
+
+    def test_create_expense_reloads_locked_trip_and_stamps_omitted_currency(self):
+        from ai.agent import handlers, schemas
+        from ai.models import AIActionDraftStatus
+        from trips.models import Trip
+
+        self.assertEqual(self.trip.currency_code, "VND")
+        Trip.objects.filter(pk=self.trip.pk).update(currency_code="USD")
+
+        result = handlers.create_expense(
+            trip=self.trip,
+            interaction=self.interaction,
+            actor=self.user,
+            args=schemas.CreateExpenseArgs(
+                title="Coffee",
+                total_amount=Decimal("25.50"),
+            ),
+        )
+
+        self.assertEqual(self.trip.currency_code, "VND")
+        self.assertEqual(result.draft.status, AIActionDraftStatus.READY)
+        self.assertEqual(result.draft.payload["currency_code"], "USD")
+        self.assertEqual(result.draft.preview["currency_code"], "USD")
+        self.assertEqual(result.draft.display["hero"]["currency"], "USD")
+        self.assertEqual(result.draft.missing_fields, [])
+
+    def test_create_expense_keeps_decimalfield_overflow_draft_needs_info(self):
+        from ai.agent import handlers, schemas
+        from ai.models import AIActionDraftStatus
+
+        self.trip.currency_code = "USD"
+        self.trip.save(update_fields=["currency_code", "updated_at"])
+        result = handlers.create_expense(
+            trip=self.trip,
+            interaction=self.interaction,
+            actor=self.user,
+            args=schemas.CreateExpenseArgs(
+                title="Coffee",
+                total_amount=Decimal("1000000000000.00"),
+            ),
+        )
+
+        self.assertEqual(result.draft.status, AIActionDraftStatus.NEEDS_INFO)
+        self.assertEqual(result.draft.payload["currency_code"], "USD")
+        self.assertEqual(
+            [field["name"] for field in result.draft.missing_fields],
+            ["total_amount"],
         )
 
     def test_set_expense_contribution_persists_target_precondition(self):

--- a/backend/ai/tests/test_change_sequences.py
+++ b/backend/ai/tests/test_change_sequences.py
@@ -869,7 +869,8 @@ class AIActionDraftSequenceAccessTests(APITestCase):
         response = self.client.post(self.cancel_url, {}, format="json")
 
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(response.data["error_code"], "AI_DRAFT_NOT_FOUND")
+        self.assertEqual(response.data["error_code"], "TRIP_NOT_FOUND")
+        self.assertEqual(response.data["detail"], "Trip not found.")
         self.trip.refresh_from_db()
         self.response_message.refresh_from_db()
         self.draft.refresh_from_db()

--- a/backend/ai/tests/test_change_sequences.py
+++ b/backend/ai/tests/test_change_sequences.py
@@ -379,7 +379,11 @@ class AIActionDraftChangeSequenceTests(TestCase):
             response_message=self.response_message,
             user=self.user,
             status=AIActionDraftStatus.NEEDS_INFO,
-            payload={"title": "Lunch", "total_amount": "500000"},
+            payload={
+                "title": "Lunch",
+                "total_amount": "500000",
+                "currency_code": self.trip.currency_code,
+            },
             missing_fields=[
                 {"name": "total_amount", "label": "Amount", "type": "money"}
             ],

--- a/backend/ai/views.py
+++ b/backend/ai/views.py
@@ -90,6 +90,14 @@ class AIActionDraftDetailAPIView(APIView):
     def get(self, request, trip_id, draft_id):
         try:
             ensure_user_can_access_trip_chat(request.user, trip_id)
+        except TripNotFoundError as exc:
+            return _error(
+                str(exc),
+                exc.error_code,
+                status.HTTP_404_NOT_FOUND,
+            )
+
+        try:
             draft = _get_draft_or_404(trip_id=trip_id, draft_id=draft_id)
         except TripNotFoundError:
             return _error(
@@ -108,10 +116,10 @@ class AIActionDraftDetailAPIView(APIView):
 
         try:
             ensure_user_can_access_trip_chat(request.user, trip_id)
-        except TripNotFoundError:
+        except TripNotFoundError as exc:
             return _error(
-                "Draft not found.",
-                "AI_DRAFT_NOT_FOUND",
+                str(exc),
+                exc.error_code,
                 status.HTTP_404_NOT_FOUND,
             )
 
@@ -142,6 +150,8 @@ class AIActionDraftDetailAPIView(APIView):
         except AIActionDraftForbiddenError as exc:
             return _error(str(exc), exc.error_code, status.HTTP_403_FORBIDDEN)
         except AIActionDraftNotReadyError as exc:
+            return _error(str(exc), exc.error_code, status.HTTP_409_CONFLICT)
+        except TripTerminalError as exc:
             return _error(str(exc), exc.error_code, status.HTTP_409_CONFLICT)
         except AIActionDraftPatchFieldNotAllowedError as exc:
             return _error(str(exc), exc.error_code, status.HTTP_400_BAD_REQUEST)
@@ -175,10 +185,10 @@ class AIActionDraftCancelAPIView(APIView):
     def post(self, request, trip_id, draft_id):
         try:
             ensure_user_can_access_trip_chat(request.user, trip_id)
-        except TripNotFoundError:
+        except TripNotFoundError as exc:
             return _error(
-                "Draft not found.",
-                "AI_DRAFT_NOT_FOUND",
+                str(exc),
+                exc.error_code,
                 status.HTTP_404_NOT_FOUND,
             )
 
@@ -212,6 +222,8 @@ class AIActionDraftCancelAPIView(APIView):
                 exc.error_code,
                 status.HTTP_403_FORBIDDEN,
             )
+        except TripTerminalError as exc:
+            return _error(str(exc), exc.error_code, status.HTTP_409_CONFLICT)
 
         return Response({"draft": build_action_draft_payload(draft, viewer=request.user)})
 
@@ -344,6 +356,7 @@ def _should_persist_confirm_failure(exc: Exception) -> bool:
             AIActionDraft.DoesNotExist,
             OperationalError,
             TransferNotSentError,
+            TripTerminalError,
         ),
     )
 
@@ -372,6 +385,14 @@ class AIActionDraftConfirmAPIView(APIView):
     def post(self, request, trip_id, draft_id):
         try:
             ensure_user_can_access_trip_chat(request.user, trip_id)
+        except TripNotFoundError as exc:
+            return _error(
+                str(exc),
+                exc.error_code,
+                status.HTTP_404_NOT_FOUND,
+            )
+
+        try:
             draft = confirm_action_draft(
                 draft_id=draft_id,
                 trip_id=trip_id,

--- a/backend/chat/tests/test_consumers.py
+++ b/backend/chat/tests/test_consumers.py
@@ -81,6 +81,11 @@ def _add_member(trip, user):
 
 
 @database_sync_to_async
+def _set_trip_status(trip, status):
+    Trip.objects.filter(pk=trip.pk).update(status=status)
+
+
+@database_sync_to_async
 def _remove_member(trip, user):
     TripMember.objects.filter(
         trip=trip,
@@ -182,6 +187,37 @@ class ChatConsumerTests(TransactionTestCase):
         )
 
         await communicator.disconnect()
+
+    async def test_active_member_can_subscribe_to_terminal_trip(self):
+        captain = await _create_user(
+            "ws-terminal-cap@example.com",
+            "wstermcap",
+            "WTC001",
+        )
+        member = await _create_user(
+            "ws-terminal-member@example.com",
+            "wstermmem",
+            "WTM001",
+        )
+        trip = await _make_trip(captain)
+        await _add_member(trip, member)
+
+        for terminal_status in (TripStatus.COMPLETED, TripStatus.CANCELLED):
+            with self.subTest(trip_status=terminal_status):
+                await _set_trip_status(trip, terminal_status)
+                communicator, connected = await _connect(member)
+                self.assertTrue(connected)
+                try:
+                    await communicator.send_json_to(
+                        {"type": "chat.subscribe", "trip_id": str(trip.id)}
+                    )
+                    subscribed = await communicator.receive_json_from(timeout=1)
+                    self.assertEqual(
+                        subscribed,
+                        {"type": "chat.subscribed", "trip_id": str(trip.id)},
+                    )
+                finally:
+                    await communicator.disconnect()
 
     async def test_subscribe_uses_canonical_trip_id_for_group(self):
         captain = await _create_user("ws-canon-cap@example.com", "wscan", "WCN001")

--- a/backend/expenses/services.py
+++ b/backend/expenses/services.py
@@ -28,6 +28,12 @@ from trips.services import (
 
 
 ZERO_DECIMAL_CURRENCIES = {"VND", "JPY", "KRW"}
+EXPENSE_AMOUNT_MAX_DIGITS = 14
+EXPENSE_AMOUNT_DECIMAL_PLACES = 2
+EXPENSE_AMOUNT_MAX_WHOLE_DIGITS = (
+    EXPENSE_AMOUNT_MAX_DIGITS - EXPENSE_AMOUNT_DECIMAL_PLACES
+)
+EXPENSE_AMOUNT_MAX_VALUE = Decimal("999999999999.99")
 MAX_OPTIMAL_SETTLEMENT_PARTICIPANTS = 16
 
 
@@ -272,6 +278,12 @@ def normalize_currency_amount(amount: Decimal, currency_code: str) -> Decimal:
     if normalized_amount <= 0:
         raise ExpenseServiceError("Amount must be greater than zero.")
 
+    if normalized_amount > EXPENSE_AMOUNT_MAX_VALUE:
+        raise ExpenseServiceError(
+            "Amount must have no more than "
+            f"{EXPENSE_AMOUNT_MAX_WHOLE_DIGITS} digits before the decimal point."
+        )
+
     return normalized_amount
 
 
@@ -287,6 +299,12 @@ def normalize_non_negative_currency_amount(amount: Decimal, currency_code: str) 
 
     if normalized_amount < 0:
         raise ExpenseServiceError("Amount must be greater than or equal to zero.")
+
+    if normalized_amount > EXPENSE_AMOUNT_MAX_VALUE:
+        raise ExpenseServiceError(
+            "Amount must have no more than "
+            f"{EXPENSE_AMOUNT_MAX_WHOLE_DIGITS} digits before the decimal point."
+        )
 
     return normalized_amount
 

--- a/backend/expenses/tests/test_expense_services.py
+++ b/backend/expenses/tests/test_expense_services.py
@@ -116,6 +116,44 @@ class ExpenseCreationServiceTests(TestCase):
         self.assertEqual(Expense.objects.count(), 0)
         self.assertEqual(ExpenseParticipant.objects.count(), 0)
 
+    def test_accepts_max_decimalfield_amount_for_usd(self):
+        self.trip.currency_code = "USD"
+        self.trip.save(update_fields=["currency_code", "updated_at"])
+
+        expense = create_expense(
+            trip_id=self.trip.id,
+            actor=self.captain,
+            title="Maximum Dinner",
+            total_amount=Decimal("999999999999.99"),
+        )
+
+        self.assertEqual(expense.total_amount, Decimal("999999999999.99"))
+        self.assertEqual(
+            sum(
+                expense.participants.values_list("share_amount", flat=True),
+                Decimal("0"),
+            ),
+            expense.total_amount,
+        )
+
+    def test_rejects_decimalfield_overflow_without_creating_expense(self):
+        self.trip.currency_code = "USD"
+        self.trip.save(update_fields=["currency_code", "updated_at"])
+
+        with self.assertRaisesMessage(
+            ExpenseServiceError,
+            "Amount must have no more than 12 digits before the decimal point.",
+        ):
+            create_expense(
+                trip_id=self.trip.id,
+                actor=self.captain,
+                title="Overflow Dinner",
+                total_amount=Decimal("1000000000000.00"),
+            )
+
+        self.assertEqual(Expense.objects.count(), 0)
+        self.assertEqual(ExpenseParticipant.objects.count(), 0)
+
 
     def test_vnd_remainder_split_is_deterministic(self):
         third_member = create_completed_user(
@@ -412,6 +450,22 @@ class ExpenseContributionServiceTests(TestCase):
             )
 
         self.assertEqual(ExpenseContribution.objects.count(), 0)
+
+    def test_set_contribution_rejects_decimalfield_overflow(self):
+        with self.assertRaisesMessage(
+            ExpenseServiceError,
+            "Amount must have no more than 12 digits before the decimal point.",
+        ):
+            set_contribution(
+                trip_id=self.trip.id,
+                expense_id=self.expense.id,
+                target_user_id=self.member.id,
+                actor=self.captain,
+                amount=Decimal("1000000000000"),
+            )
+
+        self.assertEqual(ExpenseContribution.objects.count(), 0)
+        self.assertEqual(ExpenseLedgerEntry.objects.count(), 0)
 
     def test_set_contribution_rejects_negative_amount(self):
         with self.assertRaises(ExpenseServiceError):

--- a/backend/trips/services.py
+++ b/backend/trips/services.py
@@ -1279,7 +1279,8 @@ def normalize_timeline_activity_input(data: dict) -> dict:
     return normalized
 
 
-def _timeline_json_value(value):
+def timeline_json_value(value):
+    """Convert normalized timeline values into JSON-safe canonical values."""
     if isinstance(value, datetime):
         return value.isoformat()
     if isinstance(value, time):
@@ -1287,9 +1288,9 @@ def _timeline_json_value(value):
     if isinstance(value, (Decimal, UUID)):
         return str(value)
     if isinstance(value, dict):
-        return {key: _timeline_json_value(item) for key, item in value.items()}
+        return {key: timeline_json_value(item) for key, item in value.items()}
     if isinstance(value, (list, tuple)):
-        return [_timeline_json_value(item) for item in value]
+        return [timeline_json_value(item) for item in value]
     return value
 
 
@@ -1503,7 +1504,7 @@ def plan_timeline_activity_create(
         "reminder_offsets_minutes": reminder_offsets,
     }
     return TimelineActivityCreatePlan(
-        data=_timeline_json_value(canonical_data),
+        data=timeline_json_value(canonical_data),
         apply_data=apply_data,
         final_data=final_data,
         section=references.section,
@@ -1743,7 +1744,7 @@ def plan_timeline_activity_patch(
         "reminder_offsets_minutes": final_reminder_offsets,
     }
     return TimelineActivityPatchPlan(
-        data=_timeline_json_value(apply_data),
+        data=timeline_json_value(apply_data),
         apply_data=apply_data,
         final_data=final_data,
         final_time_mode=final_time_mode,

--- a/backend/trips/services.py
+++ b/backend/trips/services.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta, timezone as dt_timezone
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta, timezone as dt_timezone
+from decimal import Decimal
+from uuid import UUID
 from zoneinfo import ZoneInfo
 
 from django.contrib.auth import get_user_model
@@ -8,6 +11,7 @@ from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from django.db.models import Count, Prefetch, Q, Subquery
 from django.utils import timezone
+from django.utils.dateparse import parse_datetime, parse_time
 from rest_framework import serializers as drf_serializers
 
 from friends.models import Friendship
@@ -931,13 +935,6 @@ def delete_section(trip_id, section_id, *, actor) -> None:
 
 # -------- Activity mutations --------
 
-def _assert_active_member(trip, user_id):
-    if not TripMember.objects.filter(
-        trip=trip, user_id=user_id, status=MemberStatus.ACTIVE
-    ).exists():
-        raise TimelineInvalidAssigneeError("Assignee must be an active member of this trip.")
-
-
 def _clear_activity_assignees_for_user(*, trip: Trip, user_id, updated_by) -> None:
     TimelineActivity.objects.filter(
         trip=trip,
@@ -1111,33 +1108,23 @@ def create_timeline_activity(trip_id, section_id, *, actor, data: dict) -> Timel
         except TimelineSection.DoesNotExist:
             raise TimelineSectionNotFoundError("Section not found.")
 
-        _apply_activity_create_invariants(data)
-
-        custom_type = None
-        if data.get("custom_type_id") is not None:
-            custom_type = _resolve_custom_type(trip, data["custom_type_id"])
-
-        assignee_scope = data.get(
-            "assignee_scope",
-            TimelineActivityAssigneeScope.USER
-            if data.get("assignee_user_id") is not None
-            else TimelineActivityAssigneeScope.NONE,
+        plan = plan_timeline_activity_create(
+            trip=trip,
+            section=section,
+            section_id=section.id,
+            data=data,
         )
+        data = plan.apply_data
+        custom_type = plan.final_custom_type
+        assignee_scope = data["assignee_scope"]
         assignee_user_id = (
-            data.get("assignee_user_id")
-            if assignee_scope == TimelineActivityAssigneeScope.USER
+            plan.final_assignee_user.id
+            if plan.final_assignee_user is not None
             else None
         )
 
-        if assignee_user_id is not None:
-            _assert_active_member(trip, assignee_user_id)
-
         place = data.get("place") or {}
         location_mode = data.get("location_mode", TimelineLocationMode.MANUAL)
-        _validate_activity_reminder_offsets_allowed(
-            data["time_mode"],
-            data.get("reminder_offsets_minutes"),
-        )
 
         activity = TimelineActivity.objects.create(
             trip=trip,
@@ -1205,69 +1192,567 @@ def _validate_activity_final_invariants(
     _validate_activity_location(location_mode, place)
 
 
-def _apply_activity_create_invariants(data: dict) -> None:
-    """Validate service-level create invariants before persistence."""
-    _validate_activity_final_invariants(
-        time_mode=data.get("time_mode"),
-        start_time=data.get("start_time"),
-        end_time=data.get("end_time"),
-        system_type=data.get("system_type", ""),
-        custom_type_id=data.get("custom_type_id"),
-        location_mode=data.get("location_mode", TimelineLocationMode.MANUAL),
-        place=data.get("place"),
-        reminder_offsets=data.get("reminder_offsets_minutes", []),
+_LEGACY_TIMELINE_SYSTEM_TYPES = {
+    "DINING": "FOOD",
+    "TRANSPORT": "TRANSPORTATION",
+    "NIGHTLIFE": "OTHER",
+}
+
+_LEGACY_TIMELINE_TIME_MODES = {
+    "ANCHOR": "AT_TIME",
+}
+
+_LEGACY_TIMELINE_ASSIGNEE_SCOPES = {
+    "GROUP": "EVERYONE",
+}
+
+
+@dataclass(frozen=True)
+class TimelineActivityCreateReferences:
+    """Trip-scoped references resolved without writing timeline state."""
+
+    section: TimelineSection | None
+    custom_type: TimelineCustomType | None
+    assignee_user: object | None
+
+
+@dataclass(frozen=True)
+class TimelineActivityCreatePlan:
+    """Pure, executable create plan shared by AI review and the service."""
+
+    data: dict
+    apply_data: dict
+    final_data: dict
+    section: TimelineSection | None
+    final_custom_type: TimelineCustomType | None
+    final_assignee_user: object | None
+
+
+@dataclass(frozen=True)
+class TimelineActivityPatchPlan:
+    """Pure, validated plan shared by AI review and the mutation service."""
+
+    data: dict
+    apply_data: dict
+    final_data: dict
+    final_time_mode: str
+    final_start_time: object
+    final_end_time: object
+    final_custom_type: TimelineCustomType | None
+    final_assignee_user: object | None
+    final_location_mode: str
+    final_place: dict | None
+    final_reminder_offsets: list[int]
+
+
+def _normalize_timeline_patch_clock(value):
+    if value is None or isinstance(value, time):
+        return value
+    if isinstance(value, datetime):
+        return value.time().replace(tzinfo=None, microsecond=0)
+    if not isinstance(value, str):
+        return value
+    parsed_datetime = parse_datetime(value)
+    if parsed_datetime is not None:
+        return parsed_datetime.time().replace(tzinfo=None, microsecond=0)
+    parsed = parse_time(value)
+    return parsed.replace(tzinfo=None, microsecond=0) if parsed is not None else value
+
+
+def _normalize_timeline_patch_input(data: dict) -> dict:
+    normalized = dict(data)
+    system_type = normalized.get("system_type")
+    if system_type in _LEGACY_TIMELINE_SYSTEM_TYPES:
+        normalized["system_type"] = _LEGACY_TIMELINE_SYSTEM_TYPES[system_type]
+    time_mode = normalized.get("time_mode")
+    if time_mode in _LEGACY_TIMELINE_TIME_MODES:
+        normalized["time_mode"] = _LEGACY_TIMELINE_TIME_MODES[time_mode]
+    assignee_scope = normalized.get("assignee_scope")
+    if assignee_scope in _LEGACY_TIMELINE_ASSIGNEE_SCOPES:
+        normalized["assignee_scope"] = _LEGACY_TIMELINE_ASSIGNEE_SCOPES[
+            assignee_scope
+        ]
+    for field in ("start_time", "end_time"):
+        if field in normalized:
+            normalized[field] = _normalize_timeline_patch_clock(normalized[field])
+    return normalized
+
+
+def _timeline_json_value(value):
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, time):
+        return value.replace(tzinfo=None, microsecond=0).isoformat()
+    if isinstance(value, (Decimal, UUID)):
+        return str(value)
+    if isinstance(value, dict):
+        return {key: _timeline_json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_timeline_json_value(item) for item in value]
+    return value
+
+
+def _activity_structured_place(activity: TimelineActivity) -> dict | None:
+    if (
+        activity.location_mode != TimelineLocationMode.STRUCTURED
+        or not activity.place_provider_id
+    ):
+        return None
+    return {
+        "provider": activity.place_provider,
+        "provider_id": activity.place_provider_id,
+        "title": activity.place_title,
+        "address": activity.place_address,
+        "lat": activity.place_lat,
+        "lng": activity.place_lng,
+    }
+
+
+def _timeline_assignee_label(user) -> str:
+    return user.display_name or user.identify_tag or "Trip member"
+
+
+def resolve_timeline_activity_create_references(
+    *,
+    trip: Trip,
+    data: dict,
+    section_id=None,
+    section: TimelineSection | None = None,
+    lock_section: bool = False,
+    require_section: bool = True,
+) -> TimelineActivityCreateReferences:
+    """Resolve only allowlisted create references inside the locked trip.
+
+    This function performs no writes and intentionally returns domain objects,
+    never provider-supplied identifiers or cross-trip metadata.
+    """
+    resolved_section = section
+    if resolved_section is not None:
+        if resolved_section.trip_id != trip.id or (
+            section_id is not None
+            and str(resolved_section.id) != str(section_id)
+        ):
+            raise TimelineSectionNotFoundError("Section not found.")
+    elif section_id is not None:
+        section_queryset = TimelineSection.objects
+        if lock_section:
+            section_queryset = section_queryset.select_for_update(of=("self",))
+        try:
+            resolved_section = section_queryset.get(pk=section_id, trip=trip)
+        except (
+            TimelineSection.DoesNotExist,
+            ValidationError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            raise TimelineSectionNotFoundError("Section not found.") from exc
+    elif require_section:
+        raise TimelineSectionNotFoundError("Section not found.")
+
+    custom_type = None
+    custom_type_id = data.get("custom_type_id")
+    if custom_type_id is not None:
+        try:
+            custom_type = _resolve_custom_type(
+                trip,
+                custom_type_id,
+                require_active=True,
+            )
+        except TimelineInvalidCustomTypeError:
+            raise
+        except (ValidationError, TypeError, ValueError) as exc:
+            raise TimelineInvalidCustomTypeError(
+                "Custom type does not belong to this trip."
+            ) from exc
+
+    assignee_user = None
+    assignee_user_id = data.get("assignee_user_id")
+    assignee_scope = data.get("assignee_scope")
+    if assignee_scope is None and assignee_user_id is not None:
+        assignee_scope = TimelineActivityAssigneeScope.USER
+    if (
+        assignee_scope == TimelineActivityAssigneeScope.USER
+        and assignee_user_id is not None
+    ):
+        try:
+            membership = (
+                TripMember.objects.select_related("user")
+                .filter(
+                    trip=trip,
+                    user_id=assignee_user_id,
+                    status=MemberStatus.ACTIVE,
+                )
+                .first()
+            )
+        except (ValidationError, TypeError, ValueError) as exc:
+            raise TimelineInvalidAssigneeError(
+                "Assignee must be an active member of this trip."
+            ) from exc
+        if membership is None:
+            raise TimelineInvalidAssigneeError(
+                "Assignee must be an active member of this trip."
+            )
+        assignee_user = membership.user
+
+    return TimelineActivityCreateReferences(
+        section=resolved_section,
+        custom_type=custom_type,
+        assignee_user=assignee_user,
     )
 
 
-def _apply_activity_patch_invariants(activity: TimelineActivity, data: dict) -> None:
-    """Validate that the merged final state still satisfies cross-field invariants."""
-    final_time_mode = data.get("time_mode", activity.time_mode)
+def plan_timeline_activity_create(
+    *,
+    trip: Trip,
+    data: dict,
+    section_id=None,
+    section: TimelineSection | None = None,
+    lock_section: bool = False,
+    require_section: bool = True,
+) -> TimelineActivityCreatePlan:
+    """Return the canonical create payload and authoritative review state.
+
+    The function performs no writes. A mutation caller must hold the Trip lock;
+    confirmation callers may additionally request a section row lock.
+    """
+    from trips.serializers import CreateTimelineActivitySerializer
+
+    if not isinstance(data, dict):
+        raise drf_serializers.ValidationError(
+            {"data": "Activity data must be an object."}
+        )
+
+    normalized = _normalize_timeline_patch_input(data)
+    explicit_fields = set(normalized)
+    serializer = CreateTimelineActivitySerializer(data=normalized)
+    serializer.is_valid(raise_exception=True)
+    apply_data = dict(serializer.validated_data)
+    references = resolve_timeline_activity_create_references(
+        trip=trip,
+        data=apply_data,
+        section_id=section_id,
+        section=section,
+        lock_section=lock_section,
+        require_section=require_section,
+    )
+
+    custom_type = references.custom_type
+    assignee_user = references.assignee_user
+    time_mode = apply_data["time_mode"]
+    location_mode = apply_data.get(
+        "location_mode",
+        TimelineLocationMode.MANUAL,
+    )
+    place = (
+        apply_data.get("place")
+        if location_mode == TimelineLocationMode.STRUCTURED
+        else None
+    )
+    reminder_offsets = list(apply_data.get("reminder_offsets_minutes", []))
+    system_type = (
+        "" if custom_type is not None else apply_data.get("system_type", "")
+    )
+    _validate_activity_final_invariants(
+        time_mode=time_mode,
+        start_time=apply_data.get("start_time"),
+        end_time=apply_data.get("end_time"),
+        system_type=system_type,
+        custom_type_id=(custom_type.id if custom_type is not None else None),
+        location_mode=location_mode,
+        place=place,
+        reminder_offsets=reminder_offsets,
+    )
+
+    canonical_data = {
+        field: apply_data[field]
+        for field in explicit_fields
+        if field in apply_data
+    }
+    if (
+        "assignee_user_id" in explicit_fields
+        and "assignee_scope" not in explicit_fields
+    ):
+        canonical_data["assignee_scope"] = apply_data["assignee_scope"]
+
+    final_data = {
+        "title": apply_data["title"],
+        "system_type": system_type,
+        "custom_type_label": (
+            custom_type.name if custom_type is not None else None
+        ),
+        "time_mode": time_mode,
+        "start_time": apply_data.get("start_time"),
+        "end_time": apply_data.get("end_time"),
+        "assignee_scope": apply_data["assignee_scope"],
+        "assignee_label": (
+            _timeline_assignee_label(assignee_user)
+            if assignee_user is not None
+            else None
+        ),
+        "location_mode": location_mode,
+        "location_label": apply_data.get("location_label", ""),
+        "place": place,
+        "location_note": apply_data.get("location_note", ""),
+        "note": apply_data.get("note", ""),
+        "meeting_point": apply_data.get("meeting_point", ""),
+        "contact_name": apply_data.get("contact_name", ""),
+        "contact_phone": apply_data.get("contact_phone", ""),
+        "booking_reference": apply_data.get("booking_reference", ""),
+        "external_link": apply_data.get("external_link", ""),
+        "reminder_offsets_minutes": reminder_offsets,
+    }
+    return TimelineActivityCreatePlan(
+        data=_timeline_json_value(canonical_data),
+        apply_data=apply_data,
+        final_data=final_data,
+        section=references.section,
+        final_custom_type=custom_type,
+        final_assignee_user=assignee_user,
+    )
+
+
+def plan_timeline_activity_patch(
+    *,
+    trip: Trip,
+    activity: TimelineActivity,
+    data: dict,
+) -> TimelineActivityPatchPlan:
+    """Return the exact executable patch and authoritative merged final state.
+
+    The function performs no writes. Callers that mutate must lock ``trip`` and
+    ``activity`` first, then execute ``apply_data`` from this plan.
+    """
+    from trips.serializers import PatchTimelineActivitySerializer
+
+    if activity.trip_id != trip.id:
+        raise TimelineActivityNotFoundError("Activity not found.")
+    if not isinstance(data, dict):
+        raise drf_serializers.ValidationError(
+            {"data": "Activity patch must be an object."}
+        )
+
+    normalized = _normalize_timeline_patch_input(data)
+    explicit_fields = set(normalized)
+    serializer_input = dict(normalized)
+
+    if {"assignee_scope", "assignee_user_id"} & explicit_fields:
+        merged_assignee_scope = normalized.get(
+            "assignee_scope",
+            activity.assignee_scope,
+        )
+        serializer_input["assignee_scope"] = merged_assignee_scope
+        serializer_input["assignee_user_id"] = normalized.get(
+            "assignee_user_id",
+            (
+                activity.assignee_user_id
+                if merged_assignee_scope
+                == TimelineActivityAssigneeScope.USER
+                else None
+            ),
+        )
+
+    serializer = PatchTimelineActivitySerializer(data=serializer_input)
+    serializer.is_valid(raise_exception=True)
+    validated = serializer.validated_data
+    apply_data = {
+        field: validated[field]
+        for field in explicit_fields
+        if field in validated
+    }
+
+    if (
+        "system_type" in apply_data
+        and not apply_data["system_type"]
+        and apply_data.get("custom_type_id") is None
+    ):
+        raise drf_serializers.ValidationError(
+            {"system_type": "system_type cannot be empty."}
+        )
+    if (
+        apply_data.get("system_type")
+        and apply_data.get("custom_type_id") is not None
+    ):
+        raise drf_serializers.ValidationError(
+            {
+                "system_type": (
+                    "Provide exactly one of system_type or custom_type_id."
+                )
+            }
+        )
+
+    final_time_mode = apply_data.get("time_mode", activity.time_mode)
+    if "time_mode" in apply_data:
+        if final_time_mode in (
+            TimelineActivityTimeMode.ALL_DAY,
+            TimelineActivityTimeMode.FLEXIBLE,
+        ):
+            apply_data.setdefault("start_time", None)
+            apply_data.setdefault("end_time", None)
+            apply_data.setdefault("reminder_offsets_minutes", [])
+        elif final_time_mode == TimelineActivityTimeMode.AT_TIME:
+            apply_data.setdefault("end_time", None)
+
+    if apply_data.get("custom_type_id") is not None:
+        apply_data.setdefault("system_type", "")
+    elif apply_data.get("system_type"):
+        apply_data.setdefault("custom_type_id", None)
+
+    final_location_mode = apply_data.get(
+        "location_mode",
+        activity.location_mode,
+    )
+    if (
+        "location_mode" in apply_data
+        and final_location_mode == TimelineLocationMode.MANUAL
+    ):
+        apply_data.setdefault("place", None)
+
+    final_assignee_scope = apply_data.get(
+        "assignee_scope",
+        activity.assignee_scope,
+    )
+    if (
+        "assignee_scope" in apply_data
+        and final_assignee_scope != TimelineActivityAssigneeScope.USER
+    ):
+        apply_data.setdefault("assignee_user_id", None)
+
     if final_time_mode in (
         TimelineActivityTimeMode.ALL_DAY,
         TimelineActivityTimeMode.FLEXIBLE,
     ):
-        final_start = data["start_time"] if "start_time" in data else None
-        final_end = data["end_time"] if "end_time" in data else None
+        final_start_time = (
+            apply_data["start_time"] if "start_time" in apply_data else None
+        )
+        final_end_time = (
+            apply_data["end_time"] if "end_time" in apply_data else None
+        )
     else:
-        final_start = data["start_time"] if "start_time" in data else activity.start_time
-        final_end = data["end_time"] if "end_time" in data else activity.end_time
+        final_start_time = apply_data.get("start_time", activity.start_time)
+        final_end_time = apply_data.get("end_time", activity.end_time)
 
-    explicit_system_type = "system_type" in data
-    final_system_type = data.get("system_type", activity.system_type)
-    if "custom_type_id" in data:
-        final_custom_type_id = data["custom_type_id"]
+    explicit_system_type = "system_type" in apply_data
+    final_system_type = apply_data.get("system_type", activity.system_type)
+    if "custom_type_id" in apply_data:
+        custom_type_id = apply_data["custom_type_id"]
+        if custom_type_id is None:
+            final_custom_type = None
+        elif (
+            activity.custom_type_id is not None
+            and str(activity.custom_type_id) == str(custom_type_id)
+        ):
+            # Existing inactive types remain reusable on their current activity;
+            # only selecting a different inactive type is forbidden.
+            final_custom_type = activity.custom_type
+        else:
+            final_custom_type = _resolve_custom_type(
+                trip,
+                custom_type_id,
+                require_active=True,
+            )
     elif explicit_system_type and final_system_type:
-        final_custom_type_id = None
+        final_custom_type = None
     else:
-        final_custom_type_id = activity.custom_type_id
-    if final_custom_type_id is not None and not (explicit_system_type and final_system_type):
+        final_custom_type = activity.custom_type
+    if final_custom_type is not None and not (
+        explicit_system_type and final_system_type
+    ):
         final_system_type = ""
 
-    final_location_mode = data.get("location_mode", activity.location_mode)
-    if final_location_mode == TimelineLocationMode.MANUAL:
-        # Switching to or staying in MANUAL implicitly clears any existing place.
-        final_place = data.get("place")
-    elif "place" in data:
-        final_place = data["place"]
+    if final_assignee_scope == TimelineActivityAssigneeScope.USER:
+        final_assignee_user_id = apply_data.get(
+            "assignee_user_id",
+            activity.assignee_user_id,
+        )
+        membership = (
+            TripMember.objects.select_related("user")
+            .filter(
+                trip=trip,
+                user_id=final_assignee_user_id,
+                status=MemberStatus.ACTIVE,
+            )
+            .first()
+        )
+        if membership is None:
+            raise TimelineInvalidAssigneeError(
+                "Assignee must be an active member of this trip."
+            )
+        final_assignee_user = membership.user
     else:
-        if activity.place_provider_id:
-            final_place = {
-                "provider": activity.place_provider,
-                "provider_id": activity.place_provider_id,
-                "title": activity.place_title,
-            }
-        else:
-            final_place = None
+        final_assignee_user_id = None
+        final_assignee_user = None
+
+    if final_location_mode == TimelineLocationMode.MANUAL:
+        final_place = apply_data.get("place")
+    elif "place" in apply_data:
+        final_place = apply_data["place"]
+    else:
+        final_place = _activity_structured_place(activity)
+
+    final_reminder_offsets = (
+        list(apply_data["reminder_offsets_minutes"])
+        if "reminder_offsets_minutes" in apply_data
+        else _configured_reminder_offsets(activity)
+    )
 
     _validate_activity_final_invariants(
         time_mode=final_time_mode,
-        start_time=final_start,
-        end_time=final_end,
+        start_time=final_start_time,
+        end_time=final_end_time,
         system_type=final_system_type,
-        custom_type_id=final_custom_type_id,
+        custom_type_id=(
+            final_custom_type.id if final_custom_type is not None else None
+        ),
         location_mode=final_location_mode,
         place=final_place,
-        reminder_offsets=data.get("reminder_offsets_minutes"),
+        reminder_offsets=final_reminder_offsets,
+    )
+
+    final_data = {
+        "title": apply_data.get("title", activity.title),
+        "system_type": final_system_type,
+        "custom_type_label": (
+            final_custom_type.name if final_custom_type is not None else None
+        ),
+        "time_mode": final_time_mode,
+        "start_time": final_start_time,
+        "end_time": final_end_time,
+        "assignee_scope": final_assignee_scope,
+        "assignee_label": (
+            _timeline_assignee_label(final_assignee_user)
+            if final_assignee_user is not None
+            else None
+        ),
+        "location_mode": final_location_mode,
+        "location_label": apply_data.get(
+            "location_label",
+            activity.location_label,
+        ),
+        "place": final_place,
+        "location_note": apply_data.get("location_note", activity.location_note),
+        "note": apply_data.get("note", activity.note),
+        "meeting_point": apply_data.get("meeting_point", activity.meeting_point),
+        "contact_name": apply_data.get("contact_name", activity.contact_name),
+        "contact_phone": apply_data.get("contact_phone", activity.contact_phone),
+        "booking_reference": apply_data.get(
+            "booking_reference",
+            activity.booking_reference,
+        ),
+        "external_link": apply_data.get("external_link", activity.external_link),
+        "reminder_offsets_minutes": final_reminder_offsets,
+    }
+    return TimelineActivityPatchPlan(
+        data=_timeline_json_value(apply_data),
+        apply_data=apply_data,
+        final_data=final_data,
+        final_time_mode=final_time_mode,
+        final_start_time=final_start_time,
+        final_end_time=final_end_time,
+        final_custom_type=final_custom_type,
+        final_assignee_user=final_assignee_user,
+        final_location_mode=final_location_mode,
+        final_place=final_place,
+        final_reminder_offsets=final_reminder_offsets,
     )
 
 
@@ -1281,26 +1766,21 @@ def patch_timeline_activity(trip_id, activity_id, *, actor, data: dict) -> Timel
         except TimelineActivity.DoesNotExist:
             raise TimelineActivityNotFoundError("Activity not found.")
 
-        existing_offsets = _configured_reminder_offsets(activity)
+        plan = plan_timeline_activity_patch(
+            trip=trip,
+            activity=activity,
+            data=data,
+        )
+        data = plan.apply_data
         should_regenerate_reminders = bool(
             {"time_mode", "start_time", "reminder_offsets_minutes"} & set(data.keys())
         )
-
-        try:
-            _apply_activity_patch_invariants(activity, data)
-        except drf_serializers.ValidationError:
-            raise
 
         if "custom_type_id" in data:
             if data["custom_type_id"] is None:
                 activity.custom_type = None
             else:
-                preserves_existing_custom_type = (
-                    activity.custom_type_id is not None
-                    and str(activity.custom_type_id) == str(data["custom_type_id"])
-                )
-                if not preserves_existing_custom_type:
-                    activity.custom_type = _resolve_custom_type(trip, data["custom_type_id"])
+                activity.custom_type = plan.final_custom_type
                 activity.system_type = ""
 
         if "system_type" in data:
@@ -1313,9 +1793,7 @@ def patch_timeline_activity(trip_id, activity_id, *, actor, data: dict) -> Timel
         if "assignee_scope" in data or "assignee_user_id" in data:
             assignee_scope = data.get("assignee_scope", activity.assignee_scope)
             if assignee_scope == TimelineActivityAssigneeScope.USER:
-                assignee_user_id = data.get("assignee_user_id", activity.assignee_user_id)
-                _assert_active_member(trip, assignee_user_id)
-                activity.assignee_user_id = assignee_user_id
+                activity.assignee_user = plan.final_assignee_user
             else:
                 activity.assignee_user_id = None
             activity.assignee_scope = assignee_scope
@@ -1365,8 +1843,10 @@ def patch_timeline_activity(trip_id, activity_id, *, actor, data: dict) -> Timel
         activity.updated_by = actor
         activity.save()
         if should_regenerate_reminders:
-            offsets = data.get("reminder_offsets_minutes", existing_offsets)
-            replace_unsent_activity_reminders(activity, offsets)
+            replace_unsent_activity_reminders(
+                activity,
+                plan.final_reminder_offsets,
+            )
     return activity
 
 

--- a/backend/trips/tests/test_timeline_activity_crud.py
+++ b/backend/trips/tests/test_timeline_activity_crud.py
@@ -358,6 +358,41 @@ class TimelineActivityCrudTests(APITestCase):
 
         self.assertFalse(TimelineActivity.objects.filter(title="Invalid reminder").exists())
 
+    def test_create_planner_is_pure_and_returns_canonical_scoped_references(self):
+        from trips.services import plan_timeline_activity_create
+
+        custom_type = TimelineCustomType.objects.create(
+            trip=self.trip,
+            name="Planner custom",
+            normalized_name="planner-custom",
+        )
+        activity_count = TimelineActivity.objects.filter(trip=self.trip).count()
+
+        plan = plan_timeline_activity_create(
+            trip=self.trip,
+            section_id=str(self.section.id),
+            data={
+                "title": "Pure planner activity",
+                "time_mode": "FLEXIBLE",
+                "custom_type_id": str(custom_type.id),
+                "assignee_user_id": str(self.member.id),
+            },
+        )
+
+        self.assertEqual(plan.section, self.section)
+        self.assertEqual(plan.data["custom_type_id"], str(custom_type.id))
+        self.assertEqual(plan.data["assignee_user_id"], str(self.member.id))
+        self.assertEqual(plan.data["assignee_scope"], "USER")
+        self.assertEqual(plan.final_data["custom_type_label"], "Planner custom")
+        self.assertEqual(
+            plan.final_data["assignee_label"],
+            self.member.display_name,
+        )
+        self.assertEqual(
+            TimelineActivity.objects.filter(trip=self.trip).count(),
+            activity_count,
+        )
+
     # -------- Patch --------
 
     def test_patch_title(self):
@@ -445,6 +480,34 @@ class TimelineActivityCrudTests(APITestCase):
         activity.refresh_from_db()
         self.assertIsNone(activity.start_time)
         self.assertIsNone(activity.end_time)
+
+    def test_patch_planner_is_pure_and_returns_canonical_transition_data(self):
+        from trips.services import plan_timeline_activity_patch
+
+        activity = make_timeline_activity(
+            trip=self.trip,
+            section=self.section,
+            time_mode="TIME_RANGE",
+        )
+        activity.start_time = time(8, 0)
+        activity.end_time = time(10, 0)
+        activity.save(update_fields=["start_time", "end_time"])
+
+        plan = plan_timeline_activity_patch(
+            trip=self.trip,
+            activity=activity,
+            data={"time_mode": "AT_TIME"},
+        )
+
+        self.assertEqual(plan.data["time_mode"], "AT_TIME")
+        self.assertIn("end_time", plan.data)
+        self.assertIsNone(plan.data["end_time"])
+        self.assertEqual(plan.final_time_mode, "AT_TIME")
+        self.assertEqual(plan.final_start_time, time(8, 0))
+        self.assertIsNone(plan.final_end_time)
+        activity.refresh_from_db()
+        self.assertEqual(activity.time_mode, "TIME_RANGE")
+        self.assertEqual(activity.end_time, time(10, 0))
 
     def test_patch_rejects_inactive_custom_type_assignment(self):
         activity = make_timeline_activity(trip=self.trip, section=self.section)

--- a/mobile/src/features/chat/__tests__/ChatComposer.test.tsx
+++ b/mobile/src/features/chat/__tests__/ChatComposer.test.tsx
@@ -1,4 +1,11 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react-native';
 import {
   CHAT_MESSAGE_MAX_LENGTH,
   ChatComposer,
@@ -43,6 +50,105 @@ describe('ChatComposer', () => {
     expect(screen.getByLabelText('Send message').props.accessibilityState.disabled).toBe(true);
     await fireEvent.press(screen.getByLabelText('Send message'));
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('offers a trailing-at command and inserts the exact GoPlanAI mention while retaining focus', async () => {
+    const onSubmit = jest.fn(async () => cleared);
+    await render(<ChatComposer onSubmit={onSubmit} />);
+
+    const input = screen.getByLabelText('Message');
+    await fireEvent.changeText(input, 'plan day 1 @');
+    expect(screen.getByLabelText('Mention suggestions')).toBeTruthy();
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Mention GoPlanAI' }),
+    );
+
+    expect(screen.getByLabelText('Message').props.value).toBe(
+      '@GoPlanAI plan day 1',
+    );
+    expect(screen.queryByLabelText('Mention suggestions')).toBeNull();
+    expect(screen.getByTestId('goplan-ai-composer-intent')).toBeTruthy();
+  });
+
+  it('shows AI quota intent for any case-insensitive mention and trims only the outer whitespace', async () => {
+    const onSubmit = jest.fn(async () => cleared);
+    await render(<ChatComposer onSubmit={onSubmit} />);
+
+    const typed = '  @goplanai Keep  internal\nspacing  ';
+    await fireEvent.changeText(screen.getByLabelText('Message'), typed);
+    expect(screen.getByText(/20 prompts\/hour/)).toBeTruthy();
+    await fireEvent.press(screen.getByLabelText('Send message'));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      '@goplanai Keep  internal\nspacing',
+    );
+  });
+
+  it('renders a distinct inert GoPlanAI token inside the active composer intent only', async () => {
+    const onSubmit = jest.fn(async () => cleared);
+    await render(<ChatComposer onSubmit={onSubmit} />);
+
+    expect(screen.queryByTestId('goplan-ai-composer-intent')).toBeNull();
+    expect(screen.queryByTestId('goplan-ai-mention-token')).toBeNull();
+
+    await fireEvent.changeText(
+      screen.getByLabelText('Message'),
+      '@goplanai plan the morning',
+    );
+
+    const intent = screen.getByTestId('goplan-ai-composer-intent');
+    expect(within(intent).getByTestId('goplan-ai-mention-token')).toBeTruthy();
+    expect(within(intent).queryByRole('button')).toBeNull();
+    expect(within(intent).queryByRole('link')).toBeNull();
+
+    await fireEvent.changeText(screen.getByLabelText('Message'), 'ordinary draft');
+    expect(screen.queryByTestId('goplan-ai-composer-intent')).toBeNull();
+    expect(screen.queryByTestId('goplan-ai-mention-token')).toBeNull();
+  });
+
+  it('blocks a bare GoPlanAI mention locally with a useful hint and zero submit', async () => {
+    const onSubmit = jest.fn(async () => cleared);
+    await render(<ChatComposer onSubmit={onSubmit} />);
+
+    await fireEvent.changeText(
+      screen.getByLabelText('Message'),
+      '  @GoPlanAI\n  ',
+    );
+
+    const send = screen.getByLabelText('Send message');
+    expect(send.props.accessibilityState.disabled).toBe(true);
+    expect(screen.getByTestId('goplan-ai-prompt-hint')).toHaveTextContent(
+      'Add a prompt for GoPlanAI before sending.',
+    );
+    await fireEvent.press(send);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('inserts an exact 2,000-character AI command but never truncates an overflowing draft', async () => {
+    const onSubmit = jest.fn(async () => cleared);
+    await render(<ChatComposer onSubmit={onSubmit} />);
+    const input = screen.getByLabelText('Message');
+    const overflowingDraft = `${'a'.repeat(1991)} @`;
+
+    await fireEvent.changeText(input, overflowingDraft);
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Mention GoPlanAI' }),
+    );
+    expect(screen.getByLabelText('Message').props.value).toBe(
+      overflowingDraft,
+    );
+    expect(screen.getByTestId('chat-composer-feedback')).toHaveTextContent(
+      'GoPlanAI mention cannot be inserted because this message would exceed 2,000 characters.',
+    );
+
+    await fireEvent.changeText(input, `${'a'.repeat(1990)} @`);
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Mention GoPlanAI' }),
+    );
+    const inserted = screen.getByLabelText('Message').props.value as string;
+    expect(inserted).toHaveLength(CHAT_MESSAGE_MAX_LENGTH);
+    expect(inserted.startsWith('@GoPlanAI ')).toBe(true);
+    expect(screen.queryByTestId('chat-composer-feedback')).toBeNull();
   });
 
   it('trims the submitted value and clears the composer when instructed', async () => {

--- a/mobile/src/features/chat/__tests__/ChatConnectionBanner.test.tsx
+++ b/mobile/src/features/chat/__tests__/ChatConnectionBanner.test.tsx
@@ -1,11 +1,31 @@
-import { act, render, screen } from '@testing-library/react-native';
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
 import { StyleSheet } from 'react-native';
+import type {
+  RealtimeDiagnosticReason,
+  RealtimeDiagnostics,
+} from '@/features/realtime/types';
 import { colors } from '@/shared/theme/tokens';
 import {
   CHAT_CONNECTION_BANNER_DELAY_MS,
   CHAT_CONNECTION_BANNER_ESCALATION_MS,
   ChatConnectionBanner,
 } from '../components/ChatConnectionBanner';
+
+function terminalDiagnostics(
+  reason: RealtimeDiagnosticReason,
+): RealtimeDiagnostics {
+  return {
+    phase: 'stopped',
+    reason,
+    category: 'retry',
+    terminal: true,
+    closeCode: null,
+    reconnectAttempt: 5,
+    retryDelayMs: null,
+    ticketPhase: null,
+    heartbeat: 'inactive',
+  };
+}
 
 describe('ChatConnectionBanner', () => {
   beforeEach(() => {
@@ -54,10 +74,9 @@ describe('ChatConnectionBanner', () => {
     await act(async () => {
       jest.advanceTimersByTime(1);
     });
-    const banner = screen.getByTestId('chat-connection-banner');
-    expect(banner.props.accessibilityRole).toBe('alert');
-    expect(banner.props.accessibilityLiveRegion).toBe('polite');
-    expect(banner.props.children).toContain('Reconnecting');
+    const alert = screen.getByRole('alert');
+    expect(alert.props.accessibilityLiveRegion).toBe('polite');
+    expect(alert.props.children).toContain('Reconnecting');
   });
 
   it('escalates a sustained disconnection without changing the truthful copy', async () => {
@@ -67,9 +86,81 @@ describe('ChatConnectionBanner', () => {
       jest.advanceTimersByTime(CHAT_CONNECTION_BANNER_ESCALATION_MS);
     });
     const banner = screen.getByTestId('chat-connection-banner');
-    expect(banner.props.children).toBe('Disconnected. Trying again shortly.');
+    expect(
+      screen.getByText(
+        'Live chat is disconnected. New messages may be delayed.',
+      ),
+    ).toBeTruthy();
     expect(StyleSheet.flatten(banner.props.style).backgroundColor).toBe(colors.warningSoft);
   });
+
+  it.each([
+    [
+      'retry_exhausted',
+      'Live chat stopped after repeated connection failures. Check your connection and try again later.',
+    ],
+    [
+      'authentication_failed',
+      'Live chat stopped because your session could not be authenticated.',
+    ],
+    [
+      'invalid_configuration',
+      'Live chat is unavailable because the app configuration is invalid.',
+    ],
+  ] as const)(
+    'explains terminal transport reason %s without promising another retry',
+    async (reason, copy) => {
+      await render(
+        <ChatConnectionBanner
+          diagnostics={terminalDiagnostics(reason)}
+          status="disconnected"
+        />,
+      );
+
+      await act(async () => {
+        jest.advanceTimersByTime(CHAT_CONNECTION_BANNER_DELAY_MS);
+      });
+      const banner = screen.getByTestId('chat-connection-banner');
+      expect(screen.getByText(copy)).toBeTruthy();
+      expect(StyleSheet.flatten(banner.props.style).backgroundColor).toBe(
+        colors.warningSoft,
+      );
+    },
+  );
+
+  it('offers a real manual retry only after automatic retries are exhausted', async () => {
+    const onRetry = jest.fn();
+    await render(
+      <ChatConnectionBanner
+        diagnostics={terminalDiagnostics('retry_exhausted')}
+        onRetry={onRetry}
+        status="disconnected"
+      />,
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(CHAT_CONNECTION_BANNER_DELAY_MS);
+    });
+    await fireEvent.press(screen.getByLabelText('Retry live connection'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['authentication_failed', 'invalid_configuration'] as const)(
+    'does not offer a misleading retry for terminal reason %s',
+    async (reason) => {
+      await render(
+        <ChatConnectionBanner
+          diagnostics={terminalDiagnostics(reason)}
+          onRetry={jest.fn()}
+          status="disconnected"
+        />,
+      );
+      await act(async () => {
+        jest.advanceTimersByTime(CHAT_CONNECTION_BANNER_DELAY_MS);
+      });
+      expect(screen.queryByLabelText('Retry live connection')).toBeNull();
+    },
+  );
 
   it('resets its delay when the non-connected status changes', async () => {
     const view = await render(<ChatConnectionBanner status="reconnecting" />);
@@ -83,6 +174,10 @@ describe('ChatConnectionBanner', () => {
     await act(async () => {
       jest.advanceTimersByTime(CHAT_CONNECTION_BANNER_DELAY_MS);
     });
-    expect(screen.getByText('Disconnected. Trying again shortly.')).toBeTruthy();
+    expect(
+      screen.getByText(
+        'Live chat is disconnected. New messages may be delayed.',
+      ),
+    ).toBeTruthy();
   });
 });

--- a/mobile/src/features/chat/__tests__/ChatMessageActionsModal.test.tsx
+++ b/mobile/src/features/chat/__tests__/ChatMessageActionsModal.test.tsx
@@ -1,10 +1,13 @@
 import { fireEvent, render, screen } from '@testing-library/react-native';
-import { Alert, StyleSheet } from 'react-native';
+import { Alert, Platform, StyleSheet } from 'react-native';
 import { ALLOWED_REACTION_EMOJIS } from '../types';
 import { ChatMessageActionsModal } from '../components/ChatMessageActionsModal';
 import { REACTION_ACCESSIBILITY_LABELS } from '../components/ChatReactionBar';
 
-jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('@expo/vector-icons', () => ({
+  FontAwesome6: () => null,
+  Ionicons: () => null,
+}));
 
 function props(overrides: Record<string, unknown> = {}) {
   return {
@@ -25,6 +28,7 @@ function props(overrides: Record<string, unknown> = {}) {
 
 describe('ChatMessageActionsModal', () => {
   afterEach(() => {
+    jest.useRealTimers();
     jest.restoreAllMocks();
   });
 
@@ -44,6 +48,16 @@ describe('ChatMessageActionsModal', () => {
       false,
       false,
     ]);
+    expect(options[2]?.props.accessibilityHint).toBe('Removes your reaction');
+    expect(options[0]?.props.accessibilityHint).toBe('Adds this reaction');
+    expect(
+      screen.getByTestId('chat-reaction-option-selected-😮', {
+        includeHiddenElements: true,
+      }),
+    ).toBeTruthy();
+    expect(
+      StyleSheet.flatten(screen.getByTestId('chat-reaction-option-😮').props.style),
+    ).toMatchObject({ borderWidth: 2 });
     expect(screen.getByTestId('chat-message-actions-modal').props.accessibilityViewIsModal).toBe(true);
   });
 
@@ -70,6 +84,86 @@ describe('ChatMessageActionsModal', () => {
     expect(onReact).toHaveBeenCalledWith('❤️');
   });
 
+  it('locks the sheet after its first reaction press to prevent a double mutation', async () => {
+    const onClose = jest.fn();
+    const onReact = jest.fn();
+    await render(<ChatMessageActionsModal {...props({ onClose, onReact })} />);
+
+    const option = screen.getByLabelText('React with heart');
+    await fireEvent.press(option);
+    await fireEvent.press(option);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onReact).toHaveBeenCalledTimes(1);
+    expect(onReact).toHaveBeenCalledWith('❤️');
+  });
+
+  it('forwards native dismissal so callers can restore accessibility focus after animation', async () => {
+    jest.replaceProperty(Platform, 'OS', 'ios');
+    const onDismiss = jest.fn();
+    await render(
+      <ChatMessageActionsModal {...props({ onDismiss })} />,
+    );
+
+    screen.getByTestId('chat-message-actions-modal').parent?.props.onDismiss?.();
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for native onDismiss before completing a normal iOS close', async () => {
+    jest.useFakeTimers();
+    jest.replaceProperty(Platform, 'OS', 'ios');
+    const onDismiss = jest.fn();
+    await render(<ChatMessageActionsModal {...props({ onDismiss })} />);
+
+    await fireEvent.press(screen.getByLabelText('Close message actions'));
+    jest.runOnlyPendingTimers();
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    screen.getByTestId('chat-message-actions-modal').parent?.props.onDismiss?.();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['close', 'requestClose', 'reaction', 'selection'] as const)(
+    'completes the Android %s path after the modal host teardown task',
+    async (action) => {
+      jest.useFakeTimers();
+      jest.replaceProperty(Platform, 'OS', 'android');
+      const onDismiss = jest.fn();
+      await render(<ChatMessageActionsModal {...props({ onDismiss })} />);
+
+      if (action === 'close') {
+        await fireEvent.press(screen.getByLabelText('Close message actions'));
+      } else if (action === 'requestClose') {
+        screen.getByTestId('chat-message-actions-modal').parent?.props
+          .onRequestClose?.();
+      } else if (action === 'reaction') {
+        await fireEvent.press(screen.getByLabelText('React with heart'));
+      } else {
+        await fireEvent.press(screen.getByLabelText('Select messages'));
+      }
+
+      expect(onDismiss).not.toHaveBeenCalled();
+      jest.runOnlyPendingTimers();
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('cancels a deferred Android dismissal callback when the owner unmounts', async () => {
+    jest.useFakeTimers();
+    jest.replaceProperty(Platform, 'OS', 'android');
+    const onDismiss = jest.fn();
+    const rendered = await render(
+      <ChatMessageActionsModal {...props({ onDismiss })} />,
+    );
+
+    await fireEvent.press(screen.getByLabelText('Close message actions'));
+    await rendered.unmount();
+    jest.runOnlyPendingTimers();
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
   it.each([
     {
       action: 'Hide for me',
@@ -84,6 +178,7 @@ describe('ChatMessageActionsModal', () => {
       callback: 'onDeleteForEveryone',
     },
   ] as const)('confirms $action with a destructive native alert', async (scenario) => {
+    jest.useFakeTimers();
     const callback = jest.fn();
     const onClose = jest.fn();
     const alert = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
@@ -95,6 +190,10 @@ describe('ChatMessageActionsModal', () => {
 
     await fireEvent.press(screen.getByLabelText(scenario.action));
     expect(onClose).toHaveBeenCalledTimes(1);
+    expect(alert).not.toHaveBeenCalled();
+    screen.getByTestId('chat-message-actions-modal').parent?.props.onDismiss?.();
+    expect(alert).not.toHaveBeenCalled();
+    jest.runOnlyPendingTimers();
     expect(alert).toHaveBeenCalledWith(scenario.title, expect.any(String), expect.any(Array));
     const buttons = alert.mock.calls[0]?.[2];
     expect(buttons?.[1]).toMatchObject({
@@ -103,6 +202,48 @@ describe('ChatMessageActionsModal', () => {
     });
     buttons?.[1]?.onPress?.();
     expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses a no-focus handoff before opening a native destructive alert', async () => {
+    jest.useFakeTimers();
+    const onClose = jest.fn();
+    const onCloseWithoutFocus = jest.fn();
+    jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+    await render(
+      <ChatMessageActionsModal
+        {...props({ onClose, onCloseWithoutFocus })}
+      />,
+    );
+
+    await fireEvent.press(screen.getByLabelText('Hide for me'));
+
+    expect(onCloseWithoutFocus).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(Alert.alert).not.toHaveBeenCalled();
+    screen.getByTestId('chat-message-actions-modal').parent?.props.onDismiss?.();
+    expect(Alert.alert).not.toHaveBeenCalled();
+    jest.runOnlyPendingTimers();
+    expect(Alert.alert).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens destructive confirmation on Android without waiting for unsupported onDismiss', async () => {
+    jest.replaceProperty(Platform, 'OS', 'android');
+    const onClose = jest.fn();
+    const onDismiss = jest.fn();
+    const alert = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+    await render(
+      <ChatMessageActionsModal {...props({ onClose, onDismiss })} />,
+    );
+
+    await fireEvent.press(screen.getByLabelText('Hide for me'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(alert).toHaveBeenCalledWith(
+      'Hide this message?',
+      expect.any(String),
+      expect.any(Array),
+    );
+    expect(onDismiss).not.toHaveBeenCalled();
   });
 
   it('enters bulk selection without treating selection as destructive', async () => {

--- a/mobile/src/features/chat/__tests__/ChatMessageBubble.test.tsx
+++ b/mobile/src/features/chat/__tests__/ChatMessageBubble.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen } from '@testing-library/react-native';
+import {
+  fireEvent,
+  render,
+  screen,
+  within,
+} from '@testing-library/react-native';
+import { makeDraftFixture } from '../ai/__fixtures__/drafts';
 import type { ChatMessage } from '../types';
 import { ChatMessageBubble } from '../components/ChatMessageBubble';
 
@@ -65,6 +71,7 @@ function props(overrides: Record<string, unknown> = {}) {
     onToggleSelection: jest.fn(),
     onRetry: jest.fn(),
     onToggleReaction: jest.fn(),
+    onApplyAIDraftSnapshot: jest.fn(),
     ...overrides,
   };
 }
@@ -139,6 +146,145 @@ describe('ChatMessageBubble', () => {
     expect(screen.getByText('Here is a simple answer.')).toBeTruthy();
     expect(screen.queryByText('MUST STAY HIDDEN')).toBeNull();
     expect(screen.queryByText('42')).toBeNull();
+  });
+
+  it('preserves ordinary user whitespace and tokenizes only a parsed GoPlanAI mention', async () => {
+    const ordinaryContent = '  Keep   ordinary\nwhitespace  ';
+    const rendered = await render(
+      <ChatMessageBubble
+        {...props({ message: message({ content: ordinaryContent }) })}
+      />,
+    );
+
+    expect(screen.getByText(ordinaryContent)).toBeTruthy();
+    expect(screen.queryByLabelText('GoPlanAI mention')).toBeNull();
+
+    await rendered.rerender(
+      <ChatMessageBubble
+        {...props({
+          message: message({ content: 'Please ask @goplanai about day 2' }),
+        })}
+      />,
+    );
+    expect(screen.getByLabelText('GoPlanAI mention')).toBeTruthy();
+  });
+
+  it('renders AI error content inertly and includes failure in the parent accessibility label', async () => {
+    await render(
+      <ChatMessageBubble
+        {...props({
+          message: message({
+            sender: {
+              id: null,
+              display_name: 'GoPlanAI',
+              identify_tag: null,
+              avatar_url: null,
+            },
+            sender_kind: 'AI',
+            ai_status: 'ERROR',
+            content:
+              '<script>mutateTrip()</script> [Open](https://evil.example)',
+          }),
+        })}
+      />,
+    );
+
+    const bubble = screen.getByTestId('chat-message-message-1');
+    expect(bubble.props.accessibilityLabel).toContain(
+      'GoPlanAI could not complete this request.',
+    );
+    expect(screen.getByTestId('chat-ai-error-message-1').props.accessibilityRole).toBe(
+      'alert',
+    );
+    const aiContent = within(screen.getByTestId('goplan-ai-message-content'));
+    expect(aiContent.getByText(/mutateTrip/)).toBeTruthy();
+    expect(aiContent.queryByRole('link')).toBeNull();
+    expect(aiContent.queryByRole('button')).toBeNull();
+  });
+
+  it('renders only unambiguous valid AI drafts outside the message Pressable and fails every duplicate id closed', async () => {
+    const known = makeDraftFixture();
+    const unknown = makeDraftFixture({
+      id: '33333333-3333-4333-8333-333333333333',
+      action_type: 'future.teleport.create',
+      display: { title: 'Teleport', kicker: 'Future' },
+    });
+    const duplicate = makeDraftFixture({
+      ...unknown,
+      summary: 'Duplicate security action',
+    });
+    await render(
+      <ChatMessageBubble
+        {...props({
+          message: message({
+            trip_id: '11111111-1111-4111-8111-111111111111',
+            sender: {
+              id: null,
+              display_name: 'GoPlanAI',
+              identify_tag: null,
+              avatar_url: null,
+            },
+            sender_kind: 'AI',
+            ai_status: 'SUCCESS',
+            action_drafts: [
+              known,
+              unknown,
+              duplicate,
+              { ...known, status: 'EXECUTED' },
+            ],
+          }),
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId(`ai-action-draft-${known.id}`)).toBeTruthy();
+    expect(screen.queryByTestId(`ai-action-draft-${unknown.id}`)).toBeNull();
+    expect(screen.getAllByRole('button', { name: 'Confirm' })).toHaveLength(1);
+    expect(screen.queryByTestId('ai-generic-draft-details')).toBeNull();
+    expect(screen.getByTestId('chat-ai-draft-malformed-message-1')).toHaveTextContent(
+      'An AI action draft could not be displayed safely.',
+    );
+    const messagePressable = screen.getByTestId('chat-message-message-1');
+    expect(
+      within(messagePressable).queryByTestId(
+        `ai-action-draft-${known.id}`,
+      ),
+    ).toBeNull();
+  });
+
+  it('keeps draft cards visible but disables their controls in read-only and selection modes', async () => {
+    const draft = makeDraftFixture();
+    const ai = message({
+      trip_id: '11111111-1111-4111-8111-111111111111',
+      sender_kind: 'AI',
+      ai_status: 'SUCCESS',
+      action_drafts: [draft],
+    });
+    const rendered = await render(
+      <ChatMessageBubble
+        {...props({ actionsEnabled: false, message: ai })}
+      />,
+    );
+
+    for (const label of ['Cancel', 'Confirm']) {
+      expect(
+        screen.getByRole('button', { name: label }).props.accessibilityState
+          .disabled,
+      ).toBe(true);
+    }
+
+    await rendered.rerender(
+      <ChatMessageBubble
+        {...props({ actionsEnabled: true, message: ai, selectionMode: true })}
+      />,
+    );
+    expect(screen.getByTestId(`ai-action-draft-${draft.id}`)).toBeTruthy();
+    for (const label of ['Cancel', 'Confirm']) {
+      expect(
+        screen.getByRole('button', { name: label }).props.accessibilityState
+          .disabled,
+      ).toBe(true);
+    }
   });
 
   it('preserves nullable deleted-user identity without rendering null as text', async () => {

--- a/mobile/src/features/chat/__tests__/ChatMessageBubble.test.tsx
+++ b/mobile/src/features/chat/__tests__/ChatMessageBubble.test.tsx
@@ -4,11 +4,15 @@ import {
   screen,
   within,
 } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
 import { makeDraftFixture } from '../ai/__fixtures__/drafts';
 import type { ChatMessage } from '../types';
 import { ChatMessageBubble } from '../components/ChatMessageBubble';
 
-jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('@expo/vector-icons', () => ({
+  FontAwesome6: () => null,
+  Ionicons: () => null,
+}));
 jest.mock('@/features/auth/components/UserAvatar', () => {
   const React = jest.requireActual<typeof import('react')>('react');
   const { View } = jest.requireActual<typeof import('react-native')>('react-native');
@@ -90,11 +94,137 @@ describe('ChatMessageBubble', () => {
     ]);
 
     await fireEvent(bubble, 'longPress');
-    expect(onOpenActions).toHaveBeenCalledWith('message-1');
+    expect(onOpenActions).toHaveBeenCalledWith(
+      'message-1',
+      expect.any(Function),
+    );
     await fireEvent(bubble, 'accessibilityAction', {
       nativeEvent: { actionName: 'openMessageActions' },
     });
     expect(onOpenActions).toHaveBeenCalledTimes(2);
+  });
+
+  it('adds one visible 44pt reaction affordance while preserving long-press actions', async () => {
+    const onOpenActions = jest.fn();
+    await render(
+      <ChatMessageBubble
+        {...props({ onOpenActions, showReactionAffordance: true })}
+      />,
+    );
+
+    const react = screen.getByLabelText('React to this message');
+    expect(react.props.accessibilityHint).toBe(
+      'Opens reactions and other message actions',
+    );
+    expect(
+      StyleSheet.flatten(screen.getByTestId('chat-reaction-affordance-message-1').props.style),
+    ).toMatchObject({ minHeight: 44, width: 44 });
+    expect(
+      StyleSheet.flatten(screen.getByTestId('chat-bubble-action-row-message-1').props.style),
+    ).toMatchObject({ minHeight: 44, flexDirection: 'row' });
+    const peerRow = screen.getByTestId('chat-bubble-action-row-message-1');
+    expect(
+      peerRow.props.children
+        .filter(Boolean)
+        .map((child: { props: { testID: string } }) => child.props.testID),
+    ).toEqual([
+      'chat-message-message-1',
+      'chat-reaction-affordance-message-1',
+    ]);
+
+    await fireEvent.press(react);
+    await fireEvent(screen.getByTestId('chat-message-message-1'), 'longPress');
+    expect(onOpenActions).toHaveBeenNthCalledWith(
+      1,
+      'message-1',
+      expect.any(Function),
+    );
+    expect(onOpenActions).toHaveBeenNthCalledWith(
+      2,
+      'message-1',
+      expect.any(Function),
+    );
+  });
+
+  it('does not expose the visible affordance when the message is busy or selection is active', async () => {
+    const onOpenActions = jest.fn();
+    const rendered = await render(
+      <ChatMessageBubble
+        {...props({
+          onOpenActions,
+          reactionBusy: true,
+          showReactionAffordance: true,
+        })}
+      />,
+    );
+
+    expect(
+      screen.getByLabelText('React to this message').props.accessibilityState,
+    ).toEqual({ disabled: true, busy: true });
+    const bubble = screen.getByTestId('chat-message-message-1');
+    expect(bubble.props.accessibilityActions).toEqual([]);
+    await fireEvent(bubble, 'longPress');
+    expect(onOpenActions).not.toHaveBeenCalled();
+
+    await rendered.rerender(
+      <ChatMessageBubble
+        {...props({ selectionMode: true, showReactionAffordance: true })}
+      />,
+    );
+    expect(screen.queryByLabelText('React to this message')).toBeNull();
+  });
+
+  it('reads an own bubble before its affordance while keeping the action visually first', async () => {
+    await render(
+      <ChatMessageBubble
+        {...props({ isOwn: true, showReactionAffordance: true })}
+      />,
+    );
+
+    const ownRow = screen.getByTestId('chat-bubble-action-row-message-1');
+    expect(
+      ownRow.props.children
+        .filter(Boolean)
+        .map((child: { props: { testID: string } }) => child.props.testID),
+    ).toEqual([
+      'chat-message-message-1',
+      'chat-reaction-affordance-message-1',
+    ]);
+    expect(StyleSheet.flatten(ownRow.props.style)).toMatchObject({
+      flexDirection: 'row-reverse',
+    });
+  });
+
+  it.each([
+    { isOwn: true, label: 'own' },
+    { isOwn: false, label: 'peer' },
+  ])('lets a long $label message shrink beside its reaction affordance', async ({ isOwn }) => {
+    await render(
+      <ChatMessageBubble
+        {...props({
+          isOwn,
+          message: message({ content: 'A'.repeat(500) }),
+          showReactionAffordance: true,
+        })}
+      />,
+    );
+
+    expect(
+      StyleSheet.flatten(
+        screen.getByTestId('chat-column-message-1').props.style,
+      ),
+    ).toMatchObject({ minWidth: 0, flexShrink: 1 });
+    expect(
+      StyleSheet.flatten(
+        screen.getByTestId('chat-bubble-action-row-message-1').props.style,
+      ),
+    ).toMatchObject({ maxWidth: '100%', minHeight: 44 });
+    expect(
+      StyleSheet.flatten(
+        screen.getByTestId('chat-message-message-1').props.style,
+      ),
+    ).toMatchObject({ flexShrink: 1 });
+    expect(screen.getByTestId('chat-reaction-affordance-message-1')).toBeTruthy();
   });
 
   it('labels own messages as You and keeps the content readable', async () => {

--- a/mobile/src/features/chat/__tests__/ChatMessageList.test.tsx
+++ b/mobile/src/features/chat/__tests__/ChatMessageList.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react-native';
-import { Alert, Text } from 'react-native';
+import { Alert, Keyboard, Text } from 'react-native';
 import { makeDraftFixture } from '../ai/__fixtures__/drafts';
 import { createAIReconciliationCoordinator } from '../ai/reconciliation';
 import { AIReconciliationCoordinatorProvider } from '../ai/reconciliationContext';
@@ -328,6 +328,22 @@ describe('ChatMessageList', () => {
 
     await fireEvent.press(screen.getByLabelText('Load earlier messages'));
     expect(onLoadOlder).toHaveBeenCalledTimes(2);
+  });
+
+  it('dismisses the software keyboard when the transcript starts dragging', async () => {
+    const dismissKeyboard = jest
+      .spyOn(Keyboard, 'dismiss')
+      .mockImplementation(() => undefined);
+    await render(
+      <ChatMessageList
+        {...props({ messages: [message('message-1')] })}
+      />,
+    );
+
+    const list = screen.getByTestId('chat-message-list');
+    expect(list.props.keyboardDismissMode).toBe('on-drag');
+    await fireEvent(list, 'scrollBeginDrag');
+    expect(dismissKeyboard).toHaveBeenCalledTimes(1);
   });
 
   it('shows a single pagination progress state while loading older history', async () => {

--- a/mobile/src/features/chat/__tests__/ChatMessageList.test.tsx
+++ b/mobile/src/features/chat/__tests__/ChatMessageList.test.tsx
@@ -1,5 +1,8 @@
 import { act, fireEvent, render, screen } from '@testing-library/react-native';
 import { Alert, Text } from 'react-native';
+import { makeDraftFixture } from '../ai/__fixtures__/drafts';
+import { createAIReconciliationCoordinator } from '../ai/reconciliation';
+import { AIReconciliationCoordinatorProvider } from '../ai/reconciliationContext';
 import type { ChatMessage } from '../types';
 import {
   CHAT_HIDE_SELECTION_LIMIT,
@@ -65,6 +68,8 @@ function props(overrides: Record<string, unknown> = {}) {
     isLoadingOlder: false,
     olderLoadError: null,
     actionsEnabled: true,
+    ambiguousAIDraftIds: emptySet,
+    aiTypingInteractionId: null,
     isHidingMessages: false,
     bottomAccessory: <Text>Composer accessory</Text>,
     onLoadOlder: jest.fn(),
@@ -75,6 +80,7 @@ function props(overrides: Record<string, unknown> = {}) {
       applied: true,
       feedback: null,
     }),
+    onApplyAIDraftSnapshot: jest.fn(),
     ...overrides,
   };
 }
@@ -123,6 +129,142 @@ describe('ChatMessageList', () => {
     ]);
     expect(screen.getAllByText('Mai')).toHaveLength(1);
     expect(screen.getAllByLabelText("Mai's profile picture")).toHaveLength(1);
+  });
+
+  it('renders correlated AI typing at the inverted newest-edge header without synthetic message data', async () => {
+    const onlyMessage = message('message-1');
+    const rendered = await render(
+      <ChatMessageList
+        {...props({
+          aiTypingInteractionId: 'interaction-7',
+          messages: [onlyMessage],
+        })}
+      />,
+    );
+
+    const list = screen.getByTestId('chat-message-list');
+    expect(list.props.data).toEqual([onlyMessage]);
+    expect(list.props.ListHeaderComponent).not.toBeNull();
+    expect(screen.getByTestId('goplan-ai-typing-interaction-7')).toBeTruthy();
+    expect(screen.getAllByTestId(/^chat-message-(?!list$)/)).toHaveLength(1);
+
+    await rendered.rerender(
+      <ChatMessageList
+        {...props({ aiTypingInteractionId: null, messages: [onlyMessage] })}
+      />,
+    );
+    expect(screen.queryByTestId('goplan-ai-typing-interaction-7')).toBeNull();
+    expect(screen.getByTestId('chat-message-list').props.data).toEqual([
+      onlyMessage,
+    ]);
+  });
+
+  it('fails every actionable card closed when two messages carry the same draft UUID', async () => {
+    const draft = makeDraftFixture({
+      id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      display: { title: 'First authority', kicker: 'Expense' },
+    });
+    const aiMessage = (id: string, title: string) =>
+      message(id, {
+        trip_id: '11111111-1111-4111-8111-111111111111',
+        sender: {
+          id: null,
+          display_name: 'GoPlanAI',
+          identify_tag: null,
+          avatar_url: null,
+        },
+        sender_kind: 'AI',
+        ai_status: 'SUCCESS',
+        action_drafts: [
+          {
+            ...draft,
+            display: { title, kicker: 'Expense' },
+          },
+        ],
+      });
+
+    await render(
+      <ChatMessageList
+        {...props({
+          messages: [
+            aiMessage('ai-one', 'First authority'),
+            aiMessage('ai-two', 'Conflicting authority'),
+          ],
+          ambiguousAIDraftIds: new Set([draft.id]),
+        })}
+      />,
+    );
+
+    expect(
+      screen.queryAllByTestId(`ai-action-draft-${draft.id}`),
+    ).toHaveLength(0);
+    expect(screen.queryAllByRole('button', { name: 'Confirm' })).toHaveLength(
+      0,
+    );
+    expect(
+      screen.getAllByText(
+        'An AI action draft could not be displayed safely.',
+      ),
+    ).toHaveLength(2);
+  });
+
+  it('does not transfer a stale editor session when duplicate ambiguity later clears to another message', async () => {
+    const draft = makeDraftFixture({
+      id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      status: 'NEEDS_INFO',
+      can_confirm: false,
+      can_edit: true,
+      missing_fields: [
+        { name: 'title', label: 'Title', type: 'text', required: true },
+      ],
+    });
+    const aiMessage = (id: string) =>
+      message(id, {
+        trip_id: '11111111-1111-4111-8111-111111111111',
+        sender: {
+          id: null,
+          display_name: 'GoPlanAI',
+          identify_tag: null,
+          avatar_url: null,
+        },
+        sender_kind: 'AI',
+        ai_status: 'SUCCESS',
+        action_drafts: [draft],
+      });
+    const first = aiMessage('ai-one');
+    const second = aiMessage('ai-two');
+    const coordinator = createAIReconciliationCoordinator({
+      resourceKey: 'user-me:11111111-1111-4111-8111-111111111111',
+      tripId: '11111111-1111-4111-8111-111111111111',
+    });
+    const transcript = (
+      messages: readonly ChatMessage[],
+      ambiguousAIDraftIds: ReadonlySet<string> = emptySet,
+    ) => (
+      <AIReconciliationCoordinatorProvider value={coordinator}>
+        <ChatMessageList
+          {...props({ messages, ambiguousAIDraftIds })}
+        />
+      </AIReconciliationCoordinatorProvider>
+    );
+    const rendered = await render(transcript([first]));
+    await fireEvent.press(screen.getByRole('button', { name: 'Edit draft' }));
+    await fireEvent.changeText(
+      screen.getByLabelText('Title'),
+      'Must not transfer',
+    );
+
+    await rendered.rerender(
+      transcript([first, second], new Set([draft.id])),
+    );
+    expect(screen.queryAllByTestId(`ai-action-draft-${draft.id}`)).toHaveLength(
+      0,
+    );
+    await rendered.rerender(transcript([second]));
+
+    expect(screen.getByTestId(`ai-action-draft-${draft.id}`)).toBeTruthy();
+    expect(screen.queryByTestId('ai-draft-field-editor')).toBeNull();
+    expect(screen.queryByText('Must not transfer')).toBeNull();
   });
 
   it('shows an honest empty state and keeps the composer accessory mounted', async () => {

--- a/mobile/src/features/chat/__tests__/ChatMessageList.test.tsx
+++ b/mobile/src/features/chat/__tests__/ChatMessageList.test.tsx
@@ -1,5 +1,12 @@
 import { act, fireEvent, render, screen } from '@testing-library/react-native';
-import { Alert, Keyboard, Text } from 'react-native';
+import {
+  Alert,
+  Keyboard,
+  Platform,
+  StyleSheet,
+  Text,
+} from 'react-native';
+import { focusAccessibilityNode } from '../ai/accessibilityFocus';
 import { makeDraftFixture } from '../ai/__fixtures__/drafts';
 import { createAIReconciliationCoordinator } from '../ai/reconciliation';
 import { AIReconciliationCoordinatorProvider } from '../ai/reconciliationContext';
@@ -11,7 +18,13 @@ import {
   toggleChatMessageSelection,
 } from '../components/ChatMessageList';
 
-jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('@expo/vector-icons', () => ({
+  FontAwesome6: () => null,
+  Ionicons: () => null,
+}));
+jest.mock('../ai/accessibilityFocus', () => ({
+  focusAccessibilityNode: jest.fn(),
+}));
 jest.mock('@/features/auth/components/UserAvatar', () => {
   const React = jest.requireActual<typeof import('react')>('react');
   const { View } = jest.requireActual<typeof import('react-native')>('react-native');
@@ -26,6 +39,7 @@ jest.mock('@/features/auth/components/UserAvatar', () => {
 
 const currentUserId = 'user-me';
 const emptySet = new Set<string>();
+const mockFocusAccessibilityNode = jest.mocked(focusAccessibilityNode);
 
 function message(id: string, overrides: Partial<ChatMessage> = {}): ChatMessage {
   return {
@@ -87,6 +101,7 @@ function props(overrides: Record<string, unknown> = {}) {
 
 describe('ChatMessageList', () => {
   afterEach(() => {
+    mockFocusAccessibilityNode.mockClear();
     jest.restoreAllMocks();
     jest.useRealTimers();
   });
@@ -122,7 +137,11 @@ describe('ChatMessageList', () => {
 
     const list = screen.getByTestId('chat-message-list');
     expect(list.props.inverted).toBe(true);
-    const bubbles = screen.getAllByTestId(/^chat-message-(?!list$)/);
+    expect(list.props.maintainVisibleContentPosition).toEqual({
+      minIndexForVisible: 0,
+      autoscrollToTopThreshold: 80,
+    });
+    const bubbles = screen.getAllByTestId(/^chat-message-(?!list$|footer-)/);
     expect(bubbles.map((bubble) => bubble.props.testID)).toEqual([
       'chat-message-newer',
       'chat-message-older',
@@ -146,7 +165,7 @@ describe('ChatMessageList', () => {
     expect(list.props.data).toEqual([onlyMessage]);
     expect(list.props.ListHeaderComponent).not.toBeNull();
     expect(screen.getByTestId('goplan-ai-typing-interaction-7')).toBeTruthy();
-    expect(screen.getAllByTestId(/^chat-message-(?!list$)/)).toHaveLength(1);
+    expect(screen.getAllByTestId(/^chat-message-(?!list$|footer-)/)).toHaveLength(1);
 
     await rendered.rerender(
       <ChatMessageList
@@ -271,9 +290,51 @@ describe('ChatMessageList', () => {
     await render(<ChatMessageList {...props()} />);
 
     expect(screen.getByText('No messages yet')).toBeTruthy();
+    const emptyStyle = screen.getByTestId('chat-empty-state').props.style;
+    expect(StyleSheet.flatten(emptyStyle)).toMatchObject({
+      flex: 1,
+      transform: [{ scaleY: -1 }],
+    });
+    expect(screen.getByTestId('chat-message-list').props.inverted).toBe(true);
     expect(
       screen.getByText('Composer accessory', { includeHiddenElements: true }),
     ).toBeTruthy();
+  });
+
+  it('gives every confirmed mutable bubble one compact reaction entry point without breaking grouping', async () => {
+    const onOpenMessages = [
+      message('older', { created_at: '2026-08-09T08:30:00.000Z' }),
+      message('newer', { created_at: '2026-08-09T08:31:00.000Z' }),
+      message('pending', {
+        client_message_id: 'client-pending',
+        created_at: '2026-08-09T08:32:00.000Z',
+      }),
+      message('removed', {
+        is_deleted_for_everyone: true,
+        created_at: '2026-08-09T08:33:00.000Z',
+      }),
+    ];
+    await render(
+      <ChatMessageList
+        {...props({
+          messages: onOpenMessages,
+          pendingClientIds: new Set(['client-pending']),
+        })}
+      />,
+    );
+
+    expect(screen.getAllByLabelText('React to this message')).toHaveLength(2);
+    expect(screen.getByTestId('chat-reaction-affordance-older')).toBeTruthy();
+    expect(screen.getByTestId('chat-reaction-affordance-newer')).toBeTruthy();
+    expect(screen.queryByTestId('chat-reaction-affordance-pending')).toBeNull();
+    expect(screen.queryByTestId('chat-reaction-affordance-removed')).toBeNull();
+    for (const id of ['older', 'newer']) {
+      expect(
+        StyleSheet.flatten(screen.getByTestId(`chat-bubble-action-row-${id}`).props.style),
+      ).toMatchObject({ minHeight: 44, flexDirection: 'row' });
+    }
+    expect(screen.getAllByText('Mai')).toHaveLength(1);
+    expect(screen.getAllByLabelText("Mai's profile picture")).toHaveLength(1);
   });
 
   it('never groups nullable deleted senders under one invented identity', async () => {
@@ -539,5 +600,209 @@ describe('ChatMessageList', () => {
     expect(screen.queryByLabelText('Message actions')).toBeNull();
     expect(screen.queryByLabelText(/Retry sending message/)).toBeNull();
     expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('restores screen-reader focus to the affordance only after the sheet dismisses', async () => {
+    jest.useFakeTimers();
+    await render(
+      <ChatMessageList {...props({ messages: [message('message-1')] })} />,
+    );
+
+    await fireEvent.press(screen.getByLabelText('React to this message'));
+    const onDismiss = screen.getByTestId('chat-message-actions-modal').parent
+      ?.props.onDismiss;
+    await fireEvent.press(screen.getByLabelText('Close message actions'));
+    expect(mockFocusAccessibilityNode).not.toHaveBeenCalled();
+    await act(() => onDismiss?.());
+    expect(mockFocusAccessibilityNode).not.toHaveBeenCalled();
+    await act(() => jest.runOnlyPendingTimers());
+
+    expect(mockFocusAccessibilityNode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        props: expect.objectContaining({
+          testID: 'chat-reaction-affordance-message-1',
+        }),
+      }),
+    );
+  });
+
+  it.each(['close', 'requestClose', 'reaction', 'selection'] as const)(
+    'restores Android screen-reader focus after a normal %s dismissal',
+    async (action) => {
+      jest.useFakeTimers();
+      jest.replaceProperty(Platform, 'OS', 'android');
+      await render(
+        <ChatMessageList {...props({ messages: [message('message-1')] })} />,
+      );
+
+      await fireEvent.press(screen.getByLabelText('React to this message'));
+      if (action === 'close') {
+        await fireEvent.press(screen.getByLabelText('Close message actions'));
+      } else if (action === 'requestClose') {
+        const requestClose = screen.getByTestId('chat-message-actions-modal')
+          .parent?.props.onRequestClose;
+        await act(() => requestClose?.());
+      } else if (action === 'reaction') {
+        await fireEvent.press(screen.getByLabelText('React with heart'));
+      } else {
+        await fireEvent.press(screen.getByLabelText('Select messages'));
+      }
+
+      expect(mockFocusAccessibilityNode).not.toHaveBeenCalled();
+      await act(() => jest.advanceTimersToNextTimer());
+      expect(mockFocusAccessibilityNode).not.toHaveBeenCalled();
+      await act(() => jest.advanceTimersToNextTimer());
+
+      expect(mockFocusAccessibilityNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          props: expect.objectContaining({
+            testID:
+              action === 'selection'
+                ? 'chat-message-message-1'
+                : 'chat-reaction-affordance-message-1',
+          }),
+        }),
+      );
+    },
+  );
+
+  it('cancels Android focus restoration when another action session opens', async () => {
+    jest.useFakeTimers();
+    jest.replaceProperty(Platform, 'OS', 'android');
+    await render(
+      <ChatMessageList
+        {...props({ messages: [message('message-1'), message('message-2')] })}
+      />,
+    );
+
+    await fireEvent.press(screen.getAllByLabelText('React to this message')[0]);
+    await fireEvent.press(screen.getByLabelText('Close message actions'));
+    await fireEvent.press(screen.getAllByLabelText('React to this message')[1]);
+    await act(() => jest.runOnlyPendingTimers());
+
+    expect(mockFocusAccessibilityNode).not.toHaveBeenCalled();
+    expect(screen.getByTestId('chat-message-actions-modal')).toBeTruthy();
+  });
+
+  it('falls back to the originating bubble when selection removes the affordance', async () => {
+    jest.useFakeTimers();
+    await render(
+      <ChatMessageList {...props({ messages: [message('message-1')] })} />,
+    );
+
+    await fireEvent.press(screen.getByLabelText('React to this message'));
+    const onDismiss = screen.getByTestId('chat-message-actions-modal').parent
+      ?.props.onDismiss;
+    await fireEvent.press(screen.getByLabelText('Select messages'));
+    expect(screen.queryByLabelText('React to this message')).toBeNull();
+    await act(() => onDismiss?.());
+    expect(mockFocusAccessibilityNode).not.toHaveBeenCalled();
+    await act(() => jest.runOnlyPendingTimers());
+
+    expect(mockFocusAccessibilityNode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        props: expect.objectContaining({ testID: 'chat-message-message-1' }),
+      }),
+    );
+  });
+
+  it('does not restore stale or duplicate focus after the originating row unmounts', async () => {
+    jest.useFakeTimers();
+    const baseProps = props({ messages: [message('message-1')] });
+    const rendered = await render(<ChatMessageList {...baseProps} />);
+
+    await fireEvent(
+      screen.getByTestId('chat-message-message-1'),
+      'longPress',
+    );
+    const onDismiss = screen.getByTestId('chat-message-actions-modal').parent
+      ?.props.onDismiss;
+    await rendered.rerender(
+      <ChatMessageList {...baseProps} messages={[]} />,
+    );
+    await act(() => onDismiss?.());
+    await act(() => onDismiss?.());
+    await act(() => jest.runOnlyPendingTimers());
+
+    expect(mockFocusAccessibilityNode).not.toHaveBeenCalled();
+  });
+
+  it('cancels a deferred focus restore when another message action session opens', async () => {
+    jest.useFakeTimers();
+    await render(
+      <ChatMessageList
+        {...props({ messages: [message('message-1'), message('message-2')] })}
+      />,
+    );
+
+    const affordances = screen.getAllByLabelText('React to this message');
+    await fireEvent.press(affordances[0]);
+    const firstDismiss = screen.getByTestId('chat-message-actions-modal').parent
+      ?.props.onDismiss;
+    await fireEvent.press(screen.getByLabelText('Close message actions'));
+    await act(() => firstDismiss?.());
+    expect(mockFocusAccessibilityNode).not.toHaveBeenCalled();
+
+    await fireEvent.press(affordances[1]);
+    await act(() => jest.runOnlyPendingTimers());
+
+    expect(mockFocusAccessibilityNode).not.toHaveBeenCalled();
+  });
+
+  it('does not focus a row that unmounts after dismissal but before the deferred task', async () => {
+    jest.useFakeTimers();
+    const baseProps = props({ messages: [message('message-1')] });
+    const rendered = await render(<ChatMessageList {...baseProps} />);
+
+    await fireEvent.press(screen.getByLabelText('React to this message'));
+    const onDismiss = screen.getByTestId('chat-message-actions-modal').parent
+      ?.props.onDismiss;
+    await fireEvent.press(screen.getByLabelText('Close message actions'));
+    await act(() => onDismiss?.());
+    await rendered.rerender(<ChatMessageList {...baseProps} messages={[]} />);
+    await act(() => jest.runOnlyPendingTimers());
+
+    expect(mockFocusAccessibilityNode).not.toHaveBeenCalled();
+  });
+
+  it('cancels a deferred focus restore when the chat list unmounts', async () => {
+    jest.useFakeTimers();
+    const rendered = await render(
+      <ChatMessageList {...props({ messages: [message('message-1')] })} />,
+    );
+
+    await fireEvent.press(screen.getByLabelText('React to this message'));
+    const onDismiss = screen.getByTestId('chat-message-actions-modal').parent
+      ?.props.onDismiss;
+    await fireEvent.press(screen.getByLabelText('Close message actions'));
+    await act(() => onDismiss?.());
+    await rendered.unmount();
+    await act(() => jest.runOnlyPendingTimers());
+
+    expect(mockFocusAccessibilityNode).not.toHaveBeenCalled();
+  });
+
+  it('leaves focus with a native destructive alert instead of reclaiming it', async () => {
+    jest.useFakeTimers();
+    const alert = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+    await render(
+      <ChatMessageList {...props({ messages: [message('message-1')] })} />,
+    );
+
+    await fireEvent.press(screen.getByLabelText('React to this message'));
+    const onDismiss = screen.getByTestId('chat-message-actions-modal').parent
+      ?.props.onDismiss;
+    await fireEvent.press(screen.getByLabelText('Hide for me'));
+    expect(alert).not.toHaveBeenCalled();
+    await act(() => onDismiss?.());
+    expect(alert).not.toHaveBeenCalled();
+    await act(() => jest.runOnlyPendingTimers());
+    expect(alert).toHaveBeenCalledWith(
+      'Hide this message?',
+      expect.any(String),
+      expect.any(Array),
+    );
+
+    expect(mockFocusAccessibilityNode).not.toHaveBeenCalled();
   });
 });

--- a/mobile/src/features/chat/__tests__/ChatReactionBar.test.tsx
+++ b/mobile/src/features/chat/__tests__/ChatReactionBar.test.tsx
@@ -54,6 +54,15 @@ describe('ChatReactionBar', () => {
     const chip = screen.getByLabelText('Thumbs up, 2 reactions, you reacted');
     expect(chip.props.accessibilityState.selected).toBe(true);
     expect(chip.props.accessibilityHint).toBe('Removes your reaction');
+    expect(
+      screen.getByTestId('chat-reaction-icon-👍', { includeHiddenElements: true }),
+    ).toBeTruthy();
+    expect(
+      screen.getByTestId('chat-reaction-selected-👍', {
+        includeHiddenElements: true,
+      }),
+    ).toBeTruthy();
+    expect(screen.queryByText('👍')).toBeNull();
     await fireEvent.press(chip);
     expect(onToggle).toHaveBeenCalledWith('👍');
   });

--- a/mobile/src/features/chat/__tests__/ChatReactionIcon.test.tsx
+++ b/mobile/src/features/chat/__tests__/ChatReactionIcon.test.tsx
@@ -1,0 +1,46 @@
+import { render } from '@testing-library/react-native';
+import { ALLOWED_REACTION_EMOJIS } from '../types';
+import {
+  ChatReactionIcon,
+  REACTION_ICON_NAMES,
+} from '../components/ChatReactionIcon';
+
+const mockFontAwesome6 = jest.fn((_props: unknown) => null);
+
+jest.mock('@expo/vector-icons', () => ({
+  FontAwesome6: (props: unknown) => mockFontAwesome6(props),
+}));
+
+describe('ChatReactionIcon', () => {
+  beforeEach(() => {
+    mockFontAwesome6.mockClear();
+  });
+
+  it('maps every backend Unicode reaction to an app-bundled vector glyph', async () => {
+    await render(
+      <>
+        {ALLOWED_REACTION_EMOJIS.map((emoji) => (
+          <ChatReactionIcon emoji={emoji} key={emoji} />
+        ))}
+      </>,
+    );
+
+    expect(mockFontAwesome6).toHaveBeenCalledTimes(ALLOWED_REACTION_EMOJIS.length);
+    const rendered = mockFontAwesome6.mock.calls.map(([props]) => props as {
+      accessibilityElementsHidden: boolean;
+      name: string;
+      solid: boolean;
+      testID: string;
+    });
+    expect(rendered.map(({ name }) => name)).toEqual(
+      ALLOWED_REACTION_EMOJIS.map((emoji) => REACTION_ICON_NAMES[emoji]),
+    );
+    expect(rendered.every(({ solid }) => solid)).toBe(true);
+    expect(rendered.every(({ accessibilityElementsHidden }) => accessibilityElementsHidden)).toBe(
+      true,
+    );
+    expect(rendered.map(({ testID }) => testID)).toEqual(
+      ALLOWED_REACTION_EMOJIS.map((emoji) => `chat-reaction-icon-${emoji}`),
+    );
+  });
+});

--- a/mobile/src/features/chat/__tests__/ChatScreen.test.tsx
+++ b/mobile/src/features/chat/__tests__/ChatScreen.test.tsx
@@ -1,4 +1,7 @@
 import { act, fireEvent, render, screen } from '@testing-library/react-native';
+import { makeDraftFixture } from '../ai/__fixtures__/drafts';
+import { aiActionDraftSourceIdentity } from '../ai/drafts';
+import { createAIReconciliationCoordinator } from '../ai/reconciliation';
 import type { ChatApiFailure, ChatMessage } from '../types';
 import { CHAT_KEYBOARD_BEHAVIOR, ChatScreen } from '../screens/ChatScreen';
 
@@ -13,6 +16,20 @@ jest.mock('../hooks/useTripChat', () => ({
 }), { virtual: true });
 jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
 jest.mock('@/features/auth/components/UserAvatar', () => ({ UserAvatar: () => null }));
+jest.mock('../ai/api', () => {
+  const actual = jest.requireActual<typeof import('../ai/api')>('../ai/api');
+  return {
+    ...actual,
+    getAIActionDraft: jest.fn(),
+    cancelAIActionDraft: jest.fn(),
+  };
+});
+
+// eslint-disable-next-line import/first
+import { cancelAIActionDraft, getAIActionDraft } from '../ai/api';
+
+const mockGetAIActionDraft = jest.mocked(getAIActionDraft);
+const mockCancelAIActionDraft = jest.mocked(cancelAIActionDraft);
 
 const emptySet = new Set<string>();
 const emptyMap = new Map<string, ChatApiFailure>();
@@ -80,6 +97,7 @@ function chatResult(overrides: Record<string, unknown> = {}) {
     pendingDeleteMessageIds: emptySet,
     isHidingMessages: false,
     mutationError: null,
+    aiTypingState: { active: null },
     currentUserId: 'user-me',
     tripStatus: 'PLANNING',
     accessStatus: 'granted',
@@ -96,6 +114,7 @@ function chatResult(overrides: Record<string, unknown> = {}) {
     toggleReaction: jest.fn().mockResolvedValue({ kind: 'applied' }),
     deleteMessage: jest.fn().mockResolvedValue({ kind: 'applied' }),
     hideMessagesForMe: jest.fn().mockResolvedValue({ kind: 'applied' }),
+    applyAIDraftSnapshot: jest.fn(),
     ...overrides,
   };
 }
@@ -104,6 +123,8 @@ describe('ChatScreen', () => {
   beforeEach(() => {
     mockParams = { tripId: 'trip-1' };
     mockUseTripChat.mockReset();
+    mockGetAIActionDraft.mockReset();
+    mockCancelAIActionDraft.mockReset();
     mockUseTripChat.mockReturnValue(chatResult());
   });
 
@@ -249,9 +270,17 @@ describe('ChatScreen', () => {
     expect(tripASend).not.toHaveBeenCalled();
   });
 
-  it('resets the composer when the signed-in user changes inside the same trip', async () => {
+  it('resets the composer when the signed-in user resource changes inside the same trip', async () => {
+    const coordinatorA = createAIReconciliationCoordinator({
+      resourceKey: 'user-a:trip-1',
+      tripId: 'trip-1',
+    });
+    const coordinatorB = createAIReconciliationCoordinator({
+      resourceKey: 'user-b:trip-1',
+      tripId: 'trip-1',
+    });
     mockUseTripChat.mockReturnValue(
-      chatResult({ currentUserId: 'user-a' }),
+      chatResult({ aiReconciliationCoordinator: coordinatorA }),
     );
     const view = await render(<ChatScreen />);
     await fireEvent.changeText(
@@ -260,11 +289,10 @@ describe('ChatScreen', () => {
     );
 
     mockUseTripChat.mockReturnValue(
-      chatResult({ currentUserId: 'user-b' }),
+      chatResult({ aiReconciliationCoordinator: coordinatorB }),
     );
     await view.rerender(<ChatScreen />);
 
-    expect(mockUseTripChat).toHaveBeenLastCalledWith({ tripId: 'trip-1' });
     expect(screen.getByLabelText('Message').props.value).toBe('');
   });
 
@@ -376,6 +404,152 @@ describe('ChatScreen', () => {
     expect(screen.getByTestId('chat-composer-feedback')).toHaveTextContent(
       'Too many messages. Try again in 3 seconds.',
     );
+  });
+
+  it('maps only an AI-mention 429 to the explicit 20-per-hour quota and keeps Retry-After', async () => {
+    const sendMessage = jest.fn().mockResolvedValue({
+      kind: 'blocked',
+      error: failure('Generic throttle detail.', {
+        errorCode: 'THROTTLED',
+        status: 429,
+        retryAfterMs: 2500,
+      }),
+    });
+    mockUseTripChat.mockReturnValue(chatResult({ sendMessage }));
+    await render(<ChatScreen />);
+
+    const input = screen.getByLabelText('Message');
+    await fireEvent.changeText(input, '  @goplanai Keep my AI prompt  ');
+    await fireEvent.press(screen.getByLabelText('Send message'));
+    await act(async () => undefined);
+
+    expect(input.props.value).toBe('  @goplanai Keep my AI prompt  ');
+    expect(screen.getByTestId('chat-composer-feedback')).toHaveTextContent(
+      'GoPlanAI allows 20 prompts per hour. Your prompt was not sent; try again later. Try again in 3 seconds.',
+    );
+  });
+
+  it('does not call the chat send path for a bare GoPlanAI mention', async () => {
+    const sendMessage = jest.fn().mockResolvedValue({
+      kind: 'created',
+      clientMessageId: 'client-ai-bare',
+    });
+    mockUseTripChat.mockReturnValue(chatResult({ sendMessage }));
+    await render(<ChatScreen />);
+
+    await fireEvent.changeText(
+      screen.getByLabelText('Message'),
+      '@GoPlanAI   ',
+    );
+    await fireEvent.press(screen.getByLabelText('Send message'));
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(screen.getByTestId('goplan-ai-prompt-hint')).toBeTruthy();
+  });
+
+  it.each([
+    ['AI_BUSY', 409, 'The current GoPlanAI interaction is still active.'],
+    ['INVALID_AI_PROMPT', 400, 'Please include a concrete AI prompt.'],
+  ])(
+    'preserves backend detail and the local composer draft for %s',
+    async (errorCode, status, detail) => {
+      const sendMessage = jest.fn().mockResolvedValue({
+        kind: 'blocked',
+        error: failure(detail, { errorCode, status }),
+      });
+      mockUseTripChat.mockReturnValue(chatResult({ sendMessage }));
+      await render(<ChatScreen />);
+
+      const input = screen.getByLabelText('Message');
+      const localDraft = '  @GoPlanAI Preserve this draft  ';
+      await fireEvent.changeText(input, localDraft);
+      await fireEvent.press(screen.getByLabelText('Send message'));
+      await act(async () => undefined);
+
+      expect(input.props.value).toBe(localDraft);
+      expect(screen.getByTestId('chat-composer-feedback')).toHaveTextContent(
+        detail,
+      );
+    },
+  );
+
+  it('passes the correlated AI typing interaction to the transcript header', async () => {
+    mockUseTripChat.mockReturnValue(
+      chatResult({
+        aiTypingState: {
+          active: {
+            interactionId: 'interaction-screen',
+            requestedByUserId: 'user-me',
+            startedAtMs: 1,
+            visualExpiresAtMs: 120_001,
+          },
+        },
+      }),
+    );
+    await render(<ChatScreen />);
+
+    expect(
+      screen.getByTestId('goplan-ai-typing-interaction-screen'),
+    ).toBeTruthy();
+  });
+
+  it('plumbs a draft HTTP snapshot back through the resource-guarded hook callback', async () => {
+    const tripId = '11111111-1111-4111-8111-111111111111';
+    const source = makeDraftFixture();
+    const cancelled = makeDraftFixture({
+      status: 'CANCELLED',
+      can_confirm: false,
+      can_cancel: false,
+      updated_at: '2026-08-10T00:01:00.000Z',
+    });
+    const applyAIDraftSnapshot = jest.fn();
+    mockParams = { tripId };
+    mockGetAIActionDraft.mockResolvedValue({ draft: source });
+    mockCancelAIActionDraft.mockResolvedValue({ draft: cancelled });
+    mockUseTripChat.mockReturnValue(
+      chatResult({
+        applyAIDraftSnapshot,
+        messages: [
+          {
+            ...message('ai-message', 'Review this proposal.'),
+            trip_id: tripId,
+            sender: {
+              id: null,
+              display_name: 'GoPlanAI',
+              identify_tag: null,
+              avatar_url: null,
+            },
+            sender_kind: 'AI',
+            ai_status: 'SUCCESS',
+            action_drafts: [source],
+          },
+        ],
+      }),
+    );
+    await render(<ChatScreen />);
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Cancel' }));
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Cancel this draft' }),
+    );
+    await act(async () => undefined);
+
+    expect(mockGetAIActionDraft).toHaveBeenCalledWith(
+      tripId,
+      source.id,
+      expect.any(AbortSignal),
+    );
+    expect(mockCancelAIActionDraft).toHaveBeenCalledWith(
+      tripId,
+      source.id,
+      expect.any(AbortSignal),
+    );
+    expect(applyAIDraftSnapshot).toHaveBeenCalledWith({
+      messageId: 'ai-message',
+      draftId: source.id,
+      expectedSourceIdentity: aiActionDraftSourceIdentity(source),
+      draft: cancelled,
+    });
   });
 
   it('surfaces catch-up, mutation, and older-page failures without hiding history', async () => {

--- a/mobile/src/features/chat/__tests__/ChatScreen.test.tsx
+++ b/mobile/src/features/chat/__tests__/ChatScreen.test.tsx
@@ -24,7 +24,10 @@ jest.mock('expo-router', () => ({
 jest.mock('../hooks/useTripChat', () => ({
   useTripChat: (input: unknown) => mockUseTripChat(input),
 }), { virtual: true });
-jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('@expo/vector-icons', () => ({
+  FontAwesome6: () => null,
+  Ionicons: () => null,
+}));
 jest.mock('@/features/auth/components/UserAvatar', () => ({ UserAvatar: () => null }));
 jest.mock('react-native-safe-area-context', () => {
   const actual = jest.requireActual<
@@ -100,6 +103,9 @@ function chatResult(overrides: Record<string, unknown> = {}) {
     roomStatus: 'ready',
     subscriptionStatus: 'subscribed',
     roomError: null,
+    readSyncError: null,
+    initialLoadError: null,
+    isLoadingInitial: false,
     messages: [] as readonly ChatMessage[],
     pendingClientIds: emptySet,
     failedClientIds: emptySet,
@@ -110,6 +116,7 @@ function chatResult(overrides: Record<string, unknown> = {}) {
     isGapFilling: false,
     isUpdating: false,
     connectionStatus: 'connected',
+    connectionDiagnostics: null,
     connectionEpoch: 1,
     isReadOnly: false,
     pendingReactionMessageIds: emptySet,
@@ -121,7 +128,10 @@ function chatResult(overrides: Record<string, unknown> = {}) {
     tripStatus: 'PLANNING',
     accessStatus: 'granted',
     loadOlder: jest.fn().mockResolvedValue(undefined),
+    retryCatchUp: jest.fn(),
+    retryConnection: jest.fn().mockReturnValue(false),
     retryInitialLoad: jest.fn().mockResolvedValue(undefined),
+    retrySubscription: jest.fn(),
     sendMessage: jest.fn().mockResolvedValue({
       kind: 'created',
       clientMessageId: 'client-1',
@@ -208,6 +218,7 @@ describe('ChatScreen', () => {
   });
 
   it('keeps history but removes every composer mutation when subscription is rejected', async () => {
+    const retrySubscription = jest.fn();
     mockUseTripChat.mockReturnValue(
       chatResult({
         subscriptionStatus: 'rejected',
@@ -217,18 +228,69 @@ describe('ChatScreen', () => {
           detail: 'Too many chat rooms are subscribed.',
         },
         messages: [message('message-1')],
+        retrySubscription,
       }),
     );
     await render(<ChatScreen />);
 
     expect(screen.getByText('Content message-1')).toBeTruthy();
-    expect(screen.getByTestId('chat-subscription-rejected')).toHaveTextContent(
-      'Too many chat rooms are subscribed.',
-    );
+    expect(screen.getByText('Too many chat rooms are subscribed.')).toBeTruthy();
     expect(screen.getByTestId('chat-read-only-footer')).toBeTruthy();
     expect(screen.queryByLabelText('Message')).toBeNull();
     expect(screen.getByTestId('chat-message-message-1').props.accessibilityActions).toEqual([]);
+    await fireEvent.press(screen.getByLabelText('Retry live chat'));
+    expect(retrySubscription).toHaveBeenCalledTimes(1);
   });
+
+  it.each([
+    ['COMPLETED', 'This completed trip’s chat is read-only.'],
+    ['CANCELLED', 'This cancelled trip’s chat is read-only.'],
+  ])(
+    'keeps terminal %s write-locked while exposing read-plane recovery',
+    async (tripStatus, terminalCopy) => {
+      const retrySubscription = jest.fn();
+      mockUseTripChat.mockReturnValue(
+        chatResult({
+          tripStatus,
+          isReadOnly: true,
+          subscriptionStatus: 'rejected',
+          connectionStatus: 'reconnecting',
+          roomError: {
+            errorCode: 'SUBSCRIPTION_LIMIT_REACHED',
+            detail: 'Too many chat rooms are subscribed.',
+          },
+          isGapFilling: true,
+          isUpdating: true,
+          retrySubscription,
+          mutationError: {
+            messageId: null,
+            error: failure('An unrelated mutation error.'),
+          },
+          messages: [message('message-1')],
+        }),
+      );
+      await render(<ChatScreen />);
+
+      expect(screen.getByTestId('chat-terminal-notice')).toHaveTextContent(
+        terminalCopy,
+      );
+      expect(screen.getByTestId('chat-read-only-footer')).toHaveTextContent(
+        terminalCopy,
+      );
+      expect(
+        screen.getByText(
+          'Live updates could not confirm this room. Retry to receive late messages.',
+        ),
+      ).toBeTruthy();
+      await fireEvent.press(screen.getByLabelText('Retry live updates'));
+      expect(retrySubscription).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('chat-catch-up-status')).toHaveTextContent(
+        'Updating read-only chat history…',
+      );
+      expect(screen.queryByTestId('chat-mutation-error')).toBeNull();
+      expect(screen.queryByTestId('chat-connection-banner')).toBeNull();
+    },
+  );
 
   it('preserves a local draft while a temporary subscription rejection hides mutations', async () => {
     const readyResult = chatResult();
@@ -334,6 +396,45 @@ describe('ChatScreen', () => {
 
     expect(screen.getByTestId('chat-terminal-notice')).toHaveTextContent(copy);
     expect(screen.getByTestId('chat-read-only-footer')).toHaveTextContent(copy);
+    expect(screen.queryByLabelText('Message')).toBeNull();
+  });
+
+  it('offers a read-only history retry without reopening terminal mutations', async () => {
+    const retryInitialLoad = jest.fn().mockResolvedValue(undefined);
+    mockUseTripChat.mockReturnValue(
+      chatResult({
+        tripStatus: 'COMPLETED',
+        isReadOnly: true,
+        initialLoadError: failure('Chat history could not be loaded.'),
+        retryInitialLoad,
+      }),
+    );
+    await render(<ChatScreen />);
+
+    expect(screen.getByTestId('chat-terminal-notice')).toBeTruthy();
+    expect(
+      screen.getByTestId('chat-terminal-history-error'),
+    ).toHaveTextContent(/Chat history could not be loaded\./);
+    expect(screen.queryByLabelText('Message')).toBeNull();
+    await fireEvent.press(screen.getByLabelText('Retry chat history'));
+    expect(retryInitialLoad).toHaveBeenCalledTimes(1);
+  });
+
+  it('replaces terminal history retry with an inline loading state', async () => {
+    mockUseTripChat.mockReturnValue(
+      chatResult({
+        tripStatus: 'COMPLETED',
+        isReadOnly: true,
+        isLoadingInitial: true,
+        initialLoadError: failure('Prior history request failed.'),
+      }),
+    );
+    await render(<ChatScreen />);
+
+    expect(screen.getByTestId('chat-terminal-history-loading')).toHaveTextContent(
+      'Loading chat history…',
+    );
+    expect(screen.queryByLabelText('Retry chat history')).toBeNull();
     expect(screen.queryByLabelText('Message')).toBeNull();
   });
 
@@ -766,6 +867,81 @@ describe('ChatScreen', () => {
     );
     expect(screen.getByText('Earlier messages could not be loaded.')).toBeTruthy();
     expect(screen.getByText('Content message-1')).toBeTruthy();
+  });
+
+  it('offers an accessible in-place retry for a failed message catch-up', async () => {
+    const retryCatchUp = jest.fn();
+    mockUseTripChat.mockReturnValue(
+      chatResult({
+        messages: [message('message-1')],
+        readSyncError: {
+          errorCode: 'CHAT_SYNC_FAILED',
+          detail: 'Missed messages could not be synchronized.',
+        },
+        retryCatchUp,
+      }),
+    );
+    await render(<ChatScreen />);
+
+    expect(screen.getByText('Missed messages could not be synchronized.')).toBeTruthy();
+    await fireEvent.press(screen.getByLabelText('Retry catching up'));
+    expect(retryCatchUp).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Content message-1')).toBeTruthy();
+  });
+
+  it('keeps a read-sync warning but hides a no-op retry until live chat is subscribed', async () => {
+    mockUseTripChat.mockReturnValue(
+      chatResult({
+        connectionStatus: 'reconnecting',
+        subscriptionStatus: 'waiting',
+        messages: [message('message-1')],
+        readSyncError: {
+          errorCode: 'CHAT_SYNC_FAILED',
+          detail: 'Read history may be stale.',
+        },
+      }),
+    );
+    await render(<ChatScreen />);
+
+    expect(screen.getByText('Read history may be stale.')).toBeTruthy();
+    expect(screen.queryByLabelText('Retry catching up')).toBeNull();
+  });
+
+  it('shows terminal transport exhaustion and restarts the actual connection', async () => {
+    const retryConnection = jest.fn().mockReturnValue(true);
+    mockUseTripChat.mockReturnValue(
+      chatResult({
+        tripStatus: 'COMPLETED',
+        isReadOnly: true,
+        connectionStatus: 'disconnected',
+        subscriptionStatus: 'waiting',
+        connectionDiagnostics: {
+          phase: 'stopped',
+          reason: 'retry_exhausted',
+          category: 'retry',
+          terminal: true,
+          closeCode: null,
+          reconnectAttempt: 10,
+          retryDelayMs: null,
+          ticketPhase: null,
+          heartbeat: 'inactive',
+        },
+        retryConnection,
+      }),
+    );
+    jest.useFakeTimers();
+    try {
+      await render(<ChatScreen />);
+      await act(async () => {
+        jest.advanceTimersByTime(2_500);
+      });
+      expect(screen.getByText(/stopped after repeated connection failures/)).toBeTruthy();
+      await fireEvent.press(screen.getByLabelText('Retry live connection'));
+      expect(retryConnection).toHaveBeenCalledTimes(1);
+      expect(screen.queryByLabelText('Message')).toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('surfaces an unknown room protocol error without disabling a healthy transcript', async () => {

--- a/mobile/src/features/chat/__tests__/ChatScreen.test.tsx
+++ b/mobile/src/features/chat/__tests__/ChatScreen.test.tsx
@@ -1,9 +1,19 @@
 import { act, fireEvent, render, screen } from '@testing-library/react-native';
+import {
+  Dimensions,
+  Keyboard,
+  StyleSheet,
+  type KeyboardEvent,
+} from 'react-native';
 import { makeDraftFixture } from '../ai/__fixtures__/drafts';
 import { aiActionDraftSourceIdentity } from '../ai/drafts';
 import { createAIReconciliationCoordinator } from '../ai/reconciliation';
 import type { ChatApiFailure, ChatMessage } from '../types';
-import { CHAT_KEYBOARD_BEHAVIOR, ChatScreen } from '../screens/ChatScreen';
+import {
+  chatKeyboardBottomInset,
+  ChatScreen,
+  stableChatKeyboardFrame,
+} from '../screens/ChatScreen';
 
 let mockParams: { tripId?: string | string[] } = { tripId: 'trip-1' };
 const mockUseTripChat = jest.fn();
@@ -16,6 +26,15 @@ jest.mock('../hooks/useTripChat', () => ({
 }), { virtual: true });
 jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
 jest.mock('@/features/auth/components/UserAvatar', () => ({ UserAvatar: () => null }));
+jest.mock('react-native-safe-area-context', () => {
+  const actual = jest.requireActual<
+    typeof import('react-native-safe-area-context')
+  >('react-native-safe-area-context');
+  return {
+    ...actual,
+    useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+  };
+});
 jest.mock('../ai/api', () => {
   const actual = jest.requireActual<typeof import('../ai/api')>('../ai/api');
   return {
@@ -120,6 +139,10 @@ function chatResult(overrides: Record<string, unknown> = {}) {
 }
 
 describe('ChatScreen', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   beforeEach(() => {
     mockParams = { tripId: 'trip-1' };
     mockUseTripChat.mockReset();
@@ -344,7 +367,54 @@ describe('ChatScreen', () => {
     expect(screen.queryByTestId('chat-mutation-error')).toBeNull();
   });
 
-  it('uses native-stack-safe insets and an iOS keyboard-aware layout', async () => {
+  it('calculates the keyboard inset from the viewport intersection', () => {
+    const dockedFrame = { height: 291, screenY: 376 };
+    expect(chatKeyboardBottomInset(667, dockedFrame, 34)).toBe(257);
+    expect(
+      chatKeyboardBottomInset(667, { height: 200, screenY: 300 }, 34),
+    ).toBe(166);
+    expect(
+      chatKeyboardBottomInset(667, { height: 291, screenY: 600 }, 34),
+    ).toBe(33);
+    expect(
+      chatKeyboardBottomInset(667, { height: 291, screenY: 700 }, 34),
+    ).toBe(0);
+    expect(
+      chatKeyboardBottomInset(667, { height: 291, screenY: 0 }, 34),
+    ).toBe(0);
+    expect(chatKeyboardBottomInset(Number.NaN, dockedFrame, 34)).toBe(0);
+  });
+
+  it('retains the last stable keyboard frame during an iOS cross-fade', () => {
+    const current = { height: 291, screenY: 376 };
+    expect(stableChatKeyboardFrame(current, { height: 320, screenY: 0 })).toBe(
+      current,
+    );
+    expect(stableChatKeyboardFrame(current, undefined)).toBe(current);
+    expect(stableChatKeyboardFrame(current, { height: 0, screenY: 667 })).toBeNull();
+    expect(
+      stableChatKeyboardFrame(current, { height: 216, screenY: 451 }),
+    ).toEqual({ height: 216, screenY: 451 });
+  });
+
+  it('uses native-stack-safe insets and follows stable keyboard frame changes', async () => {
+    let onKeyboardFrameChange: ((event: KeyboardEvent) => void) | undefined;
+    let onKeyboardHide: ((event: KeyboardEvent) => void) | undefined;
+    const addKeyboardListener = Keyboard.addListener.bind(Keyboard);
+    const listenerSpy = jest
+      .spyOn(Keyboard, 'addListener')
+      .mockImplementation((eventType, listener) => {
+        if (eventType === 'keyboardWillChangeFrame') {
+          onKeyboardFrameChange = listener;
+        } else if (eventType === 'keyboardWillHide') {
+          onKeyboardHide = listener;
+        }
+        return addKeyboardListener(eventType, listener);
+      });
+    jest.spyOn(Keyboard, 'metrics').mockReturnValue(undefined);
+    jest
+      .spyOn(Keyboard, 'scheduleLayoutAnimation')
+      .mockImplementation(() => undefined);
     await render(<ChatScreen />);
 
     expect(screen.getByTestId('chat-safe-area').props.edges).toEqual({
@@ -353,7 +423,128 @@ describe('ChatScreen', () => {
       right: 'additive',
       bottom: 'additive',
     });
-    expect(CHAT_KEYBOARD_BEHAVIOR).toBe('padding');
+    expect(onKeyboardFrameChange).toBeDefined();
+    expect(onKeyboardHide).toBeDefined();
+
+    const viewportHeight = Dimensions.get('window').height;
+
+    await act(async () => {
+      onKeyboardFrameChange?.({
+        duration: 250,
+        easing: 'keyboard',
+        endCoordinates: {
+          height: 291,
+          screenX: 0,
+          screenY: viewportHeight - 291,
+          width: 375,
+        },
+      });
+    });
+
+    expect(
+      StyleSheet.flatten(screen.getByTestId('chat-keyboard-layout').props.style),
+    ).toMatchObject({ flex: 1, paddingBottom: 291 });
+
+    await act(async () => {
+      onKeyboardFrameChange?.({
+        duration: 100,
+        easing: 'keyboard',
+        endCoordinates: {
+          height: 320,
+          screenX: 0,
+          screenY: 0,
+          width: 375,
+        },
+      });
+    });
+    expect(
+      StyleSheet.flatten(screen.getByTestId('chat-keyboard-layout').props.style),
+    ).toMatchObject({ flex: 1, paddingBottom: 291 });
+
+    await act(async () => {
+      onKeyboardFrameChange?.({
+        duration: 250,
+        easing: 'keyboard',
+        endCoordinates: {
+          height: 216,
+          screenX: 0,
+          screenY: viewportHeight - 216,
+          width: 375,
+        },
+      });
+    });
+    expect(
+      StyleSheet.flatten(screen.getByTestId('chat-keyboard-layout').props.style),
+    ).toMatchObject({ flex: 1, paddingBottom: 216 });
+
+    await act(async () => {
+      onKeyboardHide?.({
+        duration: 250,
+        easing: 'keyboard',
+        endCoordinates: {
+          height: 0,
+          screenX: 0,
+          screenY: viewportHeight,
+          width: 375,
+        },
+      });
+    });
+    expect(
+      StyleSheet.flatten(screen.getByTestId('chat-keyboard-layout').props.style),
+    ).toMatchObject({ flex: 1, paddingBottom: 0 });
+    listenerSpy.mockRestore();
+  });
+
+  it('refreshes keyboard metrics after a viewport orientation change', async () => {
+    const originalWindow = Dimensions.get('window');
+    const originalScreen = Dimensions.get('screen');
+    const portrait = { width: 375, height: 667, scale: 2, fontScale: 1 };
+    const landscape = { width: 667, height: 375, scale: 2, fontScale: 1 };
+    let metrics = {
+      height: 291,
+      screenX: 0,
+      screenY: portrait.height - 291,
+      width: portrait.width,
+    };
+    const metricsSpy = jest
+      .spyOn(Keyboard, 'metrics')
+      .mockImplementation(() => metrics);
+    jest
+      .spyOn(Keyboard, 'scheduleLayoutAnimation')
+      .mockImplementation(() => undefined);
+
+    let view: Awaited<ReturnType<typeof render>> | null = null;
+    try {
+      await act(async () => {
+        Dimensions.set({ window: portrait, screen: portrait });
+      });
+      view = await render(<ChatScreen />);
+      expect(
+        StyleSheet.flatten(screen.getByTestId('chat-keyboard-layout').props.style),
+      ).toMatchObject({ flex: 1, paddingBottom: 291 });
+
+      metrics = {
+        height: 216,
+        screenX: 0,
+        screenY: landscape.height - 216,
+        width: landscape.width,
+      };
+      await act(async () => {
+        Dimensions.set({ window: landscape, screen: landscape });
+      });
+
+      expect(metricsSpy).toHaveBeenLastCalledWith();
+      expect(
+        StyleSheet.flatten(screen.getByTestId('chat-keyboard-layout').props.style),
+      ).toMatchObject({ flex: 1, paddingBottom: 216 });
+    } finally {
+      if (view !== null) {
+        await view.unmount();
+      }
+      await act(async () => {
+        Dimensions.set({ window: originalWindow, screen: originalScreen });
+      });
+    }
   });
 
   it('clears the composer for created and transient-failed outcomes', async () => {

--- a/mobile/src/features/chat/__tests__/transcriptReducer.test.ts
+++ b/mobile/src/features/chat/__tests__/transcriptReducer.test.ts
@@ -140,12 +140,16 @@ describe('transcriptReducer', () => {
       resourceKey: RESOURCE_KEY,
       version: 0,
       roomStatus: 'idle',
+      isLoadingInitial: false,
       terminalLocked: false,
     });
     expect(first.confirmed).not.toBe(second.confirmed);
     expect(first.pending).not.toBe(second.pending);
     expect(first.hidden).not.toBe(second.hidden);
     expect(first.reactionLiveVersions).not.toBe(second.reactionLiveVersions);
+    expect(first.deferredAuthoritativePatches).not.toBe(
+      second.deferredAuthoritativePatches,
+    );
 
     const ignored = transcriptReducer(first, {
       type: 'UPSERT',
@@ -535,6 +539,115 @@ describe('transcriptReducer', () => {
       expect(after.confirmed.has('unknown')).toBe(false);
     },
   );
+
+  it('materializes a deferred full patch over a stale older page', () => {
+    const stale = message('not-loaded', { content: 'Stale older snapshot' });
+    const tombstone = message('not-loaded', {
+      content: '',
+      updated_at: '2026-08-09T10:10:00.000Z',
+      change_sequence: 10,
+      is_deleted_for_everyone: true,
+      deleted_for_everyone_at: '2026-08-09T10:10:00.000Z',
+      deleted_for_everyone_by_id: 'member-1',
+      delete_for_everyone_until: null,
+      can_delete_for_everyone: false,
+      reactions: [],
+    });
+    const initial = createTranscriptState(RESOURCE_KEY);
+    const deferred = transcriptReducer(initial, {
+      type: 'PATCH_KNOWN',
+      resourceKey: RESOURCE_KEY,
+      messages: [tombstone],
+      requestVersion: initial.version,
+    });
+
+    expect(deferred.confirmed.has(stale.id)).toBe(false);
+    expect(deferred.deferredAuthoritativePatches.has(stale.id)).toBe(true);
+
+    const materialized = transcriptReducer(deferred, {
+      type: 'OLDER_RESOLVED',
+      resourceKey: RESOURCE_KEY,
+      messages: [stale],
+      nextCursor: null,
+      requestVersion: initial.version,
+    });
+
+    expect(materialized.confirmed.get(stale.id)).toEqual(tombstone);
+    expect(materialized.deferredAuthoritativePatches.has(stale.id)).toBe(false);
+  });
+
+  it('composes deferred full and reaction authority before an older row appears', () => {
+    const stale = message('not-loaded', { content: 'Stale older snapshot' });
+    const updated = message('not-loaded', {
+      content: 'Changed while not loaded',
+      updated_at: '2026-08-09T10:10:00.000Z',
+      change_sequence: 10,
+    });
+    const latestReactions = [reaction('😂', ['member-2'])];
+    const initial = createTranscriptState(RESOURCE_KEY);
+    const withFullPatch = transcriptReducer(initial, {
+      type: 'PATCH_KNOWN',
+      resourceKey: RESOURCE_KEY,
+      messages: [updated],
+      requestVersion: initial.version,
+    });
+    const withReactionPatch = transcriptReducer(withFullPatch, {
+      type: 'REACTION_PATCH',
+      resourceKey: RESOURCE_KEY,
+      messageId: stale.id,
+      reactions: latestReactions,
+      changeSequence: 11,
+      updatedAt: '2026-08-09T10:11:00.000Z',
+    });
+
+    const materialized = transcriptReducer(withReactionPatch, {
+      type: 'UPSERT',
+      resourceKey: RESOURCE_KEY,
+      messages: [stale],
+      requestVersion: initial.version,
+    });
+
+    expect(materialized.confirmed.get(stale.id)).toMatchObject({
+      content: updated.content,
+      reactions: latestReactions,
+      change_sequence: 11,
+      updated_at: '2026-08-09T10:11:00.000Z',
+    });
+    expect(materialized.deferredAuthoritativePatches.size).toBe(0);
+  });
+
+  it('keeps a deferred tombstone authoritative over a later reaction push', () => {
+    const stale = message('not-loaded');
+    const tombstone = message('not-loaded', {
+      content: '',
+      change_sequence: 10,
+      is_deleted_for_everyone: true,
+      deleted_for_everyone_at: '2026-08-09T10:10:00.000Z',
+      reactions: [],
+    });
+    const initial = createTranscriptState(RESOURCE_KEY);
+    const deferred = transcriptReducer(initial, {
+      type: 'PATCH_KNOWN',
+      resourceKey: RESOURCE_KEY,
+      messages: [tombstone],
+    });
+    const afterImpossibleReaction = transcriptReducer(deferred, {
+      type: 'REACTION_PATCH',
+      resourceKey: RESOURCE_KEY,
+      messageId: stale.id,
+      reactions: [reaction('👍', ['member-2'])],
+      changeSequence: 11,
+      updatedAt: '2026-08-09T10:11:00.000Z',
+    });
+    const materialized = transcriptReducer(afterImpossibleReaction, {
+      type: 'UPSERT',
+      resourceKey: RESOURCE_KEY,
+      messages: [stale],
+    });
+
+    expect(afterImpossibleReaction).toBe(deferred);
+    expect(materialized.confirmed.get(stale.id)).toEqual(tombstone);
+  });
 
   it('rejects a known REST patch that began before a local optimistic mutation', () => {
     const base = message('server-1', {
@@ -1266,6 +1379,150 @@ describe('transcriptReducer', () => {
     });
     expect(afterLiveHistoryUpdate.confirmed.has('server-2')).toBe(true);
     expect(afterLiveHistoryUpdate.terminalLocked).toBe(true);
+
+    const afterTerminalHistoryLoad = transcriptReducer(locked, {
+      type: 'INIT_RESOLVED',
+      resourceKey: RESOURCE_KEY,
+      messages: [message('server-history')],
+      nextCursor: null,
+      requestVersion: locked.version,
+    });
+    expect(afterTerminalHistoryLoad.confirmed.has('server-history')).toBe(true);
+    expect(afterTerminalHistoryLoad.terminalLocked).toBe(true);
+  });
+
+  it('normalizes terminal state while preserving an active read-only page', () => {
+    let state = transcriptReducer(createTranscriptState(RESOURCE_KEY), {
+      type: 'INIT_START',
+      resourceKey: RESOURCE_KEY,
+    });
+    state = transcriptReducer(state, {
+      type: 'OLDER_START',
+      resourceKey: RESOURCE_KEY,
+    });
+    state = transcriptReducer(state, {
+      type: 'CATCHUP_PHASE',
+      resourceKey: RESOURCE_KEY,
+      phase: 'gap',
+    });
+
+    const locked = transcriptReducer(state, {
+      type: 'TERMINAL_LOCK',
+      resourceKey: RESOURCE_KEY,
+      error: terminalFailure,
+      requestVersion: state.version,
+    });
+
+    expect(locked).toMatchObject({
+      roomStatus: 'ready',
+      roomError: null,
+      terminalLocked: true,
+      isLoadingOlder: true,
+      olderLoadError: null,
+      isGapFilling: true,
+      isUpdating: false,
+    });
+    expect(
+      transcriptReducer(locked, {
+        type: 'INIT_START',
+        resourceKey: RESOURCE_KEY,
+      }),
+    ).toBe(locked);
+    expect(
+      transcriptReducer(locked, {
+        type: 'OLDER_START',
+        resourceKey: RESOURCE_KEY,
+      }),
+    ).toBe(locked);
+    const updating = transcriptReducer(locked, {
+      type: 'CATCHUP_PHASE',
+      resourceKey: RESOURCE_KEY,
+      phase: 'update',
+    });
+    expect(updating).toMatchObject({
+      terminalLocked: true,
+      isGapFilling: false,
+      isUpdating: true,
+    });
+  });
+
+  it('allows terminal history pagination to expose and settle its busy state', () => {
+    const initialized = transcriptReducer(createTranscriptState(RESOURCE_KEY), {
+      type: 'INIT_RESOLVED',
+      resourceKey: RESOURCE_KEY,
+      messages: [message('newest')],
+      nextCursor: 'older-page',
+      requestVersion: 0,
+    });
+    const locked = transcriptReducer(initialized, {
+      type: 'TERMINAL_LOCK',
+      resourceKey: RESOURCE_KEY,
+      error: terminalFailure,
+      requestVersion: initialized.version,
+    });
+    const loading = transcriptReducer(locked, {
+      type: 'OLDER_START',
+      resourceKey: RESOURCE_KEY,
+    });
+
+    expect(loading.isLoadingOlder).toBe(true);
+    expect(
+      transcriptReducer(loading, {
+        type: 'OLDER_START',
+        resourceKey: RESOURCE_KEY,
+      }),
+    ).toBe(loading);
+
+    const settled = transcriptReducer(loading, {
+      type: 'OLDER_RESOLVED',
+      resourceKey: RESOURCE_KEY,
+      messages: [message('older')],
+      nextCursor: null,
+      requestVersion: loading.version,
+    });
+    expect(settled.isLoadingOlder).toBe(false);
+    expect(settled.hasMoreOlder).toBe(false);
+    expect(settled.confirmed.has('older')).toBe(true);
+    expect(settled.terminalLocked).toBe(true);
+  });
+
+  it('exposes terminal initial-history retry without replacing the read-only room', () => {
+    const locked = transcriptReducer(createTranscriptState(RESOURCE_KEY), {
+      type: 'TERMINAL_LOCK',
+      resourceKey: RESOURCE_KEY,
+      error: terminalFailure,
+      requestVersion: 0,
+    });
+    const loading = transcriptReducer(locked, {
+      type: 'INIT_START',
+      resourceKey: RESOURCE_KEY,
+    });
+
+    expect(loading).toMatchObject({
+      roomStatus: 'ready',
+      terminalLocked: true,
+      isLoadingInitial: true,
+      roomError: null,
+    });
+    expect(
+      transcriptReducer(loading, {
+        type: 'INIT_START',
+        resourceKey: RESOURCE_KEY,
+      }),
+    ).toBe(loading);
+
+    const failed = transcriptReducer(loading, {
+      type: 'INIT_FAILED',
+      resourceKey: RESOURCE_KEY,
+      error: failure,
+      requestVersion: loading.version,
+    });
+    expect(failed).toMatchObject({
+      roomStatus: 'ready',
+      terminalLocked: true,
+      isLoadingInitial: false,
+      roomError: failure,
+    });
   });
 
   it('suspends only active work while preserving confirmed history and retryable sends', () => {

--- a/mobile/src/features/chat/__tests__/transcriptReducer.test.ts
+++ b/mobile/src/features/chat/__tests__/transcriptReducer.test.ts
@@ -12,6 +12,11 @@ import {
   transcriptReducer,
   type TranscriptState,
 } from '../application/transcriptReducer';
+import { makeDraftFixture, makeRawDraftFixture } from '../ai/__fixtures__/drafts';
+import {
+  aiActionDraftSourceIdentity,
+  type AIActionDraft,
+} from '../ai/drafts';
 import type {
   ChatApiFailure,
   ChatMessage,
@@ -99,6 +104,33 @@ function initialWith(messages: readonly ChatMessage[]): TranscriptState {
   });
 }
 
+function aiDraft(
+  overrides: Readonly<Record<string, unknown>> = {},
+): AIActionDraft {
+  return makeDraftFixture(overrides);
+}
+
+function aiMessage(
+  drafts: readonly Readonly<Record<string, unknown>>[],
+  changeSequence = 10,
+  overrides: Partial<ChatMessage> = {},
+): ChatMessage {
+  return message('ai-message', {
+    sender: {
+      id: null,
+      display_name: 'GoPlanAI',
+      identify_tag: null,
+      avatar_url: null,
+    },
+    sender_kind: 'AI',
+    ai_status: 'SUCCESS',
+    content: 'AI response',
+    change_sequence: changeSequence,
+    action_drafts: drafts,
+    ...overrides,
+  });
+}
+
 describe('transcriptReducer', () => {
   it('creates isolated immutable collections and resource-scopes every action', () => {
     const first = createTranscriptState(RESOURCE_KEY);
@@ -121,6 +153,250 @@ describe('transcriptReducer', () => {
       messages: [message('server-1')],
     });
     expect(ignored).toBe(first);
+  });
+
+  it('projects a guarded AI draft snapshot without changing the authoritative row or opaque siblings', () => {
+    const source = aiDraft({ future_source_value: { nested: true } });
+    const sibling = makeRawDraftFixture({
+      id: '33333333-3333-4333-8333-333333333333',
+      action_type: 'future.action',
+      future_sibling_value: ['keep', 7],
+    });
+    const malformed = { id: source.id, future_malformed_value: true };
+    const initialized = initialWith([
+      aiMessage([source, sibling, malformed]),
+    ]);
+    const projected = aiDraft({
+      status: 'CONFIRMED',
+      can_confirm: false,
+      updated_at: '2026-08-09T10:01:00.000Z',
+      future_projection_value: { preserved: true },
+    });
+    const after = transcriptReducer(initialized, {
+      type: 'AI_DRAFT_LOCAL_SNAPSHOT',
+      resourceKey: RESOURCE_KEY,
+      messageId: 'ai-message',
+      draftId: source.id,
+      expectedSourceIdentity: aiActionDraftSourceIdentity(source),
+      draft: projected,
+    });
+
+    expect(after.confirmed.get('ai-message')?.change_sequence).toBe(10);
+    expect(after.confirmed.get('ai-message')?.action_drafts[0]).toBe(source);
+    const effective = selectMessageById(after, 'ai-message');
+    expect(effective?.action_drafts[0]).toBe(projected);
+    expect(effective?.action_drafts[1]).toBe(sibling);
+    expect(effective?.action_drafts[2]).toBe(malformed);
+
+    const wrongResource = transcriptReducer(after, {
+      type: 'AI_DRAFT_LOCAL_SNAPSHOT',
+      resourceKey: 'trip-2:member-1',
+      messageId: 'ai-message',
+      draftId: source.id,
+      expectedSourceIdentity: aiActionDraftSourceIdentity(projected),
+      draft: source,
+    });
+    const staleSource = transcriptReducer(after, {
+      type: 'AI_DRAFT_LOCAL_SNAPSHOT',
+      resourceKey: RESOURCE_KEY,
+      messageId: 'ai-message',
+      draftId: source.id,
+      expectedSourceIdentity: aiActionDraftSourceIdentity(source),
+      draft: source,
+    });
+    expect(wrongResource).toBe(after);
+    expect(staleSource).toBe(after);
+  });
+
+  it('supports chained local AI draft projections and retains them across partial reaction pushes', () => {
+    const source = aiDraft();
+    const second = aiDraft({
+      summary: 'Edited once',
+      updated_at: '2026-08-09T10:01:00.000Z',
+    });
+    const third = aiDraft({
+      summary: 'Edited twice',
+      updated_at: '2026-08-09T10:02:00.000Z',
+    });
+    let state = initialWith([aiMessage([source])]);
+    state = transcriptReducer(state, {
+      type: 'AI_DRAFT_LOCAL_SNAPSHOT',
+      resourceKey: RESOURCE_KEY,
+      messageId: 'ai-message',
+      draftId: source.id,
+      expectedSourceIdentity: aiActionDraftSourceIdentity(source),
+      draft: second,
+    });
+    state = transcriptReducer(state, {
+      type: 'AI_DRAFT_LOCAL_SNAPSHOT',
+      resourceKey: RESOURCE_KEY,
+      messageId: 'ai-message',
+      draftId: source.id,
+      expectedSourceIdentity: aiActionDraftSourceIdentity(second),
+      draft: third,
+    });
+    state = transcriptReducer(state, {
+      type: 'REACTION_PATCH',
+      resourceKey: RESOURCE_KEY,
+      messageId: 'ai-message',
+      reactions: [reaction('👍', ['member-1'])],
+      changeSequence: 11,
+      updatedAt: '2026-08-09T10:03:00.000Z',
+    });
+
+    expect(selectMessageById(state, 'ai-message')?.action_drafts[0]).toBe(
+      third,
+    );
+    expect(state.confirmed.get('ai-message')).toMatchObject({
+      change_sequence: 11,
+      action_drafts: [source],
+    });
+    expect(
+      state.aiDraftOverlays
+        .get('ai-message')
+        ?.get(source.id)?.priorSourceIdentities,
+    ).toEqual(
+      new Set([
+        aiActionDraftSourceIdentity(source),
+        aiActionDraftSourceIdentity(second),
+      ]),
+    );
+  });
+
+  it('retains an AI projection for higher old-chain snapshots and clears it when the full row catches up', () => {
+    const source = aiDraft();
+    const second = aiDraft({
+      summary: 'Edited once',
+      updated_at: '2026-08-09T10:01:00.000Z',
+    });
+    const projected = aiDraft({
+      summary: 'Edited twice',
+      updated_at: '2026-08-09T10:02:00.000Z',
+    });
+    let state = initialWith([aiMessage([source])]);
+    state = transcriptReducer(state, {
+      type: 'AI_DRAFT_LOCAL_SNAPSHOT',
+      resourceKey: RESOURCE_KEY,
+      messageId: 'ai-message',
+      draftId: source.id,
+      expectedSourceIdentity: aiActionDraftSourceIdentity(source),
+      draft: second,
+    });
+    state = transcriptReducer(state, {
+      type: 'AI_DRAFT_LOCAL_SNAPSHOT',
+      resourceKey: RESOURCE_KEY,
+      messageId: 'ai-message',
+      draftId: source.id,
+      expectedSourceIdentity: aiActionDraftSourceIdentity(second),
+      draft: projected,
+    });
+    state = transcriptReducer(state, {
+      type: 'UPSERT',
+      resourceKey: RESOURCE_KEY,
+      messages: [aiMessage([second], 12)],
+    });
+
+    expect(selectMessageById(state, 'ai-message')?.action_drafts[0]).toBe(
+      projected,
+    );
+    expect(state.aiDraftOverlays.has('ai-message')).toBe(true);
+
+    state = transcriptReducer(state, {
+      type: 'UPSERT',
+      resourceKey: RESOURCE_KEY,
+      messages: [aiMessage([projected], 13)],
+    });
+    expect(state.aiDraftOverlays.has('ai-message')).toBe(false);
+    expect(selectMessageById(state, 'ai-message')?.action_drafts[0]).toBe(
+      projected,
+    );
+    expect(state.confirmed.get('ai-message')?.change_sequence).toBe(13);
+  });
+
+  it.each([
+    {
+      label: 'a concurrent valid draft',
+      incoming: aiMessage([
+        aiDraft({
+          summary: 'Concurrent server update',
+          updated_at: '2026-08-09T10:09:00.000Z',
+        }),
+      ], 11),
+    },
+    { label: 'a missing draft', incoming: aiMessage([], 11) },
+    {
+      label: 'a malformed draft',
+      incoming: aiMessage([
+        makeRawDraftFixture({ status: 'EXECUTED' }),
+      ], 11),
+    },
+    {
+      label: 'a tombstone',
+      incoming: aiMessage([aiDraft()], 11, {
+        is_deleted_for_everyone: true,
+      }),
+    },
+  ])('lets $label clear a stale local AI projection', ({ incoming }) => {
+    const source = aiDraft();
+    const projected = aiDraft({
+      status: 'CONFIRMED',
+      can_confirm: false,
+      updated_at: '2026-08-09T10:01:00.000Z',
+    });
+    let state = initialWith([aiMessage([source])]);
+    state = transcriptReducer(state, {
+      type: 'AI_DRAFT_LOCAL_SNAPSHOT',
+      resourceKey: RESOURCE_KEY,
+      messageId: 'ai-message',
+      draftId: source.id,
+      expectedSourceIdentity: aiActionDraftSourceIdentity(source),
+      draft: projected,
+    });
+    state = transcriptReducer(state, {
+      type: 'UPSERT',
+      resourceKey: RESOURCE_KEY,
+      messages: [incoming],
+    });
+
+    expect(state.aiDraftOverlays.has('ai-message')).toBe(false);
+    expect(selectMessageById(state, 'ai-message')?.action_drafts).toEqual(
+      incoming.action_drafts,
+    );
+  });
+
+  it('clears AI projections on hide, kick, and reset', () => {
+    const source = aiDraft();
+    const projected = aiDraft({
+      updated_at: '2026-08-09T10:01:00.000Z',
+    });
+    const initialized = initialWith([aiMessage([source])]);
+    const withProjection = transcriptReducer(initialized, {
+      type: 'AI_DRAFT_LOCAL_SNAPSHOT',
+      resourceKey: RESOURCE_KEY,
+      messageId: 'ai-message',
+      draftId: source.id,
+      expectedSourceIdentity: aiActionDraftSourceIdentity(source),
+      draft: projected,
+    });
+
+    const hidden = transcriptReducer(withProjection, {
+      type: 'HIDE_MESSAGES',
+      resourceKey: RESOURCE_KEY,
+      messageIds: ['ai-message'],
+      requestVersion: withProjection.version,
+    });
+    const kicked = transcriptReducer(withProjection, {
+      type: 'KICKED',
+      resourceKey: RESOURCE_KEY,
+    });
+    const reset = transcriptReducer(withProjection, {
+      type: 'RESET',
+      resourceKey: 'trip-2:member-1',
+    });
+
+    expect(hidden.aiDraftOverlays.size).toBe(0);
+    expect(kicked.aiDraftOverlays.size).toBe(0);
+    expect(reset.aiDraftOverlays.size).toBe(0);
   });
 
   it('merges an initial page with one shared mutation version without mutating the prior maps', () => {

--- a/mobile/src/features/chat/__tests__/useTripChat.test.tsx
+++ b/mobile/src/features/chat/__tests__/useTripChat.test.tsx
@@ -16,6 +16,10 @@ jest.mock('@/features/trips/hooks/useTripDetail', () => ({
   useTripDetail: (tripId: string | undefined) => mockUseTripDetail(tripId),
 }));
 
+jest.mock('@/features/expenses/expenseEvents', () => ({
+  publishExpenseEvent: jest.fn(),
+}));
+
 const mockSendRealtime = jest.fn();
 const mockSubscribeAll = jest.fn();
 let mockRealtimeSnapshot: RealtimeSnapshot = {
@@ -63,12 +67,18 @@ import {
   type ChatSendOutcome,
 } from '../hooks/useTripChat';
 // eslint-disable-next-line import/first
+import { makeDraftFixture } from '../ai/__fixtures__/drafts';
+// eslint-disable-next-line import/first
+import { aiActionDraftSourceIdentity } from '../ai/drafts';
+// eslint-disable-next-line import/first
 import type { ChatApiFailure, ChatMessage } from '../types';
 // eslint-disable-next-line import/first
 import type {
   RealtimeEnvelope,
   RealtimeSnapshot,
 } from '@/features/realtime/types';
+// eslint-disable-next-line import/first
+import { publishExpenseEvent } from '@/features/expenses/expenseEvents';
 // eslint-disable-next-line import/first
 import { useLayoutEffect } from 'react';
 
@@ -80,6 +90,7 @@ const mockAddChatReaction = jest.mocked(addChatReaction);
 const mockDeleteChatMessage = jest.mocked(deleteChatMessage);
 const mockHideChatMessages = jest.mocked(hideChatMessages);
 const mockNormalizeChatApiError = jest.mocked(normalizeChatApiError);
+const mockPublishExpenseEvent = jest.mocked(publishExpenseEvent);
 
 const TRIP_ID = 'a1111111-b111-4111-8111-c11111111111';
 const USER_ID = '22222222-2222-4222-8222-222222222222';
@@ -128,6 +139,24 @@ function message(overrides: Partial<ChatMessage> = {}): ChatMessage {
     action_drafts: [],
     ...overrides,
   };
+}
+
+function aiDraftMessage(
+  draft = makeDraftFixture(),
+  overrides: Partial<ChatMessage> = {},
+): ChatMessage {
+  return message({
+    sender_kind: 'AI',
+    ai_status: 'SUCCESS',
+    sender: {
+      id: null,
+      display_name: 'GoPlanAI',
+      identify_tag: null,
+      avatar_url: null,
+    },
+    action_drafts: [draft],
+    ...overrides,
+  });
 }
 
 interface Deferred<T> {
@@ -258,6 +287,7 @@ describe('useTripChat', () => {
       has_more: false,
     });
     mockNormalizeChatApiError.mockReturnValue(networkFailure);
+    mockPublishExpenseEvent.mockResolvedValue(undefined);
   });
 
   it.each([undefined, 'not-a-uuid'])(
@@ -345,6 +375,628 @@ describe('useTripChat', () => {
       type: 'chat.unsubscribe',
       trip_id: TRIP_ID,
     });
+  });
+
+  it('correlates AI typing only inside the current focused acknowledged subscription', async () => {
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+
+    await emitRealtime({
+      type: 'chat.ai_typing_started',
+      trip_id: TRIP_ID,
+      interaction_id: 'before-focus',
+      requested_by_user_id: USER_ID,
+    });
+    expect(view.result.current.aiTypingState.active).toBeNull();
+
+    const blur = await enterFocus();
+    await emitRealtime({
+      type: 'chat.ai_typing_started',
+      trip_id: TRIP_ID,
+      interaction_id: 'before-ack',
+      requested_by_user_id: USER_ID,
+    });
+    expect(view.result.current.aiTypingState.active).toBeNull();
+
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+    await emitRealtime({
+      type: 'chat.ai_typing_started',
+      trip_id: TRIP_ID,
+      interaction_id: 'interaction-old',
+      requested_by_user_id: USER_ID,
+    });
+    await emitRealtime({
+      type: 'chat.ai_typing_started',
+      trip_id: TRIP_ID,
+      interaction_id: 'interaction-current',
+      requested_by_user_id: null,
+    });
+    await emitRealtime({
+      type: 'chat.ai_typing_stopped',
+      trip_id: TRIP_ID,
+      interaction_id: 'interaction-old',
+    });
+
+    expect(view.result.current.aiTypingState.active).toMatchObject({
+      interactionId: 'interaction-current',
+      requestedByUserId: null,
+    });
+
+    await act(async () => blur());
+    expect(view.result.current.aiTypingState.active).toBeNull();
+    await emitRealtime({
+      type: 'chat.ai_typing_stopped',
+      trip_id: TRIP_ID,
+      interaction_id: 'interaction-current',
+    });
+    expect(view.result.current.aiTypingState.active).toBeNull();
+  });
+
+  it('uses the 120-second AI typing fallback only as a disposable visual timer', async () => {
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+    const blur = await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+
+    jest.useFakeTimers();
+    try {
+      await emitRealtime({
+        type: 'chat.ai_typing_started',
+        trip_id: TRIP_ID,
+        interaction_id: 'interaction-timeout',
+        requested_by_user_id: USER_ID,
+      });
+      expect(view.result.current.aiTypingState.active?.interactionId).toBe(
+        'interaction-timeout',
+      );
+
+      await act(async () => {
+        jest.advanceTimersByTime(120_000);
+      });
+      expect(view.result.current.aiTypingState.active).toBeNull();
+      expect(mockSendRealtime).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'chat.ai_typing_stopped' }),
+      );
+
+      await emitRealtime({
+        type: 'chat.ai_typing_started',
+        trip_id: TRIP_ID,
+        interaction_id: 'interaction-dispose',
+        requested_by_user_id: USER_ID,
+      });
+      await act(async () => blur());
+      expect(view.result.current.aiTypingState.active).toBeNull();
+      await act(async () => {
+        jest.advanceTimersByTime(120_000);
+      });
+      expect(view.result.current.aiTypingState.active).toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('clears AI typing on unsubscribe, connection epoch change, kick, and resource switch', async () => {
+    const tripB = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    mockUseTripDetail.mockImplementation((id: string) => readyTripDetail(id));
+    const view = await renderHook(
+      ({ id }: { id: string }) => useTripChat({ tripId: id }),
+      { initialProps: { id: TRIP_ID } },
+    );
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+    await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+
+    const start = async (interactionId: string) => {
+      await emitRealtime({
+        type: 'chat.ai_typing_started',
+        trip_id: TRIP_ID,
+        interaction_id: interactionId,
+        requested_by_user_id: USER_ID,
+      });
+      expect(view.result.current.aiTypingState.active?.interactionId).toBe(
+        interactionId,
+      );
+    };
+
+    await start('before-unsubscribe');
+    await emitRealtime({ type: 'chat.unsubscribed', trip_id: TRIP_ID });
+    expect(view.result.current.aiTypingState.active).toBeNull();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+
+    await start('before-reconnect');
+    mockRealtimeSnapshot = { status: 'reconnecting', connectionEpoch: 1 };
+    await view.rerender({ id: TRIP_ID });
+    expect(view.result.current.aiTypingState.active).toBeNull();
+
+    mockRealtimeSnapshot = { status: 'connected', connectionEpoch: 2 };
+    await view.rerender({ id: TRIP_ID });
+    await waitFor(() =>
+      expect(mockSendRealtime).toHaveBeenLastCalledWith({
+        type: 'chat.subscribe',
+        trip_id: TRIP_ID,
+      }),
+    );
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+    await start('before-kick');
+    await emitRealtime({ type: 'chat.kicked', trip_id: TRIP_ID });
+    expect(view.result.current.aiTypingState.active).toBeNull();
+
+    await view.rerender({ id: tripB });
+    expect(view.result.current.aiTypingState.active).toBeNull();
+  });
+
+  it('exposes a stable resource-guarded AI draft snapshot projection', async () => {
+    const tripB = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    const source = makeDraftFixture();
+    const projected = makeDraftFixture({
+      status: 'CONFIRMED',
+      can_confirm: false,
+      updated_at: '2026-08-09T10:01:00.000Z',
+    });
+    const aiRow = message({
+      sender_kind: 'AI',
+      ai_status: 'SUCCESS',
+      sender: {
+        id: null,
+        display_name: 'GoPlanAI',
+        identify_tag: null,
+        avatar_url: null,
+      },
+      action_drafts: [source],
+      change_sequence: 10,
+    });
+    mockUseTripDetail.mockImplementation((id: string) => readyTripDetail(id));
+    mockListChatHistory
+      .mockResolvedValueOnce({ results: [aiRow], next_cursor: null })
+      .mockResolvedValueOnce({ results: [], next_cursor: null });
+    const view = await renderHook(
+      ({ id }: { id: string }) => useTripChat({ tripId: id }),
+      { initialProps: { id: TRIP_ID } },
+    );
+    await waitFor(() => expect(view.result.current.messages).toHaveLength(1));
+    const callback = view.result.current.applyAIDraftSnapshot;
+
+    await act(async () => {
+      callback({
+        messageId: aiRow.id,
+        draftId: source.id,
+        expectedSourceIdentity: aiActionDraftSourceIdentity(source),
+        draft: projected,
+      });
+    });
+    expect(view.result.current.messages[0]).toMatchObject({
+      change_sequence: 10,
+      action_drafts: [projected],
+    });
+    expect(view.result.current.applyAIDraftSnapshot).toBe(callback);
+
+    await view.rerender({ id: tripB });
+    await act(async () => {
+      callback({
+        messageId: aiRow.id,
+        draftId: source.id,
+        expectedSourceIdentity: aiActionDraftSourceIdentity(projected),
+        draft: source,
+      });
+    });
+    expect(view.result.current.messages).toEqual([]);
+  });
+
+  it('reconciles an offscreen websocket CONFIRMED transition without a mounted draft card', async () => {
+    const source = makeDraftFixture();
+    const confirmed = makeDraftFixture({
+      status: 'CONFIRMED',
+      can_confirm: false,
+      can_cancel: false,
+      updated_at: '2026-08-09T10:01:00.000Z',
+      result: { expense_id: 'expense-offscreen' },
+    });
+    const aiRow = aiDraftMessage(source, { change_sequence: 10 });
+    mockListChatHistory.mockResolvedValue({
+      results: [aiRow],
+      next_cursor: null,
+    });
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.messages).toHaveLength(1));
+
+    await emitRealtime({
+      type: 'chat.message',
+      trip_id: TRIP_ID,
+      message: {
+        ...aiRow,
+        action_drafts: [confirmed],
+        change_sequence: 11,
+      },
+    });
+    await waitFor(() => expect(mockPublishExpenseEvent).toHaveBeenCalledTimes(1));
+    expect(mockPublishExpenseEvent).toHaveBeenCalledWith({
+      type: 'expensesChanged',
+      tripId: TRIP_ID,
+    });
+  });
+
+  it('retains an offscreen reconciliation failure across a reconnect acknowledgement', async () => {
+    const source = makeDraftFixture();
+    const confirmed = makeDraftFixture({
+      status: 'CONFIRMED',
+      can_confirm: false,
+      can_cancel: false,
+      updated_at: '2026-08-09T10:01:00.000Z',
+      result: { expense_id: 'expense-reconnect-failure' },
+    });
+    const aiRow = aiDraftMessage(source, { change_sequence: 10 });
+    mockListChatHistory.mockResolvedValue({
+      results: [aiRow],
+      next_cursor: null,
+    });
+    mockPublishExpenseEvent.mockRejectedValueOnce(
+      new Error('Expense refresh publisher failed.'),
+    );
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.messages).toHaveLength(1));
+    await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+
+    await emitRealtime({
+      type: 'chat.message',
+      trip_id: TRIP_ID,
+      message: {
+        ...aiRow,
+        action_drafts: [confirmed],
+        change_sequence: 11,
+      },
+    });
+    await waitFor(() =>
+      expect(view.result.current.roomError).toMatchObject({
+        errorCode: 'AI_RECONCILIATION_FAILED',
+      }),
+    );
+
+    mockRealtimeSnapshot = { status: 'connected', connectionEpoch: 2 };
+    await view.rerender({});
+    await waitFor(() =>
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.subscribe',
+        ),
+      ).toHaveLength(2),
+    );
+    await emitRealtime({
+      type: 'chat.error',
+      trip_id: TRIP_ID,
+      error_code: 'SUBSCRIPTION_LIMIT_REACHED',
+      detail: 'The reconnect subscription was rejected.',
+    });
+    expect(view.result.current.roomError).toEqual({
+      errorCode: 'SUBSCRIPTION_LIMIT_REACHED',
+      detail: 'The reconnect subscription was rejected.',
+    });
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+
+    expect(view.result.current.roomError).toMatchObject({
+      errorCode: 'AI_RECONCILIATION_FAILED',
+    });
+    expect(mockPublishExpenseEvent).toHaveBeenCalledTimes(1);
+
+    await emitRealtime({
+      type: 'chat.error',
+      trip_id: TRIP_ID,
+      error_code: 'TRIP_TERMINAL',
+      detail: 'This trip has ended.',
+    });
+    expect(view.result.current.roomError).toEqual({
+      errorCode: 'TRIP_TERMINAL',
+      detail: 'This trip has ended.',
+    });
+
+    mockRealtimeSnapshot = { status: 'connected', connectionEpoch: 3 };
+    await view.rerender({});
+    await waitFor(() =>
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.subscribe',
+        ),
+      ).toHaveLength(3),
+    );
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+    expect(view.result.current.roomError).toEqual({
+      errorCode: 'TRIP_TERMINAL',
+      detail: 'This trip has ended.',
+    });
+  });
+
+  it('seeds initially CONFIRMED history without publishing reconciliation', async () => {
+    const confirmed = makeDraftFixture({
+      status: 'CONFIRMED',
+      can_confirm: false,
+      can_cancel: false,
+      result: { expense_id: 'expense-history' },
+    });
+    mockListChatHistory.mockResolvedValue({
+      results: [aiDraftMessage(confirmed)],
+      next_cursor: null,
+    });
+
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+    expect(mockPublishExpenseEvent).not.toHaveBeenCalled();
+  });
+
+  it('shares one reconciliation claim between a local HTTP snapshot and websocket confirmation', async () => {
+    const source = makeDraftFixture();
+    const confirmed = makeDraftFixture({
+      status: 'CONFIRMED',
+      can_confirm: false,
+      can_cancel: false,
+      updated_at: '2026-08-09T10:01:00.000Z',
+      result: { expense_id: 'expense-shared' },
+    });
+    const aiRow = aiDraftMessage(source, { change_sequence: 10 });
+    mockListChatHistory.mockResolvedValue({
+      results: [aiRow],
+      next_cursor: null,
+    });
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.messages).toHaveLength(1));
+
+    await act(async () => {
+      await view.result.current.applyAIDraftSnapshot({
+        messageId: aiRow.id,
+        draftId: source.id,
+        expectedSourceIdentity: aiActionDraftSourceIdentity(source),
+        draft: confirmed,
+      });
+      realtimeListener?.({
+        type: 'chat.message',
+        trip_id: TRIP_ID,
+        message: {
+          ...aiRow,
+          action_drafts: [confirmed],
+          change_sequence: 11,
+        },
+      });
+      await Promise.resolve();
+    });
+
+    expect(mockPublishExpenseEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('reconciles a CONFIRMED transition accepted through changed-message catch-up', async () => {
+    const source = makeDraftFixture();
+    const confirmed = makeDraftFixture({
+      status: 'CONFIRMED',
+      can_confirm: false,
+      can_cancel: false,
+      updated_at: '2026-08-09T10:01:00.000Z',
+      result: { expense_id: 'expense-catch-up' },
+    });
+    const aiRow = aiDraftMessage(source, { change_sequence: 10 });
+    mockListChatHistory.mockResolvedValue({
+      results: [aiRow],
+      next_cursor: null,
+    });
+    mockGapFillChatMessages.mockResolvedValueOnce({
+      results: [],
+      has_more: false,
+    });
+    mockSyncChangedChatMessages.mockResolvedValueOnce({
+      results: [
+        {
+          ...aiRow,
+          action_drafts: [confirmed],
+          change_sequence: 11,
+        },
+      ],
+      has_more: false,
+    });
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.messages).toHaveLength(1));
+    await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+
+    await waitFor(() => expect(mockPublishExpenseEvent).toHaveBeenCalledTimes(1));
+  });
+
+  it('reconciles a CONFIRMED initial response that overtakes a live READY row while history is pending', async () => {
+    const source = makeDraftFixture();
+    const confirmed = makeDraftFixture({
+      status: 'CONFIRMED',
+      can_confirm: false,
+      can_cancel: false,
+      updated_at: '2026-08-09T10:01:00.000Z',
+      result: { expense_id: 'expense-init-overlap' },
+    });
+    const readyRow = aiDraftMessage(source, { change_sequence: 10 });
+    const initialPage = deferred<{
+      results: readonly ChatMessage[];
+      next_cursor: null;
+    }>();
+    mockListChatHistory.mockReturnValueOnce(initialPage.promise);
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(mockListChatHistory).toHaveBeenCalledTimes(1));
+    await emitRealtime({
+      type: 'chat.message',
+      trip_id: TRIP_ID,
+      message: readyRow,
+    });
+
+    await act(async () => {
+      initialPage.resolve({
+        results: [
+          {
+            ...readyRow,
+            action_drafts: [confirmed],
+            change_sequence: 11,
+          },
+        ],
+        next_cursor: null,
+      });
+      await initialPage.promise;
+    });
+
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+    await waitFor(() => expect(mockPublishExpenseEvent).toHaveBeenCalledTimes(1));
+  });
+
+  it('reconciles a CONFIRMED older page that overtakes a live READY row while pagination is pending', async () => {
+    const source = makeDraftFixture();
+    const confirmed = makeDraftFixture({
+      status: 'CONFIRMED',
+      can_confirm: false,
+      can_cancel: false,
+      updated_at: '2026-08-09T10:01:00.000Z',
+      result: { expense_id: 'expense-older-overlap' },
+    });
+    const anchor = message({
+      id: '44444444-4444-4444-8444-444444444444',
+      change_sequence: 20,
+    });
+    const readyRow = aiDraftMessage(source, {
+      id: '55555555-5555-4555-8555-555555555555',
+      change_sequence: 10,
+      created_at: '2026-08-09T09:00:00.000Z',
+      updated_at: '2026-08-09T09:00:00.000Z',
+    });
+    const olderPage = deferred<{
+      results: readonly ChatMessage[];
+      next_cursor: null;
+    }>();
+    mockListChatHistory
+      .mockResolvedValueOnce({ results: [anchor], next_cursor: 'older-page' })
+      .mockReturnValueOnce(olderPage.promise);
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.hasMoreOlder).toBe(true));
+
+    let loadPromise!: Promise<void>;
+    await act(async () => {
+      loadPromise = view.result.current.loadOlder();
+      await Promise.resolve();
+    });
+    await emitRealtime({
+      type: 'chat.message',
+      trip_id: TRIP_ID,
+      message: readyRow,
+    });
+    await act(async () => {
+      olderPage.resolve({
+        results: [
+          {
+            ...readyRow,
+            action_drafts: [confirmed],
+            change_sequence: 11,
+          },
+        ],
+        next_cursor: null,
+      });
+      await loadPromise;
+    });
+
+    await waitFor(() => expect(mockPublishExpenseEvent).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not reparse existing AI drafts for ordinary user UPSERT or PATCH_KNOWN rows', async () => {
+    let draftPropertyReads = 0;
+    const trackedDraft = new Proxy(makeDraftFixture(), {
+      get(target, property, receiver) {
+        draftPropertyReads += 1;
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    mockListChatHistory.mockResolvedValue({
+      results: [aiDraftMessage(trackedDraft)],
+      next_cursor: null,
+    });
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+    const readsAfterSeed = draftPropertyReads;
+    const userRow = message({
+      id: '66666666-6666-4666-8666-666666666666',
+      change_sequence: 30,
+    });
+
+    await emitRealtime({
+      type: 'chat.message',
+      trip_id: TRIP_ID,
+      message: userRow,
+    });
+    await emitRealtime({
+      type: 'chat.message_deleted',
+      trip_id: TRIP_ID,
+      message: {
+        ...userRow,
+        content: '',
+        is_deleted_for_everyone: true,
+        change_sequence: 31,
+      },
+    });
+
+    expect(draftPropertyReads).toBe(readsAfterSeed);
+  });
+
+  it('fails closed when a confirmed transition still has a duplicate draft id elsewhere in the room', async () => {
+    const source = makeDraftFixture();
+    const confirmed = makeDraftFixture({
+      status: 'CONFIRMED',
+      can_confirm: false,
+      can_cancel: false,
+      updated_at: '2026-08-09T10:01:00.000Z',
+      result: { expense_id: 'must-not-publish-duplicate' },
+    });
+    const first = aiDraftMessage(source, { change_sequence: 10 });
+    const duplicate = aiDraftMessage(source, {
+      id: '77777777-7777-4777-8777-777777777777',
+      change_sequence: 9,
+    });
+    mockListChatHistory.mockResolvedValue({
+      results: [first, duplicate],
+      next_cursor: null,
+    });
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.messages).toHaveLength(2));
+    expect(view.result.current.ambiguousAIDraftIds.has(source.id)).toBe(true);
+
+    await emitRealtime({
+      type: 'chat.message',
+      trip_id: TRIP_ID,
+      message: {
+        ...first,
+        action_drafts: [confirmed],
+        change_sequence: 11,
+      },
+    });
+
+    expect(mockPublishExpenseEvent).not.toHaveBeenCalled();
+    expect(view.result.current.ambiguousAIDraftIds.has(source.id)).toBe(true);
+  });
+
+  it('trims only outer message whitespace before sending while preserving internal spacing', async () => {
+    const rawContent = '  @goplanai Keep  internal\nspacing  ';
+    mockSendChatMessage.mockImplementationOnce(async (_tripId, input) => ({
+      disposition: 'created',
+      message: message({
+        client_message_id: input.clientMessageId,
+        content: '@GoPlanAI Keep internal spacing',
+      }),
+    }));
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+
+    const outcome = await captureInAct(() =>
+      view.result.current.sendMessage(rawContent),
+    );
+    expect(outcome.kind).toBe('created');
+    expect(mockSendChatMessage.mock.calls[0]?.[1].content).toBe(
+      '@goplanai Keep  internal\nspacing',
+    );
+
+    const empty = await captureInAct(() =>
+      view.result.current.sendMessage(' \n '),
+    );
+    expect(empty).toMatchObject({
+      kind: 'blocked',
+      error: { errorCode: 'INVALID_CONTENT' },
+    });
+    expect(mockSendChatMessage).toHaveBeenCalledTimes(1);
   });
 
   it('waits for subscribe acknowledgement and captures update cursor before gap-fill', async () => {
@@ -819,7 +1471,7 @@ describe('useTripChat', () => {
     expect(mockListChatHistory).toHaveBeenCalledTimes(1);
   });
 
-  it('restarts subscription and catch-up after a transient access error without clearing history', async () => {
+  it('restarts subscription, catch-up, and AI typing after a transient access error without clearing history', async () => {
     const anchor = message();
     const missed = message({
       id: '99999999-9999-4999-8999-999999999999',
@@ -851,11 +1503,23 @@ describe('useTripChat', () => {
     const blur = await enterFocus();
     await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
     await waitFor(() => expect(mockGapFillChatMessages).toHaveBeenCalledTimes(1));
+    await emitRealtime({
+      type: 'chat.ai_typing_started',
+      trip_id: TRIP_ID,
+      interaction_id: 'before-transient-error',
+      requested_by_user_id: USER_ID,
+    });
+    expect(view.result.current.aiTypingState.active?.interactionId).toBe(
+      'before-transient-error',
+    );
 
     tripState = transientState;
     await view.rerender({});
     await waitFor(() => expect(view.result.current.accessStatus).toBe('error'));
+    // The transcript is hidden while authority is unknown, but the reducer
+    // history must survive and reappear without another first-page load.
     expect(view.result.current.messages).toEqual([]);
+    expect(view.result.current.aiTypingState.active).toBeNull();
     expect(view.result.current.subscriptionStatus).toBe('inactive');
     expect(
       mockSendRealtime.mock.calls.filter(
@@ -882,6 +1546,15 @@ describe('useTripChat', () => {
         anchor.id,
         missed.id,
       ]),
+    );
+    await emitRealtime({
+      type: 'chat.ai_typing_started',
+      trip_id: TRIP_ID,
+      interaction_id: 'after-transient-error',
+      requested_by_user_id: USER_ID,
+    });
+    expect(view.result.current.aiTypingState.active?.interactionId).toBe(
+      'after-transient-error',
     );
     await act(async () => blur());
   });

--- a/mobile/src/features/chat/__tests__/useTripChat.test.tsx
+++ b/mobile/src/features/chat/__tests__/useTripChat.test.tsx
@@ -21,6 +21,7 @@ jest.mock('@/features/expenses/expenseEvents', () => ({
 }));
 
 const mockSendRealtime = jest.fn();
+const mockRetryConnection = jest.fn();
 const mockSubscribeAll = jest.fn();
 let mockRealtimeSnapshot: RealtimeSnapshot = {
   status: 'connected',
@@ -28,6 +29,7 @@ let mockRealtimeSnapshot: RealtimeSnapshot = {
 };
 const mockRealtimeTransport = {
   send: mockSendRealtime,
+  retryConnection: mockRetryConnection,
   subscribe: jest.fn(),
   subscribeAll: mockSubscribeAll,
 };
@@ -61,6 +63,9 @@ import {
 } from '../api';
 // eslint-disable-next-line import/first
 import {
+  CHAT_SUBSCRIPTION_ACK_TIMEOUT_MS,
+  CHAT_SUBSCRIPTION_MAX_ATTEMPTS,
+  CHAT_SUBSCRIPTION_RETRY_DELAY_MS,
   createChatClientMessageId,
   useTripChat,
   type ChatMutationOutcome,
@@ -110,6 +115,15 @@ const throttledFailure: ChatApiFailure = {
   errorCode: 'THROTTLED',
   status: 429,
   retryAfterMs: 30_000,
+  fieldErrors: null,
+};
+
+const terminalFailure: ChatApiFailure = {
+  kind: 'message',
+  message: 'This trip chat is read-only because the trip has ended.',
+  errorCode: 'TRIP_TERMINAL',
+  status: 409,
+  retryAfterMs: null,
   fieldErrors: null,
 };
 
@@ -283,6 +297,7 @@ describe('useTripChat', () => {
     });
     mockUseTripDetail.mockReturnValue(readyTripDetail());
     mockSendRealtime.mockReturnValue(true);
+    mockRetryConnection.mockReturnValue(false);
     mockSubscribeAll.mockImplementation(
       (listener: (event: RealtimeEnvelope) => void) => {
         realtimeListener = listener;
@@ -316,6 +331,101 @@ describe('useTripChat', () => {
     },
   );
 
+  it('forwards an explicit transport retry without changing chat ownership', async () => {
+    mockRetryConnection.mockReturnValue(true);
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+
+    expect(view.result.current.retryConnection()).toBe(true);
+    expect(mockRetryConnection).toHaveBeenCalledTimes(1);
+    expect(mockSendRealtime).not.toHaveBeenCalled();
+  });
+
+  it('applies terminal authority reported by an AI draft controller to the room', async () => {
+    const existing = message();
+    mockListChatHistory.mockResolvedValue({
+      results: [existing],
+      next_cursor: null,
+    });
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+
+    await act(async () => {
+      view.result.current.aiReconciliationCoordinator.reportAuthoritativeFailure(
+        terminalFailure,
+      );
+    });
+
+    expect(view.result.current.roomStatus).toBe('ready');
+    expect(view.result.current.isReadOnly).toBe(true);
+    expect(view.result.current.messages).toEqual([existing]);
+    expect(view.result.current.roomError).toMatchObject({
+      errorCode: 'TRIP_TERMINAL',
+    });
+  });
+
+  it('kicks the room for exact access authority reported by an AI draft controller', async () => {
+    mockListChatHistory.mockResolvedValue({
+      results: [message()],
+      next_cursor: null,
+    });
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+
+    await act(async () => {
+      view.result.current.aiReconciliationCoordinator.reportAuthoritativeFailure({
+        kind: 'message',
+        message: 'You no longer have access to this trip.',
+        errorCode: 'FORBIDDEN',
+        status: 403,
+        retryAfterMs: null,
+        fieldErrors: null,
+      });
+    });
+
+    expect(view.result.current.roomStatus).toBe('kicked');
+    expect(view.result.current.messages).toEqual([]);
+    expect(view.result.current.roomError).toMatchObject({
+      errorCode: 'FORBIDDEN',
+    });
+
+    await act(async () => {
+      view.result.current.aiReconciliationCoordinator.reportAuthoritativeFailure(
+        terminalFailure,
+      );
+    });
+    expect(view.result.current.roomStatus).toBe('kicked');
+    expect(view.result.current.roomError).toMatchObject({
+      errorCode: 'FORBIDDEN',
+    });
+  });
+
+  it('fences an AI draft authority reporter after switching chat resources', async () => {
+    const tripB = 'b2222222-c222-4222-8222-d22222222222';
+    mockUseTripDetail.mockImplementation((id: string) => readyTripDetail(id));
+    mockListChatHistory.mockResolvedValue({ results: [], next_cursor: null });
+    const view = await renderHook(
+      ({ id }: { id: string }) => useTripChat({ tripId: id }),
+      { initialProps: { id: TRIP_ID } },
+    );
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+    const staleCoordinator = view.result.current.aiReconciliationCoordinator;
+
+    await view.rerender({ id: tripB });
+    await waitFor(() =>
+      expect(view.result.current.aiReconciliationCoordinator).not.toBe(
+        staleCoordinator,
+      ),
+    );
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+    await act(async () => {
+      staleCoordinator.reportAuthoritativeFailure(terminalFailure);
+    });
+
+    expect(view.result.current.isReadOnly).toBe(false);
+    expect(view.result.current.roomError).toBeNull();
+  });
+
   it('subscribes only on focus and once per connected epoch without rebinding listeners', async () => {
     const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
     await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
@@ -343,6 +453,351 @@ describe('useTripChat', () => {
       type: 'chat.unsubscribe',
       trip_id: TRIP_ID,
     });
+  });
+
+  it('bounds missing subscription ACK recovery and exposes an in-place retry', async () => {
+    mockListChatHistory.mockResolvedValue({
+      results: [message()],
+      next_cursor: null,
+    });
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+
+    jest.useFakeTimers();
+    try {
+      const blur = await enterFocus();
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.subscribe',
+        ),
+      ).toHaveLength(1);
+
+      for (
+        let attempt = 1;
+        attempt < CHAT_SUBSCRIPTION_MAX_ATTEMPTS;
+        attempt += 1
+      ) {
+        await act(async () => {
+          jest.advanceTimersByTime(CHAT_SUBSCRIPTION_ACK_TIMEOUT_MS);
+        });
+        expect(
+          mockSendRealtime.mock.calls.filter(
+            ([command]) => command.type === 'chat.subscribe',
+          ),
+        ).toHaveLength(attempt + 1);
+        expect(view.result.current.subscriptionStatus).toBe('subscribing');
+      }
+
+      await act(async () => {
+        jest.advanceTimersByTime(CHAT_SUBSCRIPTION_ACK_TIMEOUT_MS);
+      });
+      expect(view.result.current.subscriptionStatus).toBe('rejected');
+      expect(view.result.current.roomError).toEqual({
+        errorCode: 'CHAT_SUBSCRIPTION_TIMEOUT',
+        detail:
+          'Live chat could not confirm this room after several attempts. Tap Retry live chat or reopen chat.',
+      });
+
+      await act(async () => view.result.current.retrySubscription());
+      expect(view.result.current.subscriptionStatus).toBe('subscribing');
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.subscribe',
+        ),
+      ).toHaveLength(CHAT_SUBSCRIPTION_MAX_ATTEMPTS + 1);
+
+      await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+      await waitFor(() =>
+        expect(view.result.current.subscriptionStatus).toBe('subscribed'),
+      );
+      await waitFor(() =>
+        expect(mockGapFillChatMessages).toHaveBeenCalledTimes(1),
+      );
+      await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+      expect(mockListChatHistory).toHaveBeenCalledTimes(1);
+      expect(mockGapFillChatMessages).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        jest.advanceTimersByTime(CHAT_SUBSCRIPTION_ACK_TIMEOUT_MS * 2);
+      });
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.subscribe',
+        ),
+      ).toHaveLength(CHAT_SUBSCRIPTION_MAX_ATTEMPTS + 1);
+      await act(async () => blur());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('keeps subscription recovery alive when the room becomes terminal', async () => {
+    mockListChatHistory.mockResolvedValue({
+      results: [message()],
+      next_cursor: null,
+    });
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+
+    jest.useFakeTimers();
+    try {
+      await enterFocus();
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.subscribe',
+        ),
+      ).toHaveLength(1);
+
+      await emitRealtime({
+        type: 'chat.error',
+        trip_id: TRIP_ID,
+        error_code: 'TRIP_TERMINAL',
+        detail: 'The trip ended before subscription acknowledgement.',
+      });
+      expect(view.result.current.subscriptionStatus).toBe('subscribing');
+
+      await act(async () => {
+        jest.advanceTimersByTime(CHAT_SUBSCRIPTION_ACK_TIMEOUT_MS);
+      });
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.subscribe',
+        ),
+      ).toHaveLength(2);
+      expect(view.result.current.subscriptionStatus).toBe('subscribing');
+
+      await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+      expect(view.result.current.subscriptionStatus).toBe('subscribed');
+      await act(async () => {
+        jest.advanceTimersByTime(CHAT_SUBSCRIPTION_ACK_TIMEOUT_MS * 2);
+      });
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.subscribe',
+        ),
+      ).toHaveLength(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('subscribes an already terminal trip for read updates only', async () => {
+    mockUseTripDetail.mockReturnValue(readyTripDetail(TRIP_ID, 'COMPLETED'));
+    mockListChatHistory.mockResolvedValue({
+      results: [message()],
+      next_cursor: null,
+    });
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.messages).toHaveLength(1));
+    expect(view.result.current.isReadOnly).toBe(true);
+
+    await enterFocus();
+
+    expect(view.result.current.subscriptionStatus).toBe('subscribing');
+    expect(
+      mockSendRealtime.mock.calls.some(
+        ([command]) => command.type === 'chat.subscribe',
+      ),
+    ).toBe(true);
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+    expect(view.result.current.subscriptionStatus).toBe('subscribed');
+    const blocked = await captureInAct(() =>
+      view.result.current.sendMessage('Terminal rooms remain write-locked'),
+    );
+    expect(blocked).toMatchObject({
+      kind: 'blocked',
+      error: { errorCode: 'TRIP_TERMINAL' },
+    });
+    expect(mockSendChatMessage).not.toHaveBeenCalled();
+  });
+
+  it('cancels subscription recovery when chat loses focus', async () => {
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+
+    jest.useFakeTimers();
+    try {
+      const blur = await enterFocus();
+      await act(async () => blur());
+      await act(async () => {
+        jest.advanceTimersByTime(CHAT_SUBSCRIPTION_ACK_TIMEOUT_MS * 4);
+      });
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.subscribe',
+        ),
+      ).toHaveLength(1);
+      expect(view.result.current.subscriptionStatus).toBe('inactive');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it.each(['auth-loss', 'unmount'] as const)(
+    'cancels subscription recovery on %s',
+    async (lifecycleEvent) => {
+      const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+      await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+
+      jest.useFakeTimers();
+      try {
+        await enterFocus();
+        if (lifecycleEvent === 'auth-loss') {
+          mockUseSession.mockReturnValue({ status: 'signedOut', user: null });
+          await view.rerender({});
+          await act(async () => {
+            await Promise.resolve();
+          });
+        } else {
+          await view.unmount();
+        }
+
+        await act(async () => {
+          jest.advanceTimersByTime(CHAT_SUBSCRIPTION_ACK_TIMEOUT_MS * 4);
+        });
+        expect(
+          mockSendRealtime.mock.calls.filter(
+            ([command]) => command.type === 'chat.subscribe',
+          ),
+        ).toHaveLength(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    },
+  );
+
+  it('invalidates the prior ACK timer when the connection epoch changes', async () => {
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+
+    jest.useFakeTimers();
+    try {
+      const blur = await enterFocus();
+      mockRealtimeSnapshot = { status: 'reconnecting', connectionEpoch: 1 };
+      await view.rerender({});
+      await act(async () => {
+        jest.advanceTimersByTime(CHAT_SUBSCRIPTION_ACK_TIMEOUT_MS * 2);
+      });
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.subscribe',
+        ),
+      ).toHaveLength(1);
+
+      mockRealtimeSnapshot = { status: 'connected', connectionEpoch: 2 };
+      await view.rerender({});
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.subscribe',
+        ),
+      ).toHaveLength(2);
+      await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+      await act(async () => {
+        jest.advanceTimersByTime(CHAT_SUBSCRIPTION_ACK_TIMEOUT_MS * 2);
+      });
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.subscribe',
+        ),
+      ).toHaveLength(2);
+      await act(async () => blur());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('ignores a cleared stale subscription recovery callback', async () => {
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+
+    const scheduledTimeouts: {
+      readonly callback: () => void;
+      readonly delayMs: number | undefined;
+    }[] = [];
+    const setTimeoutSpy = jest
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation(
+        ((callback: () => void, delayMs?: number) => {
+          scheduledTimeouts.push({ callback, delayMs });
+          return scheduledTimeouts.length as unknown as ReturnType<
+            typeof setTimeout
+          >;
+        }) as typeof setTimeout,
+      );
+    const clearTimeoutSpy = jest
+      .spyOn(globalThis, 'clearTimeout')
+      .mockImplementation(() => undefined);
+
+    try {
+      const blur = await enterFocus();
+      expect(scheduledTimeouts.map(({ delayMs }) => delayMs)).toEqual([
+        CHAT_SUBSCRIPTION_ACK_TIMEOUT_MS,
+      ]);
+
+      await emitRealtime({
+        type: 'chat.error',
+        trip_id: TRIP_ID,
+        error_code: 'TRANSIENT_SUBSCRIPTION_FAILURE',
+        detail: 'Retry this subscription.',
+      });
+      expect(scheduledTimeouts.map(({ delayMs }) => delayMs)).toEqual([
+        CHAT_SUBSCRIPTION_ACK_TIMEOUT_MS,
+        CHAT_SUBSCRIPTION_RETRY_DELAY_MS,
+      ]);
+
+      await act(async () => {
+        scheduledTimeouts[0]?.callback();
+      });
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.subscribe',
+        ),
+      ).toHaveLength(1);
+      expect(view.result.current.subscriptionStatus).toBe('waiting');
+
+      await act(async () => {
+        scheduledTimeouts[1]?.callback();
+      });
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.subscribe',
+        ),
+      ).toHaveLength(2);
+      expect(view.result.current.subscriptionStatus).toBe('subscribing');
+      await act(async () => blur());
+    } finally {
+      clearTimeoutSpy.mockRestore();
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it('bounds recovery when the transport initially refuses subscription sends', async () => {
+    mockSendRealtime.mockReturnValue(false);
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+
+    jest.useFakeTimers();
+    try {
+      const blur = await enterFocus();
+      expect(view.result.current.subscriptionStatus).toBe('waiting');
+      await act(async () => {
+        jest.advanceTimersByTime(
+          CHAT_SUBSCRIPTION_RETRY_DELAY_MS * CHAT_SUBSCRIPTION_MAX_ATTEMPTS,
+        );
+      });
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.subscribe',
+        ),
+      ).toHaveLength(CHAT_SUBSCRIPTION_MAX_ATTEMPTS);
+      expect(view.result.current.subscriptionStatus).toBe('rejected');
+      await act(async () => blur());
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('canonicalizes an uppercase deep-link id across detail, commands, ACKs, and messages', async () => {
@@ -531,6 +986,11 @@ describe('useTripChat', () => {
     await start('before-kick');
     await emitRealtime({ type: 'chat.kicked', trip_id: TRIP_ID });
     expect(view.result.current.aiTypingState.active).toBeNull();
+    expect(
+      mockSendRealtime.mock.calls.filter(
+        ([command]) => command.type === 'chat.unsubscribe',
+      ),
+    ).toHaveLength(1);
 
     await view.rerender({ id: tripB });
     expect(view.result.current.aiTypingState.active).toBeNull();
@@ -702,14 +1162,17 @@ describe('useTripChat', () => {
 
     mockRealtimeSnapshot = { status: 'connected', connectionEpoch: 3 };
     await view.rerender({});
-    await waitFor(() =>
-      expect(
-        mockSendRealtime.mock.calls.filter(
-          ([command]) => command.type === 'chat.subscribe',
-        ),
-      ).toHaveLength(3),
-    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(
+      mockSendRealtime.mock.calls.filter(
+        ([command]) => command.type === 'chat.subscribe',
+      ),
+    ).toHaveLength(3);
+    expect(view.result.current.subscriptionStatus).toBe('subscribing');
     await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+    expect(view.result.current.subscriptionStatus).toBe('subscribed');
     expect(view.result.current.roomError).toEqual({
       errorCode: 'TRIP_TERMINAL',
       detail: 'This trip has ended.',
@@ -806,6 +1269,130 @@ describe('useTripChat', () => {
     await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
 
     await waitFor(() => expect(mockPublishExpenseEvent).toHaveBeenCalledTimes(1));
+  });
+
+  it('reconciles deferred CONFIRMED authority exactly once when older history materializes it', async () => {
+    const source = makeDraftFixture();
+    const confirmed = makeDraftFixture({
+      status: 'CONFIRMED',
+      can_confirm: false,
+      can_cancel: false,
+      updated_at: '2026-08-09T10:01:00.000Z',
+      result: { expense_id: 'expense-deferred-history' },
+    });
+    const anchor = message({
+      id: '44444444-4444-4444-8444-444444444444',
+      change_sequence: 20,
+      created_at: '2026-08-09T11:00:00.000Z',
+      updated_at: '2026-08-09T11:00:00.000Z',
+    });
+    const unloadedReady = aiDraftMessage(source, {
+      id: '55555555-5555-4555-8555-555555555555',
+      change_sequence: 10,
+      created_at: '2026-08-09T09:00:00.000Z',
+      updated_at: '2026-08-09T09:00:00.000Z',
+    });
+    const deferredConfirmed = {
+      ...unloadedReady,
+      action_drafts: [confirmed],
+      change_sequence: 21,
+      updated_at: '2026-08-09T10:01:00.000Z',
+    };
+    mockListChatHistory
+      .mockResolvedValueOnce({ results: [anchor], next_cursor: 'older-page' })
+      .mockResolvedValueOnce({ results: [unloadedReady], next_cursor: null });
+    mockGapFillChatMessages.mockResolvedValueOnce({
+      results: [],
+      has_more: false,
+    });
+    mockSyncChangedChatMessages.mockResolvedValueOnce({
+      results: [deferredConfirmed],
+      has_more: false,
+    });
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.hasMoreOlder).toBe(true));
+    await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+    await waitFor(() =>
+      expect(mockSyncChangedChatMessages).toHaveBeenCalledTimes(1),
+    );
+    expect(mockPublishExpenseEvent).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await view.result.current.loadOlder();
+    });
+
+    await waitFor(() => expect(mockPublishExpenseEvent).toHaveBeenCalledTimes(1));
+    expect(
+      view.result.current.messages.find(
+        (candidate) => candidate.id === unloadedReady.id,
+      )?.action_drafts,
+    ).toEqual([confirmed]);
+
+    await emitRealtime({
+      type: 'chat.message',
+      trip_id: TRIP_ID,
+      message: { ...deferredConfirmed, change_sequence: 22 },
+    });
+    expect(mockPublishExpenseEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not republish a draft already CONFIRMED in the raw older row', async () => {
+    const confirmed = makeDraftFixture({
+      status: 'CONFIRMED',
+      can_confirm: false,
+      can_cancel: false,
+      updated_at: '2026-08-09T09:00:00.000Z',
+      result: { expense_id: 'expense-already-confirmed' },
+    });
+    const anchor = message({
+      id: '44444444-4444-4444-8444-444444444444',
+      change_sequence: 20,
+      created_at: '2026-08-09T11:00:00.000Z',
+      updated_at: '2026-08-09T11:00:00.000Z',
+    });
+    const rawConfirmed = aiDraftMessage(confirmed, {
+      id: '55555555-5555-4555-8555-555555555555',
+      content: 'Older confirmed snapshot',
+      change_sequence: 10,
+      created_at: '2026-08-09T09:00:00.000Z',
+      updated_at: '2026-08-09T09:00:00.000Z',
+    });
+    const deferredContentChange = {
+      ...rawConfirmed,
+      content: 'Confirmed row with a later non-draft change',
+      change_sequence: 21,
+      updated_at: '2026-08-09T10:01:00.000Z',
+    };
+    mockListChatHistory
+      .mockResolvedValueOnce({ results: [anchor], next_cursor: 'older-page' })
+      .mockResolvedValueOnce({ results: [rawConfirmed], next_cursor: null });
+    mockGapFillChatMessages.mockResolvedValueOnce({
+      results: [],
+      has_more: false,
+    });
+    mockSyncChangedChatMessages.mockResolvedValueOnce({
+      results: [deferredContentChange],
+      has_more: false,
+    });
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.hasMoreOlder).toBe(true));
+    await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+    await waitFor(() =>
+      expect(mockSyncChangedChatMessages).toHaveBeenCalledTimes(1),
+    );
+
+    await act(async () => {
+      await view.result.current.loadOlder();
+    });
+
+    expect(mockPublishExpenseEvent).not.toHaveBeenCalled();
+    expect(
+      view.result.current.messages.find(
+        (candidate) => candidate.id === rawConfirmed.id,
+      )?.content,
+    ).toBe(deferredContentChange.content);
   });
 
   it('reconciles a CONFIRMED initial response that overtakes a live READY row while history is pending', async () => {
@@ -1084,6 +1671,58 @@ describe('useTripChat', () => {
     });
   });
 
+  it('blocks a second same-render send after terminal authority settles the first', async () => {
+    mockSendChatMessage.mockRejectedValueOnce(new Error('trip ended'));
+    mockNormalizeChatApiError.mockReturnValueOnce(terminalFailure);
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+    const staleSend = view.result.current.sendMessage;
+    let firstOutcome!: ChatSendOutcome;
+    let secondOutcome!: ChatSendOutcome;
+
+    await act(async () => {
+      firstOutcome = await staleSend('First terminal send');
+      secondOutcome = await staleSend('Must be synchronously blocked');
+    });
+
+    expect(firstOutcome).toMatchObject({
+      kind: 'blocked',
+      error: { errorCode: 'TRIP_TERMINAL' },
+    });
+    expect(secondOutcome).toMatchObject({
+      kind: 'blocked',
+      error: { errorCode: 'TRIP_TERMINAL' },
+    });
+    expect(mockSendChatMessage).toHaveBeenCalledTimes(1);
+    expect(view.result.current.pendingClientIds.size).toBe(0);
+  });
+
+  it('blocks a stale send callback in the same tick that rejects the current subscription', async () => {
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+    await enterFocus();
+    const staleSend = view.result.current.sendMessage;
+    let outcome!: ChatSendOutcome;
+
+    await act(async () => {
+      realtimeListener?.({
+        type: 'chat.error',
+        trip_id: TRIP_ID,
+        error_code: 'SUBSCRIPTION_LIMIT_REACHED',
+        detail: 'Too many chat subscriptions.',
+      });
+      outcome = await staleSend('Must be synchronously blocked');
+    });
+
+    expect(outcome).toMatchObject({
+      kind: 'blocked',
+      error: { errorCode: 'SUBSCRIPTION_LIMIT_REACHED' },
+    });
+    expect(mockSendChatMessage).not.toHaveBeenCalled();
+    expect(view.result.current.pendingClientIds.size).toBe(0);
+    expect(view.result.current.subscriptionStatus).toBe('rejected');
+  });
+
   it('retains a failed bubble and the same client id when its retry is throttled', async () => {
     mockSendChatMessage.mockRejectedValueOnce(new Error('offline'));
     mockNormalizeChatApiError.mockReturnValueOnce(networkFailure);
@@ -1124,62 +1763,102 @@ describe('useTripChat', () => {
     });
     const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
     await waitFor(() => expect(view.result.current.messages).toHaveLength(1));
-    await enterFocus();
-    await emitRealtime({
-      type: 'chat.error',
-      trip_id: TRIP_ID,
-      error_code: 'SUBSCRIPTION_LIMIT_REACHED',
-      detail: 'Too many chat subscriptions.',
-    });
+    jest.useFakeTimers();
+    try {
+      await enterFocus();
+      await emitRealtime({
+        type: 'chat.error',
+        trip_id: TRIP_ID,
+        error_code: 'SUBSCRIPTION_LIMIT_REACHED',
+        detail: 'Too many chat subscriptions.',
+      });
 
-    expect(view.result.current.subscriptionStatus).toBe('rejected');
-    expect(view.result.current.isReadOnly).toBe(true);
-    expect(view.result.current.messages).toHaveLength(1);
+      expect(view.result.current.subscriptionStatus).toBe('rejected');
+      expect(view.result.current.isReadOnly).toBe(true);
+      expect(view.result.current.messages).toHaveLength(1);
+      await act(async () => {
+        jest.advanceTimersByTime(CHAT_SUBSCRIPTION_ACK_TIMEOUT_MS * 4);
+      });
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.subscribe',
+        ),
+      ).toHaveLength(1);
 
-    await emitRealtime({ type: 'chat.kicked', trip_id: TRIP_ID });
-    expect(view.result.current.roomStatus).toBe('kicked');
-    expect(view.result.current.messages).toEqual([]);
+      await act(async () => view.result.current.retrySubscription());
+      expect(view.result.current.subscriptionStatus).toBe('subscribing');
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.subscribe',
+        ),
+      ).toHaveLength(2);
+      await emitRealtime({
+        type: 'chat.error',
+        trip_id: TRIP_ID,
+        error_code: 'SUBSCRIPTION_LIMIT_REACHED',
+        detail: 'Too many chat subscriptions.',
+      });
+      expect(view.result.current.subscriptionStatus).toBe('rejected');
+
+      await emitRealtime({ type: 'chat.kicked', trip_id: TRIP_ID });
+      expect(view.result.current.roomStatus).toBe('kicked');
+      expect(view.result.current.messages).toEqual([]);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
-  it('rejects an open pre-ack subscription error and accepts a later valid ack', async () => {
+  it('recovers an open pre-ack subscription error and accepts a later valid ack', async () => {
     mockListChatHistory.mockResolvedValue({
       results: [message()],
       next_cursor: null,
     });
     const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
     await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
-    await enterFocus();
+    jest.useFakeTimers();
+    try {
+      await enterFocus();
+      await emitRealtime({
+        type: 'chat.error',
+        trip_id: TRIP_ID,
+        error_code: 'FUTURE_SUBSCRIBE_REJECTION',
+        detail: 'This subscription attempt was rejected.',
+      });
+      expect(view.result.current.subscriptionStatus).toBe('waiting');
+      expect(view.result.current.isReadOnly).toBe(false);
+      expect(view.result.current.roomError).toEqual({
+        errorCode: 'FUTURE_SUBSCRIBE_REJECTION',
+        detail: 'This subscription attempt was rejected.',
+      });
+      await act(async () => {
+        jest.advanceTimersByTime(CHAT_SUBSCRIPTION_RETRY_DELAY_MS);
+      });
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.subscribe',
+        ),
+      ).toHaveLength(2);
 
-    await emitRealtime({
-      type: 'chat.error',
-      trip_id: TRIP_ID,
-      error_code: 'FUTURE_SUBSCRIBE_REJECTION',
-      detail: 'This subscription attempt was rejected.',
-    });
-    expect(view.result.current.subscriptionStatus).toBe('rejected');
-    expect(view.result.current.isReadOnly).toBe(true);
-    expect(view.result.current.roomError).toEqual({
-      errorCode: 'FUTURE_SUBSCRIBE_REJECTION',
-      detail: 'This subscription attempt was rejected.',
-    });
+      await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+      expect(view.result.current.subscriptionStatus).toBe('subscribed');
+      expect(view.result.current.isReadOnly).toBe(false);
+      expect(view.result.current.roomError).toBeNull();
 
-    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
-    expect(view.result.current.subscriptionStatus).toBe('subscribed');
-    expect(view.result.current.isReadOnly).toBe(false);
-    expect(view.result.current.roomError).toBeNull();
-
-    await emitRealtime({
-      type: 'chat.error',
-      trip_id: TRIP_ID,
-      error_code: 'POST_ACK_WARNING',
-      detail: 'The healthy subscription remains active.',
-    });
-    expect(view.result.current.subscriptionStatus).toBe('subscribed');
-    expect(view.result.current.isReadOnly).toBe(false);
-    expect(view.result.current.roomError).toEqual({
-      errorCode: 'POST_ACK_WARNING',
-      detail: 'The healthy subscription remains active.',
-    });
+      await emitRealtime({
+        type: 'chat.error',
+        trip_id: TRIP_ID,
+        error_code: 'POST_ACK_WARNING',
+        detail: 'The healthy subscription remains active.',
+      });
+      expect(view.result.current.subscriptionStatus).toBe('subscribed');
+      expect(view.result.current.isReadOnly).toBe(false);
+      expect(view.result.current.roomError).toEqual({
+        errorCode: 'POST_ACK_WARNING',
+        detail: 'The healthy subscription remains active.',
+      });
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('rolls a failed optimistic reaction back to the latest websocket base', async () => {
@@ -1563,6 +2242,103 @@ describe('useTripChat', () => {
     await act(async () => blur());
   });
 
+  it('retains the pre-gap reconciliation floor through transient access suspension', async () => {
+    const anchor = message();
+    const highSequenceGapMessage = message({
+      id: 'abababab-abab-4bab-8bab-abababababab',
+      content: 'Partial gap row before access became uncertain',
+      created_at: '2026-08-09T10:02:00.000Z',
+      updated_at: '2026-08-09T10:02:00.000Z',
+      change_sequence: 100,
+    });
+    const updatedAnchor = message({
+      content: 'Lower-sequence update recovered after access returned',
+      updated_at: '2026-08-09T10:00:30.000Z',
+      change_sequence: 50,
+    });
+    const interruptedPage = deferred<{
+      results: readonly ChatMessage[];
+      has_more: boolean;
+    }>();
+    const transientState = retainedTripDetailFailure(
+      'Temporary trip-detail failure during partial catch-up.',
+    );
+    let tripState: ReturnType<typeof readyTripDetail> | typeof transientState =
+      readyTripDetail();
+    mockUseTripDetail.mockImplementation(() => tripState);
+    mockListChatHistory.mockResolvedValue({
+      results: [anchor],
+      next_cursor: null,
+    });
+    mockGapFillChatMessages
+      .mockResolvedValueOnce({
+        results: [highSequenceGapMessage],
+        has_more: true,
+      })
+      .mockReturnValueOnce(interruptedPage.promise)
+      .mockResolvedValueOnce({ results: [], has_more: false });
+    mockSyncChangedChatMessages.mockResolvedValueOnce({
+      results: [updatedAnchor],
+      has_more: false,
+    });
+
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.messages).toEqual([anchor]));
+    await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+    await waitFor(() => expect(mockGapFillChatMessages).toHaveBeenCalledTimes(2));
+    expect(
+      view.result.current.messages.some(
+        (candidate) => candidate.id === highSequenceGapMessage.id,
+      ),
+    ).toBe(true);
+
+    tripState = transientState;
+    await view.rerender({});
+    await waitFor(() => expect(view.result.current.accessStatus).toBe('error'));
+    tripState = readyTripDetail();
+    await view.rerender({});
+    await waitFor(() =>
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.subscribe',
+        ),
+      ).toHaveLength(2),
+    );
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+
+    await waitFor(() =>
+      expect(mockGapFillChatMessages).toHaveBeenLastCalledWith(
+        TRIP_ID,
+        { since: highSequenceGapMessage.id, limit: 100 },
+        expect.any(AbortSignal),
+      ),
+    );
+    await waitFor(() =>
+      expect(mockSyncChangedChatMessages).toHaveBeenCalledWith(
+        TRIP_ID,
+        {
+          changedSince: anchor.change_sequence,
+          changedSinceId: anchor.id,
+          limit: 100,
+        },
+        expect.any(AbortSignal),
+      ),
+    );
+    await waitFor(() =>
+      expect(
+        view.result.current.messages.find(
+          (candidate) => candidate.id === anchor.id,
+        )?.content,
+      ).toBe(updatedAnchor.content),
+    );
+
+    await act(async () => {
+      interruptedPage.resolve({ results: [], has_more: false });
+      await interruptedPage.promise;
+    });
+  });
+
   it('atomically suspends in-flight chat work for a retained-detail refresh error', async () => {
     const reactionRow = message();
     const deleteRow = message({
@@ -1922,6 +2698,11 @@ describe('useTripChat', () => {
       expect(view.result.current.roomStatus).toBe('kicked');
       expect(view.result.current.messages).toEqual([]);
       expect(mockListChatHistory).not.toHaveBeenCalled();
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.unsubscribe',
+        ),
+      ).toHaveLength(0);
     },
   );
 
@@ -1960,6 +2741,11 @@ describe('useTripChat', () => {
         errorCode,
         detail: `Exact ${errorCode} detail.`,
       });
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.unsubscribe',
+        ),
+      ).toHaveLength(1);
 
       tripState = readyTripDetail();
       mockRealtimeSnapshot = { status: 'connected', connectionEpoch: 2 };
@@ -1974,6 +2760,11 @@ describe('useTripChat', () => {
       ).toHaveLength(1);
       expect(mockListChatHistory).toHaveBeenCalledTimes(1);
       await act(async () => blur());
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.unsubscribe',
+        ),
+      ).toHaveLength(1);
     },
   );
 
@@ -2025,7 +2816,7 @@ describe('useTripChat', () => {
     await emitRealtime({
       type: 'chat.error',
       trip_id: TRIP_ID,
-      error_code: 'FUTURE_SUBSCRIBE_REJECTION',
+      error_code: 'SUBSCRIPTION_LIMIT_REACHED',
       detail: 'The refocused attempt was rejected.',
     });
     expect(view.result.current.subscriptionStatus).toBe('rejected');
@@ -2064,6 +2855,569 @@ describe('useTripChat', () => {
         expect.any(AbortSignal),
       ),
     );
+  });
+
+  it('reconciles from the history snapshot when a high-sequence live row arrives before initial history', async () => {
+    const history = deferred<{
+      results: readonly ChatMessage[];
+      next_cursor: string | null;
+    }>();
+    const anchor = message();
+    const live = message({
+      id: 'abababab-abab-4bab-8bab-abababababab',
+      content: 'Live after the history snapshot',
+      created_at: '2026-08-09T10:02:00.000Z',
+      updated_at: '2026-08-09T10:02:00.000Z',
+      change_sequence: 100,
+    });
+    const missed = message({
+      id: 'bcbcbcbc-bcbc-4cbc-8cbc-bcbcbcbcbcbc',
+      content: 'Created between history and subscribe',
+      created_at: '2026-08-09T10:01:00.000Z',
+      updated_at: '2026-08-09T10:01:00.000Z',
+      change_sequence: 75,
+    });
+    const updatedAnchor = message({
+      content: 'Updated after the history snapshot',
+      updated_at: '2026-08-09T10:00:30.000Z',
+      change_sequence: 50,
+    });
+    mockListChatHistory.mockReturnValueOnce(history.promise);
+    mockGapFillChatMessages.mockResolvedValueOnce({
+      results: [missed, live],
+      has_more: false,
+    });
+    mockSyncChangedChatMessages.mockResolvedValueOnce({
+      results: [updatedAnchor, missed, live],
+      has_more: false,
+    });
+
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+    await emitRealtime({
+      type: 'chat.message',
+      trip_id: TRIP_ID,
+      message: live,
+    });
+
+    await act(async () => {
+      history.resolve({ results: [anchor], next_cursor: null });
+      await history.promise;
+    });
+
+    await waitFor(() =>
+      expect(mockGapFillChatMessages).toHaveBeenCalledWith(
+        TRIP_ID,
+        { since: anchor.id, limit: 100 },
+        expect.any(AbortSignal),
+      ),
+    );
+    await waitFor(() =>
+      expect(mockSyncChangedChatMessages).toHaveBeenCalledWith(
+        TRIP_ID,
+        {
+          changedSince: anchor.change_sequence,
+          changedSinceId: anchor.id,
+          limit: 100,
+        },
+        expect.any(AbortSignal),
+      ),
+    );
+    await waitFor(() =>
+      expect(
+        view.result.current.messages.find(
+          (candidate) => candidate.id === anchor.id,
+        )?.content,
+      ).toBe(updatedAnchor.content),
+    );
+    expect(view.result.current.messages.map((candidate) => candidate.id)).toEqual([
+      anchor.id,
+      missed.id,
+      live.id,
+    ]);
+  });
+
+  it('retries a transient catch-up failure in place exactly when requested', async () => {
+    const anchor = message();
+    const missed = message({
+      id: 'abababab-abab-4bab-8bab-abababababab',
+      content: 'Recovered missed message',
+      created_at: '2026-08-09T10:01:00.000Z',
+      updated_at: '2026-08-09T10:01:00.000Z',
+      change_sequence: 2,
+    });
+    mockListChatHistory.mockResolvedValue({
+      results: [anchor],
+      next_cursor: null,
+    });
+    mockGapFillChatMessages
+      .mockRejectedValueOnce(new Error('temporary gap failure'))
+      .mockResolvedValueOnce({ results: [missed], has_more: false });
+
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.messages).toEqual([anchor]));
+    await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+
+    await waitFor(() =>
+      expect(view.result.current.roomError).toEqual({
+        errorCode: 'CHAT_SYNC_FAILED',
+        detail: networkFailure.message,
+      }),
+    );
+    expect(mockGapFillChatMessages).toHaveBeenCalledTimes(1);
+    expect(view.result.current.isGapFilling).toBe(false);
+
+    await view.rerender({});
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockGapFillChatMessages).toHaveBeenCalledTimes(1);
+
+    await act(async () => view.result.current.retryCatchUp());
+    await waitFor(() => expect(mockGapFillChatMessages).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(view.result.current.messages.map((item) => item.id)).toEqual([
+        anchor.id,
+        missed.id,
+      ]),
+    );
+    expect(view.result.current.roomError).toBeNull();
+    expect(
+      view.result.current.messages.filter((item) => item.id === missed.id),
+    ).toHaveLength(1);
+
+    await act(async () => view.result.current.retryCatchUp());
+    expect(mockGapFillChatMessages).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries from the original change cursor after a partial high-sequence gap page', async () => {
+    const anchor = message();
+    const highSequenceGapMessage = message({
+      id: 'abababab-abab-4bab-8bab-abababababab',
+      content: 'New message with a later shared sequence',
+      created_at: '2026-08-09T10:01:00.000Z',
+      updated_at: '2026-08-09T10:01:00.000Z',
+      change_sequence: 100,
+    });
+    const updatedAnchor = message({
+      content: 'Recovered lower-sequence update',
+      updated_at: '2026-08-09T10:00:30.000Z',
+      change_sequence: 50,
+    });
+    mockListChatHistory.mockResolvedValue({
+      results: [anchor],
+      next_cursor: null,
+    });
+    mockGapFillChatMessages
+      .mockResolvedValueOnce({
+        results: [highSequenceGapMessage],
+        has_more: true,
+      })
+      .mockRejectedValueOnce(new Error('second gap page failed'))
+      .mockResolvedValueOnce({ results: [], has_more: false });
+    mockSyncChangedChatMessages.mockResolvedValueOnce({
+      results: [updatedAnchor],
+      has_more: false,
+    });
+
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.messages).toEqual([anchor]));
+    await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+
+    await waitFor(() =>
+      expect(view.result.current.roomError?.errorCode).toBe('CHAT_SYNC_FAILED'),
+    );
+    expect(mockGapFillChatMessages).toHaveBeenCalledTimes(2);
+    expect(
+      view.result.current.messages.some(
+        (candidate) => candidate.id === highSequenceGapMessage.id,
+      ),
+    ).toBe(true);
+
+    await act(async () => view.result.current.retryCatchUp());
+
+    await waitFor(() =>
+      expect(mockSyncChangedChatMessages).toHaveBeenCalledWith(
+        TRIP_ID,
+        {
+          changedSince: anchor.change_sequence,
+          changedSinceId: anchor.id,
+          limit: 100,
+        },
+        expect.any(AbortSignal),
+      ),
+    );
+    await waitFor(() =>
+      expect(
+        view.result.current.messages.find(
+          (candidate) => candidate.id === anchor.id,
+        )?.content,
+      ).toBe(updatedAnchor.content),
+    );
+    expect(mockGapFillChatMessages).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps the last reconciled floor across disconnect and a higher-sequence HTTP send', async () => {
+    const anchor = message();
+    const sent = message({
+      id: 'abababab-abab-4bab-8bab-abababababab',
+      content: 'Sent while realtime was disconnected',
+      client_message_id: 'bcbcbcbc-bcbc-4cbc-8cbc-bcbcbcbcbcbc',
+      created_at: '2026-08-09T10:02:00.000Z',
+      updated_at: '2026-08-09T10:02:00.000Z',
+      change_sequence: 100,
+    });
+    const updatedAnchor = message({
+      content: 'Recovered older unseen update',
+      updated_at: '2026-08-09T10:00:30.000Z',
+      change_sequence: 50,
+    });
+    mockListChatHistory.mockResolvedValue({
+      results: [anchor],
+      next_cursor: null,
+    });
+    mockGapFillChatMessages
+      .mockResolvedValueOnce({ results: [], has_more: false })
+      .mockResolvedValueOnce({ results: [sent], has_more: false });
+    mockSyncChangedChatMessages
+      .mockResolvedValueOnce({ results: [], has_more: false })
+      .mockResolvedValueOnce({
+        results: [updatedAnchor, sent],
+        has_more: false,
+      });
+    mockSendChatMessage.mockImplementationOnce(
+      async (_tripId, input) => ({
+        disposition: 'created',
+        message: {
+          ...sent,
+          client_message_id: input.clientMessageId,
+        },
+      }),
+    );
+
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.messages).toEqual([anchor]));
+    await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+    await waitFor(() => expect(mockSyncChangedChatMessages).toHaveBeenCalledTimes(1));
+
+    mockRealtimeSnapshot = { status: 'reconnecting', connectionEpoch: 1 };
+    await view.rerender({});
+    await captureInAct(() =>
+      view.result.current.sendMessage('Sent while realtime was disconnected'),
+    );
+    expect(
+      view.result.current.messages.some(
+        (candidate) => candidate.id === sent.id,
+      ),
+    ).toBe(true);
+
+    mockRealtimeSnapshot = { status: 'connected', connectionEpoch: 2 };
+    await view.rerender({});
+    await waitFor(() =>
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.subscribe',
+        ),
+      ).toHaveLength(2),
+    );
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+
+    await waitFor(() =>
+      expect(mockSyncChangedChatMessages).toHaveBeenLastCalledWith(
+        TRIP_ID,
+        {
+          changedSince: anchor.change_sequence,
+          changedSinceId: anchor.id,
+          limit: 100,
+        },
+        expect.any(AbortSignal),
+      ),
+    );
+    await waitFor(() =>
+      expect(
+        view.result.current.messages.find(
+          (candidate) => candidate.id === anchor.id,
+        )?.content,
+      ).toBe(updatedAnchor.content),
+    );
+  });
+
+  it('resumes a capped gap reconcile from its last verified page', async () => {
+    const anchor = message();
+    const pageMessages = Array.from({ length: 51 }, (_, index) =>
+      message({
+        id: `00000000-0000-4000-8000-${(index + 1)
+          .toString(16)
+          .padStart(12, '0')}`,
+        content: `Gap page ${index + 1}`,
+        created_at: `2026-08-09T10:01:${String(index).padStart(2, '0')}.000Z`,
+        updated_at: `2026-08-09T10:01:${String(index).padStart(2, '0')}.000Z`,
+        change_sequence: index + 2,
+      }),
+    );
+    mockListChatHistory.mockResolvedValue({
+      results: [anchor],
+      next_cursor: null,
+    });
+    for (const candidate of pageMessages.slice(0, 50)) {
+      mockGapFillChatMessages.mockResolvedValueOnce({
+        results: [candidate],
+        has_more: true,
+      });
+    }
+    mockGapFillChatMessages.mockResolvedValueOnce({
+      results: [pageMessages[50]!],
+      has_more: false,
+    });
+
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+    await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+    await waitFor(() =>
+      expect(view.result.current.roomError?.errorCode).toBe('GAP_FILL_INCOMPLETE'),
+    );
+    expect(mockGapFillChatMessages).toHaveBeenCalledTimes(50);
+
+    await act(async () => view.result.current.retryCatchUp());
+
+    await waitFor(() => expect(mockGapFillChatMessages).toHaveBeenCalledTimes(51));
+    expect(mockGapFillChatMessages.mock.calls[50]?.[1]).toMatchObject({
+      since: pageMessages[49]!.id,
+    });
+    await waitFor(() => expect(view.result.current.roomError).toBeNull());
+  });
+
+  it('resumes a capped change reconcile from its last verified cursor', async () => {
+    const anchor = message();
+    const updates = Array.from({ length: 51 }, (_, index) =>
+      message({
+        content: `Update ${index + 1}`,
+        updated_at: `2026-08-09T10:01:${String(index).padStart(2, '0')}.000Z`,
+        change_sequence: index + 2,
+      }),
+    );
+    mockListChatHistory.mockResolvedValue({
+      results: [anchor],
+      next_cursor: null,
+    });
+    mockGapFillChatMessages
+      .mockResolvedValueOnce({ results: [], has_more: false })
+      .mockResolvedValueOnce({ results: [], has_more: false });
+    for (const candidate of updates.slice(0, 50)) {
+      mockSyncChangedChatMessages.mockResolvedValueOnce({
+        results: [candidate],
+        has_more: true,
+      });
+    }
+    mockSyncChangedChatMessages.mockResolvedValueOnce({
+      results: [updates[50]!],
+      has_more: false,
+    });
+
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+    await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+    await waitFor(() =>
+      expect(view.result.current.roomError?.errorCode).toBe(
+        'CHANGE_SYNC_INCOMPLETE',
+      ),
+    );
+    expect(mockSyncChangedChatMessages).toHaveBeenCalledTimes(50);
+
+    await act(async () => view.result.current.retryCatchUp());
+
+    await waitFor(() =>
+      expect(mockSyncChangedChatMessages).toHaveBeenCalledTimes(51),
+    );
+    expect(mockSyncChangedChatMessages.mock.calls[50]?.[1]).toMatchObject({
+      changedSince: updates[49]!.change_sequence,
+      changedSinceId: updates[49]!.id,
+    });
+    await waitFor(() => expect(view.result.current.roomError).toBeNull());
+  });
+
+  it('locks mutations authoritatively when catch-up reports a terminal trip', async () => {
+    const anchor = message();
+    const pendingGap = deferred<{
+      results: readonly ChatMessage[];
+      has_more: boolean;
+    }>();
+    const pendingSend = deferred<{
+      disposition: 'created';
+      message: ChatMessage;
+    }>();
+    mockListChatHistory.mockResolvedValue({
+      results: [anchor],
+      next_cursor: null,
+    });
+    mockGapFillChatMessages.mockReturnValueOnce(pendingGap.promise);
+    mockSendChatMessage.mockReturnValueOnce(pendingSend.promise);
+
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.messages).toEqual([anchor]));
+    await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+    await waitFor(() => expect(mockGapFillChatMessages).toHaveBeenCalledTimes(1));
+
+    let pendingSendOutcome!: Promise<ChatSendOutcome>;
+    await act(async () => {
+      pendingSendOutcome = view.result.current.sendMessage(
+        'Must be cancelled by the terminal lock',
+      );
+      await Promise.resolve();
+    });
+    const pendingClientMessageId = mockSendChatMessage.mock.calls[0]?.[1]
+      .clientMessageId;
+    if (pendingClientMessageId === undefined) {
+      throw new Error('Expected the pending send to own a client id.');
+    }
+    const pendingSendSignal = mockSendChatMessage.mock.calls[0]?.[2];
+    expect(pendingSendSignal?.aborted).toBe(false);
+    expect(
+      view.result.current.pendingClientIds.has(pendingClientMessageId),
+    ).toBe(true);
+
+    mockNormalizeChatApiError.mockReturnValueOnce(terminalFailure);
+    await act(async () => {
+      pendingGap.reject(new Error('trip ended during catch-up'));
+      await pendingGap.promise.catch(() => undefined);
+    });
+    await waitFor(() => expect(view.result.current.isReadOnly).toBe(true));
+    expect(view.result.current.roomError).toEqual({
+      errorCode: 'TRIP_TERMINAL',
+      detail: terminalFailure.message,
+    });
+    expect(pendingSendSignal?.aborted).toBe(true);
+    expect(view.result.current.pendingClientIds.size).toBe(0);
+
+    const blocked = await captureInAct(() =>
+      view.result.current.sendMessage('Must not reach the API'),
+    );
+    expect(blocked).toMatchObject({
+      kind: 'blocked',
+      error: { errorCode: 'TRIP_TERMINAL' },
+    });
+    expect(mockSendChatMessage).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      pendingSend.resolve({
+        disposition: 'created',
+        message: message({
+          id: 'cdcdcdcd-cdcd-4dcd-8dcd-cdcdcdcdcdcd',
+          content: 'Must stay cancelled',
+          client_message_id: pendingClientMessageId,
+        }),
+      });
+    });
+    await expect(pendingSendOutcome).resolves.toMatchObject({
+      kind: 'failed',
+      error: { errorCode: 'SEND_CANCELLED' },
+    });
+    expect(
+      view.result.current.messages.some(
+        (candidate) => candidate.id === 'cdcdcdcd-cdcd-4dcd-8dcd-cdcdcdcdcdcd',
+      ),
+    ).toBe(false);
+  });
+
+  it('does not spin when terminal authority is returned by read catch-up', async () => {
+    const anchor = message();
+    mockListChatHistory.mockResolvedValue({ results: [anchor], next_cursor: null });
+    mockGapFillChatMessages
+      .mockRejectedValueOnce(new Error('terminal read response one'))
+      .mockRejectedValueOnce(new Error('terminal read response two'));
+    mockNormalizeChatApiError.mockReturnValue(terminalFailure);
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.messages).toEqual([anchor]));
+    await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+
+    await waitFor(() =>
+      expect(view.result.current.readSyncError).toEqual({
+        errorCode: 'CHAT_SYNC_FAILED',
+        detail: terminalFailure.message,
+      }),
+    );
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(mockGapFillChatMessages).toHaveBeenCalledTimes(1);
+    expect(view.result.current.isReadOnly).toBe(true);
+
+    await act(async () => view.result.current.retryCatchUp());
+    await waitFor(() => expect(mockGapFillChatMessages).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(mockGapFillChatMessages).toHaveBeenCalledTimes(2);
+    expect(view.result.current.readSyncError?.errorCode).toBe('CHAT_SYNC_FAILED');
+  });
+
+  it('preserves a websocket terminal lock when a pending catch-up fails later', async () => {
+    const anchor = message();
+    const pendingGap = deferred<{
+      results: readonly ChatMessage[];
+      has_more: boolean;
+    }>();
+    mockListChatHistory.mockResolvedValue({
+      results: [anchor],
+      next_cursor: null,
+    });
+    mockGapFillChatMessages.mockReturnValueOnce(pendingGap.promise);
+
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.messages).toEqual([anchor]));
+    await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+    await waitFor(() => expect(mockGapFillChatMessages).toHaveBeenCalledTimes(1));
+
+    await emitRealtime({
+      type: 'chat.error',
+      trip_id: TRIP_ID,
+      error_code: 'TRIP_TERMINAL',
+      detail: 'This trip ended while catch-up was pending.',
+    });
+    expect(view.result.current.isReadOnly).toBe(true);
+    expect(view.result.current.roomError).toEqual({
+      errorCode: 'TRIP_TERMINAL',
+      detail: 'This trip ended while catch-up was pending.',
+    });
+
+    mockNormalizeChatApiError.mockReturnValueOnce(networkFailure);
+    await act(async () => {
+      pendingGap.reject(new Error('late transient catch-up failure'));
+      await pendingGap.promise.catch(() => undefined);
+    });
+    await waitFor(() => expect(view.result.current.isGapFilling).toBe(false));
+    expect(view.result.current.roomError).toEqual({
+      errorCode: 'TRIP_TERMINAL',
+      detail: 'This trip ended while catch-up was pending.',
+    });
+
+    await emitRealtime({
+      type: 'chat.error',
+      trip_id: TRIP_ID,
+      error_code: 'SERVER_ERROR',
+      detail: 'A later nonterminal websocket error.',
+    });
+    expect(view.result.current.roomError).toEqual({
+      errorCode: 'TRIP_TERMINAL',
+      detail: 'This trip ended while catch-up was pending.',
+    });
+
+    await waitFor(() =>
+      expect(mockGapFillChatMessages).toHaveBeenCalledTimes(2),
+    );
+    expect(view.result.current.readSyncError).toBeNull();
+    expect(view.result.current.isReadOnly).toBe(true);
   });
 
   it('keeps a newer catch-up active when an aborted older run settles later', async () => {
@@ -2152,7 +3506,7 @@ describe('useTripChat', () => {
         mockSendRealtime.mock.calls.filter(
           ([command]) => command.type === 'chat.subscribe',
         ),
-      ).toHaveLength(2),
+      ).toHaveLength(3),
     );
     await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
     await waitFor(() => expect(mockGapFillChatMessages).toHaveBeenCalledTimes(2));
@@ -2476,14 +3830,98 @@ describe('useTripChat', () => {
       detail: 'A future recoverable conflict.',
     });
 
-    await emitRealtime({
-      type: 'chat.error',
-      trip_id: TRIP_ID,
-      error_code: 'TRIP_TERMINAL',
-      detail: 'This trip is complete.',
+    const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout');
+    const clearTimeoutSpy = jest.spyOn(globalThis, 'clearTimeout');
+    try {
+      await emitRealtime({
+        type: 'chat.ai_typing_started',
+        trip_id: TRIP_ID,
+        interaction_id: 'terminal-websocket-typing',
+        requested_by_user_id: USER_ID,
+      });
+      expect(view.result.current.aiTypingState.active?.interactionId).toBe(
+        'terminal-websocket-typing',
+      );
+      const typingTimerIndex = setTimeoutSpy.mock.calls.findLastIndex(
+        ([, delayMs]) => delayMs === 120_000,
+      );
+      expect(typingTimerIndex).toBeGreaterThanOrEqual(0);
+      const typingTimerHandle = setTimeoutSpy.mock.results[typingTimerIndex]?.value;
+
+      await emitRealtime({
+        type: 'chat.error',
+        trip_id: TRIP_ID,
+        error_code: 'TRIP_TERMINAL',
+        detail: 'This trip is complete.',
+      });
+      expect(view.result.current.isReadOnly).toBe(true);
+      expect(view.result.current.messages).toHaveLength(1);
+      expect(view.result.current.mutationError).toBeNull();
+      expect(view.result.current.aiTypingState.active?.interactionId).toBe(
+        'terminal-websocket-typing',
+      );
+      expect(clearTimeoutSpy).not.toHaveBeenCalledWith(typingTimerHandle);
+
+      await emitRealtime({
+        type: 'chat.error',
+        trip_id: TRIP_ID,
+        error_code: 'TRIP_TERMINAL',
+        detail: 'This repeated terminal event must stay idempotent.',
+      });
+      expect(view.result.current.mutationError).toBeNull();
+      await emitRealtime({
+        type: 'chat.ai_typing_stopped',
+        trip_id: TRIP_ID,
+        interaction_id: 'terminal-websocket-typing',
+      });
+      expect(view.result.current.aiTypingState.active).toBeNull();
+    } finally {
+      setTimeoutSpy.mockRestore();
+      clearTimeoutSpy.mockRestore();
+    }
+  });
+
+  it('preserves AI typing when trip detail becomes terminal', async () => {
+    let tripState = readyTripDetail();
+    mockUseTripDetail.mockImplementation(() => tripState);
+    mockListChatHistory.mockResolvedValue({
+      results: [message()],
+      next_cursor: null,
     });
-    expect(view.result.current.isReadOnly).toBe(true);
-    expect(view.result.current.messages).toHaveLength(1);
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.roomStatus).toBe('ready'));
+    await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+
+    const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout');
+    const clearTimeoutSpy = jest.spyOn(globalThis, 'clearTimeout');
+    try {
+      await emitRealtime({
+        type: 'chat.ai_typing_started',
+        trip_id: TRIP_ID,
+        interaction_id: 'terminal-trip-detail-typing',
+        requested_by_user_id: USER_ID,
+      });
+      expect(view.result.current.aiTypingState.active?.interactionId).toBe(
+        'terminal-trip-detail-typing',
+      );
+      const typingTimerIndex = setTimeoutSpy.mock.calls.findLastIndex(
+        ([, delayMs]) => delayMs === 120_000,
+      );
+      expect(typingTimerIndex).toBeGreaterThanOrEqual(0);
+      const typingTimerHandle = setTimeoutSpy.mock.results[typingTimerIndex]?.value;
+
+      tripState = readyTripDetail(TRIP_ID, 'COMPLETED');
+      await view.rerender({});
+      expect(view.result.current.isReadOnly).toBe(true);
+      expect(view.result.current.aiTypingState.active?.interactionId).toBe(
+        'terminal-trip-detail-typing',
+      );
+      expect(clearTimeoutSpy).not.toHaveBeenCalledWith(typingTimerHandle);
+    } finally {
+      setTimeoutSpy.mockRestore();
+      clearTimeoutSpy.mockRestore();
+    }
   });
 
   it('preserves a websocket terminal notice when pending initial history later succeeds', async () => {
@@ -2515,6 +3953,311 @@ describe('useTripChat', () => {
       errorCode: 'TRIP_TERMINAL',
       detail: 'This trip ended while history was loading.',
     });
+    expect(view.result.current.isReadOnly).toBe(true);
+    expect(view.result.current.messages).toHaveLength(1);
+  });
+
+  it('waits for pending initial history before terminal read catch-up', async () => {
+    const initialPage = deferred<{
+      results: readonly ChatMessage[];
+      next_cursor: string | null;
+    }>();
+    const anchor = message();
+    mockUseTripDetail.mockReturnValue(readyTripDetail(TRIP_ID, 'COMPLETED'));
+    mockListChatHistory.mockReturnValueOnce(initialPage.promise);
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(mockListChatHistory).toHaveBeenCalledTimes(1));
+
+    await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockListChatHistory).toHaveBeenCalledTimes(1);
+    expect(mockGapFillChatMessages).not.toHaveBeenCalled();
+
+    await act(async () => {
+      initialPage.resolve({ results: [anchor], next_cursor: 'older-page' });
+      await initialPage.promise;
+    });
+
+    await waitFor(() =>
+      expect(mockGapFillChatMessages).toHaveBeenCalledWith(
+        TRIP_ID,
+        { since: anchor.id, limit: 100 },
+        expect.any(AbortSignal),
+      ),
+    );
+    expect(mockListChatHistory).toHaveBeenCalledTimes(1);
+    expect(view.result.current.hasMoreOlder).toBe(true);
+    expect(view.result.current.isReadOnly).toBe(true);
+  });
+
+  it('recovers a committed ambiguous send on terminal transition without another POST', async () => {
+    const anchor = message();
+    let tripState = readyTripDetail();
+    const pendingSend = deferred<{
+      disposition: 'created';
+      message: ChatMessage;
+    }>();
+    mockUseTripDetail.mockImplementation(() => tripState);
+    mockListChatHistory.mockResolvedValue({ results: [anchor], next_cursor: null });
+    mockSendChatMessage.mockReturnValueOnce(pendingSend.promise);
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.messages).toEqual([anchor]));
+    await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+    await waitFor(() => expect(mockGapFillChatMessages).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(view.result.current.isGapFilling).toBe(false));
+    await waitFor(() => expect(view.result.current.isUpdating).toBe(false));
+
+    let sendOutcome!: Promise<ChatSendOutcome>;
+    await act(async () => {
+      sendOutcome = view.result.current.sendMessage('Committed before terminal');
+      await Promise.resolve();
+    });
+    const clientMessageId = mockSendChatMessage.mock.calls[0]?.[1]
+      .clientMessageId;
+    if (clientMessageId === undefined) {
+      throw new Error('Expected the pending send to own a client id.');
+    }
+    const committed = message({
+      id: 'dededede-dede-4ede-8ede-dededededede',
+      content: 'Committed before terminal',
+      client_message_id: clientMessageId,
+      created_at: '2026-08-09T10:01:00.000Z',
+      updated_at: '2026-08-09T10:01:00.000Z',
+      change_sequence: 2,
+    });
+    mockGapFillChatMessages.mockResolvedValueOnce({
+      results: [committed],
+      has_more: false,
+    });
+
+    tripState = readyTripDetail(TRIP_ID, 'COMPLETED');
+    await view.rerender({});
+    await waitFor(() =>
+      expect(mockGapFillChatMessages).toHaveBeenCalledTimes(2),
+    );
+    await waitFor(() =>
+      expect(
+        view.result.current.messages.filter(
+          (candidate) => candidate.client_message_id === clientMessageId,
+        ),
+      ).toEqual([committed]),
+    );
+    expect(mockSendChatMessage).toHaveBeenCalledTimes(1);
+    expect(view.result.current.isReadOnly).toBe(true);
+
+    await act(async () => {
+      pendingSend.resolve({ disposition: 'created', message: committed });
+      await pendingSend.promise;
+    });
+    await expect(sendOutcome).resolves.toMatchObject({
+      kind: 'failed',
+      error: { errorCode: 'SEND_CANCELLED' },
+    });
+    expect(mockSendChatMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('catches up terminal read updates after reconnect without a mutation POST', async () => {
+    const anchor = message();
+    const committed = message({
+      id: 'efefefef-efef-4fef-8fef-efefefefefef',
+      content: 'Recovered after terminal reconnect',
+      client_message_id: '99999999-9999-4999-8999-999999999999',
+      created_at: '2026-08-09T10:01:00.000Z',
+      updated_at: '2026-08-09T10:01:00.000Z',
+      change_sequence: 2,
+    });
+    mockUseTripDetail.mockReturnValue(readyTripDetail(TRIP_ID, 'COMPLETED'));
+    mockListChatHistory.mockResolvedValue({ results: [anchor], next_cursor: null });
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.messages).toEqual([anchor]));
+    await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+    await waitFor(() => expect(mockGapFillChatMessages).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(view.result.current.isGapFilling).toBe(false));
+
+    mockGapFillChatMessages.mockResolvedValueOnce({
+      results: [committed],
+      has_more: false,
+    });
+    mockRealtimeSnapshot = { status: 'reconnecting', connectionEpoch: 1 };
+    await view.rerender({});
+    mockRealtimeSnapshot = { status: 'connected', connectionEpoch: 2 };
+    await view.rerender({});
+    await waitFor(() =>
+      expect(
+        mockSendRealtime.mock.calls.filter(
+          ([command]) => command.type === 'chat.subscribe',
+        ),
+      ).toHaveLength(2),
+    );
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+
+    await waitFor(() =>
+      expect(mockGapFillChatMessages).toHaveBeenCalledTimes(2),
+    );
+    await waitFor(() =>
+      expect(view.result.current.messages).toEqual([anchor, committed]),
+    );
+    expect(view.result.current.isReadOnly).toBe(true);
+    expect(mockSendChatMessage).not.toHaveBeenCalled();
+  });
+
+  it('exposes and retries terminal read synchronization failures', async () => {
+    const anchor = message();
+    mockUseTripDetail.mockReturnValue(readyTripDetail(TRIP_ID, 'COMPLETED'));
+    mockListChatHistory.mockResolvedValue({ results: [anchor], next_cursor: null });
+    mockGapFillChatMessages
+      .mockRejectedValueOnce(new Error('terminal read sync failed'))
+      .mockRejectedValueOnce(new Error('terminal resubscribe sync failed'))
+      .mockResolvedValueOnce({ results: [], has_more: false });
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.messages).toEqual([anchor]));
+    await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+
+    await waitFor(() =>
+      expect(view.result.current.readSyncError).toEqual({
+        errorCode: 'CHAT_SYNC_FAILED',
+        detail: networkFailure.message,
+      }),
+    );
+    expect(view.result.current.tripStatus).toBe('COMPLETED');
+    expect(view.result.current.isReadOnly).toBe(true);
+
+    await act(async () => view.result.current.retrySubscription());
+    expect(view.result.current.readSyncError).toBeNull();
+    expect(view.result.current.subscriptionStatus).toBe('subscribing');
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+    await waitFor(() =>
+      expect(view.result.current.readSyncError?.errorCode).toBe(
+        'CHAT_SYNC_FAILED',
+      ),
+    );
+
+    await act(async () => view.result.current.retryCatchUp());
+    await waitFor(() => expect(mockGapFillChatMessages).toHaveBeenCalledTimes(3));
+    await waitFor(() => expect(view.result.current.readSyncError).toBeNull());
+    expect(view.result.current.isReadOnly).toBe(true);
+  });
+
+  it('keeps terminal history pagination live after a pending first page resolves', async () => {
+    const initialPage = deferred<{
+      results: readonly ChatMessage[];
+      next_cursor: string | null;
+    }>();
+    const olderPage = deferred<{
+      results: readonly ChatMessage[];
+      next_cursor: string | null;
+    }>();
+    const newest = message();
+    const older = message({
+      id: 'abababab-abab-4bab-8bab-abababababab',
+      content: 'Older terminal history',
+      created_at: '2026-08-09T09:00:00.000Z',
+      updated_at: '2026-08-09T09:00:00.000Z',
+    });
+    mockListChatHistory
+      .mockReturnValueOnce(initialPage.promise)
+      .mockReturnValueOnce(olderPage.promise);
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(mockListChatHistory).toHaveBeenCalledTimes(1));
+
+    await emitRealtime({
+      type: 'chat.error',
+      trip_id: TRIP_ID,
+      error_code: 'TRIP_TERMINAL',
+      detail: 'This trip ended while history was loading.',
+    });
+    await act(async () => {
+      initialPage.resolve({ results: [newest], next_cursor: 'older-page' });
+      await initialPage.promise;
+    });
+    await waitFor(() => expect(view.result.current.hasMoreOlder).toBe(true));
+
+    let firstOlderLoad!: Promise<void>;
+    await act(async () => {
+      firstOlderLoad = view.result.current.loadOlder();
+      await Promise.resolve();
+    });
+    expect(view.result.current.isLoadingOlder).toBe(true);
+
+    await act(async () => view.result.current.loadOlder());
+    expect(mockListChatHistory).toHaveBeenCalledTimes(2);
+
+    expect(mockListChatHistory).toHaveBeenLastCalledWith(
+      TRIP_ID,
+      { cursor: 'older-page', limit: 30 },
+      expect.any(AbortSignal),
+    );
+    await act(async () => {
+      olderPage.resolve({ results: [older], next_cursor: null });
+      await firstOlderLoad;
+    });
+    expect(view.result.current.isLoadingOlder).toBe(false);
+    expect(view.result.current.messages.map((candidate) => candidate.id)).toEqual([
+      older.id,
+      newest.id,
+    ]);
+    expect(view.result.current.hasMoreOlder).toBe(false);
+    expect(view.result.current.isReadOnly).toBe(true);
+  });
+
+  it('preserves terminal authority when pending initial history rejects later', async () => {
+    const initialPage = deferred<{
+      results: readonly ChatMessage[];
+      next_cursor: null;
+    }>();
+    mockListChatHistory.mockReturnValueOnce(initialPage.promise);
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(mockListChatHistory).toHaveBeenCalledTimes(1));
+
+    await emitRealtime({
+      type: 'chat.error',
+      trip_id: TRIP_ID,
+      error_code: 'TRIP_TERMINAL',
+      detail: 'This trip ended while history was loading.',
+    });
+    mockNormalizeChatApiError.mockReturnValueOnce(networkFailure);
+    await act(async () => {
+      initialPage.reject(new Error('late initial history failure'));
+      await initialPage.promise.catch(() => undefined);
+    });
+
+    expect(view.result.current.roomStatus).toBe('ready');
+    expect(view.result.current.roomError).toEqual({
+      errorCode: 'TRIP_TERMINAL',
+      detail: 'This trip ended while history was loading.',
+    });
+    expect(view.result.current.initialLoadError).toEqual(networkFailure);
+    expect(view.result.current.isReadOnly).toBe(true);
+    const retryPage = deferred<{
+      results: readonly ChatMessage[];
+      next_cursor: null;
+    }>();
+    mockListChatHistory.mockReturnValueOnce(retryPage.promise);
+    let retry!: Promise<void>;
+    await act(async () => {
+      retry = view.result.current.retryInitialLoad();
+      await Promise.resolve();
+    });
+    expect(mockListChatHistory).toHaveBeenCalledTimes(2);
+    expect(view.result.current.isLoadingInitial).toBe(true);
+    expect(view.result.current.roomStatus).toBe('ready');
+    expect(view.result.current.isReadOnly).toBe(true);
+
+    await act(async () => view.result.current.retryInitialLoad());
+    expect(mockListChatHistory).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      retryPage.resolve({ results: [message()], next_cursor: null });
+      await retry;
+    });
+    expect(view.result.current.isLoadingInitial).toBe(false);
+    expect(view.result.current.initialLoadError).toBeNull();
     expect(view.result.current.isReadOnly).toBe(true);
   });
 
@@ -2548,6 +4291,179 @@ describe('useTripChat', () => {
     await view.rerender({});
     expect(view.result.current.messages).toEqual([confirmed]);
     expect(view.result.current.failedClientIds.size).toBe(0);
+  });
+
+  it('applies catch-up authority that arrives before a stale older page', async () => {
+    const anchor = message({
+      id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      content: 'Newest loaded anchor',
+    });
+    const staleOlder = message({
+      id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+      content: 'Stale older snapshot',
+      created_at: '2026-08-09T09:00:00.000Z',
+      updated_at: '2026-08-09T09:00:00.000Z',
+    });
+    const tombstone = message({
+      ...staleOlder,
+      content: '',
+      updated_at: '2026-08-09T10:10:00.000Z',
+      change_sequence: 10,
+      is_deleted_for_everyone: true,
+      deleted_for_everyone_at: '2026-08-09T10:10:00.000Z',
+      deleted_for_everyone_by_id: USER_ID,
+      delete_for_everyone_until: null,
+      can_delete_for_everyone: false,
+      reactions: [],
+    });
+    const olderPage = deferred<{
+      results: readonly ChatMessage[];
+      next_cursor: string | null;
+    }>();
+    mockListChatHistory
+      .mockResolvedValueOnce({ results: [anchor], next_cursor: 'older-page' })
+      .mockReturnValueOnce(olderPage.promise);
+    mockSyncChangedChatMessages.mockResolvedValueOnce({
+      results: [tombstone],
+      has_more: false,
+    });
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.hasMoreOlder).toBe(true));
+
+    let olderLoad!: Promise<void>;
+    await act(async () => {
+      olderLoad = view.result.current.loadOlder();
+      await Promise.resolve();
+    });
+    await enterFocus();
+    await emitRealtime({ type: 'chat.subscribed', trip_id: TRIP_ID });
+    await waitFor(() =>
+      expect(mockSyncChangedChatMessages).toHaveBeenCalledTimes(1),
+    );
+    expect(
+      view.result.current.messages.some(
+        (candidate) => candidate.id === staleOlder.id,
+      ),
+    ).toBe(false);
+
+    await act(async () => {
+      olderPage.resolve({ results: [staleOlder], next_cursor: null });
+      await olderLoad;
+    });
+
+    expect(
+      view.result.current.messages.find(
+        (candidate) => candidate.id === staleOlder.id,
+      ),
+    ).toEqual(tombstone);
+  });
+
+  it('applies an unknown live reaction when its stale older row materializes', async () => {
+    const anchor = message({
+      id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      content: 'Newest loaded anchor',
+    });
+    const staleOlder = message({
+      id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+      content: 'Older row',
+      created_at: '2026-08-09T09:00:00.000Z',
+      updated_at: '2026-08-09T09:00:00.000Z',
+    });
+    const latestReactions = [
+      { emoji: '😂' as const, count: 1, reacted_by_ids: [USER_ID] },
+    ];
+    const olderPage = deferred<{
+      results: readonly ChatMessage[];
+      next_cursor: string | null;
+    }>();
+    mockListChatHistory
+      .mockResolvedValueOnce({ results: [anchor], next_cursor: 'older-page' })
+      .mockReturnValueOnce(olderPage.promise);
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.hasMoreOlder).toBe(true));
+
+    let olderLoad!: Promise<void>;
+    await act(async () => {
+      olderLoad = view.result.current.loadOlder();
+      await Promise.resolve();
+    });
+    await emitRealtime({
+      type: 'chat.reaction_update',
+      trip_id: TRIP_ID,
+      message_id: staleOlder.id,
+      reactions: latestReactions,
+      change_sequence: 11,
+      updated_at: '2026-08-09T10:11:00.000Z',
+    });
+    await act(async () => {
+      olderPage.resolve({ results: [staleOlder], next_cursor: null });
+      await olderLoad;
+    });
+
+    expect(
+      view.result.current.messages.find(
+        (candidate) => candidate.id === staleOlder.id,
+      ),
+    ).toMatchObject({
+      reactions: latestReactions,
+      change_sequence: 11,
+      updated_at: '2026-08-09T10:11:00.000Z',
+    });
+  });
+
+  it('applies an unknown live tombstone when its stale older row materializes', async () => {
+    const anchor = message({
+      id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      content: 'Newest loaded anchor',
+    });
+    const staleOlder = message({
+      id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+      content: 'Older row',
+      created_at: '2026-08-09T09:00:00.000Z',
+      updated_at: '2026-08-09T09:00:00.000Z',
+    });
+    const tombstone = message({
+      ...staleOlder,
+      content: '',
+      change_sequence: 12,
+      updated_at: '2026-08-09T10:12:00.000Z',
+      is_deleted_for_everyone: true,
+      deleted_for_everyone_at: '2026-08-09T10:12:00.000Z',
+      deleted_for_everyone_by_id: USER_ID,
+      delete_for_everyone_until: null,
+      can_delete_for_everyone: false,
+      reactions: [],
+    });
+    const olderPage = deferred<{
+      results: readonly ChatMessage[];
+      next_cursor: string | null;
+    }>();
+    mockListChatHistory
+      .mockResolvedValueOnce({ results: [anchor], next_cursor: 'older-page' })
+      .mockReturnValueOnce(olderPage.promise);
+    const view = await renderHook(() => useTripChat({ tripId: TRIP_ID }));
+    await waitFor(() => expect(view.result.current.hasMoreOlder).toBe(true));
+
+    let olderLoad!: Promise<void>;
+    await act(async () => {
+      olderLoad = view.result.current.loadOlder();
+      await Promise.resolve();
+    });
+    await emitRealtime({
+      type: 'chat.message_deleted',
+      trip_id: TRIP_ID,
+      message: tombstone,
+    });
+    await act(async () => {
+      olderPage.resolve({ results: [staleOlder], next_cursor: null });
+      await olderLoad;
+    });
+
+    expect(
+      view.result.current.messages.find(
+        (candidate) => candidate.id === staleOlder.id,
+      ),
+    ).toEqual(tombstone);
   });
 
   it('single-flights older pagination and exposes a later page failure', async () => {

--- a/mobile/src/features/chat/ai/__fixtures__/drafts.ts
+++ b/mobile/src/features/chat/ai/__fixtures__/drafts.ts
@@ -1,0 +1,44 @@
+import { requireAIActionDraft, type AIActionDraft } from '../drafts';
+
+export function makeRawDraftFixture(
+  overrides: Readonly<Record<string, unknown>> = {},
+): Record<string, unknown> {
+  return {
+    id: '22222222-2222-4222-8222-222222222222',
+    action_type: 'expense.create',
+    status: 'READY',
+    required_confirmation: 'CAPTAIN',
+    can_confirm: true,
+    can_cancel: true,
+    can_edit: false,
+    display: {
+      icon: 'expense',
+      tone: 'create',
+      kicker: 'Expense',
+      title: 'Dinner',
+      hero: { kind: 'amount', value: '1,200,000', currency: 'VND' },
+      meta: [{ label: 'Collector', value: 'Lan' }],
+    },
+    summary: 'Create dinner expense',
+    preview: {
+      title: 'Dinner',
+      total_amount: '1200000',
+      currency_code: 'VND',
+      collector_name: 'Lan',
+    },
+    missing_fields: [],
+    result: {},
+    error_code: '',
+    error_detail: '',
+    expires_at: '2099-06-01T00:00:00.000Z',
+    created_at: '2026-05-13T00:00:00.000Z',
+    updated_at: '2026-05-13T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+export function makeDraftFixture(
+  overrides: Readonly<Record<string, unknown>> = {},
+): AIActionDraft {
+  return requireAIActionDraft(makeRawDraftFixture(overrides));
+}

--- a/mobile/src/features/chat/ai/__tests__/AIActionDraftCardController.test.tsx
+++ b/mobile/src/features/chat/ai/__tests__/AIActionDraftCardController.test.tsx
@@ -1,0 +1,2008 @@
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
+import {
+  AxiosError,
+  AxiosHeaders,
+  type InternalAxiosRequestConfig,
+} from 'axios';
+import { Suspense, useState } from 'react';
+import type { AIActionDraftEnvelope } from '../drafts';
+import { AIActionDraftCardController } from '../components/AIActionDraftCardController';
+import { makeDraftFixture as makeDraft } from '../__fixtures__/drafts';
+import {
+  createAIReconciliationCoordinator,
+  reconcileNewlyConfirmedDraft,
+  type AIReconciliationCoordinator,
+} from '../reconciliation';
+import { AIReconciliationCoordinatorProvider } from '../reconciliationContext';
+
+jest.mock('../api', () => {
+  const actual = jest.requireActual<typeof import('../api')>('../api');
+  return {
+    ...actual,
+    cancelAIActionDraft: jest.fn(),
+    getAIActionDraft: jest.fn(),
+    patchAIActionDraft: jest.fn(),
+  };
+});
+
+jest.mock('../confirmController', () => {
+  const actual = jest.requireActual<typeof import('../confirmController')>(
+    '../confirmController',
+  );
+  return {
+    ...actual,
+    checkConfirmStatus: jest.fn(),
+    confirmDraftAfterExplicitApproval: jest.fn(),
+  };
+});
+
+jest.mock('../reconciliation', () => {
+  const actual = jest.requireActual<typeof import('../reconciliation')>(
+    '../reconciliation',
+  );
+  return {
+    ...actual,
+    reconcileNewlyConfirmedDraft: jest.fn(),
+  };
+});
+
+jest.mock('../accessibilityFocus', () => ({
+  focusAccessibilityNode: jest.fn(),
+}));
+
+// eslint-disable-next-line import/first
+import {
+  cancelAIActionDraft,
+  getAIActionDraft,
+  patchAIActionDraft,
+} from '../api';
+// eslint-disable-next-line import/first
+import {
+  checkConfirmStatus,
+  confirmDraftAfterExplicitApproval,
+  createConfirmAmbiguityState,
+} from '../confirmController';
+// eslint-disable-next-line import/first
+import { createAIActionDraftControllerSessionStore } from '../controllerSession';
+// eslint-disable-next-line import/first
+import { focusAccessibilityNode } from '../accessibilityFocus';
+// eslint-disable-next-line import/first
+import * as reconciliationContext from '../reconciliationContext';
+
+const mockPatch = jest.mocked(patchAIActionDraft);
+const mockCancel = jest.mocked(cancelAIActionDraft);
+const mockGet = jest.mocked(getAIActionDraft);
+const mockConfirm = jest.mocked(confirmDraftAfterExplicitApproval);
+const mockCheck = jest.mocked(checkConfirmStatus);
+const mockReconcile = jest.mocked(reconcileNewlyConfirmedDraft);
+const mockFocusAccessibilityNode = jest.mocked(focusAccessibilityNode);
+const TRIP_A = '11111111-1111-4111-8111-111111111111';
+const TRIP_B = '22222222-2222-4222-8222-222222222222';
+
+function editableDraft(id: string, title: string) {
+  return makeDraft({
+    id,
+    status: 'NEEDS_INFO',
+    can_confirm: false,
+    can_cancel: true,
+    can_edit: true,
+    display: { title, kicker: 'Expense' },
+    missing_fields: [{ name: 'title', label: 'Title' }],
+  });
+}
+
+function readyDraft(id: string, title: string) {
+  return makeDraft({
+    id,
+    status: 'READY',
+    can_confirm: true,
+    can_cancel: true,
+    can_edit: false,
+    display: { title, kicker: 'Expense' },
+  });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+function axiosConfig(): InternalAxiosRequestConfig {
+  return { headers: new AxiosHeaders() };
+}
+
+function expiredPatchError(draft: ReturnType<typeof makeDraft>): AxiosError {
+  const config = axiosConfig();
+  return new AxiosError('Draft expired', 'ERR_BAD_RESPONSE', config, {}, {
+    status: 409,
+    data: {
+      detail: 'Draft expired.',
+      error_code: 'AI_DRAFT_EXPIRED',
+      draft,
+    },
+    headers: new AxiosHeaders(),
+    statusText: 'Conflict',
+    config,
+  });
+}
+
+async function flushPresentationCarryover(): Promise<void> {
+  await act(
+    async () =>
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      }),
+  );
+}
+
+describe('AIActionDraftCardController resource lifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockReconcile.mockResolvedValue(null);
+  });
+
+  it('does not mutate the room session store during an abandoned render', async () => {
+    const draft = readyDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Abandoned draft',
+    );
+    const sessionStore = createAIActionDraftControllerSessionStore(
+      `user-a:${TRIP_A}`,
+    );
+    const setSession = jest.spyOn(sessionStore, 'set');
+    const useSessionStore = jest
+      .spyOn(
+        reconciliationContext,
+        'useRoomAIActionDraftControllerSessionStore',
+      )
+      .mockReturnValue(sessionStore);
+    function SuspendRender(): never {
+      throw new Promise<void>(() => undefined);
+    }
+
+    try {
+      const rendered = await render(
+        <Suspense fallback={null}>
+            <AIActionDraftCardController
+              draft={draft}
+              onDraftChanged={jest.fn()}
+              tripId={TRIP_A}
+            />
+            <SuspendRender />
+        </Suspense>,
+      );
+      expect(setSession).not.toHaveBeenCalled();
+      await rendered.unmount();
+    } finally {
+      useSessionStore.mockRestore();
+    }
+  });
+
+  it('keeps server-authorized controls visible but starts no controller operation while interaction is disabled', async () => {
+    const draft = readyDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Read-only draft',
+    );
+    await render(
+      <AIActionDraftCardController
+        draft={draft}
+        interactionDisabled
+        onDraftChanged={jest.fn()}
+        tripId={TRIP_A}
+      />,
+    );
+
+    for (const label of ['Cancel', 'Confirm']) {
+      const control = screen.getByRole('button', { name: label });
+      expect(control.props.accessibilityState.disabled).toBe(true);
+      await fireEvent.press(control);
+    }
+    expect(mockPatch).not.toHaveBeenCalled();
+    expect(mockCancel).not.toHaveBeenCalled();
+    expect(mockConfirm).not.toHaveBeenCalled();
+    expect(mockCheck).not.toHaveBeenCalled();
+  });
+
+  it('aborts resource A and ignores its late completion after switching to B', async () => {
+    const pendingA = deferred<AIActionDraftEnvelope>();
+    let signalA: AbortSignal | undefined;
+    mockPatch.mockImplementationOnce(async (_tripId, _draftId, _payload, signal) => {
+      signalA = signal;
+      return pendingA.promise;
+    });
+    const changedA = jest.fn();
+    const changedB = jest.fn();
+    const draftA = editableDraft('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', 'Draft A');
+    const draftB = editableDraft('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', 'Draft B');
+    mockGet.mockResolvedValueOnce({ draft: draftA });
+    const rendered = await render(
+      <AIActionDraftCardController
+        draft={draftA}
+        onDraftChanged={changedA}
+        tripId={TRIP_A}
+      />,
+    );
+    await fireEvent.press(screen.getByRole('button', { name: 'Edit draft' }));
+    await fireEvent.changeText(screen.getByLabelText('Title'), 'Late A');
+    await fireEvent.press(screen.getByRole('button', { name: 'Save draft information' }));
+    expect(signalA?.aborted).toBe(false);
+
+    await rendered.rerender(
+      <AIActionDraftCardController
+        draft={draftB}
+        onDraftChanged={changedB}
+        tripId={TRIP_B}
+      />,
+    );
+    expect(signalA?.aborted).toBe(true);
+    expect(screen.getByText('Draft B')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Edit draft' }).props.accessibilityState.disabled).toBe(
+      false,
+    );
+
+    await act(async () => {
+      pendingA.resolve({
+        draft: makeDraft({ ...draftA, updated_at: '2026-05-13T01:00:00.000Z' }),
+      });
+      await pendingA.promise;
+    });
+    expect(changedA).not.toHaveBeenCalled();
+    expect(changedB).not.toHaveBeenCalled();
+    expect(screen.getByText('Draft B')).toBeTruthy();
+  });
+
+  it('aborts and fences a late completion after unmount', async () => {
+    const pending = deferred<AIActionDraftEnvelope>();
+    let signal: AbortSignal | undefined;
+    mockPatch.mockImplementationOnce(async (_tripId, _draftId, _payload, requestSignal) => {
+      signal = requestSignal;
+      return pending.promise;
+    });
+    const changed = jest.fn();
+    const source = editableDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    mockGet.mockResolvedValueOnce({ draft: source });
+    const rendered = await render(
+      <AIActionDraftCardController
+        draft={source}
+        onDraftChanged={changed}
+        tripId={TRIP_A}
+      />,
+    );
+    await fireEvent.press(screen.getByRole('button', { name: 'Edit draft' }));
+    await fireEvent.changeText(screen.getByLabelText('Title'), 'Late A');
+    await fireEvent.press(screen.getByRole('button', { name: 'Save draft information' }));
+    await rendered.unmount();
+    expect(signal?.aborted).toBe(true);
+    await act(async () => {
+      pending.resolve({ draft: editableDraft('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', 'Late') });
+      await pending.promise;
+    });
+    expect(changed).not.toHaveBeenCalled();
+  });
+
+  it('aborts an old operation when the same draft receives a newer permission snapshot', async () => {
+    const pending = deferred<AIActionDraftEnvelope>();
+    let signal: AbortSignal | undefined;
+    mockPatch.mockImplementationOnce(async (_tripId, _draftId, _payload, requestSignal) => {
+      signal = requestSignal;
+      return pending.promise;
+    });
+    const changed = jest.fn();
+    const draftId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const oldDraft = editableDraft(draftId, 'Old draft');
+    mockGet.mockResolvedValueOnce({ draft: oldDraft });
+    const rendered = await render(
+      <AIActionDraftCardController
+        draft={oldDraft}
+        onDraftChanged={changed}
+        tripId={TRIP_A}
+      />,
+    );
+    await fireEvent.press(screen.getByRole('button', { name: 'Edit draft' }));
+    await fireEvent.changeText(screen.getByLabelText('Title'), 'Stale edit');
+    await fireEvent.press(screen.getByRole('button', { name: 'Save draft information' }));
+    const newerDraft = makeDraft({
+      ...oldDraft,
+      can_cancel: false,
+      can_edit: false,
+      display: { title: 'New permission snapshot', kicker: 'Expense' },
+      updated_at: '2026-05-13T00:10:00.000Z',
+    });
+    await rendered.rerender(
+      <AIActionDraftCardController
+        draft={newerDraft}
+        onDraftChanged={changed}
+        tripId={TRIP_A}
+      />,
+    );
+    expect(signal?.aborted).toBe(true);
+    expect(screen.getByText('New permission snapshot')).toBeTruthy();
+    await act(async () => {
+      pending.resolve({
+        draft: makeDraft({
+          ...oldDraft,
+          display: { title: 'Stale response', kicker: 'Expense' },
+          updated_at: '2026-05-13T00:05:00.000Z',
+        }),
+      });
+      await pending.promise;
+    });
+    expect(changed).not.toHaveBeenCalled();
+    expect(screen.getByText('New permission snapshot')).toBeTruthy();
+    expect(screen.queryByText('Stale response')).toBeNull();
+  });
+
+  it('fails closed when a mocked PATCH returns another valid draft id', async () => {
+    const source = editableDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Original draft',
+    );
+    mockGet.mockResolvedValueOnce({ draft: source });
+    mockPatch.mockResolvedValueOnce({
+      draft: editableDraft(
+        'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+        'Wrong draft',
+      ),
+    });
+    const changed = jest.fn();
+    await render(
+      <AIActionDraftCardController
+        draft={source}
+        onDraftChanged={changed}
+        tripId={TRIP_A}
+      />,
+    );
+    await fireEvent.press(screen.getByRole('button', { name: 'Edit draft' }));
+    await fireEvent.changeText(screen.getByLabelText('Title'), 'Edited title');
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Save draft information' }),
+    );
+    expect(changed).not.toHaveBeenCalled();
+    expect(screen.getByText('Original draft')).toBeTruthy();
+    expect(screen.queryByText('Wrong draft')).toBeNull();
+    expect(screen.getByText(/invalid response/i)).toBeTruthy();
+  });
+
+  it('keeps rejected editor values visible and read-only after PATCH returns expiry authority', async () => {
+    const source = editableDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const expired = makeDraft({
+      ...source,
+      status: 'EXPIRED',
+      can_confirm: false,
+      can_cancel: false,
+      can_edit: false,
+      missing_fields: [],
+      updated_at: '2026-05-13T00:10:00.000Z',
+    });
+    mockGet.mockResolvedValueOnce({ draft: source });
+    mockPatch.mockRejectedValueOnce(expiredPatchError(expired));
+
+    function Harness() {
+      const [draft, setDraft] = useState(source);
+      return (
+        <AIActionDraftCardController
+          draft={draft}
+          onDraftChanged={setDraft}
+          tripId={TRIP_A}
+        />
+      );
+    }
+
+    await render(<Harness />);
+    await fireEvent.press(screen.getByRole('button', { name: 'Edit draft' }));
+    await fireEvent.changeText(screen.getByLabelText('Title'), 'Do not lose this');
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Save draft information' }),
+    );
+    expect(screen.getByLabelText('Draft status: Expired')).toBeTruthy();
+    expect(screen.getByLabelText('Title').props.value).toBe('Do not lose this');
+    expect(screen.getByLabelText('Title').props.editable).toBe(false);
+    expect(
+      screen.getByRole('button', { name: 'Save draft information' }).props
+        .accessibilityState.disabled,
+    ).toBe(true);
+    expect(
+      screen.getByText('This draft expired. Your edits were not applied.'),
+    ).toBeTruthy();
+    await flushPresentationCarryover();
+  });
+
+  it('aborts and fences a late cancel after switching resources', async () => {
+    const pending = deferred<AIActionDraftEnvelope>();
+    let signal: AbortSignal | undefined;
+    mockCancel.mockImplementationOnce(async (_tripId, _draftId, requestSignal) => {
+      signal = requestSignal;
+      return pending.promise;
+    });
+    const changedA = jest.fn();
+    const changedB = jest.fn();
+    const draftA = readyDraft('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', 'Draft A');
+    const draftB = readyDraft('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', 'Draft B');
+    mockGet.mockResolvedValueOnce({ draft: draftA });
+    const rendered = await render(
+      <AIActionDraftCardController
+        draft={draftA}
+        onDraftChanged={changedA}
+        tripId={TRIP_A}
+      />,
+    );
+    await fireEvent.press(screen.getByRole('button', { name: 'Cancel' }));
+    await fireEvent.press(screen.getByRole('button', { name: 'Cancel this draft' }));
+    expect(signal?.aborted).toBe(false);
+    await rendered.rerender(
+      <AIActionDraftCardController
+        draft={draftB}
+        onDraftChanged={changedB}
+        tripId={TRIP_B}
+      />,
+    );
+    expect(signal?.aborted).toBe(true);
+    await act(async () => {
+      pending.resolve({
+        draft: makeDraft({ ...draftA, status: 'CANCELLED', can_cancel: false }),
+      });
+      await pending.promise;
+    });
+    expect(changedA).not.toHaveBeenCalled();
+    expect(changedB).not.toHaveBeenCalled();
+    expect(screen.getByText('Draft B')).toBeTruthy();
+  });
+
+  it.each([
+    ['CANCELLED', 'Draft cancelled.'],
+    ['EXPIRED', 'The draft expired before it could be cancelled.'],
+    ['FAILED', 'The draft failed and was not cancelled.'],
+  ] as const)(
+    'describes a cancel response with terminal status %s truthfully',
+    async (status, message) => {
+      const source = readyDraft(
+        'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        'Draft A',
+      );
+      mockGet.mockResolvedValueOnce({ draft: source });
+      mockCancel.mockResolvedValueOnce({
+        draft: makeDraft({
+          ...source,
+          status,
+          can_confirm: false,
+          can_cancel: false,
+          can_edit: false,
+        }),
+      });
+      const changed = jest.fn();
+      await render(
+        <AIActionDraftCardController
+          draft={source}
+          onDraftChanged={changed}
+          tripId={TRIP_A}
+        />,
+      );
+      await fireEvent.press(screen.getByRole('button', { name: 'Cancel' }));
+      await fireEvent.press(
+        screen.getByRole('button', { name: 'Cancel this draft' }),
+      );
+      expect(screen.getByText(message)).toBeTruthy();
+      expect(changed).toHaveBeenCalledTimes(1);
+      expect(mockReconcile).not.toHaveBeenCalled();
+    },
+  );
+
+  it('reconciles exactly once and never claims cancellation when cancel observes CONFIRMED', async () => {
+    const source = readyDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const confirmed = makeDraft({
+      ...source,
+      status: 'CONFIRMED',
+      can_confirm: false,
+      can_cancel: false,
+      can_edit: false,
+    });
+    mockGet.mockResolvedValueOnce({ draft: source });
+    mockCancel.mockResolvedValueOnce({ draft: confirmed });
+    const changed = jest.fn();
+
+    function Harness() {
+      const [draft, setDraft] = useState(source);
+      return (
+        <AIActionDraftCardController
+          draft={draft}
+          onDraftChanged={(next) => {
+            changed(next);
+            setDraft(next);
+          }}
+          tripId={TRIP_A}
+        />
+      );
+    }
+
+    await render(<Harness />);
+    await fireEvent.press(screen.getByRole('button', { name: 'Cancel' }));
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Cancel this draft' }),
+    );
+    expect(
+      screen.getByText('The draft was already confirmed and could not be cancelled.'),
+    ).toBeTruthy();
+    expect(screen.queryByText('Draft cancelled.')).toBeNull();
+    expect(mockReconcile).toHaveBeenCalledTimes(1);
+    expect(mockReconcile).toHaveBeenCalledWith({
+      tripId: TRIP_A,
+      previousStatus: 'READY',
+      draft: confirmed,
+    });
+    expect(changed).toHaveBeenCalledTimes(1);
+    await flushPresentationCarryover();
+  });
+
+  it('aborts and fences a late confirm after switching resources', async () => {
+    const draftA = readyDraft('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', 'Draft A');
+    const draftB = readyDraft('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', 'Draft B');
+    const pending = deferred<ReturnType<typeof createConfirmAmbiguityState>>();
+    let signal: AbortSignal | undefined;
+    mockConfirm.mockImplementationOnce(async (options) => {
+      signal = options.signal;
+      return pending.promise;
+    });
+    const changedA = jest.fn();
+    const changedB = jest.fn();
+    mockGet.mockResolvedValueOnce({ draft: draftA });
+    const rendered = await render(
+      <AIActionDraftCardController
+        draft={draftA}
+        onDraftChanged={changedA}
+        tripId={TRIP_A}
+      />,
+    );
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm this action' }));
+    expect(signal?.aborted).toBe(false);
+    await rendered.rerender(
+      <AIActionDraftCardController
+        draft={draftB}
+        onDraftChanged={changedB}
+        tripId={TRIP_B}
+      />,
+    );
+    expect(signal?.aborted).toBe(true);
+    await act(async () => {
+      pending.resolve(
+        createConfirmAmbiguityState(
+          makeDraft({ ...draftA, status: 'CONFIRMED', can_confirm: false }),
+        ),
+      );
+      await pending.promise;
+    });
+    expect(changedA).not.toHaveBeenCalled();
+    expect(changedB).not.toHaveBeenCalled();
+    expect(screen.getByText('Draft B')).toBeTruthy();
+  });
+
+  it('hides confirm after ambiguity, then aborts and fences a late Check status', async () => {
+    const draftA = readyDraft('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', 'Draft A');
+    const draftB = readyDraft('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', 'Draft B');
+    const unknown = {
+      ...createConfirmAmbiguityState(draftA),
+      kind: 'unknown' as const,
+      message: 'The confirmation outcome is unknown.',
+      canCheckStatus: true,
+    };
+    mockConfirm.mockResolvedValueOnce(unknown);
+    mockGet.mockResolvedValueOnce({ draft: draftA });
+    const pending = deferred<ReturnType<typeof createConfirmAmbiguityState>>();
+    let signal: AbortSignal | undefined;
+    mockCheck.mockImplementationOnce(async (options) => {
+      signal = options.signal;
+      return pending.promise;
+    });
+    const changedA = jest.fn();
+    const changedB = jest.fn();
+    const rendered = await render(
+      <AIActionDraftCardController
+        draft={draftA}
+        onDraftChanged={changedA}
+        tripId={TRIP_A}
+      />,
+    );
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm this action' }));
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('button', { name: 'Confirm' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Confirm this action' })).toBeNull();
+    expect(screen.getAllByRole('button', { name: 'Check status' })).toHaveLength(1);
+    const callsBeforeCheck = changedA.mock.calls.length;
+    await fireEvent.press(screen.getByRole('button', { name: 'Check status' }));
+    expect(signal?.aborted).toBe(false);
+    await rendered.rerender(
+      <AIActionDraftCardController
+        draft={draftB}
+        onDraftChanged={changedB}
+        tripId={TRIP_B}
+      />,
+    );
+    expect(signal?.aborted).toBe(true);
+    await act(async () => {
+      pending.resolve(createConfirmAmbiguityState(draftA));
+      await pending.promise;
+    });
+    expect(changedA).toHaveBeenCalledTimes(callsBeforeCheck);
+    expect(changedB).not.toHaveBeenCalled();
+    expect(screen.getByText('Draft B')).toBeTruthy();
+  });
+
+  it('keeps 429 READY confirmation disabled until Retry-After then requires a new modal approval', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(Date.parse('2026-08-10T00:00:00.000Z'));
+    let unmount: (() => void | Promise<void>) | null = null;
+    try {
+      const draft = readyDraft(
+        'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        'Draft A',
+      );
+      const readyAfterStatusCheck = makeDraft({
+        ...draft,
+        updated_at: '2026-05-13T00:10:00.000Z',
+      });
+      mockGet.mockResolvedValueOnce({ draft });
+      mockConfirm.mockResolvedValueOnce({
+        ...createConfirmAmbiguityState(readyAfterStatusCheck),
+        kind: 'ready_for_explicit_confirmation',
+        failure: {
+          kind: 'throttled',
+          message: 'GoPlanAI allows 30 action confirmations per hour.',
+          operation: 'confirm',
+          errorCode: 'THROTTLED',
+          status: 429,
+          retryAfterMs: 2_000,
+          fieldErrors: null,
+          draft: null,
+        },
+        message:
+          'GoPlanAI allows 30 action confirmations per hour. Retry-After: 2 seconds. The action is still ready for a new explicit confirmation.',
+        confirmRetryAtMs: Date.now() + 2_000,
+      });
+      function Harness() {
+        const [current, setCurrent] = useState(draft);
+        return (
+          <AIActionDraftCardController
+            draft={current}
+            onDraftChanged={setCurrent}
+            tripId={TRIP_A}
+          />
+        );
+      }
+      const rendered = await render(<Harness />);
+      unmount = rendered.unmount;
+      await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+      await fireEvent.press(
+        screen.getByRole('button', { name: 'Confirm this action' }),
+      );
+      expect(mockConfirm).toHaveBeenCalledTimes(1);
+      expect(screen.getByText(/30 action confirmations per hour/)).toBeTruthy();
+      expect(
+        screen.getByRole('button', { name: 'Confirm' }).props.accessibilityState
+          .disabled,
+      ).toBe(true);
+      expect(screen.getByText('Confirmation available in 2s')).toBeTruthy();
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(2_000);
+      });
+      expect(
+        screen.getByRole('button', { name: 'Confirm' }).props.accessibilityState
+          .disabled,
+      ).toBe(false);
+      await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+      expect(
+        screen.getByRole('button', { name: 'Confirm this action' }),
+      ).toBeTruthy();
+      expect(mockConfirm).toHaveBeenCalledTimes(1);
+    } finally {
+      await unmount?.();
+      jest.useRealTimers();
+    }
+  });
+
+  it('retains 429 metadata and Check status when the follow-up GET outcome is unknown', async () => {
+    const draft = readyDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    mockGet.mockResolvedValueOnce({ draft });
+    mockConfirm.mockResolvedValueOnce({
+      ...createConfirmAmbiguityState(draft),
+      kind: 'unknown',
+      failure: {
+        kind: 'throttled',
+        message: 'GoPlanAI allows 30 action confirmations per hour.',
+        operation: 'confirm',
+        errorCode: 'THROTTLED',
+        status: 429,
+        retryAfterMs: 30_000,
+        fieldErrors: null,
+        draft: null,
+      },
+      message:
+        'GoPlanAI allows 30 action confirmations per hour. Retry-After: 30 seconds. The status check failed.',
+      canCheckStatus: true,
+      confirmRetryAtMs: Date.now() + 30_000,
+    });
+    await render(
+      <AIActionDraftCardController
+        draft={draft}
+        onDraftChanged={jest.fn()}
+        tripId={TRIP_A}
+      />,
+    );
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Confirm this action' }),
+    );
+    expect(screen.getByText(/Retry-After: 30 seconds/)).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Confirm' })).toBeNull();
+    expect(screen.getAllByRole('button', { name: 'Check status' })).toHaveLength(1);
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps an ambiguous confirm session across a virtualized row unmount without offering a second POST', async () => {
+    const draft = readyDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const coordinator = createAIReconciliationCoordinator({
+      resourceKey: `user-a:${TRIP_A}`,
+      tripId: TRIP_A,
+    });
+    const unknown = {
+      ...createConfirmAmbiguityState(draft),
+      kind: 'unknown' as const,
+      message:
+        'The confirmation outcome is unknown. Use Check status; do not confirm again.',
+      canCheckStatus: true,
+    };
+    mockGet.mockResolvedValueOnce({ draft });
+    mockConfirm.mockResolvedValueOnce(unknown);
+    const changed = jest.fn();
+    const row = (visible: boolean) => (
+      <AIReconciliationCoordinatorProvider value={coordinator}>
+        {visible ? (
+          <AIActionDraftCardController
+            draft={draft}
+            onDraftChanged={changed}
+            tripId={TRIP_A}
+          />
+        ) : null}
+      </AIReconciliationCoordinatorProvider>
+    );
+    const rendered = await render(row(true));
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Confirm this action' }),
+    );
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: 'Check status' })).toBeTruthy();
+
+    await rendered.rerender(row(false));
+    await rendered.rerender(row(true));
+
+    expect(screen.queryByRole('button', { name: 'Confirm' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Check status' })).toBeTruthy();
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed to Check status when virtualization aborts an in-flight confirm', async () => {
+    const draft = readyDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const coordinator = createAIReconciliationCoordinator({
+      resourceKey: `user-a:${TRIP_A}`,
+      tripId: TRIP_A,
+    });
+    const pendingConfirm =
+      deferred<ReturnType<typeof createConfirmAmbiguityState>>();
+    let confirmSignal: AbortSignal | undefined;
+    mockGet.mockResolvedValueOnce({ draft });
+    mockConfirm.mockImplementationOnce(async (options) => {
+      confirmSignal = options.signal;
+      return pendingConfirm.promise;
+    });
+    const row = (visible: boolean) => (
+      <AIReconciliationCoordinatorProvider value={coordinator}>
+        {visible ? (
+          <AIActionDraftCardController
+            draft={draft}
+            onDraftChanged={jest.fn()}
+            tripId={TRIP_A}
+          />
+        ) : null}
+      </AIReconciliationCoordinatorProvider>
+    );
+    const rendered = await render(row(true));
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Confirm this action' }),
+    );
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+    expect(confirmSignal?.aborted).toBe(false);
+
+    await rendered.rerender(row(false));
+    expect(confirmSignal?.aborted).toBe(true);
+    await rendered.rerender(row(true));
+
+    expect(screen.queryByRole('button', { name: 'Confirm' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Check status' })).toBeTruthy();
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      pendingConfirm.resolve(createConfirmAmbiguityState(draft));
+      await pendingConfirm.promise;
+    });
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('rebases an offscreen unknown session when authoritative CONFIRMED arrives before remount', async () => {
+    const draft = readyDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const confirmed = makeDraft({
+      ...draft,
+      status: 'CONFIRMED',
+      can_confirm: false,
+      can_cancel: false,
+      can_edit: false,
+      updated_at: '2026-05-13T00:10:00.000Z',
+    });
+    const coordinator = createAIReconciliationCoordinator({
+      resourceKey: `user-a:${TRIP_A}`,
+      tripId: TRIP_A,
+    });
+    mockGet.mockResolvedValueOnce({ draft });
+    mockConfirm.mockResolvedValueOnce({
+      ...createConfirmAmbiguityState(draft),
+      kind: 'unknown',
+      message: 'The confirmation outcome is unknown.',
+      canCheckStatus: true,
+    });
+    const row = (visible: boolean, incoming: ReturnType<typeof makeDraft>) => (
+      <AIReconciliationCoordinatorProvider value={coordinator}>
+        {visible ? (
+          <AIActionDraftCardController
+            draft={incoming}
+            onDraftChanged={jest.fn()}
+            tripId={TRIP_A}
+          />
+        ) : null}
+      </AIReconciliationCoordinatorProvider>
+    );
+    const rendered = await render(row(true, draft));
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Confirm this action' }),
+    );
+    expect(screen.getByRole('button', { name: 'Check status' })).toBeTruthy();
+
+    await rendered.rerender(row(false, draft));
+    await rendered.rerender(row(false, confirmed));
+    await rendered.rerender(row(true, confirmed));
+
+    expect(screen.getByLabelText('Draft status: Confirmed')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Check status' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Confirm' })).toBeNull();
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not leak an unknown session across users in the same trip resource', async () => {
+    const draft = readyDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const coordinatorA = createAIReconciliationCoordinator({
+      resourceKey: `user-a:${TRIP_A}`,
+      tripId: TRIP_A,
+    });
+    const coordinatorB = createAIReconciliationCoordinator({
+      resourceKey: `user-b:${TRIP_A}`,
+      tripId: TRIP_A,
+    });
+    mockGet.mockResolvedValueOnce({ draft });
+    mockConfirm.mockResolvedValueOnce({
+      ...createConfirmAmbiguityState(draft),
+      kind: 'unknown',
+      message: 'The confirmation outcome is unknown.',
+      canCheckStatus: true,
+    });
+    const row = (coordinator: AIReconciliationCoordinator) => (
+      <AIReconciliationCoordinatorProvider value={coordinator}>
+        <AIActionDraftCardController
+          draft={draft}
+          onDraftChanged={jest.fn()}
+          tripId={TRIP_A}
+        />
+      </AIReconciliationCoordinatorProvider>
+    );
+    const rendered = await render(row(coordinatorA));
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Confirm this action' }),
+    );
+    expect(screen.getByRole('button', { name: 'Check status' })).toBeTruthy();
+
+    await rendered.rerender(row(coordinatorB));
+
+    expect(screen.queryByRole('button', { name: 'Check status' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeTruthy();
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a future Retry-After unknown session across a virtualized row unmount', async () => {
+    const draft = readyDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const coordinator = createAIReconciliationCoordinator({
+      resourceKey: `user-a:${TRIP_A}`,
+      tripId: TRIP_A,
+    });
+    mockGet.mockResolvedValueOnce({ draft });
+    mockConfirm.mockResolvedValueOnce({
+      ...createConfirmAmbiguityState(draft),
+      kind: 'unknown',
+      failure: {
+        kind: 'throttled',
+        message: 'GoPlanAI allows 30 action confirmations per hour.',
+        operation: 'confirm',
+        errorCode: 'THROTTLED',
+        status: 429,
+        retryAfterMs: 30_000,
+        fieldErrors: null,
+        draft: null,
+      },
+      message:
+        'GoPlanAI allows 30 action confirmations per hour. Retry-After: 30 seconds. The confirmation outcome is unknown.',
+      canCheckStatus: true,
+      confirmRetryAtMs: Date.now() + 30_000,
+    });
+    const row = (visible: boolean) => (
+      <AIReconciliationCoordinatorProvider value={coordinator}>
+        {visible ? (
+          <AIActionDraftCardController
+            draft={draft}
+            onDraftChanged={jest.fn()}
+            tripId={TRIP_A}
+          />
+        ) : null}
+      </AIReconciliationCoordinatorProvider>
+    );
+    const rendered = await render(row(true));
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Confirm this action' }),
+    );
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+
+    await rendered.rerender(row(false));
+    await rendered.rerender(row(true));
+
+    expect(screen.getByText(/Retry-After: 30 seconds/)).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Confirm' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Check status' })).toBeTruthy();
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps exact expired PATCH values across a virtualized row unmount', async () => {
+    const source = editableDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const expired = makeDraft({
+      ...source,
+      status: 'EXPIRED',
+      can_confirm: false,
+      can_cancel: false,
+      can_edit: false,
+      updated_at: '2026-05-13T00:10:00.000Z',
+    });
+    const coordinator = createAIReconciliationCoordinator({
+      resourceKey: `user-a:${TRIP_A}`,
+      tripId: TRIP_A,
+    });
+    const pendingPatch = deferred<AIActionDraftEnvelope>();
+    mockGet.mockResolvedValueOnce({ draft: source });
+    mockPatch.mockReturnValueOnce(pendingPatch.promise);
+    const row = (visible: boolean, draft: ReturnType<typeof makeDraft>) => (
+      <AIReconciliationCoordinatorProvider value={coordinator}>
+        {visible ? (
+          <AIActionDraftCardController
+            draft={draft}
+            onDraftChanged={jest.fn()}
+            tripId={TRIP_A}
+          />
+        ) : null}
+      </AIReconciliationCoordinatorProvider>
+    );
+    const rendered = await render(row(true, source));
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Edit draft' }));
+    const exactSubmittedTitle = '  Preserve\nthese exact bytes  ';
+    await fireEvent.changeText(
+      screen.getByLabelText('Title'),
+      exactSubmittedTitle,
+    );
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Save draft information' }),
+    );
+    await rendered.rerender(row(true, expired));
+    expect(screen.getByLabelText('Title').props.value).toBe(
+      exactSubmittedTitle,
+    );
+
+    await rendered.rerender(row(false, expired));
+    await rendered.rerender(row(true, expired));
+
+    expect(screen.getByLabelText('Title').props.value).toBe(
+      exactSubmittedTitle,
+    );
+    expect(screen.getByLabelText('Title').props.editable).toBe(false);
+    expect(
+      screen.getByText('This draft expired. Your edits were not applied.'),
+    ).toBeTruthy();
+    await act(async () => {
+      pendingPatch.resolve({ draft: expired });
+      await pendingPatch.promise;
+    });
+  });
+
+  it('keeps an open editor and exact unsaved multi-field values across row detach', async () => {
+    const source = makeDraft({
+      ...editableDraft(
+        'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        'Draft A',
+      ),
+      missing_fields: [
+        { name: 'title', label: 'Title', type: 'text', required: true },
+        { name: 'notes', label: 'Notes', type: 'text', required: false },
+      ],
+    });
+    const coordinator = createAIReconciliationCoordinator({
+      resourceKey: `user-a:${TRIP_A}`,
+      tripId: TRIP_A,
+    });
+    const row = (visible: boolean, draft = source) => (
+      <AIReconciliationCoordinatorProvider value={coordinator}>
+        {visible ? (
+          <AIActionDraftCardController
+            draft={draft}
+            onDraftChanged={jest.fn()}
+            tripId={TRIP_A}
+          />
+        ) : null}
+      </AIReconciliationCoordinatorProvider>
+    );
+    const rendered = await render(row(true));
+    await fireEvent.press(screen.getByRole('button', { name: 'Edit draft' }));
+    const exactTitle = '  Unsaved\n title  ';
+    const exactNotes = '  Preserve   notes  ';
+    const titleInput = screen.getByLabelText('Title');
+    const notesInput = screen.getByLabelText('Notes');
+    await act(async () => {
+      titleInput.props.onChangeText(exactTitle);
+      notesInput.props.onChangeText(exactNotes);
+    });
+
+    await rendered.rerender(row(false));
+    await rendered.rerender(row(true));
+
+    expect(screen.getByTestId('ai-draft-field-editor')).toBeTruthy();
+    expect(screen.getByLabelText('Title').props.value).toBe(exactTitle);
+    expect(screen.getByLabelText('Notes').props.value).toBe(exactNotes);
+    expect(mockPatch).not.toHaveBeenCalled();
+  });
+
+  it('keeps submitted values editable for retry when row detach aborts PATCH', async () => {
+    const source = editableDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const coordinator = createAIReconciliationCoordinator({
+      resourceKey: `user-a:${TRIP_A}`,
+      tripId: TRIP_A,
+    });
+    const pendingPatch = deferred<AIActionDraftEnvelope>();
+    let patchSignal: AbortSignal | undefined;
+    mockGet.mockResolvedValueOnce({ draft: source });
+    mockPatch.mockImplementationOnce(
+      async (_tripId, _draftId, _payload, signal) => {
+        patchSignal = signal;
+        return pendingPatch.promise;
+      },
+    );
+    const row = (visible: boolean) => (
+      <AIReconciliationCoordinatorProvider value={coordinator}>
+        {visible ? (
+          <AIActionDraftCardController
+            draft={source}
+            onDraftChanged={jest.fn()}
+            tripId={TRIP_A}
+          />
+        ) : null}
+      </AIReconciliationCoordinatorProvider>
+    );
+    const rendered = await render(row(true));
+    await fireEvent.press(screen.getByRole('button', { name: 'Edit draft' }));
+    const exactTitle = '  Retry\n exact title  ';
+    await fireEvent.changeText(screen.getByLabelText('Title'), exactTitle);
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Save draft information' }),
+    );
+    expect(patchSignal?.aborted).toBe(false);
+
+    await rendered.rerender(row(false));
+    expect(patchSignal?.aborted).toBe(true);
+    await rendered.rerender(row(true));
+
+    expect(screen.getByTestId('ai-draft-field-editor')).toBeTruthy();
+    expect(screen.getByLabelText('Title').props.value).toBe(exactTitle);
+    expect(screen.getByLabelText('Title').props.editable).toBe(true);
+    await act(async () => {
+      pendingPatch.resolve({ draft: source });
+      await pendingPatch.promise;
+    });
+  });
+
+  it('clears a persisted editor when authority revokes editing or the room resource changes', async () => {
+    const sourceA = editableDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const revokedA = makeDraft({
+      ...sourceA,
+      can_edit: false,
+      can_cancel: false,
+    });
+    const sourceB = editableDraft(
+      'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+      'Draft B',
+    );
+    const coordinatorA = createAIReconciliationCoordinator({
+      resourceKey: `user-a:${TRIP_A}`,
+      tripId: TRIP_A,
+    });
+    const coordinatorB = createAIReconciliationCoordinator({
+      resourceKey: `user-a:${TRIP_B}`,
+      tripId: TRIP_B,
+    });
+    const row = (
+      coordinator: AIReconciliationCoordinator,
+      tripId: string,
+      draft: ReturnType<typeof makeDraft>,
+    ) => (
+      <AIReconciliationCoordinatorProvider value={coordinator}>
+        <AIActionDraftCardController
+          draft={draft}
+          onDraftChanged={jest.fn()}
+          tripId={tripId}
+        />
+      </AIReconciliationCoordinatorProvider>
+    );
+    const rendered = await render(row(coordinatorA, TRIP_A, sourceA));
+    await fireEvent.press(screen.getByRole('button', { name: 'Edit draft' }));
+    await fireEvent.changeText(
+      screen.getByLabelText('Title'),
+      'Must not cross authority',
+    );
+
+    await rendered.rerender(row(coordinatorA, TRIP_A, revokedA));
+    expect(screen.queryByTestId('ai-draft-field-editor')).toBeNull();
+    expect(screen.queryByText('Must not cross authority')).toBeNull();
+
+    await rendered.rerender(row(coordinatorB, TRIP_B, sourceB));
+    expect(screen.queryByTestId('ai-draft-field-editor')).toBeNull();
+    expect(screen.queryByText('Must not cross authority')).toBeNull();
+  });
+
+  it('applies same-updated-at permission and authority revocation immediately', async () => {
+    const initial = makeDraft();
+    const rendered = await render(
+      <AIActionDraftCardController
+        draft={initial}
+        onDraftChanged={jest.fn()}
+        tripId={TRIP_A}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeTruthy();
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    expect(screen.getByRole('button', { name: 'Confirm this action' })).toBeTruthy();
+    await rendered.rerender(
+      <AIActionDraftCardController
+        draft={makeDraft({
+          can_confirm: false,
+          can_cancel: false,
+          can_edit: false,
+          required_confirmation: 'TRANSFER_RECIPIENT',
+        })}
+        onDraftChanged={jest.fn()}
+        tripId={TRIP_A}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'Confirm' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).toBeNull();
+    await rendered.rerender(
+      <AIActionDraftCardController
+        draft={initial}
+        onDraftChanged={jest.fn()}
+        tripId={TRIP_A}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Confirm this action' })).toBeNull();
+  });
+
+  it('joins an offscreen room reconciliation claim and surfaces its shared rejection without republishing', async () => {
+    let rejectPublisher: (error: unknown) => void = () => undefined;
+    const publisher = new Promise<null>((_resolve, reject) => {
+      rejectPublisher = reject;
+    });
+    mockReconcile.mockReturnValueOnce(publisher);
+    const source = readyDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const confirmed = makeDraft({
+      ...source,
+      status: 'CONFIRMED',
+      can_confirm: false,
+      can_cancel: false,
+      result: { expense_id: 'expense-shared-failure' },
+      updated_at: '2026-05-13T01:00:00.000Z',
+    });
+    const coordinator = createAIReconciliationCoordinator({
+      resourceKey: `user:${TRIP_A}`,
+      tripId: TRIP_A,
+      reconcile: mockReconcile,
+    });
+    const offscreenClaim = coordinator.reconcile({
+      previousStatus: source.status,
+      draft: confirmed,
+    });
+    void offscreenClaim.catch(() => undefined);
+    const rendered = await render(
+      <AIReconciliationCoordinatorProvider value={coordinator}>
+        <AIActionDraftCardController
+          draft={source}
+          onDraftChanged={jest.fn()}
+          tripId={TRIP_A}
+        />
+      </AIReconciliationCoordinatorProvider>,
+    );
+
+    await rendered.rerender(
+      <AIReconciliationCoordinatorProvider value={coordinator}>
+        <AIActionDraftCardController
+          draft={confirmed}
+          onDraftChanged={jest.fn()}
+          tripId={TRIP_A}
+        />
+      </AIReconciliationCoordinatorProvider>,
+    );
+    await act(async () => {
+      rejectPublisher(new Error('publisher failed'));
+      await offscreenClaim.catch(() => undefined);
+    });
+
+    expect(mockReconcile).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByText(
+        'The action was confirmed, but another trip screen could not refresh automatically.',
+      ),
+    ).toBeTruthy();
+  });
+
+  it('disables and explains an editor that expires locally while open', async () => {
+    const expiresAt = '2026-08-10T00:00:01.000Z';
+    const draft = editableDraft('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', 'Draft A');
+    const rendered = await render(
+      <AIActionDraftCardController
+        draft={makeDraft({ ...draft, expires_at: expiresAt })}
+        nowMs={Date.parse(expiresAt) - 1}
+        onDraftChanged={jest.fn()}
+        tripId={TRIP_A}
+      />,
+    );
+    await fireEvent.press(screen.getByRole('button', { name: 'Edit draft' }));
+    await fireEvent.changeText(screen.getByLabelText('Title'), 'Unsaved title');
+    await rendered.rerender(
+      <AIActionDraftCardController
+        draft={makeDraft({ ...draft, expires_at: expiresAt })}
+        nowMs={Date.parse(expiresAt)}
+        onDraftChanged={jest.fn()}
+        tripId={TRIP_A}
+      />,
+    );
+    expect(screen.getByLabelText('Title').props.editable).toBe(false);
+    expect(
+      screen.getByRole('button', { name: 'Save draft information' }).props.accessibilityState
+        .disabled,
+    ).toBe(true);
+    expect(screen.getByText('This draft expired. Your edits were not applied.')).toBeTruthy();
+  });
+
+  it('retains the exact submitted edit when websocket expiry wins before PATCH settles', async () => {
+    const draftId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const source = editableDraft(draftId, 'Draft A');
+    const expired = makeDraft({
+      ...source,
+      status: 'EXPIRED',
+      can_confirm: false,
+      can_cancel: false,
+      can_edit: false,
+      updated_at: '2026-05-13T00:10:00.000Z',
+    });
+    const pendingPatch = deferred<AIActionDraftEnvelope>();
+    let patchSignal: AbortSignal | undefined;
+    mockGet.mockResolvedValueOnce({ draft: source });
+    mockPatch.mockImplementationOnce(
+      async (_tripId, _draftId, _payload, signal) => {
+        patchSignal = signal;
+        return pendingPatch.promise;
+      },
+    );
+    const rendered = await render(
+      <AIActionDraftCardController
+        draft={source}
+        onDraftChanged={jest.fn()}
+        tripId={TRIP_A}
+      />,
+    );
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Edit draft' }));
+    const exactSubmittedTitle = '  Do not trim\nthis value  ';
+    await fireEvent.changeText(screen.getByLabelText('Title'), exactSubmittedTitle);
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Save draft information' }),
+    );
+    await rendered.rerender(
+      <AIActionDraftCardController
+        draft={expired}
+        onDraftChanged={jest.fn()}
+        tripId={TRIP_A}
+      />,
+    );
+
+    expect(screen.getByLabelText('Draft status: Expired')).toBeTruthy();
+    expect(patchSignal?.aborted).toBe(true);
+    expect(screen.getByLabelText('Title').props.value).toBe(exactSubmittedTitle);
+    expect(screen.getByLabelText('Title').props.editable).toBe(false);
+    expect(
+      screen.getByRole('button', { name: 'Save draft information' }).props
+        .accessibilityState.busy,
+    ).toBe(false);
+    expect(
+      screen.getByText('This draft expired. Your edits were not applied.'),
+    ).toBeTruthy();
+
+    await act(async () => {
+      pendingPatch.resolve({ draft: expired });
+      await pendingPatch.promise;
+    });
+  });
+
+  it('reconciles a websocket CONFIRMED transition exactly once before confirm HTTP settles', async () => {
+    const source = readyDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const confirmed = makeDraft({
+      ...source,
+      status: 'CONFIRMED',
+      can_confirm: false,
+      can_cancel: false,
+      can_edit: false,
+      updated_at: '2026-05-13T00:10:00.000Z',
+    });
+    const pendingConfirm = deferred<ReturnType<typeof createConfirmAmbiguityState>>();
+    let confirmSignal: AbortSignal | undefined;
+    mockGet.mockResolvedValueOnce({ draft: source });
+    mockConfirm.mockImplementationOnce(async (options) => {
+      confirmSignal = options.signal;
+      return pendingConfirm.promise;
+    });
+    const rendered = await render(
+      <AIActionDraftCardController
+        draft={source}
+        onDraftChanged={jest.fn()}
+        tripId={TRIP_A}
+      />,
+    );
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Confirm this action' }),
+    );
+    await rendered.rerender(
+      <AIActionDraftCardController
+        draft={confirmed}
+        onDraftChanged={jest.fn()}
+        tripId={TRIP_A}
+      />,
+    );
+    await act(async () => Promise.resolve());
+    expect(confirmSignal?.aborted).toBe(true);
+    expect(screen.queryByRole('button', { name: 'Confirm' })).toBeNull();
+    expect(mockReconcile).toHaveBeenCalledTimes(1);
+    expect(mockReconcile).toHaveBeenCalledWith({
+      tripId: TRIP_A,
+      previousStatus: 'READY',
+      draft: confirmed,
+    });
+
+    await act(async () => {
+      pendingConfirm.resolve(createConfirmAmbiguityState(confirmed));
+      await pendingConfirm.promise;
+    });
+    expect(mockReconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it('reconciles a websocket CONFIRMED transition exactly once before cancel HTTP settles', async () => {
+    const source = readyDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const confirmed = makeDraft({
+      ...source,
+      status: 'CONFIRMED',
+      can_confirm: false,
+      can_cancel: false,
+      can_edit: false,
+      updated_at: '2026-05-13T00:10:00.000Z',
+    });
+    const pendingCancel = deferred<AIActionDraftEnvelope>();
+    let cancelSignal: AbortSignal | undefined;
+    mockGet.mockResolvedValueOnce({ draft: source });
+    mockCancel.mockImplementationOnce(async (_tripId, _draftId, signal) => {
+      cancelSignal = signal;
+      return pendingCancel.promise;
+    });
+    const rendered = await render(
+      <AIActionDraftCardController
+        draft={source}
+        onDraftChanged={jest.fn()}
+        tripId={TRIP_A}
+      />,
+    );
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Cancel' }));
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Cancel this draft' }),
+    );
+    await rendered.rerender(
+      <AIActionDraftCardController
+        draft={confirmed}
+        onDraftChanged={jest.fn()}
+        tripId={TRIP_A}
+      />,
+    );
+    await act(async () => Promise.resolve());
+    expect(cancelSignal?.aborted).toBe(true);
+    expect(screen.queryByRole('button', { name: 'Cancel' })).toBeNull();
+    expect(mockReconcile).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      pendingCancel.resolve({ draft: confirmed });
+      await pendingCancel.promise;
+    });
+    expect(mockReconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not publish reconciliation when first mounted from confirmed history', async () => {
+    const confirmed = makeDraft({
+      status: 'CONFIRMED',
+      can_confirm: false,
+      can_cancel: false,
+      can_edit: false,
+    });
+    await render(
+      <AIActionDraftCardController
+        draft={confirmed}
+        onDraftChanged={jest.fn()}
+        tripId={TRIP_A}
+      />,
+    );
+    await act(async () => Promise.resolve());
+    expect(mockReconcile).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['confirm', 'can_confirm', 'Confirm', 'Confirm this action'],
+    ['cancel', 'can_cancel', 'Cancel', 'Cancel this draft'],
+  ] as const)(
+    'preflights and stops %s when viewer authority is revoked without a row version change',
+    async (_operation, permission, triggerLabel, explicitLabel) => {
+      const source = readyDraft(
+        'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        'Draft A',
+      );
+      const revoked = makeDraft({ ...source, [permission]: false });
+      mockGet.mockResolvedValueOnce({ draft: revoked });
+      const changed = jest.fn();
+      function Harness() {
+        const [draft, setDraft] = useState(source);
+        return (
+          <AIActionDraftCardController
+            draft={draft}
+            onDraftChanged={(next) => {
+              changed(next);
+              setDraft(next);
+            }}
+            tripId={TRIP_A}
+          />
+        );
+      }
+      await render(<Harness />);
+
+      await fireEvent.press(screen.getByRole('button', { name: triggerLabel }));
+      await fireEvent.press(screen.getByRole('button', { name: explicitLabel }));
+
+      expect(mockGet).toHaveBeenCalledTimes(1);
+      expect(mockConfirm).not.toHaveBeenCalled();
+      expect(mockCancel).not.toHaveBeenCalled();
+      expect(changed).toHaveBeenCalledWith(revoked);
+      expect(screen.queryByRole('button', { name: triggerLabel })).toBeNull();
+      expect(screen.queryByRole('button', { name: explicitLabel })).toBeNull();
+    },
+  );
+
+  it('preflights and stops PATCH when can_edit is revoked without a row version change', async () => {
+    const source = editableDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const revoked = makeDraft({ ...source, can_edit: false });
+    mockGet.mockResolvedValueOnce({ draft: revoked });
+    const changed = jest.fn();
+    function Harness() {
+      const [draft, setDraft] = useState(source);
+      return (
+        <AIActionDraftCardController
+          draft={draft}
+          onDraftChanged={(next) => {
+            changed(next);
+            setDraft(next);
+          }}
+          tripId={TRIP_A}
+        />
+      );
+    }
+    await render(<Harness />);
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Edit draft' }));
+    await fireEvent.changeText(screen.getByLabelText('Title'), 'Stale edit');
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Save draft information' }),
+    );
+
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    expect(mockPatch).not.toHaveBeenCalled();
+    expect(changed).toHaveBeenCalledWith(revoked);
+    expect(screen.queryByRole('button', { name: 'Edit draft' })).toBeNull();
+  });
+
+  it('requires a fresh explicit confirmation when the server restatement changes during preflight', async () => {
+    const source = readyDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const changedSummary = makeDraft({
+      ...source,
+      display: { ...source.display, title: 'Different expense' },
+      summary: 'Create a materially different expense',
+      preview: { title: 'Different expense', total_amount: '999' },
+    });
+    mockGet.mockResolvedValueOnce({ draft: changedSummary });
+    const changed = jest.fn();
+    function Harness() {
+      const [draft, setDraft] = useState(source);
+      return (
+        <AIActionDraftCardController
+          draft={draft}
+          onDraftChanged={(next) => {
+            changed(next);
+            setDraft(next);
+          }}
+          tripId={TRIP_A}
+        />
+      );
+    }
+    await render(<Harness />);
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Confirm this action' }),
+    );
+
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    expect(mockConfirm).not.toHaveBeenCalled();
+    expect(changed).toHaveBeenCalledWith(changedSummary);
+    expect(screen.queryByRole('button', { name: 'Confirm this action' })).toBeNull();
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    expect(
+      screen.getByText('Create expense “Different expense”.'),
+    ).toBeTruthy();
+    expect(mockConfirm).not.toHaveBeenCalled();
+  });
+
+  it('routes confirm-controller reconciliation through the same resource-scoped exact-once gate', async () => {
+    const source = readyDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const confirmed = makeDraft({
+      ...source,
+      status: 'CONFIRMED',
+      can_confirm: false,
+      can_cancel: false,
+      can_edit: false,
+      updated_at: '2026-05-13T00:10:00.000Z',
+    });
+    mockGet.mockResolvedValueOnce({ draft: source });
+    mockConfirm.mockImplementationOnce(async (options) => {
+      const reconcile = options.dependencies?.reconcile;
+      if (reconcile === undefined) {
+        throw new Error('Expected injected confirm dependencies.');
+      }
+      await reconcile({
+        tripId: TRIP_A,
+        previousDraft: source,
+        nextDraft: confirmed,
+      });
+      await reconcile({
+        tripId: TRIP_A,
+        previousDraft: source,
+        nextDraft: confirmed,
+      });
+      return {
+        ...createConfirmAmbiguityState(confirmed),
+        kind: 'confirmed',
+        observedConfirmed: true,
+      };
+    });
+    function Harness() {
+      const [draft, setDraft] = useState(source);
+      return (
+        <AIActionDraftCardController
+          draft={draft}
+          onDraftChanged={setDraft}
+          tripId={TRIP_A}
+        />
+      );
+    }
+    await render(<Harness />);
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Confirm this action' }),
+    );
+    await act(async () => Promise.resolve());
+
+    expect(mockReconcile).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText('Draft status: Confirmed')).toBeTruthy();
+  });
+
+  it('clears an old submitted edit when a non-expired authority snapshot advances before a later expiry', async () => {
+    const source = editableDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const newer = makeDraft({
+      ...source,
+      display: { title: 'Newer draft', kicker: 'Expense' },
+      updated_at: '2026-05-13T00:10:00.000Z',
+    });
+    const expired = makeDraft({
+      ...newer,
+      status: 'EXPIRED',
+      can_confirm: false,
+      can_cancel: false,
+      can_edit: false,
+      missing_fields: [],
+      updated_at: '2026-05-13T00:20:00.000Z',
+    });
+    const pendingPatch = deferred<AIActionDraftEnvelope>();
+    mockGet.mockResolvedValueOnce({ draft: source });
+    mockPatch.mockReturnValueOnce(pendingPatch.promise);
+    const rendered = await render(
+      <AIActionDraftCardController
+        draft={source}
+        onDraftChanged={jest.fn()}
+        tripId={TRIP_A}
+      />,
+    );
+    await fireEvent.press(screen.getByRole('button', { name: 'Edit draft' }));
+    await fireEvent.changeText(screen.getByLabelText('Title'), 'Must be cleared');
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Save draft information' }),
+    );
+    await rendered.rerender(
+      <AIActionDraftCardController
+        draft={newer}
+        onDraftChanged={jest.fn()}
+        tripId={TRIP_A}
+      />,
+    );
+    await rendered.rerender(
+      <AIActionDraftCardController
+        draft={expired}
+        onDraftChanged={jest.fn()}
+        tripId={TRIP_A}
+      />,
+    );
+
+    expect(screen.getByLabelText('Draft status: Expired')).toBeTruthy();
+    expect(screen.queryByLabelText('Title')).toBeNull();
+    expect(screen.queryByText('Must be cleared')).toBeNull();
+    await act(async () => {
+      pendingPatch.resolve({ draft: newer });
+      await pendingPatch.promise;
+    });
+  });
+
+  it('keeps modal focus return alive across the controller source boundary', async () => {
+    jest.useFakeTimers();
+    let unmount: (() => void | Promise<void>) | null = null;
+    try {
+      const source = readyDraft(
+        'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        'Draft A',
+      );
+      const confirmed = makeDraft({
+        ...source,
+        status: 'CONFIRMED',
+        can_confirm: false,
+        can_cancel: false,
+        can_edit: false,
+        updated_at: '2026-05-13T00:10:00.000Z',
+      });
+      const pendingConfirm = deferred<ReturnType<typeof createConfirmAmbiguityState>>();
+      mockGet.mockResolvedValueOnce({ draft: source });
+      mockConfirm.mockReturnValueOnce(pendingConfirm.promise);
+      mockFocusAccessibilityNode.mockClear();
+      const rendered = await render(
+        <AIActionDraftCardController
+          draft={source}
+          onDraftChanged={jest.fn()}
+          tripId={TRIP_A}
+        />,
+      );
+      unmount = rendered.unmount;
+      await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+      const modal = screen.getByTestId('ai-draft-confirm-modal');
+      await act(async () => modal.props.onShow());
+      await fireEvent.press(
+        screen.getByRole('button', { name: 'Confirm this action' }),
+      );
+      await rendered.rerender(
+        <AIActionDraftCardController
+          draft={confirmed}
+          onDraftChanged={jest.fn()}
+          tripId={TRIP_A}
+        />,
+      );
+      await act(async () => {
+        modal.props.onDismiss();
+        jest.runOnlyPendingTimers();
+      });
+
+      expect(mockFocusAccessibilityNode).toHaveBeenCalledTimes(2);
+      expect(mockFocusAccessibilityNode.mock.calls[1]?.[0]).not.toBeNull();
+      await act(async () => {
+        pendingConfirm.resolve(createConfirmAmbiguityState(confirmed));
+        await pendingConfirm.promise;
+      });
+    } finally {
+      await unmount?.();
+      await act(async () => jest.runOnlyPendingTimers());
+      jest.useRealTimers();
+    }
+  });
+
+  it('keeps Check status only after a same-resource READY update aborts an in-flight confirm', async () => {
+    const source = readyDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const newer = makeDraft({
+      ...source,
+      display: { title: 'Fresh draft', kicker: 'Expense' },
+      updated_at: '2026-05-13T00:10:00.000Z',
+    });
+    const pendingConfirm = deferred<ReturnType<typeof createConfirmAmbiguityState>>();
+    let confirmSignal: AbortSignal | undefined;
+    mockGet.mockResolvedValueOnce({ draft: source });
+    mockConfirm.mockImplementationOnce(async (options) => {
+      confirmSignal = options.signal;
+      return pendingConfirm.promise;
+    });
+    mockCheck.mockResolvedValueOnce({
+      ...createConfirmAmbiguityState(newer),
+      kind: 'ready_for_explicit_confirmation',
+      message: 'The action is still ready. Review it again before confirming.',
+    });
+    const coordinator = createAIReconciliationCoordinator({
+      resourceKey: `user-a:${TRIP_A}`,
+      tripId: TRIP_A,
+    });
+    const row = (visible: boolean, draft: ReturnType<typeof makeDraft>) => (
+      <AIReconciliationCoordinatorProvider value={coordinator}>
+        {visible ? (
+          <AIActionDraftCardController
+            draft={draft}
+            onDraftChanged={jest.fn()}
+            tripId={TRIP_A}
+          />
+        ) : null}
+      </AIReconciliationCoordinatorProvider>
+    );
+    const rendered = await render(row(true, source));
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Confirm this action' }),
+    );
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+    expect(confirmSignal?.aborted).toBe(false);
+
+    await rendered.rerender(row(true, newer));
+
+    expect(confirmSignal?.aborted).toBe(true);
+    expect(screen.queryByRole('button', { name: 'Confirm' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Check status' })).toBeTruthy();
+
+    await rendered.rerender(row(false, newer));
+    await rendered.rerender(row(true, newer));
+    expect(screen.queryByRole('button', { name: 'Confirm' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Check status' })).toBeTruthy();
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Check status' }));
+    expect(mockCheck).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeTruthy();
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    expect(
+      screen.getByRole('button', { name: 'Confirm this action' }),
+    ).toBeTruthy();
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      pendingConfirm.resolve(createConfirmAmbiguityState(source));
+      await pendingConfirm.promise;
+    });
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves an already-unknown confirmation across newer nonterminal restatement and authority snapshots', async () => {
+    const source = readyDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const restated = makeDraft({
+      ...source,
+      display: { title: 'Fresh restatement', kicker: 'Expense' },
+      summary: 'Fresh confirmation restatement',
+    });
+    const needsInfo = editableDraft(
+      source.id,
+      'Fresh permissions require more information',
+    );
+    const unknown = {
+      ...createConfirmAmbiguityState(source),
+      kind: 'unknown' as const,
+      message: 'The confirmation outcome is unknown.',
+      canCheckStatus: true,
+    };
+    mockGet.mockResolvedValueOnce({ draft: source });
+    mockConfirm.mockResolvedValueOnce(unknown);
+    const rendered = await render(
+      <AIActionDraftCardController
+        draft={source}
+        onDraftChanged={jest.fn()}
+        tripId={TRIP_A}
+      />,
+    );
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Confirm this action' }),
+    );
+    expect(screen.getByRole('button', { name: 'Check status' })).toBeTruthy();
+
+    await rendered.rerender(
+      <AIActionDraftCardController
+        draft={restated}
+        onDraftChanged={jest.fn()}
+        tripId={TRIP_A}
+      />,
+    );
+    expect(screen.getByText('Fresh restatement')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Check status' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Confirm' })).toBeNull();
+
+    await rendered.rerender(
+      <AIActionDraftCardController
+        draft={needsInfo}
+        onDraftChanged={jest.fn()}
+        tripId={TRIP_A}
+      />,
+    );
+
+    expect(
+      screen.getByText('Fresh permissions require more information'),
+    ).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Check status' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Confirm' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Edit draft' })).toBeNull();
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['CONFIRMED', 'Confirmed'],
+    ['CANCELLED', 'Cancelled'],
+    ['EXPIRED', 'Expired'],
+    ['FAILED', 'Failed'],
+  ] as const)(
+    'lets authoritative %s resolve an already-unknown confirmation',
+    async (status, label) => {
+      const source = readyDraft(
+        'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        'Draft A',
+      );
+      const terminal = makeDraft({
+        ...source,
+        status,
+        can_confirm: false,
+        can_cancel: false,
+        can_edit: false,
+        updated_at: '2026-05-13T00:10:00.000Z',
+      });
+      mockGet.mockResolvedValueOnce({ draft: source });
+      mockConfirm.mockResolvedValueOnce({
+        ...createConfirmAmbiguityState(source),
+        kind: 'unknown',
+        message: 'The confirmation outcome is unknown.',
+        canCheckStatus: true,
+      });
+      const rendered = await render(
+        <AIActionDraftCardController
+          draft={source}
+          onDraftChanged={jest.fn()}
+          tripId={TRIP_A}
+        />,
+      );
+      await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+      await fireEvent.press(
+        screen.getByRole('button', { name: 'Confirm this action' }),
+      );
+      expect(screen.getByRole('button', { name: 'Check status' })).toBeTruthy();
+
+      await rendered.rerender(
+        <AIActionDraftCardController
+          draft={terminal}
+          onDraftChanged={jest.fn()}
+          tripId={TRIP_A}
+        />,
+      );
+
+      expect(screen.getByLabelText(`Draft status: ${label}`)).toBeTruthy();
+      expect(screen.queryByRole('button', { name: 'Check status' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Confirm' })).toBeNull();
+      expect(mockConfirm).toHaveBeenCalledTimes(1);
+    },
+  );
+});

--- a/mobile/src/features/chat/ai/__tests__/AIActionDraftCardController.test.tsx
+++ b/mobile/src/features/chat/ai/__tests__/AIActionDraftCardController.test.tsx
@@ -104,10 +104,12 @@ function readyDraft(id: string, title: string) {
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((next) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((next, fail) => {
     resolve = next;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, reject, resolve };
 }
 
 function axiosConfig(): InternalAxiosRequestConfig {
@@ -127,6 +129,35 @@ function expiredPatchError(draft: ReturnType<typeof makeDraft>): AxiosError {
     statusText: 'Conflict',
     config,
   });
+}
+
+function authoritativeDraftError(
+  errorCode: 'TRIP_TERMINAL' | 'FORBIDDEN' | 'TRIP_NOT_FOUND',
+): AxiosError {
+  const config = axiosConfig();
+  const accessLost = errorCode !== 'TRIP_TERMINAL';
+  const status =
+    errorCode === 'TRIP_TERMINAL'
+      ? 409
+      : errorCode === 'TRIP_NOT_FOUND'
+        ? 404
+        : 403;
+  return new AxiosError('Room authority changed', 'ERR_BAD_RESPONSE', config, {}, {
+    status,
+    data: {
+      detail: accessLost
+        ? 'You no longer have access to this trip.'
+        : 'Completed or cancelled trips are read-only.',
+      error_code: errorCode,
+    },
+    headers: new AxiosHeaders(),
+    statusText: accessLost ? 'Forbidden' : 'Conflict',
+    config,
+  });
+}
+
+function terminalDraftError(): AxiosError {
+  return authoritativeDraftError('TRIP_TERMINAL');
 }
 
 async function flushPresentationCarryover(): Promise<void> {
@@ -204,6 +235,479 @@ describe('AIActionDraftCardController resource lifecycle', () => {
     expect(mockCancel).not.toHaveBeenCalled();
     expect(mockConfirm).not.toHaveBeenCalled();
     expect(mockCheck).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['preflight', 'FORBIDDEN'],
+    ['patch', 'TRIP_TERMINAL'],
+  ] as const)(
+    'reports a live %s room-authority failure exactly once',
+    async (failureStage, errorCode) => {
+      const source = editableDraft(
+        'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        'Draft A',
+      );
+      const failure = authoritativeDraftError(errorCode);
+      const reportAuthoritativeFailure = jest.fn();
+      const coordinator = createAIReconciliationCoordinator({
+        resourceKey: `user-a:${TRIP_A}`,
+        tripId: TRIP_A,
+        reportAuthoritativeFailure,
+      });
+      if (failureStage === 'preflight') {
+        mockGet.mockRejectedValueOnce(failure);
+      } else {
+        mockGet.mockResolvedValueOnce({ draft: source });
+        mockPatch.mockRejectedValueOnce(failure);
+      }
+
+      await render(
+        <AIReconciliationCoordinatorProvider value={coordinator}>
+          <AIActionDraftCardController
+            draft={source}
+            onDraftChanged={jest.fn()}
+            tripId={TRIP_A}
+          />
+        </AIReconciliationCoordinatorProvider>,
+      );
+      await fireEvent.press(screen.getByRole('button', { name: 'Edit draft' }));
+      await fireEvent.changeText(screen.getByLabelText('Title'), 'Local edit');
+      await fireEvent.press(
+        screen.getByRole('button', { name: 'Save draft information' }),
+      );
+
+      expect(reportAuthoritativeFailure).toHaveBeenCalledTimes(1);
+      expect(reportAuthoritativeFailure).toHaveBeenCalledWith(
+        expect.objectContaining({ errorCode }),
+      );
+    },
+  );
+
+  it.each(['confirm', 'check'] as const)(
+    'reports %s authority normalized inside the confirm controller exactly once',
+    async (operation) => {
+      const source = readyDraft(
+        'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        'Draft A',
+      );
+      const failure = authoritativeDraftError('TRIP_NOT_FOUND');
+      const reportAuthoritativeFailure = jest.fn();
+      const coordinator = createAIReconciliationCoordinator({
+        resourceKey: `user-a:${TRIP_A}`,
+        tripId: TRIP_A,
+        reportAuthoritativeFailure,
+      });
+      mockGet.mockResolvedValueOnce({ draft: source });
+      if (operation === 'confirm') {
+        mockConfirm.mockImplementationOnce(async (options) => {
+          const normalized = options.dependencies?.normalizeError(
+            failure,
+            'get',
+            source.id,
+          );
+          if (normalized === undefined) {
+            throw new Error('Expected scoped confirm dependencies.');
+          }
+          return {
+            ...createConfirmAmbiguityState(source),
+            kind: 'unknown',
+            failure: normalized,
+            message: normalized.message,
+            canCheckStatus: true,
+          };
+        });
+      } else {
+        mockConfirm.mockResolvedValueOnce({
+          ...createConfirmAmbiguityState(source),
+          kind: 'unknown',
+          message: 'The confirmation outcome is unknown.',
+          canCheckStatus: true,
+        });
+        mockCheck.mockImplementationOnce(async (options) => {
+          const normalized = options.dependencies?.normalizeError(
+            failure,
+            'get',
+            source.id,
+          );
+          if (normalized === undefined) {
+            throw new Error('Expected scoped check dependencies.');
+          }
+          return {
+            ...options.state,
+            kind: 'unknown',
+            failure: normalized,
+            message: normalized.message,
+            canCheckStatus: true,
+          };
+        });
+      }
+
+      await render(
+        <AIReconciliationCoordinatorProvider value={coordinator}>
+          <AIActionDraftCardController
+            draft={source}
+            onDraftChanged={jest.fn()}
+            tripId={TRIP_A}
+          />
+        </AIReconciliationCoordinatorProvider>,
+      );
+      await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+      await fireEvent.press(
+        screen.getByRole('button', { name: 'Confirm this action' }),
+      );
+      if (operation === 'check') {
+        await fireEvent.press(
+          screen.getByRole('button', { name: 'Check status' }),
+        );
+      }
+
+      expect(reportAuthoritativeFailure).toHaveBeenCalledTimes(1);
+      expect(reportAuthoritativeFailure).toHaveBeenCalledWith(
+        expect.objectContaining({ errorCode: 'TRIP_NOT_FOUND' }),
+      );
+    },
+  );
+
+  it('reports a live cancel room-authority failure exactly once', async () => {
+    const source = readyDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const reportAuthoritativeFailure = jest.fn();
+    const coordinator = createAIReconciliationCoordinator({
+      resourceKey: `user-a:${TRIP_A}`,
+      tripId: TRIP_A,
+      reportAuthoritativeFailure,
+    });
+    mockGet.mockResolvedValueOnce({ draft: source });
+    mockCancel.mockRejectedValueOnce(
+      authoritativeDraftError('TRIP_NOT_FOUND'),
+    );
+
+    await render(
+      <AIReconciliationCoordinatorProvider value={coordinator}>
+        <AIActionDraftCardController
+          draft={source}
+          onDraftChanged={jest.fn()}
+          tripId={TRIP_A}
+        />
+      </AIReconciliationCoordinatorProvider>,
+    );
+    await fireEvent.press(screen.getByRole('button', { name: 'Cancel' }));
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Cancel this draft' }),
+    );
+
+    expect(reportAuthoritativeFailure).toHaveBeenCalledTimes(1);
+    expect(reportAuthoritativeFailure).toHaveBeenCalledWith(
+      expect.objectContaining({ errorCode: 'TRIP_NOT_FOUND' }),
+    );
+  });
+
+  it('does not report room authority from a stale disabled operation', async () => {
+    const source = editableDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const pendingPatch = deferred<AIActionDraftEnvelope>();
+    const reportAuthoritativeFailure = jest.fn();
+    const coordinator = createAIReconciliationCoordinator({
+      resourceKey: `user-a:${TRIP_A}`,
+      tripId: TRIP_A,
+      reportAuthoritativeFailure,
+    });
+    mockGet.mockResolvedValueOnce({ draft: source });
+    mockPatch.mockReturnValueOnce(pendingPatch.promise);
+    const rendered = await render(
+      <AIReconciliationCoordinatorProvider value={coordinator}>
+        <AIActionDraftCardController
+          draft={source}
+          onDraftChanged={jest.fn()}
+          tripId={TRIP_A}
+        />
+      </AIReconciliationCoordinatorProvider>,
+    );
+    await fireEvent.press(screen.getByRole('button', { name: 'Edit draft' }));
+    await fireEvent.changeText(screen.getByLabelText('Title'), 'Local edit');
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Save draft information' }),
+    );
+    await rendered.rerender(
+      <AIReconciliationCoordinatorProvider value={coordinator}>
+        <AIActionDraftCardController
+          draft={source}
+          interactionDisabled
+          onDraftChanged={jest.fn()}
+          tripId={TRIP_A}
+        />
+      </AIReconciliationCoordinatorProvider>,
+    );
+
+    await act(async () => {
+      pendingPatch.reject(authoritativeDraftError('TRIP_TERMINAL'));
+      await pendingPatch.promise.catch(() => undefined);
+    });
+    expect(reportAuthoritativeFailure).not.toHaveBeenCalled();
+  });
+
+  it('aborts and fences an in-flight PATCH when interaction becomes disabled', async () => {
+    const source = editableDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const pendingPatch = deferred<AIActionDraftEnvelope>();
+    let patchSignal: AbortSignal | undefined;
+    const changed = jest.fn();
+    mockGet.mockResolvedValueOnce({ draft: source });
+    mockPatch.mockImplementationOnce(
+      async (_tripId, _draftId, _payload, signal) => {
+        patchSignal = signal;
+        return pendingPatch.promise;
+      },
+    );
+    const rendered = await render(
+      <AIActionDraftCardController
+        draft={source}
+        onDraftChanged={changed}
+        tripId={TRIP_A}
+      />,
+    );
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Edit draft' }));
+    await fireEvent.changeText(screen.getByLabelText('Title'), 'Local edit');
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Save draft information' }),
+    );
+    expect(patchSignal?.aborted).toBe(false);
+
+    await rendered.rerender(
+      <AIActionDraftCardController
+        draft={source}
+        interactionDisabled
+        onDraftChanged={changed}
+        tripId={TRIP_A}
+      />,
+    );
+
+    expect(patchSignal?.aborted).toBe(true);
+    expect(
+      screen.getByRole('button', { name: 'Save draft information' }).props
+        .accessibilityState,
+    ).toMatchObject({ busy: false, disabled: true });
+    expect(screen.getByText(/draft actions became unavailable/i)).toBeTruthy();
+
+    await act(async () => {
+      pendingPatch.resolve({
+        draft: makeDraft({
+          ...source,
+          display: { title: 'Late PATCH', kicker: 'Expense' },
+          updated_at: '2026-05-13T00:10:00.000Z',
+        }),
+      });
+      await pendingPatch.promise;
+    });
+    expect(changed).not.toHaveBeenCalled();
+    expect(screen.queryByText('Late PATCH')).toBeNull();
+
+    await rendered.rerender(
+      <AIActionDraftCardController
+        draft={source}
+        onDraftChanged={changed}
+        tripId={TRIP_A}
+      />,
+    );
+    expect(
+      screen.getByRole('button', { name: 'Save draft information' }).props
+        .accessibilityState,
+    ).toMatchObject({ busy: false, disabled: false });
+  });
+
+  it('escalates terminal PATCH authority from one draft to the room coordinator', async () => {
+    const source = editableDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const reportAuthoritativeFailure = jest.fn();
+    const coordinator = createAIReconciliationCoordinator({
+      resourceKey: `user-a:${TRIP_A}`,
+      tripId: TRIP_A,
+      reportAuthoritativeFailure,
+    });
+    mockGet.mockResolvedValueOnce({ draft: source });
+    mockPatch.mockRejectedValueOnce(terminalDraftError());
+
+    await render(
+      <AIReconciliationCoordinatorProvider value={coordinator}>
+        <AIActionDraftCardController
+          draft={source}
+          onDraftChanged={jest.fn()}
+          tripId={TRIP_A}
+        />
+      </AIReconciliationCoordinatorProvider>,
+    );
+    await fireEvent.press(screen.getByRole('button', { name: 'Edit draft' }));
+    await fireEvent.changeText(screen.getByLabelText('Title'), 'Local edit');
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Save draft information' }),
+    );
+
+    expect(reportAuthoritativeFailure).toHaveBeenCalledTimes(1);
+    expect(reportAuthoritativeFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errorCode: 'TRIP_TERMINAL',
+        status: 409,
+      }),
+    );
+  });
+
+  it('aborts and fences an in-flight cancel when interaction becomes disabled', async () => {
+    const source = readyDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const confirmed = makeDraft({
+      ...source,
+      status: 'CONFIRMED',
+      can_confirm: false,
+      can_cancel: false,
+      updated_at: '2026-05-13T00:10:00.000Z',
+    });
+    const pendingCancel = deferred<AIActionDraftEnvelope>();
+    let cancelSignal: AbortSignal | undefined;
+    const changed = jest.fn();
+    mockGet.mockResolvedValueOnce({ draft: source });
+    mockCancel.mockImplementationOnce(async (_tripId, _draftId, signal) => {
+      cancelSignal = signal;
+      return pendingCancel.promise;
+    });
+    const rendered = await render(
+      <AIActionDraftCardController
+        draft={source}
+        onDraftChanged={changed}
+        tripId={TRIP_A}
+      />,
+    );
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Cancel' }));
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Cancel this draft' }),
+    );
+    expect(cancelSignal?.aborted).toBe(false);
+
+    await rendered.rerender(
+      <AIActionDraftCardController
+        draft={source}
+        interactionDisabled
+        onDraftChanged={changed}
+        tripId={TRIP_A}
+      />,
+    );
+
+    expect(cancelSignal?.aborted).toBe(true);
+    expect(
+      screen.getByRole('button', { name: 'Cancel' }).props.accessibilityState,
+    ).toMatchObject({ busy: false, disabled: true });
+
+    await act(async () => {
+      pendingCancel.resolve({ draft: confirmed });
+      await pendingCancel.promise;
+    });
+    expect(changed).not.toHaveBeenCalled();
+    expect(mockReconcile).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Draft status: Ready')).toBeTruthy();
+
+    await rendered.rerender(
+      <AIActionDraftCardController
+        draft={source}
+        onDraftChanged={changed}
+        tripId={TRIP_A}
+      />,
+    );
+    expect(
+      screen.getByRole('button', { name: 'Cancel' }).props.accessibilityState,
+    ).toMatchObject({ busy: false, disabled: false });
+  });
+
+  it('fails closed and fences an in-flight confirm when interaction becomes disabled', async () => {
+    const source = readyDraft(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'Draft A',
+    );
+    const confirmed = makeDraft({
+      ...source,
+      status: 'CONFIRMED',
+      can_confirm: false,
+      can_cancel: false,
+      updated_at: '2026-05-13T00:10:00.000Z',
+    });
+    const pendingConfirm = deferred<ReturnType<typeof createConfirmAmbiguityState>>();
+    let confirmSignal: AbortSignal | undefined;
+    const changed = jest.fn();
+    mockGet.mockResolvedValueOnce({ draft: source });
+    mockConfirm.mockImplementationOnce(async (options) => {
+      confirmSignal = options.signal;
+      const next = await pendingConfirm.promise;
+      const reconcile = options.dependencies?.reconcile;
+      if (reconcile === undefined) {
+        throw new Error('Expected injected confirm dependencies.');
+      }
+      await reconcile({
+        tripId: TRIP_A,
+        previousDraft: source,
+        nextDraft: confirmed,
+      });
+      return next;
+    });
+    const rendered = await render(
+      <AIActionDraftCardController
+        draft={source}
+        onDraftChanged={changed}
+        tripId={TRIP_A}
+      />,
+    );
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Confirm this action' }),
+    );
+    expect(confirmSignal?.aborted).toBe(false);
+
+    await rendered.rerender(
+      <AIActionDraftCardController
+        draft={source}
+        interactionDisabled
+        onDraftChanged={changed}
+        tripId={TRIP_A}
+      />,
+    );
+
+    expect(confirmSignal?.aborted).toBe(true);
+    expect(screen.queryByRole('button', { name: 'Confirm' })).toBeNull();
+    expect(
+      screen.getByRole('button', { name: 'Check status' }).props
+        .accessibilityState,
+    ).toMatchObject({ busy: false, disabled: true });
+    expect(screen.getByText(/draft actions became unavailable/i)).toBeTruthy();
+
+    await act(async () => {
+      pendingConfirm.resolve(createConfirmAmbiguityState(confirmed));
+      await pendingConfirm.promise;
+    });
+    expect(changed).not.toHaveBeenCalled();
+    expect(mockReconcile).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Draft status: Ready')).toBeTruthy();
+
+    await rendered.rerender(
+      <AIActionDraftCardController
+        draft={source}
+        onDraftChanged={changed}
+        tripId={TRIP_A}
+      />,
+    );
+    expect(
+      screen.getByRole('button', { name: 'Check status' }).props
+        .accessibilityState,
+    ).toMatchObject({ busy: false, disabled: false });
   });
 
   it('aborts resource A and ignores its late completion after switching to B', async () => {

--- a/mobile/src/features/chat/ai/__tests__/ActionDraftCard.test.tsx
+++ b/mobile/src/features/chat/ai/__tests__/ActionDraftCard.test.tsx
@@ -1,0 +1,693 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+} from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
+import { focusAccessibilityNode } from '../accessibilityFocus';
+import { ActionDraftCard, type ActionDraftCardProps } from '../components/ActionDraftCard';
+import type { AIActionDraftStatus } from '../drafts';
+import { makeDraftFixture as makeDraft } from '../__fixtures__/drafts';
+
+jest.mock('../accessibilityFocus', () => ({
+  focusAccessibilityNode: jest.fn(),
+}));
+
+const mockFocusAccessibilityNode = jest.mocked(focusAccessibilityNode);
+
+const NOW_MS = Date.parse('2026-08-10T00:00:00.000Z');
+
+function callbacks() {
+  return {
+    onPatch: jest.fn(async () => undefined),
+    onConfirm: jest.fn(async () => undefined),
+    onCancel: jest.fn(async () => undefined),
+    onCheckStatus: jest.fn(async () => undefined),
+  };
+}
+
+async function renderCard(
+  draft = makeDraft(),
+  overrides: Partial<ActionDraftCardProps> = {},
+) {
+  const handlers = callbacks();
+  await render(
+    <ActionDraftCard
+      draft={draft}
+      nowMs={NOW_MS}
+      {...handlers}
+      {...overrides}
+    />,
+  );
+  return handlers;
+}
+
+const STATUS_LABEL: Readonly<Record<AIActionDraftStatus, string>> = {
+  NEEDS_INFO: 'Needs info',
+  READY: 'Ready',
+  CONFIRMED: 'Confirmed',
+  CANCELLED: 'Cancelled',
+  EXPIRED: 'Expired',
+  FAILED: 'Failed',
+};
+
+describe('AI action draft card status shell', () => {
+  it.each([
+    'NEEDS_INFO',
+    'READY',
+    'CONFIRMED',
+    'CANCELLED',
+    'EXPIRED',
+    'FAILED',
+  ] as const)('renders the complete %s state', async (status) => {
+    const isActive = status === 'READY' || status === 'NEEDS_INFO';
+    await renderCard(
+      makeDraft({
+        status,
+        can_confirm: status === 'READY',
+        can_cancel: isActive,
+        can_edit: status === 'NEEDS_INFO',
+        missing_fields:
+          status === 'NEEDS_INFO'
+            ? [{ name: 'title', label: 'Title', required: true }]
+            : [],
+        result: status === 'CONFIRMED' ? { expense_id: 'expense-1' } : {},
+        error_code: status === 'FAILED' ? 'AI_DRAFT_STALE' : '',
+        error_detail: status === 'FAILED' ? 'The target changed.' : '',
+      }),
+    );
+    expect(
+      screen.getByLabelText(`Draft status: ${STATUS_LABEL[status]}`),
+    ).toBeTruthy();
+  });
+
+  it('renders unknown actions through generic summary/preview and keeps server actions', async () => {
+    await renderCard(
+      makeDraft({
+        action_type: 'future.teleport.create',
+        required_confirmation: 'FUTURE_AUTHORITY',
+        display: { title: 'Teleport everyone', kicker: 'Future action' },
+        summary: 'Move everyone to Mars',
+        preview: { destination: { planet: 'Mars' }, seats: 4 },
+      }),
+    );
+    expect(screen.getByTestId('ai-generic-draft-details')).toBeTruthy();
+    expect(screen.getByText('Move everyone to Mars')).toBeTruthy();
+    expect(screen.getByText('{planet: Mars}')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
+  });
+
+  it('shows controls solely from can_confirm/can_cancel/can_edit', async () => {
+    await renderCard(
+      makeDraft({
+        status: 'CANCELLED',
+        can_confirm: true,
+        can_cancel: false,
+        can_edit: true,
+        missing_fields: [{ name: 'title', label: 'Title' }],
+      }),
+    );
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Edit draft' })).toBeTruthy();
+  });
+
+  it('reflects an expiry race locally while retaining disabled server-authorized controls', async () => {
+    await renderCard(
+      makeDraft({
+        status: 'READY',
+        can_confirm: true,
+        can_cancel: true,
+        expires_at: '2026-08-10T00:00:00.000Z',
+      }),
+    );
+    expect(screen.getByLabelText('Draft status: Expired')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Confirm' }).props.accessibilityState.disabled).toBe(
+      true,
+    );
+    expect(screen.getByRole('button', { name: 'Cancel' }).props.accessibilityState.disabled).toBe(
+      true,
+    );
+  });
+
+  it('updates the visible expiry as time passes without a refetch', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW_MS);
+    let unmount: (() => void | Promise<void>) | null = null;
+    try {
+      const rendered = await render(
+        <ActionDraftCard
+          draft={makeDraft({
+            expires_at: '2026-08-10T00:00:01.000Z',
+          })}
+          {...callbacks()}
+        />,
+      );
+      unmount = rendered.unmount;
+      expect(screen.getByText('Expires in 1s')).toBeTruthy();
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(1_000);
+      });
+      expect(screen.getByLabelText('Draft status: Expired')).toBeTruthy();
+      expect(screen.getByTestId('ai-draft-expiry').props.children).toBe('Expired');
+    } finally {
+      await unmount?.();
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('AI action draft explicit mutation controls', () => {
+  it('keeps server-authorized controls visible but disables every mutation entry while interaction is disabled', async () => {
+    const draft = makeDraft({
+      status: 'NEEDS_INFO',
+      can_confirm: true,
+      can_cancel: true,
+      can_edit: true,
+      missing_fields: [{ name: 'title', label: 'Title' }],
+    });
+    const handlers = await renderCard(draft, { interactionDisabled: true });
+
+    for (const label of ['Edit draft', 'Cancel', 'Confirm']) {
+      const control = screen.getByRole('button', { name: label });
+      expect(control.props.accessibilityState.disabled).toBe(true);
+      await fireEvent.press(control);
+    }
+    expect(screen.queryByTestId('ai-draft-confirm-modal')).toBeNull();
+    expect(screen.queryByTestId('ai-draft-cancel-modal')).toBeNull();
+    expect(screen.queryByLabelText('Title')).toBeNull();
+    expect(handlers.onPatch).not.toHaveBeenCalled();
+    expect(handlers.onConfirm).not.toHaveBeenCalled();
+    expect(handlers.onCancel).not.toHaveBeenCalled();
+  });
+
+  it('keeps Check status visible but inert while interaction is disabled', async () => {
+    const handlers = await renderCard(makeDraft(), {
+      confirmOutcomeUnknown: true,
+      interactionDisabled: true,
+    });
+    const check = screen.getByRole('button', { name: 'Check status' });
+    expect(check.props.accessibilityState.disabled).toBe(true);
+    await fireEvent.press(check);
+    expect(handlers.onCheckStatus).not.toHaveBeenCalled();
+  });
+
+  it('requires a restatement before calling confirm', async () => {
+    const handlers = await renderCard();
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    expect(handlers.onConfirm).not.toHaveBeenCalled();
+    const modal = screen.getByTestId('ai-draft-confirm-modal');
+    expect(modal.props.presentationStyle).toBe('formSheet');
+    expect(screen.getByTestId('ai-draft-confirm-modal-content').props.accessibilityViewIsModal).toBe(
+      true,
+    );
+    expect(screen.getByText(/Create expense “Dinner” for 1,200,000 VND/)).toBeTruthy();
+    expect(screen.getByText('The server requires an active trip captain.')).toBeTruthy();
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Confirm this action' }),
+    );
+    expect(handlers.onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismisses the native confirmation review without executing it', async () => {
+    const handlers = await renderCard();
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    const modal = screen.getByTestId('ai-draft-confirm-modal');
+    await act(async () => {
+      modal.props.onRequestClose();
+    });
+    expect(screen.queryByTestId('ai-draft-confirm-modal')).toBeNull();
+    expect(handlers.onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('moves VoiceOver focus into the modal and returns it to the trigger on close', async () => {
+    jest.useFakeTimers();
+    try {
+      mockFocusAccessibilityNode.mockClear();
+      await renderCard();
+      await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+      const modal = screen.getByTestId('ai-draft-confirm-modal');
+      await act(async () => {
+        modal.props.onShow();
+      });
+      expect(mockFocusAccessibilityNode).toHaveBeenCalledTimes(1);
+      await fireEvent.press(
+        screen.getByRole('button', { name: 'Back to review' }),
+      );
+      await act(async () => {
+        modal.props.onDismiss();
+        jest.runOnlyPendingTimers();
+      });
+      expect(mockFocusAccessibilityNode).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('returns VoiceOver focus exactly once to a surviving status target when a fast terminal update removes the trigger', async () => {
+    jest.useFakeTimers();
+    let unmount: (() => void | Promise<void>) | null = null;
+    try {
+      mockFocusAccessibilityNode.mockClear();
+      const source = makeDraft();
+      const handlers = callbacks();
+      const rendered = await render(
+        <ActionDraftCard draft={source} nowMs={NOW_MS} {...handlers} />,
+      );
+      unmount = rendered.unmount;
+      await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+      const modal = screen.getByTestId('ai-draft-confirm-modal');
+      await act(async () => {
+        modal.props.onShow();
+      });
+      await fireEvent.press(
+        screen.getByRole('button', { name: 'Confirm this action' }),
+      );
+      await rendered.rerender(
+        <ActionDraftCard
+          draft={makeDraft({
+            ...source,
+            status: 'CONFIRMED',
+            can_confirm: false,
+            can_cancel: false,
+            can_edit: false,
+          })}
+          nowMs={NOW_MS}
+          {...handlers}
+        />,
+      );
+      await act(async () => {
+        modal.props.onDismiss();
+        jest.runOnlyPendingTimers();
+      });
+
+      expect(mockFocusAccessibilityNode).toHaveBeenCalledTimes(2);
+      expect(mockFocusAccessibilityNode.mock.calls[1]?.[0]).not.toBeNull();
+    } finally {
+      await unmount?.();
+      await act(async () => {
+        jest.runOnlyPendingTimers();
+      });
+      jest.useRealTimers();
+    }
+  });
+
+  it('moves focus to stable status when terminal state arrives after modal dismissal focused a disappearing trigger', async () => {
+    jest.useFakeTimers();
+    try {
+      mockFocusAccessibilityNode.mockClear();
+      const source = makeDraft();
+      const handlers = callbacks();
+      const rendered = await render(
+        <ActionDraftCard draft={source} nowMs={NOW_MS} {...handlers} />,
+      );
+      await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+      const modal = screen.getByTestId('ai-draft-confirm-modal');
+      await act(async () => {
+        modal.props.onShow();
+      });
+      await fireEvent.press(
+        screen.getByRole('button', { name: 'Confirm this action' }),
+      );
+      await act(async () => {
+        modal.props.onDismiss();
+        jest.runOnlyPendingTimers();
+      });
+      expect(mockFocusAccessibilityNode).toHaveBeenCalledTimes(2);
+
+      await rendered.rerender(
+        <ActionDraftCard
+          draft={makeDraft({
+            ...source,
+            status: 'CONFIRMED',
+            can_confirm: false,
+            can_cancel: false,
+            can_edit: false,
+          })}
+          nowMs={NOW_MS}
+          {...handlers}
+        />,
+      );
+      await act(async () => {
+        jest.runOnlyPendingTimers();
+      });
+
+      expect(mockFocusAccessibilityNode).toHaveBeenCalledTimes(3);
+      expect(mockFocusAccessibilityNode.mock.calls[2]?.[0]).not.toBeNull();
+      await rendered.unmount();
+    } finally {
+      await act(async () => {
+        jest.runOnlyPendingTimers();
+      });
+      jest.useRealTimers();
+    }
+  });
+
+  it('cleans a pending modal focus return when the card unmounts', async () => {
+    jest.useFakeTimers();
+    try {
+      mockFocusAccessibilityNode.mockClear();
+      const rendered = await render(
+        <ActionDraftCard draft={makeDraft()} nowMs={NOW_MS} {...callbacks()} />,
+      );
+      await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+      const modal = screen.getByTestId('ai-draft-confirm-modal');
+      await act(async () => {
+        modal.props.onShow();
+      });
+      await fireEvent.press(
+        screen.getByRole('button', { name: 'Back to review' }),
+      );
+      await rendered.unmount();
+      await act(async () => {
+        jest.runOnlyPendingTimers();
+      });
+      expect(mockFocusAccessibilityNode).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('locks the explicit confirm callback against rapid duplicate presses', async () => {
+    let release: () => void = () => undefined;
+    const onConfirm = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        }),
+    );
+    await renderCard(makeDraft(), { onConfirm });
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    const explicit = screen.getByRole('button', { name: 'Confirm this action' });
+    await fireEvent.press(explicit);
+    await fireEvent.press(explicit);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    release();
+    await act(async () => Promise.resolve());
+  });
+
+  it('does not let stale action cleanup release the lock owned by a newer source action', async () => {
+    jest.useFakeTimers();
+    let releaseOld: () => void = () => undefined;
+    let releaseNew: () => void = () => undefined;
+    let oldOperation = Promise.resolve();
+    let newOperation = Promise.resolve();
+    const onCancel = jest
+      .fn<Promise<void>, Parameters<ActionDraftCardProps['onCancel']>>()
+      .mockImplementationOnce(
+        () => {
+          oldOperation = new Promise<void>((resolve) => {
+            releaseOld = resolve;
+          });
+          return oldOperation;
+        },
+      )
+      .mockImplementationOnce(
+        () => {
+          newOperation = new Promise<void>((resolve) => {
+            releaseNew = resolve;
+          });
+          return newOperation;
+        },
+      );
+    const source = makeDraft();
+    const rendered = await render(
+      <ActionDraftCard
+        draft={source}
+        nowMs={NOW_MS}
+        {...callbacks()}
+        onCancel={onCancel}
+      />,
+    );
+    try {
+      await fireEvent.press(screen.getByRole('button', { name: 'Cancel' }));
+      await fireEvent.press(
+        screen.getByRole('button', { name: 'Cancel this draft' }),
+      );
+
+      await rendered.rerender(
+        <ActionDraftCard
+          draft={makeDraft({
+            ...source,
+            updated_at: '2026-08-10T00:01:00.000Z',
+          })}
+          nowMs={NOW_MS}
+          {...callbacks()}
+          onCancel={onCancel}
+        />,
+      );
+      await act(async () => Promise.resolve());
+      await fireEvent.press(screen.getByRole('button', { name: 'Cancel' }));
+      const currentAction = screen.getByRole('button', {
+        name: 'Cancel this draft',
+      });
+      await fireEvent.press(currentAction);
+      expect(onCancel).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        releaseOld();
+        await oldOperation;
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      await fireEvent.press(screen.getByRole('button', { name: 'Cancel' }));
+      await fireEvent.press(
+        screen.getByRole('button', { name: 'Cancel this draft' }),
+      );
+      expect(onCancel).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        releaseNew();
+        await newOperation;
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    } finally {
+      await rendered.unmount();
+      await act(async () => {
+        jest.runOnlyPendingTimers();
+      });
+      jest.useRealTimers();
+    }
+  });
+
+  it('disables an already-open explicit review when a Retry-After deadline arrives', async () => {
+    const handlers = callbacks();
+    const draft = makeDraft();
+    const rendered = await render(
+      <ActionDraftCard draft={draft} nowMs={NOW_MS} {...handlers} />,
+    );
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    await rendered.rerender(
+      <ActionDraftCard
+        confirmRetryAtMs={NOW_MS + 30_000}
+        draft={draft}
+        nowMs={NOW_MS}
+        {...handlers}
+      />,
+    );
+    expect(
+      screen.getByRole('button', { name: 'Confirm this action' }).props
+        .accessibilityState.disabled,
+    ).toBe(true);
+    expect(
+      screen.getByText(
+        'Confirmation available in 30s. Close this review and wait before confirming.',
+      ),
+    ).toBeTruthy();
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Confirm this action' }),
+    );
+    expect(handlers.onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('requires a separate cancel confirmation', async () => {
+    const handlers = await renderCard();
+    await fireEvent.press(screen.getByRole('button', { name: 'Cancel' }));
+    expect(handlers.onCancel).not.toHaveBeenCalled();
+    expect(screen.getByTestId('ai-draft-cancel-modal').props.presentationStyle).toBe(
+      'formSheet',
+    );
+    expect(screen.getByTestId('ai-draft-cancel-modal-content').props.accessibilityViewIsModal).toBe(
+      true,
+    );
+    expect(screen.getByText(/will not change trip data/)).toBeTruthy();
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Cancel this draft' }),
+    );
+    expect(handlers.onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('unknown confirmation state offers Check status and no Retry confirm', async () => {
+    const handlers = await renderCard(makeDraft(), {
+      confirmOutcomeUnknown: true,
+    });
+    expect(screen.queryByRole('button', { name: 'Confirm' })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Retry confirm/ })).toBeNull();
+    await fireEvent.press(screen.getByRole('button', { name: 'Check status' }));
+    expect(handlers.onCheckStatus).toHaveBeenCalledTimes(1);
+    expect(handlers.onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('closes an open confirm review when the outcome becomes unknown', async () => {
+    const handlers = callbacks();
+    const draft = makeDraft();
+    const rendered = await render(
+      <ActionDraftCard draft={draft} nowMs={NOW_MS} {...handlers} />,
+    );
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    expect(screen.getByRole('button', { name: 'Confirm this action' })).toBeTruthy();
+    await rendered.rerender(
+      <ActionDraftCard
+        confirmOutcomeUnknown
+        draft={draft}
+        nowMs={NOW_MS}
+        {...handlers}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'Confirm' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Confirm this action' })).toBeNull();
+    expect(screen.getAllByRole('button', { name: 'Check status' })).toHaveLength(1);
+  });
+
+  it('sends only fields the user edited from the inline editor', async () => {
+    const draft = makeDraft({
+      status: 'NEEDS_INFO',
+      can_confirm: false,
+      can_cancel: true,
+      can_edit: true,
+      missing_fields: [
+        { name: 'title', label: 'Title' },
+        { name: 'total_amount', label: 'Amount', type: 'money' },
+      ],
+    });
+    const handlers = await renderCard(draft);
+    await fireEvent.press(screen.getByRole('button', { name: 'Edit draft' }));
+    await fireEvent.changeText(screen.getByLabelText('Title'), 'Lunch');
+    await fireEvent.press(
+      screen.getByRole('button', { name: 'Save draft information' }),
+    );
+    expect(handlers.onPatch).toHaveBeenCalledWith(
+      draft,
+      { title: 'Lunch' },
+      {
+        fields: draft.missing_fields,
+        values: { title: 'Lunch' },
+      },
+    );
+  });
+});
+
+describe('specialized draft renderers at narrow width and Dynamic Type', () => {
+  it('renders timeline section/date/time/type/location/assignee without ellipsis', async () => {
+    const date = '2026-12-31 — New Year’s Eve';
+    await renderCard(
+      makeDraft({
+        action_type: 'timeline.activity.create',
+        display: { title: 'A deliberately long museum visit', kicker: 'Activity' },
+        preview: {
+          section_label: 'Day 12 — Historic district',
+          section_date: date,
+          data: {
+            title: 'A deliberately long museum visit',
+            start_time: '08:30',
+            end_time: '11:45',
+            system_type: 'SIGHTSEEING',
+            location_label: 'The exceptionally long National History Museum address',
+            assignee_scope: 'EVERYONE',
+          },
+        },
+      }),
+    );
+    const dateText = screen.getByText(date);
+    expect(dateText.props.numberOfLines).toBeUndefined();
+    expect(dateText.props.ellipsizeMode).toBeUndefined();
+    expect(screen.getByText('08:30 – 11:45')).toBeTruthy();
+    expect(screen.getByText('Sightseeing')).toBeTruthy();
+    expect(screen.getByText('Whole group')).toBeTruthy();
+  });
+
+  it('renders full expense money/payer/participants/split with scalable wrapping styles', async () => {
+    const amount = '123,456,789,012,345.67';
+    await renderCard(
+      makeDraft({
+        display: {
+          title: 'Shared expedition dinner',
+          kicker: 'Expense',
+          hero: { kind: 'amount', value: amount, currency: 'VND' },
+        },
+        preview: {
+          payer_name: 'A payer with a very long display name',
+          participants: ['Lan', 'Minh', 'An', 'Binh'],
+          split_method: 'Exact amounts per participant',
+        },
+      }),
+    );
+    const amountText = screen.getByText(amount);
+    expect(amountText.props.numberOfLines).toBeUndefined();
+    expect(amountText.props.ellipsizeMode).toBeUndefined();
+    expect(amountText.props.allowFontScaling).toBeUndefined();
+    expect(StyleSheet.flatten(amountText.props.style)).toMatchObject({
+      flexShrink: 1,
+    });
+    expect(screen.getByText('A payer with a very long display name')).toBeTruthy();
+    expect(screen.getByText('[Lan, Minh, An, Binh]')).toBeTruthy();
+    expect(screen.getByText('Exact amounts per participant')).toBeTruthy();
+  });
+
+  it('states settlement and transfer consequences plainly', async () => {
+    const { rerender } = await render(
+      <ActionDraftCard
+        draft={makeDraft({
+          action_type: 'settlement.finalize',
+          display: { title: 'Finalize settlement', kicker: 'Settlement' },
+        })}
+        nowMs={NOW_MS}
+        {...callbacks()}
+      />,
+    );
+    expect(screen.getByText(/locks the current settlement calculation/)).toBeTruthy();
+    await rerender(
+      <ActionDraftCard
+        draft={makeDraft({
+          action_type: 'settlement.transfer.confirm_received',
+          display: {
+            title: 'Transfer',
+            kicker: 'Transfer',
+            hero: { kind: 'amount', value: '999999999999', currency: 'USD' },
+            meta: [
+              { label: 'From', value: 'Minh' },
+              { label: 'To', value: 'Lan' },
+            ],
+          },
+        })}
+        nowMs={NOW_MS}
+        {...callbacks()}
+      />,
+    );
+    expect(screen.getByText('Minh → Lan')).toBeTruthy();
+    expect(screen.getByText(/recipient is asserting.*received/)).toBeTruthy();
+  });
+
+  it('uses 100% card width, wrapping controls, 44pt targets, and explicit labels', async () => {
+    await renderCard();
+    expect(
+      StyleSheet.flatten(
+        screen.getByTestId(
+          'ai-action-draft-22222222-2222-4222-8222-222222222222',
+        ).props.style,
+      ),
+    ).toMatchObject({ width: '100%', minWidth: 0 });
+    expect(
+      StyleSheet.flatten(screen.getByTestId('ai-draft-actions').props.style),
+    ).toMatchObject({ flexWrap: 'wrap' });
+    for (const label of ['Confirm', 'Cancel']) {
+      expect(
+        StyleSheet.flatten(screen.getByRole('button', { name: label }).props.style),
+      ).toMatchObject({ minWidth: 44, minHeight: 44 });
+    }
+  });
+
+});

--- a/mobile/src/features/chat/ai/__tests__/ActionDraftCard.test.tsx
+++ b/mobile/src/features/chat/ai/__tests__/ActionDraftCard.test.tsx
@@ -3,6 +3,7 @@ import {
   fireEvent,
   render,
   screen,
+  within,
 } from '@testing-library/react-native';
 import { StyleSheet } from 'react-native';
 import { focusAccessibilityNode } from '../accessibilityFocus';
@@ -209,6 +210,240 @@ describe('AI action draft explicit mutation controls', () => {
       screen.getByRole('button', { name: 'Confirm this action' }),
     );
     expect(handlers.onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('restates timeline date, time, and location before explicit confirmation', async () => {
+    await renderCard(
+      makeDraft({
+        action_type: 'timeline.activity.create',
+        display: { title: 'QA sunset walk', kicker: 'Activity' },
+        preview: {
+          section_date: '2026-08-11',
+          data: {
+            title: 'QA sunset walk',
+            start_time: '18:00',
+            end_time: '20:00',
+            location_label: 'Da Nang',
+          },
+        },
+      }),
+    );
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    const restatement = screen.getByText(
+      'Create timeline activity “QA sunset walk”. Date: 2026-08-11. Time: 18:00 – 20:00. Location: Da Nang.',
+    );
+    expect(restatement.props.numberOfLines).toBeUndefined();
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  it('restates the authoritative target and resolved end-time-only update', async () => {
+    await renderCard(
+      makeDraft({
+        action_type: 'timeline.activity.update',
+        display: {
+          title: 'Old stop',
+          kicker: 'Update activity',
+          meta: [
+            { label: 'Target', value: 'Old stop' },
+            { label: 'Date', value: 'Day 1 · 2026-08-11' },
+            { label: 'Time', value: '08:00 – 10:00' },
+            { label: 'Location', value: 'Old Quarter' },
+          ],
+        },
+        preview: {
+          activity_id: '33333333-3333-4333-8333-333333333333',
+          data: { end_time: '10:00:00' },
+          target_title: 'Old stop',
+          section_label: 'Day 1',
+          section_date: '2026-08-11',
+          resolved_data: {
+            title: 'Old stop',
+            time_mode: 'TIME_RANGE',
+            start_time: '08:00:00',
+            end_time: '10:00:00',
+            location_label: 'Old Quarter',
+          },
+        },
+      }),
+    );
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    expect(
+      screen.getByText(
+        'Update timeline activity “Old stop”. Date: Day 1 · 2026-08-11. Time: 08:00 – 10:00. Location: Old Quarter.',
+      ),
+    ).toBeTruthy();
+  });
+
+  it('restates every allowlisted hidden timeline delta as inert text', async () => {
+    await renderCard(
+      makeDraft({
+        action_type: 'timeline.activity.create',
+        display: {
+          title: 'Hidden detail review',
+          kicker: 'Activity',
+          meta: [
+            { label: 'Date', value: 'Day 1 · 2026-08-11' },
+            { label: 'Time', value: '09:00' },
+            { label: 'Location', value: 'Not set' },
+            { label: 'Custom type', value: 'Photo walk' },
+            { label: 'Assignee', value: 'Lan Nguyen' },
+            { label: 'Booking reference', value: 'BK-42' },
+            { label: 'Contact name', value: 'Lan' },
+            { label: 'Contact phone', value: '+84 123' },
+            { label: 'External link', value: 'https://example.com/booking' },
+            { label: 'Location note', value: 'Use the east entrance' },
+            { label: 'Meeting point', value: 'Hotel lobby' },
+            { label: 'Note', value: 'Bring water' },
+            { label: 'Reminders', value: '1 day before · 30 minutes before' },
+            { label: 'Internal precondition', value: 'must-not-render' },
+          ],
+        },
+        preview: {
+          section_label: 'Day 1',
+          section_date: '2026-08-11',
+          data: { custom_type_id: 'hidden-uuid' },
+          resolved_data: {
+            title: 'Hidden detail review',
+            custom_type_label: 'Photo walk',
+            time_mode: 'AT_TIME',
+            start_time: '09:00:00',
+          },
+        },
+      }),
+    );
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    const modal = within(screen.getByTestId('ai-draft-confirm-modal-content'));
+    const restatement = modal.getByText(/Custom type: Photo walk\./);
+    expect(restatement).toBeTruthy();
+    expect(modal.getByText(/Assignee: Lan Nguyen\./)).toBeTruthy();
+    expect(modal.getByText(/Booking reference: BK-42\./)).toBeTruthy();
+    expect(modal.getByText(/Contact name: Lan\./)).toBeTruthy();
+    expect(modal.getByText(/Contact phone: \+84 123\./)).toBeTruthy();
+    expect(
+      modal.getByText(/External link: https:\/\/example\.com\/booking\./),
+    ).toBeTruthy();
+    expect(modal.getByText(/Location note: Use the east entrance\./)).toBeTruthy();
+    expect(modal.getByText(/Meeting point: Hotel lobby\./)).toBeTruthy();
+    expect(modal.getByText(/Note: Bring water\./)).toBeTruthy();
+    expect(
+      modal.getByText(/Reminders: 1 day before · 30 minutes before\./),
+    ).toBeTruthy();
+    expect(modal.queryByText(/must-not-render/)).toBeNull();
+    expect(modal.queryByText(/hidden-uuid/)).toBeNull();
+    expect(modal.queryByRole('link')).toBeNull();
+  });
+
+  it('restates explicit hidden clears while omitting missing deltas', async () => {
+    await renderCard(
+      makeDraft({
+        action_type: 'timeline.activity.update',
+        display: {
+          title: 'Clear hidden details',
+          kicker: 'Update activity',
+          meta: [
+            { label: 'Target', value: 'Clear hidden details' },
+            { label: 'Date', value: 'Day 1 · 2026-08-11' },
+            { label: 'Time', value: 'Flexible' },
+            { label: 'Location', value: 'Not set' },
+            { label: 'Contact name', value: 'Cleared' },
+            { label: 'External link', value: 'Cleared' },
+            { label: 'Note', value: 'Cleared' },
+            { label: 'Reminders', value: 'Cleared' },
+          ],
+        },
+        preview: {
+          target_title: 'Clear hidden details',
+          data: {
+            contact_name: '',
+            external_link: '',
+            note: '',
+            reminder_offsets_minutes: [],
+          },
+          resolved_data: {
+            title: 'Clear hidden details',
+            time_mode: 'FLEXIBLE',
+          },
+        },
+      }),
+    );
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    const modal = within(screen.getByTestId('ai-draft-confirm-modal-content'));
+    expect(modal.getByText(/Contact name: Cleared\./)).toBeTruthy();
+    expect(modal.getByText(/External link: Cleared\./)).toBeTruthy();
+    expect(modal.getByText(/Note: Cleared\./)).toBeTruthy();
+    expect(modal.getByText(/Reminders: Cleared\./)).toBeTruthy();
+    expect(modal.queryByText(/Booking reference:/)).toBeNull();
+  });
+
+  it.each([
+    ['preserved', 'Riverside Cafe'],
+    ['cleared', 'Cleared'],
+    ['not set', 'Not set'],
+  ] as const)('restates a %s timeline location explicitly', async (_, location) => {
+    await renderCard(
+      makeDraft({
+        action_type: 'timeline.activity.update',
+        display: {
+          title: 'Cafe stop',
+          kicker: 'Update activity',
+          meta: [
+            { label: 'Target', value: 'Cafe stop' },
+            { label: 'Date', value: 'Day 1 · 2026-08-11' },
+            { label: 'Time', value: 'Flexible' },
+            { label: 'Location', value: location },
+          ],
+        },
+        preview: {
+          data: location === 'Cleared' ? { location_label: '' } : { note: 'Note' },
+          target_title: 'Cafe stop',
+          resolved_data: {
+            title: 'Cafe stop',
+            time_mode: 'FLEXIBLE',
+            location_label:
+              location === 'Riverside Cafe' ? 'Riverside Cafe' : '',
+          },
+        },
+      }),
+    );
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    expect(screen.getByText(new RegExp(`Location: ${location}\\.`))).toBeTruthy();
+  });
+
+  it('keeps malformed timeline context inert and does not bypass confirmation', async () => {
+    const handlers = await renderCard(
+      makeDraft({
+        action_type: 'timeline.activity.update',
+        display: {
+          title: 'Safe target',
+          kicker: 'Update activity',
+          meta: [
+            { label: 'Target', value: { href: 'https://malicious.example' } },
+            { label: 'Date', value: ['not', 'trusted'] },
+            { label: 'Time', value: { onPress: 'confirm' } },
+            { label: 'Location', value: null },
+          ],
+        },
+        preview: {
+          target_title: { href: 'https://malicious.example' },
+          resolved_data: {
+            title: { onPress: 'confirm' },
+            start_time: ['08:00'],
+            place: { title: { href: 'https://malicious.example' } },
+          },
+        },
+      }),
+    );
+
+    await fireEvent.press(screen.getByRole('button', { name: 'Confirm' }));
+    expect(screen.getByText('Update timeline activity “Safe target”.')).toBeTruthy();
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.queryByText(/malicious\.example/)).toBeNull();
+    expect(handlers.onConfirm).not.toHaveBeenCalled();
   });
 
   it('dismisses the native confirmation review without executing it', async () => {
@@ -607,6 +842,89 @@ describe('specialized draft renderers at narrow width and Dynamic Type', () => {
     expect(screen.getByText('08:30 – 11:45')).toBeTruthy();
     expect(screen.getByText('Sightseeing')).toBeTruthy();
     expect(screen.getByText('Whole group')).toBeTruthy();
+  });
+
+  it('never renders a raw timeline section UUID as user-facing context', async () => {
+    const sectionId = '77777777-7777-4777-8777-777777777777';
+    await renderCard(
+      makeDraft({
+        action_type: 'timeline.activity.create',
+        display: { title: 'Private section reference', kicker: 'Activity' },
+        preview: {
+          section_id: sectionId,
+          resolved_data: {
+            title: 'Private section reference',
+            time_mode: 'FLEXIBLE',
+          },
+        },
+      }),
+    );
+
+    expect(screen.queryByText(sectionId)).toBeNull();
+  });
+
+  it('omits a blank current timeline external link', async () => {
+    await renderCard(
+      makeDraft({
+        action_type: 'timeline.activity.update',
+        display: { title: 'No booking link', kicker: 'Update activity' },
+        preview: {
+          resolved_data: {
+            title: 'No booking link',
+            time_mode: 'FLEXIBLE',
+            external_link: '',
+          },
+        },
+      }),
+    );
+
+    expect(screen.queryByText('External link')).toBeNull();
+    expect(screen.queryByText(/^Link \(text only\):/)).toBeNull();
+  });
+
+  it('renders an explicit external-link clear only through display metadata', async () => {
+    await renderCard(
+      makeDraft({
+        action_type: 'timeline.activity.update',
+        display: {
+          title: 'Clear booking link',
+          kicker: 'Update activity',
+          meta: [{ label: 'External link', value: 'Cleared' }],
+        },
+        preview: {
+          data: { external_link: '' },
+          resolved_data: {
+            title: 'Clear booking link',
+            time_mode: 'FLEXIBLE',
+            external_link: '',
+          },
+        },
+      }),
+    );
+
+    expect(screen.getAllByText('External link')).toHaveLength(1);
+    expect(screen.getAllByText('Cleared')).toHaveLength(1);
+    expect(screen.queryByText(/^Link \(text only\):/)).toBeNull();
+  });
+
+  it('keeps a non-empty external link as unique inert text', async () => {
+    const externalLink = 'https://example.com/reservation';
+    await renderCard(
+      makeDraft({
+        action_type: 'timeline.activity.create',
+        display: { title: 'Booking link', kicker: 'Activity' },
+        preview: {
+          resolved_data: {
+            title: 'Booking link',
+            time_mode: 'FLEXIBLE',
+            external_link: externalLink,
+          },
+        },
+      }),
+    );
+
+    expect(screen.getByText(`Link (text only): ${externalLink}`)).toBeTruthy();
+    expect(screen.queryByRole('link')).toBeNull();
   });
 
   it('renders full expense money/payer/participants/split with scalable wrapping styles', async () => {

--- a/mobile/src/features/chat/ai/__tests__/accessibilityFocus.test.ts
+++ b/mobile/src/features/chat/ai/__tests__/accessibilityFocus.test.ts
@@ -1,25 +1,20 @@
+import type { HostInstance } from 'react-native';
 import { focusAccessibilityNode } from '../accessibilityFocus';
 
 describe('AI modal accessibility focus helper', () => {
-  it('resolves the native node handle before requesting VoiceOver focus', () => {
-    const findNodeHandle = jest.fn(() => 42);
-    const setAccessibilityFocus = jest.fn();
+  it('requests focus on the mounted host instance', () => {
+    const node = {} as HostInstance;
+    const sendAccessibilityEvent = jest.fn();
     expect(
-      focusAccessibilityNode(7, {
-        findNodeHandle,
-        setAccessibilityFocus,
-      }),
+      focusAccessibilityNode(node, { sendAccessibilityEvent }),
     ).toBe(true);
-    expect(findNodeHandle).toHaveBeenCalledWith(7);
-    expect(setAccessibilityFocus).toHaveBeenCalledWith(42);
+    expect(sendAccessibilityEvent).toHaveBeenCalledWith(node, 'focus');
   });
 
-  it('does not request focus after the target or native handle unmounts', () => {
-    const findNodeHandle = jest.fn(() => null);
-    const setAccessibilityFocus = jest.fn();
-    const dependencies = { findNodeHandle, setAccessibilityFocus };
+  it('does not request focus after the target unmounts', () => {
+    const sendAccessibilityEvent = jest.fn();
+    const dependencies = { sendAccessibilityEvent };
     expect(focusAccessibilityNode(null, dependencies)).toBe(false);
-    expect(focusAccessibilityNode(7, dependencies)).toBe(false);
-    expect(setAccessibilityFocus).not.toHaveBeenCalled();
+    expect(sendAccessibilityEvent).not.toHaveBeenCalled();
   });
 });

--- a/mobile/src/features/chat/ai/__tests__/accessibilityFocus.test.ts
+++ b/mobile/src/features/chat/ai/__tests__/accessibilityFocus.test.ts
@@ -1,0 +1,25 @@
+import { focusAccessibilityNode } from '../accessibilityFocus';
+
+describe('AI modal accessibility focus helper', () => {
+  it('resolves the native node handle before requesting VoiceOver focus', () => {
+    const findNodeHandle = jest.fn(() => 42);
+    const setAccessibilityFocus = jest.fn();
+    expect(
+      focusAccessibilityNode(7, {
+        findNodeHandle,
+        setAccessibilityFocus,
+      }),
+    ).toBe(true);
+    expect(findNodeHandle).toHaveBeenCalledWith(7);
+    expect(setAccessibilityFocus).toHaveBeenCalledWith(42);
+  });
+
+  it('does not request focus after the target or native handle unmounts', () => {
+    const findNodeHandle = jest.fn(() => null);
+    const setAccessibilityFocus = jest.fn();
+    const dependencies = { findNodeHandle, setAccessibilityFocus };
+    expect(focusAccessibilityNode(null, dependencies)).toBe(false);
+    expect(focusAccessibilityNode(7, dependencies)).toBe(false);
+    expect(setAccessibilityFocus).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/features/chat/ai/__tests__/api.test.ts
+++ b/mobile/src/features/chat/ai/__tests__/api.test.ts
@@ -1,0 +1,248 @@
+import {
+  AxiosError,
+  AxiosHeaders,
+  type AxiosResponse,
+  type InternalAxiosRequestConfig,
+} from 'axios';
+
+jest.mock('@/shared/api/client', () => ({
+  apiClient: {
+    get: jest.fn(),
+    patch: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { apiClient } from '@/shared/api/client';
+// eslint-disable-next-line import/first
+import {
+  cancelAIActionDraft,
+  confirmAIActionDraft,
+  getAIActionDraft,
+  isAmbiguousConfirmFailure,
+  normalizeAIActionDraftApiError,
+  parseRetryAfterMs,
+  patchAIActionDraft,
+} from '../api';
+// eslint-disable-next-line import/first
+import { makeRawDraftFixture as makeRawDraft } from '../__fixtures__/drafts';
+
+const mockGet = jest.mocked(apiClient.get);
+const mockPatch = jest.mocked(apiClient.patch);
+const mockPost = jest.mocked(apiClient.post);
+
+function config(): InternalAxiosRequestConfig {
+  return { headers: new AxiosHeaders() };
+}
+
+function response<T>(data: T, status: number = 200): AxiosResponse<T> {
+  return {
+    data,
+    status,
+    statusText: '',
+    headers: {},
+    config: config(),
+  };
+}
+
+function axiosError(
+  status: number,
+  data: unknown,
+  headers: Record<string, string> = {},
+): AxiosError {
+  const requestConfig = config();
+  return new AxiosError('Request failed', 'ERR_BAD_RESPONSE', requestConfig, {}, {
+    status,
+    data,
+    headers: new AxiosHeaders(headers),
+    statusText: 'Request failed',
+    config: requestConfig,
+  });
+}
+
+describe('AI action draft direct-Django API', () => {
+  const tripId = '11111111-1111-4111-8111-111111111111';
+  const draftId = '22222222-2222-4222-8222-222222222222';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses canonical UUID GET/PATCH/confirm/cancel routes and PATCH {payload}', async () => {
+    const envelope = { draft: makeRawDraft() };
+    mockGet.mockResolvedValueOnce(response(envelope));
+    mockPatch.mockResolvedValueOnce(response(envelope));
+    mockPost
+      .mockResolvedValueOnce(response(envelope))
+      .mockResolvedValueOnce(response(envelope));
+
+    await getAIActionDraft(tripId, draftId);
+    await patchAIActionDraft(tripId, draftId, { total_amount: '500000' });
+    await confirmAIActionDraft(tripId, draftId);
+    await cancelAIActionDraft(tripId, draftId);
+
+    const path = `/trips/${tripId}/ai/action-drafts/${draftId}`;
+    expect(mockGet).toHaveBeenCalledWith(path, { signal: undefined });
+    expect(mockPatch).toHaveBeenCalledWith(
+      path,
+      { payload: { total_amount: '500000' } },
+      { signal: undefined },
+    );
+    expect(mockPost).toHaveBeenNthCalledWith(
+      1,
+      `${path}/confirm`,
+      undefined,
+      { signal: undefined },
+    );
+    expect(mockPost).toHaveBeenNthCalledWith(
+      2,
+      `${path}/cancel`,
+      undefined,
+      { signal: undefined },
+    );
+  });
+
+  it.each([
+    ['spaces', 'trip 1', draftId],
+    ['non-UUID text', tripId, 'draft'],
+  ])('fails closed for non-canonical path input: %s', async (_label, trip, draft) => {
+    await expect(getAIActionDraft(trip, draft)).rejects.toThrow('canonical UUID');
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('canonicalizes uppercase and surrounding whitespace before issuing a request', async () => {
+    mockGet.mockResolvedValueOnce(response({ draft: makeRawDraft() }));
+    await getAIActionDraft(` ${tripId.toUpperCase()} `, ` ${draftId.toUpperCase()} `);
+    expect(mockGet).toHaveBeenCalledWith(
+      `/trips/${tripId}/ai/action-drafts/${draftId}`,
+      { signal: undefined },
+    );
+  });
+
+  it('rejects malformed success payloads instead of trusting Axios generics', async () => {
+    mockGet.mockResolvedValueOnce(response({ draft: { id: 'only-an-id' } }));
+    await expect(getAIActionDraft(tripId, draftId)).rejects.toThrow(
+      'invalid response',
+    );
+  });
+
+  it.each([
+    ['GET', () => getAIActionDraft(tripId, draftId), () => mockGet.mockResolvedValueOnce(
+      response({ draft: makeRawDraft({ id: '33333333-3333-4333-8333-333333333333' }) }),
+    )],
+    ['PATCH', () => patchAIActionDraft(tripId, draftId, { title: 'Lunch' }), () =>
+      mockPatch.mockResolvedValueOnce(
+        response({ draft: makeRawDraft({ id: '33333333-3333-4333-8333-333333333333' }) }),
+      )],
+    ['confirm', () => confirmAIActionDraft(tripId, draftId), () =>
+      mockPost.mockResolvedValueOnce(
+        response({ draft: makeRawDraft({ id: '33333333-3333-4333-8333-333333333333' }) }),
+      )],
+    ['cancel', () => cancelAIActionDraft(tripId, draftId), () =>
+      mockPost.mockResolvedValueOnce(
+        response({ draft: makeRawDraft({ id: '33333333-3333-4333-8333-333333333333' }) }),
+      )],
+  ] as const)(
+    'rejects a valid but mismatched draft id in a %s success envelope',
+    async (_operation, request, arrange) => {
+      arrange();
+      await expect(request()).rejects.toThrow('invalid response');
+    },
+  );
+
+  it('normalizes optional current draft, field errors, error code, and Retry-After', () => {
+    const failure = normalizeAIActionDraftApiError(
+      axiosError(
+        400,
+        {
+          detail: 'Field validation failed.',
+          error_code: 'FIELD_VALIDATION_FAILED',
+          field_errors: {
+            total_amount: 'Enter a positive amount.',
+            ignored_non_string: 9,
+          },
+          draft: makeRawDraft({ status: 'NEEDS_INFO', can_confirm: false }),
+        },
+        { 'Retry-After': '17' },
+      ),
+      'patch',
+    );
+    expect(failure.errorCode).toBe('FIELD_VALIDATION_FAILED');
+    expect(failure.fieldErrors).toEqual({
+      total_amount: 'Enter a positive amount.',
+    });
+    expect(failure.draft?.status).toBe('NEEDS_INFO');
+    expect(failure.retryAfterMs).toBeNull();
+  });
+
+  it('ignores malformed optional error drafts without losing the server detail', () => {
+    const failure = normalizeAIActionDraftApiError(
+      axiosError(409, {
+        detail: 'Draft changed.',
+        error_code: 'AI_DRAFT_STALE',
+        draft: { id: 'malformed' },
+      }),
+      'confirm',
+    );
+    expect(failure.draft).toBeNull();
+    expect(failure.message).toBe('Draft changed.');
+  });
+
+  it('ignores a valid error draft whose canonical id does not match the request', () => {
+    const failure = normalizeAIActionDraftApiError(
+      axiosError(409, {
+        detail: 'Draft changed.',
+        error_code: 'AI_DRAFT_STALE',
+        draft: makeRawDraft({
+          id: '33333333-3333-4333-8333-333333333333',
+          status: 'EXPIRED',
+        }),
+      }),
+      'patch',
+      Date.parse('2026-08-10T00:00:00.000Z'),
+      draftId,
+    );
+    expect(failure.draft).toBeNull();
+    expect(failure.message).toBe('Draft changed.');
+  });
+
+  it('names the 30/hour confirmation limit and parses Retry-After', () => {
+    const failure = normalizeAIActionDraftApiError(
+      axiosError(
+        429,
+        { detail: 'Request was throttled.', error_code: 'THROTTLED' },
+        { 'Retry-After': '30' },
+      ),
+      'confirm',
+    );
+    expect(failure.kind).toBe('throttled');
+    expect(failure.message).toContain('30 action confirmations per hour');
+    expect(failure.retryAfterMs).toBe(30_000);
+    expect(isAmbiguousConfirmFailure(failure)).toBe(true);
+  });
+
+  it('parses seconds and HTTP-date Retry-After while rejecting invalid values', () => {
+    expect(parseRetryAfterMs('12', 0)).toBe(12_000);
+    expect(parseRetryAfterMs('Thu, 01 Jan 1970 00:01:00 GMT', 0)).toBe(60_000);
+    expect(parseRetryAfterMs('0', 0)).toBeNull();
+    expect(parseRetryAfterMs('not-a-date', 0)).toBeNull();
+    expect(parseRetryAfterMs('9007199254741', 0)).toBeNull();
+    expect(
+      parseRetryAfterMs(
+        'Fri, 13 Sep 275760 00:00:00 GMT',
+        -8_640_000_000_000_000,
+      ),
+    ).toBeNull();
+  });
+
+  it.each([
+    [new AxiosError('timeout', 'ECONNABORTED'), true],
+    [axiosError(500, { detail: 'Server error.' }), true],
+    [axiosError(429, { detail: 'Throttled.' }), true],
+    [axiosError(409, { detail: 'Stale.' }), false],
+  ])('classifies confirm ambiguity without guessing (%#)', (error, ambiguous) => {
+    const failure = normalizeAIActionDraftApiError(error, 'confirm');
+    expect(isAmbiguousConfirmFailure(failure)).toBe(ambiguous);
+  });
+});

--- a/mobile/src/features/chat/ai/__tests__/confirmController.test.ts
+++ b/mobile/src/features/chat/ai/__tests__/confirmController.test.ts
@@ -1,0 +1,284 @@
+import type { AIActionDraftApiFailure } from '../api';
+import {
+  checkConfirmStatus,
+  confirmDraftAfterExplicitApproval,
+  createConfirmAmbiguityState,
+  type ConfirmControllerDependencies,
+} from '../confirmController';
+import type { AIActionDraft } from '../drafts';
+import { makeDraftFixture as makeDraft } from '../__fixtures__/drafts';
+
+function failure(
+  operation: 'confirm' | 'get',
+  overrides: Partial<AIActionDraftApiFailure> = {},
+): AIActionDraftApiFailure {
+  return {
+    kind: 'message',
+    message: 'Request failed.',
+    operation,
+    errorCode: null,
+    status: 409,
+    retryAfterMs: null,
+    fieldErrors: null,
+    draft: null,
+    ...overrides,
+  };
+}
+
+function dependencies(options: {
+  readonly confirmResult?: AIActionDraft;
+  readonly confirmError?: AIActionDraftApiFailure;
+  readonly getResult?: AIActionDraft;
+  readonly getError?: AIActionDraftApiFailure;
+}) {
+  const confirm = jest.fn(async () => {
+    if (options.confirmError !== undefined) {
+      throw new Error('confirm failed');
+    }
+    return { draft: options.confirmResult ?? makeDraft({ status: 'CONFIRMED' }) };
+  });
+  const get = jest.fn(async () => {
+    if (options.getError !== undefined) {
+      throw new Error('get failed');
+    }
+    return { draft: options.getResult ?? makeDraft() };
+  });
+  const reconcile = jest.fn(async () => undefined);
+  const normalizeError: ConfirmControllerDependencies['normalizeError'] = (
+    _error,
+    operation,
+  ) => {
+    if (operation === 'confirm') {
+      return options.confirmError ?? failure('confirm');
+    }
+    return options.getError ?? failure('get');
+  };
+  const value: ConfirmControllerDependencies = {
+    confirm,
+    get,
+    reconcile,
+    normalizeError,
+  };
+  return { value, confirm, get, reconcile };
+}
+
+describe('confirm ambiguity controller', () => {
+  it('confirms once and reconciles a newly CONFIRMED response', async () => {
+    const draft = makeDraft();
+    const deps = dependencies({
+      confirmResult: makeDraft({
+        status: 'CONFIRMED',
+        can_confirm: false,
+        can_cancel: false,
+      }),
+    });
+    const result = await confirmDraftAfterExplicitApproval({
+      tripId: 'trip-1',
+      state: createConfirmAmbiguityState(draft),
+      dependencies: deps.value,
+    });
+    expect(result.kind).toBe('confirmed');
+    expect(deps.confirm).toHaveBeenCalledTimes(1);
+    expect(deps.get).not.toHaveBeenCalled();
+    expect(deps.reconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it('after a timeout sends one POST, follows with GET CONFIRMED, and reconciles', async () => {
+    const deps = dependencies({
+      confirmError: failure('confirm', {
+        kind: 'network',
+        status: null,
+        message: 'Cannot reach the server.',
+      }),
+      getResult: makeDraft({
+        status: 'CONFIRMED',
+        can_confirm: false,
+        can_cancel: false,
+      }),
+    });
+    const result = await confirmDraftAfterExplicitApproval({
+      tripId: 'trip-1',
+      state: createConfirmAmbiguityState(makeDraft()),
+      dependencies: deps.value,
+    });
+    expect(result.kind).toBe('confirmed');
+    expect(deps.confirm).toHaveBeenCalledTimes(1);
+    expect(deps.get).toHaveBeenCalledTimes(1);
+    expect(deps.reconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['READY', 'ready_for_explicit_confirmation'],
+    ['CANCELLED', 'resolved'],
+    ['EXPIRED', 'resolved'],
+    ['FAILED', 'resolved'],
+    ['NEEDS_INFO', 'resolved'],
+  ] as const)(
+    'maps an ambiguous confirm followed by GET %s without a second POST',
+    async (status, kind) => {
+      const deps = dependencies({
+        confirmError: failure('confirm', { status: 500 }),
+        getResult: makeDraft({
+          status,
+          can_confirm: status === 'READY',
+          can_cancel: status === 'READY' || status === 'NEEDS_INFO',
+          can_edit: status === 'NEEDS_INFO',
+        }),
+      });
+      const result = await confirmDraftAfterExplicitApproval({
+        tripId: 'trip-1',
+        state: createConfirmAmbiguityState(makeDraft()),
+        dependencies: deps.value,
+      });
+      expect(result.kind).toBe(kind);
+      expect(deps.confirm).toHaveBeenCalledTimes(1);
+      expect(deps.get).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each([
+    failure('confirm', { status: 500 }),
+    failure('confirm', { kind: 'throttled', status: 429 }),
+    failure('confirm', { kind: 'network', status: null }),
+    failure('confirm', { kind: 'message', status: null }),
+  ])('never auto-retries ambiguous timeout/5xx/429 (%#)', async (confirmError) => {
+    const deps = dependencies({
+      confirmError,
+      getError: failure('get', { kind: 'network', status: null }),
+    });
+    const result = await confirmDraftAfterExplicitApproval({
+      tripId: 'trip-1',
+      state: createConfirmAmbiguityState(makeDraft()),
+      dependencies: deps.value,
+    });
+    expect(result.kind).toBe('unknown');
+    expect(result.canCheckStatus).toBe(true);
+    expect(deps.confirm).toHaveBeenCalledTimes(1);
+    expect(deps.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the confirm limit and Retry-After context when 429 resolves to READY', async () => {
+    const deps = dependencies({
+      confirmError: failure('confirm', {
+        kind: 'throttled',
+        status: 429,
+        retryAfterMs: 90_000,
+        message:
+          'GoPlanAI allows 30 action confirmations per hour. Confirmation was not retried; checking the draft status is required.',
+      }),
+      getResult: makeDraft({
+        status: 'READY',
+        can_confirm: true,
+        can_cancel: true,
+      }),
+    });
+    const result = await confirmDraftAfterExplicitApproval({
+      tripId: 'trip-1',
+      state: createConfirmAmbiguityState(makeDraft()),
+      dependencies: deps.value,
+    });
+    expect(result.kind).toBe('ready_for_explicit_confirmation');
+    expect(result.message).toContain('30 action confirmations per hour');
+    expect(result.message).toContain('90 seconds');
+    expect(result.message).toContain('new explicit confirmation');
+    expect(deps.confirm).toHaveBeenCalledTimes(1);
+    expect(deps.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('retains 429 metadata and Check status when the follow-up GET also fails', async () => {
+    const throttle = failure('confirm', {
+      kind: 'throttled',
+      status: 429,
+      retryAfterMs: 30_000,
+      message: 'GoPlanAI allows 30 action confirmations per hour.',
+    });
+    const deps = dependencies({
+      confirmError: throttle,
+      getError: failure('get', { kind: 'network', status: null }),
+    });
+    const result = await confirmDraftAfterExplicitApproval({
+      tripId: 'trip-1',
+      state: createConfirmAmbiguityState(makeDraft()),
+      dependencies: deps.value,
+      nowMs: 1_000,
+    });
+    expect(result.kind).toBe('unknown');
+    expect(result.failure).toBe(throttle);
+    expect(result.confirmRetryAtMs).toBe(31_000);
+    expect(result.message).toContain('30 action confirmations per hour');
+    expect(result.message).toContain('Retry-After: 30 seconds');
+    expect(result.canCheckStatus).toBe(true);
+    expect(deps.confirm).toHaveBeenCalledTimes(1);
+    expect(deps.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('Check status is GET-only and can resolve unknown to CONFIRMED', async () => {
+    const firstDeps = dependencies({
+      confirmError: failure('confirm', { kind: 'network', status: null }),
+      getError: failure('get', { kind: 'network', status: null }),
+    });
+    const unknown = await confirmDraftAfterExplicitApproval({
+      tripId: 'trip-1',
+      state: createConfirmAmbiguityState(makeDraft()),
+      dependencies: firstDeps.value,
+    });
+    const checkDeps = dependencies({
+      getResult: makeDraft({
+        status: 'CONFIRMED',
+        can_confirm: false,
+        can_cancel: false,
+      }),
+    });
+    const resolved = await checkConfirmStatus({
+      tripId: 'trip-1',
+      state: unknown,
+      dependencies: checkDeps.value,
+    });
+    expect(resolved.kind).toBe('confirmed');
+    expect(checkDeps.confirm).not.toHaveBeenCalled();
+    expect(checkDeps.get).toHaveBeenCalledTimes(1);
+    expect(checkDeps.reconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies optional drafts from non-ambiguous stale/expired/forbidden/not-ready errors', async () => {
+    for (const errorCode of [
+      'AI_DRAFT_STALE',
+      'AI_DRAFT_EXPIRED',
+      'AI_DRAFT_FORBIDDEN',
+      'AI_DRAFT_NOT_READY',
+    ]) {
+      const updated = makeDraft({
+        status: errorCode === 'AI_DRAFT_EXPIRED' ? 'EXPIRED' : 'READY',
+        can_confirm: errorCode !== 'AI_DRAFT_EXPIRED',
+      });
+      const deps = dependencies({
+        confirmError: failure('confirm', {
+          errorCode,
+          status: errorCode === 'AI_DRAFT_FORBIDDEN' ? 403 : 409,
+          draft: updated,
+        }),
+      });
+      const result = await confirmDraftAfterExplicitApproval({
+        tripId: 'trip-1',
+        state: createConfirmAmbiguityState(makeDraft()),
+        dependencies: deps.value,
+      });
+      expect(result.draft).toBe(updated);
+      expect(result.kind).toBe('rejected');
+      expect(deps.confirm).toHaveBeenCalledTimes(1);
+      expect(deps.get).not.toHaveBeenCalled();
+    }
+  });
+
+  it('does not POST when the server can_confirm authority is false', async () => {
+    const deps = dependencies({});
+    const result = await confirmDraftAfterExplicitApproval({
+      tripId: 'trip-1',
+      state: createConfirmAmbiguityState(makeDraft({ can_confirm: false })),
+      dependencies: deps.value,
+    });
+    expect(result.kind).toBe('rejected');
+    expect(deps.confirm).not.toHaveBeenCalled();
+    expect(deps.get).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/features/chat/ai/__tests__/contentAndMentionUi.test.tsx
+++ b/mobile/src/features/chat/ai/__tests__/contentAndMentionUi.test.tsx
@@ -1,0 +1,100 @@
+import {
+  fireEvent,
+  render,
+  screen,
+} from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
+import { AIMessageContent } from '../components/AIMessageContent';
+import { AITypingIndicator } from '../components/AITypingIndicator';
+import {
+  GoPlanAIComposerIntent,
+  GoPlanAIMentionCommandMenu,
+  GoPlanAIMentionMessageText,
+} from '../components/AIMention';
+import { parseConstrainedAIText } from '../constrainedText';
+
+describe('constrained untrusted AI text', () => {
+  it('parses only allowlisted headings, lists, inline code, emphasis, and fences', () => {
+    expect(
+      parseConstrainedAIText(
+        '# Plan\n- Visit `museum`\n1. **Book** tickets\n```bash\npnpm test\n```',
+      ),
+    ).toEqual([
+      {
+        kind: 'heading',
+        level: 1,
+        segments: [{ kind: 'text', text: 'Plan' }],
+      },
+      {
+        kind: 'list_item',
+        ordered: false,
+        ordinal: null,
+        segments: [
+          { kind: 'text', text: 'Visit ' },
+          { kind: 'code', text: 'museum' },
+        ],
+      },
+      {
+        kind: 'list_item',
+        ordered: true,
+        ordinal: 1,
+        segments: [{ kind: 'strong', text: 'Book' }, { kind: 'text', text: ' tickets' }],
+      },
+      { kind: 'code_block', language: 'bash', code: 'pnpm test' },
+    ]);
+  });
+
+  it('renders HTML, markdown links, images, and script text inertly with no link/action role', async () => {
+    const content =
+      '<script>doTripMutation()</script> [Open trip](https://evil.example) ![pixel](https://evil.example/p.png)';
+    await render(<AIMessageContent content={content} />);
+    expect(screen.getByText(/doTripMutation/)).toBeTruthy();
+    expect(screen.getByText(/https:\/\/evil\.example/)).toBeTruthy();
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('renders fenced code as selectable text in horizontal scroll without evaluating it', async () => {
+    await render(
+      <AIMessageContent content={'```javascript\neval("danger")\n```'} />,
+    );
+    const scroller = screen.getByLabelText('javascript code block');
+    expect(scroller.props.horizontal).toBe(true);
+    const code = screen.getByText('eval("danger")');
+    expect(code.props.selectable).toBe(true);
+  });
+});
+
+describe('GoPlanAI mention and typing primitives', () => {
+  it('renders a distinct inert token in normalized sent content', async () => {
+    await render(<GoPlanAIMentionMessageText content="plan day 1 @GoPlanAI" />);
+    expect(screen.getByLabelText('GoPlanAI mention')).toBeTruthy();
+    expect(screen.getByText(' plan day 1')).toBeTruthy();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('offers an accessible 44pt command item and inserts through one callback', async () => {
+    const onSelect = jest.fn();
+    await render(
+      <GoPlanAIMentionCommandMenu open onSelect={onSelect} />,
+    );
+    const item = screen.getByRole('button', { name: 'Mention GoPlanAI' });
+    expect(StyleSheet.flatten(item.props.style)).toMatchObject({ minHeight: 44 });
+    await fireEvent.press(item);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('makes quota intent visible before send and exposes correlated typing identity', async () => {
+    await render(
+      <>
+        <GoPlanAIComposerIntent />
+        <AITypingIndicator interactionId="interaction-7" />
+      </>,
+    );
+    expect(screen.getByText(/20 prompts\/hour/)).toBeTruthy();
+    expect(screen.getByTestId('goplan-ai-typing-interaction-7')).toBeTruthy();
+    expect(screen.getByLabelText('GoPlanAI is replying').props.accessibilityLiveRegion).toBe(
+      'polite',
+    );
+  });
+});

--- a/mobile/src/features/chat/ai/__tests__/controllerSession.test.ts
+++ b/mobile/src/features/chat/ai/__tests__/controllerSession.test.ts
@@ -1,0 +1,36 @@
+import { makeDraftFixture } from '../__fixtures__/drafts';
+import { createConfirmAmbiguityState } from '../confirmController';
+import { createAIActionDraftControllerSessionStore } from '../controllerSession';
+import { aiActionDraftSourceIdentity } from '../drafts';
+
+describe('AI action draft controller session store', () => {
+  it('rejects stale row cleanup writes while a draft id is room-ambiguous', () => {
+    const draft = makeDraftFixture();
+    const session = {
+      localState: {
+        sourceVersion: aiActionDraftSourceIdentity(draft),
+        draft,
+        feedback: 'Must not transfer',
+        fieldErrors: null,
+        confirmState: createConfirmAmbiguityState(draft),
+        retainedExpiredEdit: null,
+      },
+      retainedExpiredEdit: null,
+      editor: null,
+    };
+    const store = createAIActionDraftControllerSessionStore(
+      'user-a:trip-a',
+    );
+    store.set(draft.id, session);
+    expect(store.get(draft.id)).toBe(session);
+
+    store.setAmbiguousDraftIds(new Set([draft.id]));
+    expect(store.get(draft.id)).toBeNull();
+    store.set(draft.id, session);
+    expect(store.get(draft.id)).toBeNull();
+
+    store.setAmbiguousDraftIds(new Set());
+    store.set(draft.id, session);
+    expect(store.get(draft.id)).toBe(session);
+  });
+});

--- a/mobile/src/features/chat/ai/__tests__/drafts.test.ts
+++ b/mobile/src/features/chat/ai/__tests__/drafts.test.ts
@@ -1,0 +1,105 @@
+import {
+  AI_ACTION_DRAFT_STATUSES,
+  parseAIActionDraft,
+  requireAIActionDraftEnvelope,
+} from '../drafts';
+import { makeRawDraftFixture as makeRawDraft } from '../__fixtures__/drafts';
+
+describe('AI action draft runtime contract', () => {
+  it('contains exactly the six backend statuses and never EXECUTED', () => {
+    expect(AI_ACTION_DRAFT_STATUSES).toEqual([
+      'NEEDS_INFO',
+      'READY',
+      'CONFIRMED',
+      'CANCELLED',
+      'EXPIRED',
+      'FAILED',
+    ]);
+    expect(parseAIActionDraft(makeRawDraft({ status: 'EXECUTED' }))).toBeNull();
+  });
+
+  it.each(AI_ACTION_DRAFT_STATUSES)('accepts status %s', (status) => {
+    expect(parseAIActionDraft(makeRawDraft({ status }))?.status).toBe(status);
+  });
+
+  it('preserves unknown action, confirmation, display, preview, and top-level values', () => {
+    const draft = parseAIActionDraft(
+      makeRawDraft({
+        action_type: 'future.action.teleport',
+        required_confirmation: 'FUTURE_AUTHORITY',
+        display: { title: 'Teleport', future_hint: { color: 'ultraviolet' } },
+        preview: { destination: { planet: 'Mars' } },
+        future_top_level: { retained: true },
+      }),
+    );
+    expect(draft).not.toBeNull();
+    expect(draft?.action_type).toBe('future.action.teleport');
+    expect(draft?.required_confirmation).toBe('FUTURE_AUTHORITY');
+    expect(draft?.display.future_hint).toEqual({ color: 'ultraviolet' });
+    expect(draft?.preview.destination).toEqual({ planet: 'Mars' });
+    expect(draft?.future_top_level).toEqual({ retained: true });
+  });
+
+  it('canonicalizes a valid draft UUID and rejects unusable ids', () => {
+    expect(
+      parseAIActionDraft(
+        makeRawDraft({ id: ' 22222222-2222-4222-8222-22222222222A ' }),
+      )?.id,
+    ).toBe('22222222-2222-4222-8222-22222222222a');
+    expect(parseAIActionDraft(makeRawDraft({ id: 'draft-1' }))).toBeNull();
+  });
+
+  it('preserves enriched missing-field extensions while validating known shapes', () => {
+    const draft = parseAIActionDraft(
+      makeRawDraft({
+        missing_fields: [
+          {
+            name: 'section_id',
+            label: 'Timeline day',
+            type: 'select',
+            required: true,
+            constraints: { future_rule: 'keep-me' },
+            options: [{ label: 'Day 1', value: 'section-1', future: 1 }],
+            presets: [{ label: 'Morning', start: '08:00', end: '10:00' }],
+            future_field_hint: 'retained',
+          },
+        ],
+      }),
+    );
+    expect(draft?.missing_fields[0].future_field_hint).toBe('retained');
+    expect(draft?.missing_fields[0].constraints?.future_rule).toBe('keep-me');
+    expect(draft?.missing_fields[0].options?.[0].future).toBe(1);
+  });
+
+  it.each([
+    ['missing id', { id: '' }],
+    ['unknown status', { status: 'PENDING' }],
+    ['non-boolean authority', { can_confirm: 'yes' }],
+    ['array display', { display: [] }],
+    ['non-record preview', { preview: 'bad' }],
+    ['non-list missing fields', { missing_fields: {} }],
+    ['duplicate missing field', {
+      missing_fields: [
+        { name: 'title', label: 'Title' },
+        { name: 'title', label: 'Again' },
+      ],
+    }],
+    ['malformed option', {
+      missing_fields: [
+        { name: 'status', label: 'Status', options: [{ label: 'Done' }] },
+      ],
+    }],
+    ['invalid expiry', { expires_at: 'tomorrow-ish' }],
+  ])('rejects malformed payload: %s', (_label, overrides) => {
+    expect(parseAIActionDraft(makeRawDraft(overrides))).toBeNull();
+  });
+
+  it('strictly requires the success envelope', () => {
+    expect(requireAIActionDraftEnvelope({ draft: makeRawDraft() }).draft.id).toBe(
+      '22222222-2222-4222-8222-222222222222',
+    );
+    expect(() => requireAIActionDraftEnvelope({ payload: makeRawDraft() })).toThrow(
+      'invalid response',
+    );
+  });
+});

--- a/mobile/src/features/chat/ai/__tests__/editing.test.ts
+++ b/mobile/src/features/chat/ai/__tests__/editing.test.ts
@@ -1,0 +1,228 @@
+import type { AIActionDraftApiFailure } from '../api';
+import {
+  buildEditedDraftPayload,
+  createDraftEditingState,
+  rebaseDraftEditingState,
+  saveDraftEdits,
+  setDraftEditedValue,
+  type DraftEditingDependencies,
+} from '../editing';
+import { makeDraftFixture as makeDraft } from '../__fixtures__/drafts';
+
+function failure(
+  overrides: Partial<AIActionDraftApiFailure> = {},
+): AIActionDraftApiFailure {
+  return {
+    kind: 'message',
+    message: 'Draft update failed.',
+    operation: 'patch',
+    errorCode: null,
+    status: 400,
+    retryAfterMs: null,
+    fieldErrors: null,
+    draft: null,
+    ...overrides,
+  };
+}
+
+function editableDraft() {
+  return makeDraft({
+    status: 'NEEDS_INFO',
+    can_confirm: false,
+    can_edit: true,
+    missing_fields: [
+      { name: 'title', label: 'Title', required: true },
+      { name: 'total_amount', label: 'Amount', type: 'money' },
+    ],
+  });
+}
+
+describe('AI draft editing state', () => {
+  it('builds PATCH data from edited allowed fields only', () => {
+    const initial = createDraftEditingState(editableDraft());
+    const disallowed = setDraftEditedValue(initial, 'server_only', 'bad');
+    expect(disallowed).toBe(initial);
+    const edited = setDraftEditedValue(initial, 'title', 'Lunch');
+    expect(buildEditedDraftPayload(edited)).toEqual({
+      ok: true,
+      payload: { title: 'Lunch' },
+    });
+  });
+
+  it('expands synthetic time ranges using the server-provided pair', () => {
+    const draft = makeDraft({
+      status: 'NEEDS_INFO',
+      can_confirm: false,
+      can_edit: true,
+      missing_fields: [
+        {
+          name: 'time_range',
+          label: 'Time',
+          type: 'time_range',
+          constraints: { pair: ['starts_at', 'ends_at'] },
+        },
+      ],
+    });
+    let state = createDraftEditingState(draft);
+    state = setDraftEditedValue(state, 'starts_at', '08:00');
+    state = setDraftEditedValue(state, 'ends_at', '09:00');
+    expect(buildEditedDraftPayload(state)).toEqual({
+      ok: true,
+      payload: { starts_at: '08:00', ends_at: '09:00' },
+    });
+  });
+
+  it('parses JSON as unknown data and reports malformed JSON inline', () => {
+    const draft = makeDraft({
+      status: 'NEEDS_INFO',
+      can_confirm: false,
+      can_edit: true,
+      missing_fields: [{ name: 'data', label: 'Details', type: 'json' }],
+    });
+    const valid = setDraftEditedValue(
+      createDraftEditingState(draft),
+      'data',
+      '{"title":"Museum"}',
+    );
+    expect(buildEditedDraftPayload(valid)).toEqual({
+      ok: true,
+      payload: { data: { title: 'Museum' } },
+    });
+    const invalid = setDraftEditedValue(valid, 'data', '{bad');
+    expect(buildEditedDraftPayload(invalid)).toEqual({
+      ok: false,
+      field: 'data',
+      message: 'Enter valid JSON.',
+    });
+  });
+
+  it('rebases partial server updates and does not resubmit fields no longer missing', () => {
+    let state = createDraftEditingState(editableDraft());
+    state = setDraftEditedValue(state, 'title', 'Lunch');
+    state = setDraftEditedValue(state, 'total_amount', '500000');
+    const nextDraft = makeDraft({
+      status: 'NEEDS_INFO',
+      can_confirm: false,
+      can_edit: true,
+      updated_at: '2026-05-13T00:01:00.000Z',
+      missing_fields: [
+        { name: 'total_amount', label: 'Amount', type: 'money' },
+      ],
+    });
+    const rebased = rebaseDraftEditingState(state, nextDraft);
+    expect(rebased.editedValues).toEqual({ total_amount: '500000' });
+    expect(buildEditedDraftPayload(rebased)).toEqual({
+      ok: true,
+      payload: { total_amount: '500000' },
+    });
+  });
+
+  it('uses the strict payload, applies the returned draft, and lets status flip to READY', async () => {
+    const patch = jest.fn(async () => ({
+      draft: makeDraft({
+        status: 'READY',
+        can_confirm: true,
+        can_edit: false,
+        missing_fields: [],
+      }),
+    }));
+    const dependencies: DraftEditingDependencies = {
+      patch,
+      normalizeError: jest.fn(),
+    };
+    const state = setDraftEditedValue(
+      createDraftEditingState(editableDraft()),
+      'title',
+      'Lunch',
+    );
+    const outcome = await saveDraftEdits({
+      tripId: 'trip-1',
+      state,
+      dependencies,
+    });
+    expect(patch).toHaveBeenCalledWith('trip-1', '22222222-2222-4222-8222-222222222222', {
+      title: 'Lunch',
+    });
+    expect(outcome.applied).toBe(true);
+    expect(outcome.state.draft.status).toBe('READY');
+  });
+
+  it('applies optional error drafts and structured field errors', async () => {
+    const current = editableDraft();
+    const serverDraft = makeDraft({
+      status: 'NEEDS_INFO',
+      can_confirm: false,
+      can_edit: true,
+      updated_at: '2026-05-13T00:02:00.000Z',
+      missing_fields: [{ name: 'total_amount', label: 'Amount', type: 'money' }],
+    });
+    const apiFailure = failure({
+      errorCode: 'FIELD_VALIDATION_FAILED',
+      fieldErrors: { total_amount: 'Enter a positive amount.' },
+      draft: serverDraft,
+    });
+    const state = setDraftEditedValue(
+      createDraftEditingState(current),
+      'total_amount',
+      '-1',
+    );
+    const outcome = await saveDraftEdits({
+      tripId: 'trip-1',
+      state,
+      dependencies: {
+        patch: jest.fn(async () => Promise.reject(new Error('validation'))),
+        normalizeError: () => apiFailure,
+      },
+    });
+    expect(outcome.state.draft.updated_at).toBe(serverDraft.updated_at);
+    expect(outcome.state.fieldErrors).toEqual({
+      total_amount: 'Enter a positive amount.',
+    });
+  });
+
+  it('retains unsaved values and plainly reports expiry mid-edit', async () => {
+    const state = setDraftEditedValue(
+      createDraftEditingState(editableDraft()),
+      'title',
+      'Do not lose this',
+    );
+    const expired = makeDraft({
+      status: 'EXPIRED',
+      can_confirm: false,
+      can_cancel: false,
+      can_edit: false,
+      missing_fields: [],
+    });
+    const outcome = await saveDraftEdits({
+      tripId: 'trip-1',
+      state,
+      dependencies: {
+        patch: jest.fn(async () => Promise.reject(new Error('expired'))),
+        normalizeError: () =>
+          failure({
+            message: 'Draft expired.',
+            errorCode: 'AI_DRAFT_EXPIRED',
+            status: 409,
+            draft: expired,
+          }),
+      },
+    });
+    expect(outcome.state.message).toBe(
+      'This draft expired. Your edits were not applied.',
+    );
+    expect(outcome.state.expiredWithUnsavedEdits).toBe(true);
+    expect(outcome.state.editedValues).toEqual({ title: 'Do not lose this' });
+  });
+
+  it('never calls PATCH when can_edit is false', async () => {
+    const patch = jest.fn();
+    const state = createDraftEditingState(makeDraft({ can_edit: false }));
+    const outcome = await saveDraftEdits({
+      tripId: 'trip-1',
+      state,
+      dependencies: { patch, normalizeError: jest.fn() },
+    });
+    expect(patch).not.toHaveBeenCalled();
+    expect(outcome.state.message).toContain('does not allow');
+  });
+});

--- a/mobile/src/features/chat/ai/__tests__/expiryClock.test.ts
+++ b/mobile/src/features/chat/ai/__tests__/expiryClock.test.ts
@@ -1,0 +1,73 @@
+import { createAIExpiryDeadlineClock } from '../expiryClock';
+
+describe('shared AI draft expiry deadline clock', () => {
+  it('keeps one scheduled deadline for all subscribers and clears it after the last unsubscribe', () => {
+    let nowMs = 0;
+    let nextHandle = 0;
+    const activeHandles = new Map<number, () => void>();
+    const scheduler = {
+      set: jest.fn((callback: () => void) => {
+        nextHandle += 1;
+        activeHandles.set(nextHandle, callback);
+        return nextHandle;
+      }),
+      clear: jest.fn((handle: unknown) => {
+        if (typeof handle === 'number') {
+          activeHandles.delete(handle);
+        }
+      }),
+    };
+    const clock = createAIExpiryDeadlineClock({
+      now: () => nowMs,
+      scheduler,
+    });
+    const first = clock.subscribe(120_000, jest.fn());
+    expect(activeHandles.size).toBe(1);
+    const second = clock.subscribe(180_000, jest.fn());
+    expect(activeHandles.size).toBe(1);
+    first();
+    expect(activeHandles.size).toBe(1);
+    second();
+    expect(activeHandles.size).toBe(0);
+    nowMs = 1;
+  });
+
+  it('notifies only at the next visible label boundary instead of every second', () => {
+    let nowMs = 0;
+    let callback: (() => void) | null = null;
+    let delayMs: number | null = null;
+    const listener = jest.fn();
+    const clock = createAIExpiryDeadlineClock({
+      now: () => nowMs,
+      scheduler: {
+        set: (next, delay) => {
+          callback = next;
+          delayMs = delay;
+          return 1;
+        },
+        clear: () => {
+          callback = null;
+        },
+      },
+    });
+    const unsubscribe = clock.subscribe(180_000, listener);
+    expect(delayMs).toBe(60_000);
+    expect(listener).toHaveBeenCalledTimes(1);
+    nowMs = 60_000;
+    const scheduled = callback as (() => void) | null;
+    scheduled?.();
+    expect(listener).toHaveBeenCalledTimes(2);
+    unsubscribe();
+  });
+
+  it('keeps a far-future deadline on a safe visible boundary instead of an immediate timer', () => {
+    const set = jest.fn(() => 1);
+    const clock = createAIExpiryDeadlineClock({
+      now: () => 0,
+      scheduler: { set, clear: jest.fn() },
+    });
+    const unsubscribe = clock.subscribe(8_640_000_000_000_000, jest.fn());
+    expect(set).toHaveBeenCalledWith(expect.any(Function), 60_000);
+    unsubscribe();
+  });
+});

--- a/mobile/src/features/chat/ai/__tests__/mention.test.ts
+++ b/mobile/src/features/chat/ai/__tests__/mention.test.ts
@@ -1,0 +1,81 @@
+import {
+  GOPLAN_AI_MENTION,
+  GOPLAN_AI_RATE_LIMIT_MESSAGE,
+  goPlanAISendFailureMessage,
+  insertGoPlanAIMention,
+  isGoPlanAIThrottledSend,
+  parseGoPlanAIMention,
+  shouldOfferGoPlanAICommand,
+  tokenizeGoPlanAIMention,
+} from '../mention';
+
+describe('GoPlanAI mention contract', () => {
+  it.each([
+    {
+      value: 'hello team',
+      expected: {
+        hasMention: false,
+        prompt: 'hello team',
+        displayContent: 'hello team',
+      },
+    },
+    {
+      value: 'plan day 1 @GoPlanAI',
+      expected: {
+        hasMention: true,
+        prompt: 'plan day 1',
+        displayContent: '@GoPlanAI plan day 1',
+      },
+    },
+    {
+      value: '@GoPlanAI',
+      expected: {
+        hasMention: true,
+        prompt: '',
+        displayContent: '@GoPlanAI',
+      },
+    },
+  ])('ports the web parser case for "$value"', ({ value, expected }) => {
+    expect(parseGoPlanAIMention(value)).toEqual(expected);
+  });
+
+  it('is case-insensitive, respects the word boundary, removes all mentions, and collapses whitespace', () => {
+    expect(
+      parseGoPlanAIMention('  @goplanai\n plan   @GoPlanAI day 1  '),
+    ).toEqual({
+      hasMention: true,
+      prompt: 'plan day 1',
+      displayContent: '@GoPlanAI plan day 1',
+    });
+    expect(parseGoPlanAIMention('@GoPlanAIx plan').hasMention).toBe(false);
+  });
+
+  it('offers only a trailing command trigger and inserts the exact literal', () => {
+    expect(shouldOfferGoPlanAICommand('hello @')).toBe(true);
+    expect(shouldOfferGoPlanAICommand('hello @g')).toBe(false);
+    const inserted = insertGoPlanAIMention('plan day 1 @');
+    expect(inserted.displayContent).toBe(`${GOPLAN_AI_MENTION} plan day 1`);
+  });
+
+  it('returns inert mention/text segments and detects only AI throttles', () => {
+    expect(tokenizeGoPlanAIMention('plan @GoPlanAI')).toEqual([
+      { kind: 'mention', text: '@GoPlanAI' },
+      { kind: 'text', text: ' plan' },
+    ]);
+    expect(isGoPlanAIThrottledSend('@GoPlanAI help', 429)).toBe(true);
+    expect(isGoPlanAIThrottledSend('hello', 429)).toBe(false);
+    expect(isGoPlanAIThrottledSend('@GoPlanAI help', 409)).toBe(false);
+    expect(
+      goPlanAISendFailureMessage('@GoPlanAI help', {
+        status: 429,
+        message: 'Generic throttle.',
+      }),
+    ).toBe(GOPLAN_AI_RATE_LIMIT_MESSAGE);
+    expect(
+      goPlanAISendFailureMessage('hello', {
+        status: 429,
+        message: 'Ordinary chat limit.',
+      }),
+    ).toBe('Ordinary chat limit.');
+  });
+});

--- a/mobile/src/features/chat/ai/__tests__/reconciliation.test.ts
+++ b/mobile/src/features/chat/ai/__tests__/reconciliation.test.ts
@@ -186,4 +186,31 @@ describe('AI draft cross-surface reconciliation', () => {
     await expect(first).rejects.toBe(failure);
     expect(reconcile).toHaveBeenCalledTimes(1);
   });
+
+  it('routes room authority only to the currently attached reporter', () => {
+    const initialReporter = jest.fn();
+    const replacementReporter = jest.fn();
+    const coordinator = createAIReconciliationCoordinator({
+      resourceKey: 'user:trip-1',
+      tripId: 'trip-1',
+      reportAuthoritativeFailure: initialReporter,
+    });
+    const failure = {
+      kind: 'message' as const,
+      message: 'This trip is read-only.',
+      errorCode: 'TRIP_TERMINAL',
+      status: 409,
+      retryAfterMs: null,
+      fieldErrors: null,
+    };
+
+    coordinator.reportAuthoritativeFailure(failure);
+    coordinator.setAuthoritativeFailureReporter(replacementReporter);
+    coordinator.reportAuthoritativeFailure(failure);
+    coordinator.setAuthoritativeFailureReporter(null);
+    coordinator.reportAuthoritativeFailure(failure);
+
+    expect(initialReporter).toHaveBeenCalledTimes(1);
+    expect(replacementReporter).toHaveBeenCalledTimes(1);
+  });
 });

--- a/mobile/src/features/chat/ai/__tests__/reconciliation.test.ts
+++ b/mobile/src/features/chat/ai/__tests__/reconciliation.test.ts
@@ -1,0 +1,189 @@
+jest.mock('@/features/expenses/expenseEvents', () => ({
+  publishExpenseEvent: jest.fn(async () => undefined),
+}));
+jest.mock('@/features/timeline/timelineEvents', () => ({
+  publishTimelineEvent: jest.fn(async () => undefined),
+}));
+
+// eslint-disable-next-line import/first
+import { publishExpenseEvent } from '@/features/expenses/expenseEvents';
+// eslint-disable-next-line import/first
+import { publishTimelineEvent } from '@/features/timeline/timelineEvents';
+// eslint-disable-next-line import/first
+import { KNOWN_AI_ACTION_TYPES, type AIActionDraftStatus } from '../drafts';
+// eslint-disable-next-line import/first
+import {
+  createAIReconciliationCoordinator,
+  reconcileNewlyConfirmedDraft,
+  reconciliationChannelForAction,
+  type AIReconciliationPublishers,
+} from '../reconciliation';
+// eslint-disable-next-line import/first
+import { makeDraftFixture as makeDraft } from '../__fixtures__/drafts';
+
+const TIMELINE_ACTIONS = [
+  'timeline.activity.create',
+  'timeline.activity.update',
+  'timeline.activity.delete',
+  'timeline.activity.status.update',
+] as const;
+
+const EXPENSE_ACTIONS = [
+  'expense.create',
+  'expense.update',
+  'expense.delete',
+  'expense.contribution.set',
+  'settlement.finalize',
+  'settlement.reopen',
+  'settlement.transfer.mark_sent',
+  'settlement.transfer.confirm_received',
+] as const;
+
+describe('AI draft cross-surface reconciliation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('table covers all twelve backend action types exactly once', () => {
+    expect([...TIMELINE_ACTIONS, ...EXPENSE_ACTIONS]).toEqual(
+      KNOWN_AI_ACTION_TYPES,
+    );
+  });
+
+  it.each(TIMELINE_ACTIONS)('%s publishes timelineChanged only', async (actionType) => {
+    const timeline = jest.fn(async () => undefined);
+    const expenses = jest.fn(async () => undefined);
+    const publishers: AIReconciliationPublishers = { timeline, expenses };
+    await expect(
+      reconcileNewlyConfirmedDraft({
+        tripId: 'trip-1',
+        previousStatus: 'READY',
+        draft: makeDraft({ action_type: actionType, status: 'CONFIRMED' }),
+        publishers,
+      }),
+    ).resolves.toBe('timeline');
+    expect(timeline).toHaveBeenCalledWith('trip-1');
+    expect(expenses).not.toHaveBeenCalled();
+  });
+
+  it.each(EXPENSE_ACTIONS)('%s publishes expensesChanged only', async (actionType) => {
+    const timeline = jest.fn(async () => undefined);
+    const expenses = jest.fn(async () => undefined);
+    const publishers: AIReconciliationPublishers = { timeline, expenses };
+    await expect(
+      reconcileNewlyConfirmedDraft({
+        tripId: 'trip-1',
+        previousStatus: 'READY',
+        draft: makeDraft({ action_type: actionType, status: 'CONFIRMED' }),
+        publishers,
+      }),
+    ).resolves.toBe('expenses');
+    expect(expenses).toHaveBeenCalledWith('trip-1');
+    expect(timeline).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'NEEDS_INFO',
+    'READY',
+    'CANCELLED',
+    'EXPIRED',
+    'FAILED',
+  ] as const)('publishes nothing for %s', async (status) => {
+    const timeline = jest.fn(async () => undefined);
+    const expenses = jest.fn(async () => undefined);
+    await reconcileNewlyConfirmedDraft({
+      tripId: 'trip-1',
+      previousStatus: 'READY',
+      draft: makeDraft({ status }),
+      publishers: { timeline, expenses },
+    });
+    expect(timeline).not.toHaveBeenCalled();
+    expect(expenses).not.toHaveBeenCalled();
+  });
+
+  it('publishes nothing for unknown actions or an already-observed confirmation', async () => {
+    const timeline = jest.fn(async () => undefined);
+    const expenses = jest.fn(async () => undefined);
+    const publishers = { timeline, expenses };
+    await reconcileNewlyConfirmedDraft({
+      tripId: 'trip-1',
+      previousStatus: 'READY',
+      draft: makeDraft({ action_type: 'future.action', status: 'CONFIRMED' }),
+      publishers,
+    });
+    await reconcileNewlyConfirmedDraft({
+      tripId: 'trip-1',
+      previousStatus: 'CONFIRMED',
+      draft: makeDraft({ status: 'CONFIRMED' }),
+      publishers,
+    });
+    expect(reconciliationChannelForAction('future.action')).toBeNull();
+    expect(timeline).not.toHaveBeenCalled();
+    expect(expenses).not.toHaveBeenCalled();
+  });
+
+  it('default publishers emit the exact existing timeline/expense event contracts', async () => {
+    await reconcileNewlyConfirmedDraft({
+      tripId: 'trip-timeline',
+      previousStatus: 'READY',
+      draft: makeDraft({
+        action_type: 'timeline.activity.delete',
+        status: 'CONFIRMED',
+      }),
+    });
+    await reconcileNewlyConfirmedDraft({
+      tripId: 'trip-expense',
+      previousStatus: 'READY',
+      draft: makeDraft({
+        action_type: 'settlement.transfer.mark_sent',
+        status: 'CONFIRMED',
+      }),
+    });
+    expect(publishTimelineEvent).toHaveBeenCalledWith({
+      type: 'timelineChanged',
+      tripId: 'trip-timeline',
+    });
+    expect(publishExpenseEvent).toHaveBeenCalledWith({
+      type: 'expensesChanged',
+      tripId: 'trip-expense',
+    });
+  });
+
+  it('accepts every status type without deriving from display text', () => {
+    const statuses: readonly AIActionDraftStatus[] = [
+      'NEEDS_INFO',
+      'READY',
+      'CONFIRMED',
+      'CANCELLED',
+      'EXPIRED',
+      'FAILED',
+    ];
+    expect(statuses).toHaveLength(6);
+  });
+
+  it('retains one rejected claim when an injected reconciler throws synchronously', async () => {
+    const failure = new Error('Synchronous publisher failure.');
+    const reconcile = jest.fn(() => {
+      throw failure;
+    });
+    const coordinator = createAIReconciliationCoordinator({
+      resourceKey: 'user:trip-1',
+      tripId: 'trip-1',
+      reconcile,
+    });
+    const confirmed = makeDraft({ status: 'CONFIRMED' });
+
+    const first = coordinator.reconcile({
+      previousStatus: 'READY',
+      draft: confirmed,
+    });
+    const second = coordinator.reconcile({
+      previousStatus: 'READY',
+      draft: confirmed,
+    });
+
+    expect(second).toBe(first);
+    await expect(first).rejects.toBe(failure);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/src/features/chat/ai/__tests__/typingExpiry.test.ts
+++ b/mobile/src/features/chat/ai/__tests__/typingExpiry.test.ts
@@ -1,0 +1,119 @@
+import { getAIActionDraftExpiry, isLocallyExpired } from '../expiry';
+import {
+  AI_TYPING_VISUAL_TIMEOUT_MS,
+  EMPTY_AI_TYPING_STATE,
+  createAITypingVisualController,
+  reduceAITypingState,
+  type AITypingState,
+} from '../typingState';
+import { makeDraftFixture as makeDraft } from '../__fixtures__/drafts';
+
+describe('GoPlanAI typing correlation', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(1_000);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('clears only a matching stopped event', () => {
+    const first = reduceAITypingState(EMPTY_AI_TYPING_STATE, {
+      type: 'started',
+      interactionId: 'interaction-new',
+      requestedByUserId: 'user-1',
+      nowMs: 1_000,
+    });
+    expect(
+      reduceAITypingState(first, {
+        type: 'stopped',
+        interactionId: 'interaction-old',
+      }),
+    ).toBe(first);
+    expect(
+      reduceAITypingState(first, {
+        type: 'stopped',
+        interactionId: 'interaction-new',
+      }),
+    ).toEqual(EMPTY_AI_TYPING_STATE);
+  });
+
+  it('uses a 120-second visual-only timeout for the matching interaction', () => {
+    const changes: AITypingState[] = [];
+    const controller = createAITypingVisualController({
+      now: () => Date.now(),
+      onChange: (state) => changes.push(state),
+      scheduler: {
+        set: (callback, delayMs) => setTimeout(callback, delayMs),
+        clear: (handle) => {
+          if (typeof handle === 'number') {
+            clearTimeout(handle);
+          }
+        },
+      },
+    });
+
+    controller.start('interaction-1', null);
+    jest.advanceTimersByTime(AI_TYPING_VISUAL_TIMEOUT_MS - 1);
+    expect(controller.getState().active?.interactionId).toBe('interaction-1');
+    jest.advanceTimersByTime(1);
+    expect(controller.getState()).toEqual(EMPTY_AI_TYPING_STATE);
+    expect(changes).toHaveLength(2);
+  });
+
+  it('a late older stop and older timer cannot clear a newer interaction', () => {
+    const controller = createAITypingVisualController({
+      now: () => Date.now(),
+      onChange: jest.fn(),
+      scheduler: {
+        set: (callback, delayMs) => setTimeout(callback, delayMs),
+        clear: (handle) => {
+          if (typeof handle === 'number') {
+            clearTimeout(handle);
+          }
+        },
+      },
+    });
+    controller.start('older', 'user-1');
+    jest.advanceTimersByTime(60_000);
+    controller.start('newer', 'user-2');
+    controller.stop('older');
+    jest.advanceTimersByTime(60_000);
+    expect(controller.getState().active?.interactionId).toBe('newer');
+    jest.advanceTimersByTime(60_000);
+    expect(controller.getState().active).toBeNull();
+  });
+});
+
+describe('AI action draft expiry projection', () => {
+  const expiresAt = '2026-08-10T05:00:00.000Z';
+  const expiresAtMs = Date.parse(expiresAt);
+
+  it('changes an active draft at the exact boundary without mutating server state', () => {
+    const draft = makeDraft({ expires_at: expiresAt });
+    expect(isLocallyExpired(draft, expiresAtMs - 1)).toBe(false);
+    expect(getAIActionDraftExpiry(draft, expiresAtMs - 1)).toMatchObject({
+      isExpired: false,
+      remainingMs: 1,
+      visualStatus: 'READY',
+      label: 'Expires in 1s',
+    });
+    expect(getAIActionDraftExpiry(draft, expiresAtMs)).toEqual({
+      isExpired: true,
+      remainingMs: 0,
+      visualStatus: 'EXPIRED',
+      label: 'Expired',
+    });
+    expect(draft.status).toBe('READY');
+  });
+
+  it('never rewrites an already terminal status based on its timestamp', () => {
+    const cancelled = makeDraft({ status: 'CANCELLED', expires_at: expiresAt });
+    expect(getAIActionDraftExpiry(cancelled, expiresAtMs + 10_000)).toMatchObject({
+      isExpired: false,
+      visualStatus: 'CANCELLED',
+      label: 'Closed',
+    });
+  });
+});

--- a/mobile/src/features/chat/ai/accessibilityFocus.ts
+++ b/mobile/src/features/chat/ai/accessibilityFocus.ts
@@ -1,0 +1,32 @@
+import { AccessibilityInfo, findNodeHandle } from 'react-native';
+
+export type AccessibilityFocusTarget = Parameters<typeof findNodeHandle>[0];
+
+export interface AccessibilityFocusDependencies {
+  readonly findNodeHandle: (
+    node: AccessibilityFocusTarget,
+  ) => number | null;
+  readonly setAccessibilityFocus: (handle: number) => void;
+}
+
+const DEFAULT_ACCESSIBILITY_FOCUS_DEPENDENCIES: AccessibilityFocusDependencies = {
+  findNodeHandle: (node) => findNodeHandle(node),
+  setAccessibilityFocus: (handle) =>
+    AccessibilityInfo.setAccessibilityFocus(handle),
+};
+
+export function focusAccessibilityNode(
+  node: AccessibilityFocusTarget,
+  dependencies: AccessibilityFocusDependencies =
+    DEFAULT_ACCESSIBILITY_FOCUS_DEPENDENCIES,
+): boolean {
+  if (node === null) {
+    return false;
+  }
+  const handle = dependencies.findNodeHandle(node);
+  if (handle === null) {
+    return false;
+  }
+  dependencies.setAccessibilityFocus(handle);
+  return true;
+}

--- a/mobile/src/features/chat/ai/accessibilityFocus.ts
+++ b/mobile/src/features/chat/ai/accessibilityFocus.ts
@@ -1,18 +1,17 @@
-import { AccessibilityInfo, findNodeHandle } from 'react-native';
+import { AccessibilityInfo, type HostInstance } from 'react-native';
 
-export type AccessibilityFocusTarget = Parameters<typeof findNodeHandle>[0];
+export type AccessibilityFocusTarget = HostInstance | null;
 
 export interface AccessibilityFocusDependencies {
-  readonly findNodeHandle: (
-    node: AccessibilityFocusTarget,
-  ) => number | null;
-  readonly setAccessibilityFocus: (handle: number) => void;
+  readonly sendAccessibilityEvent: (
+    node: HostInstance,
+    eventType: 'focus',
+  ) => void;
 }
 
 const DEFAULT_ACCESSIBILITY_FOCUS_DEPENDENCIES: AccessibilityFocusDependencies = {
-  findNodeHandle: (node) => findNodeHandle(node),
-  setAccessibilityFocus: (handle) =>
-    AccessibilityInfo.setAccessibilityFocus(handle),
+  sendAccessibilityEvent: (node, eventType) =>
+    AccessibilityInfo.sendAccessibilityEvent(node, eventType),
 };
 
 export function focusAccessibilityNode(
@@ -23,10 +22,6 @@ export function focusAccessibilityNode(
   if (node === null) {
     return false;
   }
-  const handle = dependencies.findNodeHandle(node);
-  if (handle === null) {
-    return false;
-  }
-  dependencies.setAccessibilityFocus(handle);
+  dependencies.sendAccessibilityEvent(node, 'focus');
   return true;
 }

--- a/mobile/src/features/chat/ai/api.ts
+++ b/mobile/src/features/chat/ai/api.ts
@@ -1,0 +1,239 @@
+import { isAxiosError } from 'axios';
+import { apiClient } from '@/shared/api/client';
+import { normalizeApiError, type ApiError } from '@/shared/api/errors';
+import {
+  isAIRecord,
+  canonicalizeAIUuid,
+  parseAIActionDraft,
+  requireMatchingAIActionDraft,
+  requireMatchingAIActionDraftEnvelope,
+  type AIActionDraft,
+  type AIActionDraftEnvelope,
+} from './drafts';
+
+export type AIActionDraftOperation = 'get' | 'patch' | 'confirm' | 'cancel';
+
+export interface AIActionDraftApiFailure {
+  readonly kind: ApiError['kind'];
+  readonly message: string;
+  readonly operation: AIActionDraftOperation;
+  readonly errorCode: string | null;
+  readonly status: number | null;
+  readonly retryAfterMs: number | null;
+  readonly fieldErrors: Readonly<Record<string, string>> | null;
+  readonly draft: AIActionDraft | null;
+}
+
+function requireCanonicalUuid(value: string, label: string): string {
+  const canonical = canonicalizeAIUuid(value);
+  if (canonical === null) {
+    throw new RangeError(`${label} must be a canonical UUID.`);
+  }
+  return canonical;
+}
+
+export function aiActionDraftPath(tripId: string, draftId: string): string {
+  const canonicalTripId = requireCanonicalUuid(tripId, 'Trip id');
+  const canonicalDraftId = requireCanonicalUuid(draftId, 'Draft id');
+  return `/trips/${canonicalTripId}/ai/action-drafts/${canonicalDraftId}`;
+}
+
+export async function getAIActionDraft(
+  tripId: string,
+  draftId: string,
+  signal?: AbortSignal,
+): Promise<AIActionDraftEnvelope> {
+  const response = await apiClient.get<unknown>(
+    aiActionDraftPath(tripId, draftId),
+    { signal },
+  );
+  return requireMatchingAIActionDraftEnvelope(response.data, draftId);
+}
+
+export async function patchAIActionDraft(
+  tripId: string,
+  draftId: string,
+  payload: Readonly<Record<string, unknown>>,
+  signal?: AbortSignal,
+): Promise<AIActionDraftEnvelope> {
+  const response = await apiClient.patch<unknown>(
+    aiActionDraftPath(tripId, draftId),
+    { payload: { ...payload } },
+    { signal },
+  );
+  return requireMatchingAIActionDraftEnvelope(response.data, draftId);
+}
+
+export async function confirmAIActionDraft(
+  tripId: string,
+  draftId: string,
+  signal?: AbortSignal,
+): Promise<AIActionDraftEnvelope> {
+  const response = await apiClient.post<unknown>(
+    `${aiActionDraftPath(tripId, draftId)}/confirm`,
+    undefined,
+    { signal },
+  );
+  return requireMatchingAIActionDraftEnvelope(response.data, draftId);
+}
+
+export async function cancelAIActionDraft(
+  tripId: string,
+  draftId: string,
+  signal?: AbortSignal,
+): Promise<AIActionDraftEnvelope> {
+  const response = await apiClient.post<unknown>(
+    `${aiActionDraftPath(tripId, draftId)}/cancel`,
+    undefined,
+    { signal },
+  );
+  return requireMatchingAIActionDraftEnvelope(response.data, draftId);
+}
+
+function parseFieldErrors(
+  value: unknown,
+): Readonly<Record<string, string>> | null {
+  if (!isAIRecord(value)) {
+    return null;
+  }
+  const fieldErrors: Record<string, string> = {};
+  for (const [field, message] of Object.entries(value)) {
+    if (typeof message === 'string') {
+      fieldErrors[field] = message;
+    }
+  }
+  return Object.keys(fieldErrors).length > 0 ? fieldErrors : null;
+}
+
+function headerValue(headers: unknown, name: string): unknown {
+  if (!isAIRecord(headers)) {
+    return undefined;
+  }
+  const getter = headers.get;
+  if (typeof getter === 'function') {
+    return Reflect.apply(getter, headers, [name]);
+  }
+  const lowerName = name.toLowerCase();
+  for (const [headerName, value] of Object.entries(headers)) {
+    if (headerName.toLowerCase() === lowerName) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+export function parseRetryAfterMs(
+  value: unknown,
+  nowMs: number = Date.now(),
+): number | null {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return null;
+  }
+  const normalized = String(value).trim();
+  if (/^\d+$/.test(normalized)) {
+    const seconds = Number(normalized);
+    const milliseconds = seconds * 1_000;
+    return Number.isSafeInteger(seconds) && Number.isSafeInteger(milliseconds) && milliseconds > 0
+      ? milliseconds
+      : null;
+  }
+  const retryAtMs = Date.parse(normalized);
+  const delayMs = retryAtMs - nowMs;
+  return Number.isFinite(retryAtMs) && Number.isSafeInteger(delayMs) && delayMs > 0
+    ? delayMs
+    : null;
+}
+
+function fallbackForOperation(operation: AIActionDraftOperation): string {
+  if (operation === 'patch') {
+    return 'The draft could not be updated.';
+  }
+  if (operation === 'confirm') {
+    return 'The confirmation outcome could not be determined.';
+  }
+  if (operation === 'cancel') {
+    return 'The draft could not be cancelled.';
+  }
+  return 'The latest draft status could not be loaded.';
+}
+
+function throttledMessage(operation: AIActionDraftOperation): string | null {
+  if (operation === 'confirm') {
+    return 'GoPlanAI allows 30 action confirmations per hour. Confirmation was not retried; checking the draft status is required.';
+  }
+  return null;
+}
+
+export function normalizeAIActionDraftApiError(
+  error: unknown,
+  operation: AIActionDraftOperation,
+  nowMs: number = Date.now(),
+  requestedDraftId?: string,
+): AIActionDraftApiFailure {
+  const base = normalizeApiError(error);
+  if (!isAxiosError(error)) {
+    return {
+      kind: base.kind,
+      message: base.message || fallbackForOperation(operation),
+      operation,
+      errorCode: base.errorCode ?? null,
+      status: base.status ?? null,
+      retryAfterMs: null,
+      fieldErrors: base.fieldErrors ?? null,
+      draft: null,
+    };
+  }
+
+  const response = error.response;
+  const status = response?.status ?? base.status ?? null;
+  const body = isAIRecord(response?.data) ? response.data : null;
+  const detail = body && typeof body.detail === 'string' ? body.detail : null;
+  const errorCode =
+    body && typeof body.error_code === 'string'
+      ? body.error_code
+      : (base.errorCode ?? null);
+  const parsedDraft = body ? parseAIActionDraft(body.draft) : null;
+  let draft: AIActionDraft | null = parsedDraft;
+  if (parsedDraft !== null && requestedDraftId !== undefined) {
+    try {
+      draft = requireMatchingAIActionDraft(parsedDraft, requestedDraftId);
+    } catch {
+      draft = null;
+    }
+  }
+  const explicitFieldErrors = body ? parseFieldErrors(body.field_errors) : null;
+  const retryAfterMs =
+    status === 429
+      ? parseRetryAfterMs(headerValue(response?.headers, 'retry-after'), nowMs)
+      : null;
+  const specificThrottle = status === 429 ? throttledMessage(operation) : null;
+  const message =
+    specificThrottle === null
+      ? (detail ?? base.message ?? fallbackForOperation(operation))
+      : detail === null
+        ? specificThrottle
+        : `${specificThrottle} Server response: ${detail}`;
+
+  return {
+    kind: status === 429 ? 'throttled' : base.kind,
+    message,
+    operation,
+    errorCode,
+    status,
+    retryAfterMs,
+    fieldErrors: explicitFieldErrors ?? base.fieldErrors ?? null,
+    draft,
+  };
+}
+
+export function isAmbiguousConfirmFailure(
+  failure: AIActionDraftApiFailure,
+): boolean {
+  return (
+    failure.operation === 'confirm' &&
+    (failure.status === null ||
+      failure.kind === 'network' ||
+      failure.status === 429 ||
+      (failure.status !== null && failure.status >= 500))
+  );
+}

--- a/mobile/src/features/chat/ai/components/AIActionDraftCardController.tsx
+++ b/mobile/src/features/chat/ai/components/AIActionDraftCardController.tsx
@@ -11,6 +11,7 @@ import {
   getAIActionDraft,
   normalizeAIActionDraftApiError,
   patchAIActionDraft,
+  type AIActionDraftApiFailure,
 } from '../api';
 import {
   checkConfirmStatus,
@@ -88,6 +89,21 @@ function isTerminalDraft(draft: AIActionDraft): boolean {
     draft.status === 'CANCELLED' ||
     draft.status === 'EXPIRED' ||
     draft.status === 'FAILED'
+  );
+}
+
+const ROOM_AUTHORITY_ERROR_CODES = new Set([
+  'TRIP_TERMINAL',
+  'TRIP_NOT_FOUND',
+  'FORBIDDEN',
+]);
+
+function isRoomAuthoritativeFailure(
+  failure: AIActionDraftApiFailure,
+): boolean {
+  return (
+    failure.errorCode !== null &&
+    ROOM_AUTHORITY_ERROR_CODES.has(failure.errorCode)
   );
 }
 
@@ -210,6 +226,9 @@ const DETACHED_CONFIRM_FEEDBACK =
 const INTERRUPTED_CONFIRM_FEEDBACK =
   'The confirmation outcome is unknown because newer draft information arrived before confirmation completed. Use Check status; do not confirm again.';
 
+const INTERACTION_DISABLED_CONFIRM_FEEDBACK =
+  'The confirmation outcome is unknown because draft actions became unavailable before confirmation completed. When available, use Check status; do not confirm again.';
+
 function failClosedConfirm(
   state: AIActionDraftControllerLocalState,
   feedback: string,
@@ -235,6 +254,9 @@ function failClosedDetachedConfirm(
 
 const DETACHED_PATCH_FEEDBACK =
   'The draft update was interrupted when this card left the visible list. Review the saved local values before trying again.';
+
+const INTERACTION_DISABLED_PATCH_FEEDBACK =
+  'The draft update was interrupted because draft actions became unavailable. Review the saved local values before trying again.';
 
 function controllerResourceKey(tripId: string, draft: AIActionDraft): string {
   return JSON.stringify([
@@ -309,6 +331,9 @@ function AIActionDraftCardControllerResource({
   const interactionDisabledRef = useRef(interactionDisabled);
   const generationRef = useRef(0);
   const activeControllerRef = useRef<AbortController | null>(null);
+  const reportedRoomAuthorityScopesRef = useRef(
+    new WeakSet<OperationScope>(),
+  );
   const incomingSourceIdentity =
     aiActionDraftMutationSnapshotIdentity(incomingDraft);
   const previousIncomingDraftRef = useRef(incomingDraft);
@@ -445,10 +470,6 @@ function AIActionDraftCardControllerResource({
     setEditorState(nextSession.editor);
   }, [incomingDraft, incomingSourceIdentity, persistSession, tripId]);
 
-  useLayoutEffect(() => {
-    interactionDisabledRef.current = interactionDisabled;
-  }, [interactionDisabled]);
-
   const ownsScope = (scope: OperationScope): boolean =>
     mountedRef.current &&
     generationRef.current === scope.generation &&
@@ -479,6 +500,41 @@ function AIActionDraftCardControllerResource({
     [incomingDraft, persistSession],
   );
 
+  useLayoutEffect(() => {
+    const becameDisabled =
+      interactionDisabled && !interactionDisabledRef.current;
+    interactionDisabledRef.current = interactionDisabled;
+    if (!becameDisabled) {
+      return;
+    }
+
+    const interruptedOperation = pendingRef.current;
+    if (
+      interruptedOperation === null ||
+      interruptedOperation === 'check'
+    ) {
+      return;
+    }
+
+    generationRef.current += 1;
+    activeControllerRef.current?.abort();
+    activeControllerRef.current = null;
+    busyRef.current = false;
+    pendingRef.current = null;
+    setPending(null);
+
+    if (interruptedOperation === 'confirm') {
+      updateCurrentState((state) =>
+        failClosedConfirm(state, INTERACTION_DISABLED_CONFIRM_FEEDBACK),
+      );
+    } else if (interruptedOperation === 'patch') {
+      updateCurrentState((state) => ({
+        ...state,
+        feedback: INTERACTION_DISABLED_PATCH_FEEDBACK,
+      }));
+    }
+  }, [interactionDisabled, updateCurrentState]);
+
   const reconcileConfirmedOnce = useCallback(
     (
       previousStatus: AIActionDraft['status'],
@@ -506,6 +562,42 @@ function AIActionDraftCardControllerResource({
       feedback: 'The AI action draft server returned an invalid response.',
     }));
   };
+
+  const reportRoomAuthority = (
+    failure: AIActionDraftApiFailure | null,
+    scope: OperationScope,
+  ): void => {
+    if (
+      failure !== null &&
+      isLiveScope(scope) &&
+      isRoomAuthoritativeFailure(failure) &&
+      !reportedRoomAuthorityScopesRef.current.has(scope)
+    ) {
+      reportedRoomAuthorityScopesRef.current.add(scope);
+      reconciliationCoordinator.reportAuthoritativeFailure(failure);
+    }
+  };
+
+  const confirmDependenciesForScope = (
+    scope: OperationScope,
+  ): ConfirmControllerDependencies => ({
+    ...confirmDependencies,
+    normalizeError: (error, operation, requestedDraftId) => {
+      const failure = confirmDependencies.normalizeError(
+        error,
+        operation,
+        requestedDraftId,
+      );
+      reportRoomAuthority(failure, scope);
+      return failure;
+    },
+    reconcile: async (options) => {
+      if (!isLiveScope(scope)) {
+        return;
+      }
+      await confirmDependencies.reconcile(options);
+    },
+  });
 
   const applyDraft = (
     next: AIActionDraft,
@@ -636,6 +728,7 @@ function AIActionDraftCardControllerResource({
         Date.now(),
         current.id,
       );
+      reportRoomAuthority(failure, scope);
       if (failure.draft !== null) {
         let matchingFailureDraft: AIActionDraft;
         try {
@@ -778,6 +871,7 @@ function AIActionDraftCardControllerResource({
         Date.now(),
         current.id,
       );
+      reportRoomAuthority(failure, scope);
       let failureDraft: AIActionDraft | null = null;
       if (failure.draft !== null) {
         try {
@@ -851,11 +945,12 @@ function AIActionDraftCardControllerResource({
           ? { ...confirmState, draft: authoritative }
           : createConfirmAmbiguityState(authoritative);
       const next = await confirmDraftAfterExplicitApproval({
-        dependencies: confirmDependencies,
+        dependencies: confirmDependenciesForScope(scope),
         tripId,
         state,
         signal: scope.controller.signal,
       });
+      reportRoomAuthority(next.failure, scope);
       applyConfirmState(next, authoritative.id, scope);
     } finally {
       finish(scope);
@@ -932,6 +1027,7 @@ function AIActionDraftCardControllerResource({
         Date.now(),
         current.id,
       );
+      reportRoomAuthority(failure, scope);
       if (failure.draft !== null) {
         applyDraft(failure.draft, current.id, scope);
       }
@@ -951,11 +1047,12 @@ function AIActionDraftCardControllerResource({
     }
     try {
       const next = await checkConfirmStatus({
-        dependencies: confirmDependencies,
+        dependencies: confirmDependenciesForScope(scope),
         tripId,
         state: confirmState,
         signal: scope.controller.signal,
       });
+      reportRoomAuthority(next.failure, scope);
       applyConfirmState(next, confirmState.draft.id, scope);
     } finally {
       finish(scope);

--- a/mobile/src/features/chat/ai/components/AIActionDraftCardController.tsx
+++ b/mobile/src/features/chat/ai/components/AIActionDraftCardController.tsx
@@ -1,0 +1,1049 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  cancelAIActionDraft,
+  getAIActionDraft,
+  normalizeAIActionDraftApiError,
+  patchAIActionDraft,
+} from '../api';
+import {
+  checkConfirmStatus,
+  confirmDraftAfterExplicitApproval,
+  createConfirmAmbiguityState,
+  DEFAULT_CONFIRM_CONTROLLER_DEPENDENCIES,
+  type ConfirmAmbiguityState,
+  type ConfirmControllerDependencies,
+} from '../confirmController';
+import {
+  createAIActionDraftControllerSessionStore,
+  type AIActionDraftControllerLocalState,
+  type AIActionDraftControllerSession,
+  type AIActionDraftControllerSessionStore,
+  type AIActionDraftPersistedEdit,
+  type AIActionDraftRetainedExpiredEdit,
+} from '../controllerSession';
+import {
+  aiActionDraftMutationSnapshotIdentity,
+  canonicalizeAIUuid,
+  requireMatchingAIActionDraft,
+  type AIActionDraft,
+} from '../drafts';
+import {
+  createAIReconciliationCoordinator,
+  reconcileNewlyConfirmedDraft,
+  type AIReconciliationCoordinator,
+} from '../reconciliation';
+import {
+  useRoomAIActionDraftControllerSessionStore,
+  useRoomAIReconciliationCoordinator,
+} from '../reconciliationContext';
+import {
+  ActionDraftCard,
+  type AIActionDraftPendingOperation,
+  type AIActionDraftSubmittedEdit,
+} from './ActionDraftCard';
+
+export interface AIActionDraftCardControllerProps {
+  readonly tripId: string;
+  readonly draft: AIActionDraft;
+  readonly onDraftChanged: (draft: AIActionDraft) => void;
+  readonly interactionDisabled?: boolean;
+  readonly nowMs?: number;
+}
+
+interface AIActionDraftCardControllerResourceProps
+  extends AIActionDraftCardControllerProps {
+  readonly sessionKey: string;
+  readonly sessionStore: AIActionDraftControllerSessionStore;
+}
+
+interface OperationScope {
+  readonly controller: AbortController;
+  readonly generation: number;
+}
+
+function localStateForDraft(
+  draft: AIActionDraft,
+  retainedExpiredEdit: AIActionDraftSubmittedEdit | null = null,
+): AIActionDraftControllerLocalState {
+  return {
+    sourceVersion: aiActionDraftMutationSnapshotIdentity(draft),
+    draft,
+    feedback: null,
+    fieldErrors: null,
+    confirmState: createConfirmAmbiguityState(draft),
+    retainedExpiredEdit,
+  };
+}
+
+function isTerminalDraft(draft: AIActionDraft): boolean {
+  return (
+    draft.status === 'CONFIRMED' ||
+    draft.status === 'CANCELLED' ||
+    draft.status === 'EXPIRED' ||
+    draft.status === 'FAILED'
+  );
+}
+
+const UNKNOWN_CONFIRM_FEEDBACK =
+  'The confirmation outcome is unknown. Use Check status; do not confirm again.';
+
+function rebindUnknownConfirmation(
+  stored: AIActionDraftControllerLocalState,
+  incomingDraft: AIActionDraft,
+): AIActionDraftControllerLocalState {
+  const message =
+    stored.confirmState.message ?? stored.feedback ?? UNKNOWN_CONFIRM_FEEDBACK;
+  return {
+    ...stored,
+    sourceVersion: aiActionDraftMutationSnapshotIdentity(incomingDraft),
+    draft: incomingDraft,
+    feedback: message,
+    fieldErrors: null,
+    confirmState: {
+      ...stored.confirmState,
+      kind: 'unknown',
+      draft: incomingDraft,
+      message,
+      canCheckStatus: true,
+    },
+    retainedExpiredEdit: null,
+  };
+}
+
+function stateForIncomingDraft(
+  stored: AIActionDraftControllerLocalState,
+  incomingDraft: AIActionDraft,
+): AIActionDraftControllerLocalState {
+  const incomingVersion = aiActionDraftMutationSnapshotIdentity(incomingDraft);
+  if (stored.sourceVersion === incomingVersion) {
+    return stored;
+  }
+  if (
+    stored.confirmState.kind === 'unknown' &&
+    !isTerminalDraft(incomingDraft)
+  ) {
+    return rebindUnknownConfirmation(stored, incomingDraft);
+  }
+  if (aiActionDraftMutationSnapshotIdentity(stored.draft) === incomingVersion) {
+    return { ...stored, sourceVersion: incomingVersion };
+  }
+  return localStateForDraft(incomingDraft);
+}
+
+function sessionForIncomingDraft(
+  stored: AIActionDraftControllerSession | null,
+  incomingDraft: AIActionDraft,
+  tripId: string,
+): AIActionDraftControllerSession {
+  if (stored === null) {
+    return {
+      localState: localStateForDraft(incomingDraft),
+      retainedExpiredEdit: null,
+      editor: null,
+    };
+  }
+  const incomingVersion = aiActionDraftMutationSnapshotIdentity(incomingDraft);
+  if (stored.localState.sourceVersion === incomingVersion) {
+    return stored;
+  }
+  if (
+    stored.localState.confirmState.kind === 'unknown' &&
+    !isTerminalDraft(incomingDraft)
+  ) {
+    return {
+      localState: rebindUnknownConfirmation(
+        stored.localState,
+        incomingDraft,
+      ),
+      retainedExpiredEdit: null,
+      editor: null,
+    };
+  }
+  if (
+    aiActionDraftMutationSnapshotIdentity(stored.localState.draft) ===
+    incomingVersion
+  ) {
+    return {
+      ...stored,
+      localState: { ...stored.localState, sourceVersion: incomingVersion },
+    };
+  }
+
+  const retained = stored.retainedExpiredEdit;
+  const editor = stored.editor;
+  const sameResource =
+    retained !== null &&
+    retained.tripId === canonicalResourceId(tripId) &&
+    retained.draftId === canonicalResourceId(incomingDraft.id);
+  const isCorrelatedExpiry =
+    incomingDraft.status === 'EXPIRED' &&
+    retained !== null &&
+    (retained.submittedSourceIdentity === stored.localState.sourceVersion ||
+      stored.localState.draft.status === 'EXPIRED');
+  const nextRetained =
+    sameResource && isCorrelatedExpiry
+      ? retained
+      : incomingDraft.status === 'EXPIRED' &&
+          editor !== null &&
+          editor.tripId === canonicalResourceId(tripId) &&
+          editor.draftId === canonicalResourceId(incomingDraft.id) &&
+          editor.submittedSourceIdentity === stored.localState.sourceVersion
+        ? editor
+        : null;
+  return {
+    localState: localStateForDraft(incomingDraft, nextRetained),
+    retainedExpiredEdit: nextRetained,
+    editor: null,
+  };
+}
+
+const DETACHED_CONFIRM_FEEDBACK =
+  'The confirmation outcome is unknown because this draft left the visible list. Use Check status; do not confirm again.';
+
+const INTERRUPTED_CONFIRM_FEEDBACK =
+  'The confirmation outcome is unknown because newer draft information arrived before confirmation completed. Use Check status; do not confirm again.';
+
+function failClosedConfirm(
+  state: AIActionDraftControllerLocalState,
+  feedback: string,
+): AIActionDraftControllerLocalState {
+  return {
+    ...state,
+    feedback,
+    confirmState: {
+      ...state.confirmState,
+      kind: 'unknown',
+      draft: state.draft,
+      message: feedback,
+      canCheckStatus: true,
+    },
+  };
+}
+
+function failClosedDetachedConfirm(
+  state: AIActionDraftControllerLocalState,
+): AIActionDraftControllerLocalState {
+  return failClosedConfirm(state, DETACHED_CONFIRM_FEEDBACK);
+}
+
+const DETACHED_PATCH_FEEDBACK =
+  'The draft update was interrupted when this card left the visible list. Review the saved local values before trying again.';
+
+function controllerResourceKey(tripId: string, draft: AIActionDraft): string {
+  return JSON.stringify([
+    canonicalResourceId(tripId),
+    canonicalResourceId(draft.id),
+  ]);
+}
+
+function canonicalResourceId(value: string): string {
+  return canonicalizeAIUuid(value) ?? value.trim().toLowerCase();
+}
+
+function cancelOutcomeFeedback(
+  draft: AIActionDraft,
+  reconciliationFailed: boolean,
+): string {
+  const suffix = reconciliationFailed
+    ? ' Another trip screen could not refresh automatically.'
+    : '';
+  if (draft.status === 'CANCELLED') {
+    return 'Draft cancelled.';
+  }
+  if (draft.status === 'CONFIRMED') {
+    return `The draft was already confirmed and could not be cancelled.${suffix}`;
+  }
+  if (draft.status === 'EXPIRED') {
+    return 'The draft expired before it could be cancelled.';
+  }
+  if (draft.status === 'FAILED') {
+    return 'The draft failed and was not cancelled.';
+  }
+  return `The draft was not cancelled. Latest status: ${draft.status}.`;
+}
+
+function AIActionDraftCardControllerResource({
+  tripId,
+  draft: incomingDraft,
+  onDraftChanged,
+  interactionDisabled = false,
+  nowMs,
+  sessionKey,
+  sessionStore,
+}: AIActionDraftCardControllerResourceProps) {
+  const [initialSession] = useState<AIActionDraftControllerSession>(() => {
+    return sessionForIncomingDraft(
+      sessionStore.get(sessionKey),
+      incomingDraft,
+      tripId,
+    );
+  });
+  const [localState, setLocalState] =
+    useState<AIActionDraftControllerLocalState>(initialSession.localState);
+  const localStateRef = useRef(initialSession.localState);
+  const [retainedExpiredEdit, setRetainedExpiredEditState] =
+    useState<AIActionDraftRetainedExpiredEdit | null>(
+      initialSession.retainedExpiredEdit,
+    );
+  const retainedExpiredEditRef =
+    useRef<AIActionDraftRetainedExpiredEdit | null>(
+      initialSession.retainedExpiredEdit,
+    );
+  const [editor, setEditorState] =
+    useState<AIActionDraftPersistedEdit | null>(initialSession.editor);
+  const editorRef =
+    useRef<AIActionDraftPersistedEdit | null>(initialSession.editor);
+  const [pending, setPending] = useState<AIActionDraftPendingOperation>(null);
+  const pendingRef = useRef<AIActionDraftPendingOperation>(null);
+  const currentState = stateForIncomingDraft(localState, incomingDraft);
+  const { draft, feedback, fieldErrors, confirmState } = currentState;
+  const mountedRef = useRef(true);
+  const busyRef = useRef(false);
+  const interactionDisabledRef = useRef(interactionDisabled);
+  const generationRef = useRef(0);
+  const activeControllerRef = useRef<AbortController | null>(null);
+  const incomingSourceIdentity =
+    aiActionDraftMutationSnapshotIdentity(incomingDraft);
+  const previousIncomingDraftRef = useRef(incomingDraft);
+  const activeIncomingSourceIdentityRef = useRef(incomingSourceIdentity);
+  const roomReconciliationCoordinator =
+    useRoomAIReconciliationCoordinator();
+  const fallbackReconciliationCoordinatorRef =
+    useRef<AIReconciliationCoordinator | null>(null);
+  if (fallbackReconciliationCoordinatorRef.current === null) {
+    const fallback = createAIReconciliationCoordinator({
+      tripId,
+      reconcile: reconcileNewlyConfirmedDraft,
+    });
+    fallback.seedConfirmedDrafts([incomingDraft]);
+    fallbackReconciliationCoordinatorRef.current = fallback;
+  }
+  const reconciliationCoordinator =
+    roomReconciliationCoordinator !== null &&
+    canonicalResourceId(roomReconciliationCoordinator.tripId) ===
+      canonicalResourceId(tripId)
+      ? roomReconciliationCoordinator
+      : fallbackReconciliationCoordinatorRef.current;
+
+  const persistSession = useCallback(
+    (
+      nextLocalState: AIActionDraftControllerLocalState =
+        localStateRef.current,
+      nextRetainedExpiredEdit: AIActionDraftRetainedExpiredEdit | null =
+        retainedExpiredEditRef.current,
+      nextEditor: AIActionDraftPersistedEdit | null = editorRef.current,
+    ): void => {
+      localStateRef.current = nextLocalState;
+      retainedExpiredEditRef.current = nextRetainedExpiredEdit;
+      editorRef.current = nextEditor;
+      sessionStore.set(sessionKey, {
+        localState: nextLocalState,
+        retainedExpiredEdit: nextRetainedExpiredEdit,
+        editor: nextEditor,
+      });
+    },
+    [sessionKey, sessionStore],
+  );
+
+  const retainExpiredEdit = (
+    next: AIActionDraftRetainedExpiredEdit | null,
+  ): void => {
+    persistSession(localStateRef.current, next, editorRef.current);
+    if (mountedRef.current) {
+      setRetainedExpiredEditState(next);
+    }
+  };
+
+  const setEditor = (next: AIActionDraftPersistedEdit | null): void => {
+    persistSession(
+      localStateRef.current,
+      retainedExpiredEditRef.current,
+      next,
+    );
+    if (mountedRef.current) {
+      setEditorState(next);
+    }
+  };
+
+  useLayoutEffect(() => {
+    mountedRef.current = true;
+    persistSession();
+    return () => {
+      if (pendingRef.current === 'confirm') {
+        const failClosed = failClosedDetachedConfirm(localStateRef.current);
+        persistSession(
+          failClosed,
+          retainedExpiredEditRef.current,
+          editorRef.current,
+        );
+      } else if (pendingRef.current === 'patch') {
+        persistSession(
+          {
+            ...localStateRef.current,
+            feedback: DETACHED_PATCH_FEEDBACK,
+          },
+          retainedExpiredEditRef.current,
+          editorRef.current,
+        );
+      }
+      mountedRef.current = false;
+      busyRef.current = false;
+      pendingRef.current = null;
+      generationRef.current += 1;
+      activeControllerRef.current?.abort();
+      activeControllerRef.current = null;
+    };
+  }, [persistSession]);
+
+  useLayoutEffect(() => {
+    if (activeIncomingSourceIdentityRef.current === incomingSourceIdentity) {
+      return;
+    }
+    const interruptedOperation = pendingRef.current;
+    activeIncomingSourceIdentityRef.current = incomingSourceIdentity;
+    generationRef.current += 1;
+    activeControllerRef.current?.abort();
+    activeControllerRef.current = null;
+    busyRef.current = false;
+    pendingRef.current = null;
+    setPending(null);
+    let nextSession = sessionForIncomingDraft(
+      {
+        localState: localStateRef.current,
+        retainedExpiredEdit: retainedExpiredEditRef.current,
+        editor: editorRef.current,
+      },
+      incomingDraft,
+      tripId,
+    );
+    if (
+      interruptedOperation === 'confirm' &&
+      !isTerminalDraft(incomingDraft)
+    ) {
+      nextSession = {
+        ...nextSession,
+        localState: failClosedConfirm(
+          nextSession.localState,
+          INTERRUPTED_CONFIRM_FEEDBACK,
+        ),
+      };
+    }
+    persistSession(
+      nextSession.localState,
+      nextSession.retainedExpiredEdit,
+      nextSession.editor,
+    );
+    setLocalState(nextSession.localState);
+    setRetainedExpiredEditState(nextSession.retainedExpiredEdit);
+    setEditorState(nextSession.editor);
+  }, [incomingDraft, incomingSourceIdentity, persistSession, tripId]);
+
+  useLayoutEffect(() => {
+    interactionDisabledRef.current = interactionDisabled;
+  }, [interactionDisabled]);
+
+  const ownsScope = (scope: OperationScope): boolean =>
+    mountedRef.current &&
+    generationRef.current === scope.generation &&
+    activeControllerRef.current === scope.controller;
+
+  const isLiveScope = (scope: OperationScope): boolean =>
+    ownsScope(scope) && !scope.controller.signal.aborted;
+
+  const updateCurrentState = useCallback(
+    (
+      update: (
+        state: AIActionDraftControllerLocalState,
+      ) => AIActionDraftControllerLocalState,
+    ): void => {
+      if (!mountedRef.current) {
+        return;
+      }
+      const next = update(
+        stateForIncomingDraft(localStateRef.current, incomingDraft),
+      );
+      persistSession(
+        next,
+        retainedExpiredEditRef.current,
+        editorRef.current,
+      );
+      setLocalState(next);
+    },
+    [incomingDraft, persistSession],
+  );
+
+  const reconcileConfirmedOnce = useCallback(
+    (
+      previousStatus: AIActionDraft['status'],
+      nextDraft: AIActionDraft,
+    ): Promise<void> =>
+      reconciliationCoordinator
+        .reconcile({ previousStatus, draft: nextDraft })
+        .then(() => undefined),
+    [reconciliationCoordinator],
+  );
+
+  const confirmDependencies: ConfirmControllerDependencies = {
+    ...DEFAULT_CONFIRM_CONTROLLER_DEPENDENCIES,
+    reconcile: async ({ previousDraft, nextDraft }) => {
+      await reconcileConfirmedOnce(previousDraft.status, nextDraft);
+    },
+  };
+
+  const showContractFailure = (scope: OperationScope): void => {
+    if (!isLiveScope(scope)) {
+      return;
+    }
+    updateCurrentState((state) => ({
+      ...state,
+      feedback: 'The AI action draft server returned an invalid response.',
+    }));
+  };
+
+  const applyDraft = (
+    next: AIActionDraft,
+    requestedDraftId: string,
+    scope: OperationScope,
+  ): AIActionDraft | null => {
+    if (!isLiveScope(scope)) {
+      return null;
+    }
+    let matchingDraft: AIActionDraft;
+    try {
+      matchingDraft = requireMatchingAIActionDraft(next, requestedDraftId);
+    } catch {
+      showContractFailure(scope);
+      return null;
+    }
+    updateCurrentState((state) => ({ ...state, draft: matchingDraft }));
+    if (isLiveScope(scope)) {
+      onDraftChanged(matchingDraft);
+    }
+    return matchingDraft;
+  };
+
+  const applyConfirmState = (
+    next: ConfirmAmbiguityState,
+    requestedDraftId: string,
+    scope: OperationScope,
+  ): boolean => {
+    if (!isLiveScope(scope)) {
+      return false;
+    }
+    let matchingDraft: AIActionDraft;
+    try {
+      matchingDraft = requireMatchingAIActionDraft(
+        next.draft,
+        requestedDraftId,
+      );
+    } catch {
+      showContractFailure(scope);
+      return false;
+    }
+    const nextFeedback = next.reconciliationFailed
+      ? 'The action was confirmed, but another trip screen could not refresh automatically.'
+      : next.message;
+    const matchingConfirmState = { ...next, draft: matchingDraft };
+    updateCurrentState((state) => ({
+      ...state,
+      draft: matchingDraft,
+      confirmState: matchingConfirmState,
+      feedback: nextFeedback,
+    }));
+    if (isLiveScope(scope)) {
+      onDraftChanged(matchingDraft);
+    }
+    return true;
+  };
+
+  const begin = (
+    operation: Exclude<AIActionDraftPendingOperation, null>,
+  ): OperationScope | null => {
+    if (
+      !mountedRef.current ||
+      busyRef.current ||
+      interactionDisabledRef.current
+    ) {
+      return null;
+    }
+    const controller = new AbortController();
+    const generation = generationRef.current + 1;
+    generationRef.current = generation;
+    activeControllerRef.current = controller;
+    busyRef.current = true;
+    pendingRef.current = operation;
+    setPending(operation);
+    updateCurrentState((state) => ({ ...state, feedback: null }));
+    return { controller, generation };
+  };
+
+  const finish = (scope: OperationScope): void => {
+    if (!ownsScope(scope)) {
+      return;
+    }
+    activeControllerRef.current = null;
+    busyRef.current = false;
+    pendingRef.current = null;
+    setPending(null);
+  };
+
+  const persistedEditFor = (
+    current: AIActionDraft,
+    edit: AIActionDraftSubmittedEdit,
+  ): AIActionDraftPersistedEdit => ({
+    ...edit,
+    tripId: canonicalResourceId(tripId),
+    draftId: canonicalResourceId(current.id),
+    submittedSourceIdentity: aiActionDraftMutationSnapshotIdentity(current),
+  });
+
+  const persistEditableDraft = (
+    edit: AIActionDraftSubmittedEdit | null,
+  ): void => {
+    setEditor(edit === null ? null : persistedEditFor(draft, edit));
+  };
+
+  const preflightMutation = async (
+    current: AIActionDraft,
+    permission: 'can_edit' | 'can_confirm' | 'can_cancel',
+    scope: OperationScope,
+  ): Promise<AIActionDraft | null> => {
+    let freshDraft: AIActionDraft;
+    try {
+      const response = await getAIActionDraft(
+        tripId,
+        current.id,
+        scope.controller.signal,
+      );
+      if (!isLiveScope(scope)) {
+        return null;
+      }
+      freshDraft = requireMatchingAIActionDraft(response.draft, current.id);
+    } catch (error: unknown) {
+      if (!isLiveScope(scope)) {
+        return null;
+      }
+      const failure = normalizeAIActionDraftApiError(
+        error,
+        'get',
+        Date.now(),
+        current.id,
+      );
+      if (failure.draft !== null) {
+        let matchingFailureDraft: AIActionDraft;
+        try {
+          matchingFailureDraft = requireMatchingAIActionDraft(
+            failure.draft,
+            current.id,
+          );
+        } catch {
+          showContractFailure(scope);
+          return null;
+        }
+        let reconciliationFailed = false;
+        try {
+          await reconcileConfirmedOnce(current.status, matchingFailureDraft);
+        } catch {
+          reconciliationFailed = true;
+        }
+        if (!isLiveScope(scope)) {
+          return null;
+        }
+        if (matchingFailureDraft.status !== 'EXPIRED') {
+          retainExpiredEdit(null);
+        }
+        setEditor(null);
+        applyDraft(matchingFailureDraft, current.id, scope);
+        updateCurrentState((state) => ({
+          ...state,
+          draft: matchingFailureDraft,
+          confirmState: createConfirmAmbiguityState(matchingFailureDraft),
+          feedback: reconciliationFailed
+            ? 'The action was confirmed, but another trip screen could not refresh automatically.'
+            : failure.message,
+        }));
+        return null;
+      }
+      updateCurrentState((state) => ({
+        ...state,
+        feedback: failure.message,
+      }));
+      return null;
+    }
+
+    const changed =
+      aiActionDraftMutationSnapshotIdentity(freshDraft) !==
+      aiActionDraftMutationSnapshotIdentity(current);
+    if (changed || !freshDraft[permission]) {
+      let reconciliationFailed = false;
+      try {
+        await reconcileConfirmedOnce(current.status, freshDraft);
+      } catch {
+        reconciliationFailed = true;
+      }
+      if (!isLiveScope(scope)) {
+        return null;
+      }
+      if (freshDraft.status !== 'EXPIRED') {
+        retainExpiredEdit(null);
+      }
+      setEditor(null);
+      const feedback = reconciliationFailed
+        ? 'The draft changed on the server. The action is confirmed, but another trip screen could not refresh automatically.'
+        : 'The draft changed on the server. Review the latest values before trying again.';
+      applyDraft(freshDraft, current.id, scope);
+      updateCurrentState((state) => ({
+        ...state,
+        draft: freshDraft,
+        confirmState: createConfirmAmbiguityState(freshDraft),
+        fieldErrors: null,
+        feedback,
+      }));
+      return null;
+    }
+    return freshDraft;
+  };
+
+  const patch = async (
+    current: AIActionDraft,
+    payload: Readonly<Record<string, unknown>>,
+    submittedEdit: AIActionDraftSubmittedEdit,
+  ): Promise<void> => {
+    if (!current.can_edit) {
+      return;
+    }
+    const scope = begin('patch');
+    if (scope === null) {
+      return;
+    }
+    updateCurrentState((state) => ({ ...state, fieldErrors: null }));
+    const submittedResource = persistedEditFor(current, submittedEdit);
+    retainExpiredEdit(submittedResource);
+    setEditor(submittedResource);
+    try {
+      const authoritative = await preflightMutation(
+        current,
+        'can_edit',
+        scope,
+      );
+      if (authoritative === null) {
+        return;
+      }
+      const response = await patchAIActionDraft(
+        tripId,
+        authoritative.id,
+        payload,
+        scope.controller.signal,
+      );
+      if (!isLiveScope(scope)) {
+        return;
+      }
+      let responseDraft: AIActionDraft;
+      try {
+        responseDraft = requireMatchingAIActionDraft(
+          response.draft,
+          authoritative.id,
+        );
+      } catch {
+        showContractFailure(scope);
+        return;
+      }
+      retainExpiredEdit(null);
+      setEditor(null);
+      const nextConfirmState = createConfirmAmbiguityState(responseDraft);
+      if (applyDraft(responseDraft, authoritative.id, scope) === null) {
+        return;
+      }
+      updateCurrentState((state) => ({
+        ...state,
+        draft: responseDraft,
+        confirmState: nextConfirmState,
+        feedback: 'Draft updated.',
+        retainedExpiredEdit: null,
+      }));
+    } catch (error: unknown) {
+      if (!isLiveScope(scope)) {
+        return;
+      }
+      const failure = normalizeAIActionDraftApiError(
+        error,
+        'patch',
+        Date.now(),
+        current.id,
+      );
+      let failureDraft: AIActionDraft | null = null;
+      if (failure.draft !== null) {
+        try {
+          failureDraft = requireMatchingAIActionDraft(
+            failure.draft,
+            current.id,
+          );
+        } catch {
+          failureDraft = null;
+        }
+      }
+      const expired =
+        failure.errorCode === 'AI_DRAFT_EXPIRED' ||
+        failureDraft?.status === 'EXPIRED';
+      if (expired) {
+        const retainedResource: AIActionDraftRetainedExpiredEdit = {
+          ...submittedEdit,
+          tripId: canonicalResourceId(tripId),
+          draftId: canonicalResourceId(current.id),
+          submittedSourceIdentity:
+            aiActionDraftMutationSnapshotIdentity(current),
+        };
+        retainExpiredEdit(retainedResource);
+        setEditor(null);
+        updateCurrentState((state) => ({
+          ...state,
+          retainedExpiredEdit: submittedEdit,
+        }));
+      } else {
+        retainExpiredEdit(null);
+        if (failureDraft !== null) {
+          setEditor(null);
+        }
+      }
+      if (failureDraft !== null) {
+        applyDraft(failureDraft, current.id, scope);
+      }
+      updateCurrentState((state) => ({
+        ...state,
+        fieldErrors: failure.fieldErrors,
+        feedback: expired ? null : failure.message,
+      }));
+    } finally {
+      finish(scope);
+    }
+  };
+
+  const confirm = async (current: AIActionDraft): Promise<void> => {
+    if (
+      !current.can_confirm ||
+      (confirmState.confirmRetryAtMs !== null &&
+        Date.now() < confirmState.confirmRetryAtMs)
+    ) {
+      return;
+    }
+    const scope = begin('confirm');
+    if (scope === null) {
+      return;
+    }
+    try {
+      const authoritative = await preflightMutation(
+        current,
+        'can_confirm',
+        scope,
+      );
+      if (authoritative === null) {
+        return;
+      }
+      const state =
+        confirmState.draft.id === authoritative.id
+          ? { ...confirmState, draft: authoritative }
+          : createConfirmAmbiguityState(authoritative);
+      const next = await confirmDraftAfterExplicitApproval({
+        dependencies: confirmDependencies,
+        tripId,
+        state,
+        signal: scope.controller.signal,
+      });
+      applyConfirmState(next, authoritative.id, scope);
+    } finally {
+      finish(scope);
+    }
+  };
+
+  const cancel = async (current: AIActionDraft): Promise<void> => {
+    if (!current.can_cancel) {
+      return;
+    }
+    const scope = begin('cancel');
+    if (scope === null) {
+      return;
+    }
+    try {
+      const authoritative = await preflightMutation(
+        current,
+        'can_cancel',
+        scope,
+      );
+      if (authoritative === null) {
+        return;
+      }
+      const response = await cancelAIActionDraft(
+        tripId,
+        authoritative.id,
+        scope.controller.signal,
+      );
+      if (!isLiveScope(scope)) {
+        return;
+      }
+      let responseDraft: AIActionDraft;
+      try {
+        responseDraft = requireMatchingAIActionDraft(
+          response.draft,
+          authoritative.id,
+        );
+      } catch {
+        showContractFailure(scope);
+        return;
+      }
+      let reconciliationFailed = false;
+      if (responseDraft.status === 'CONFIRMED') {
+        try {
+          await reconcileConfirmedOnce(authoritative.status, responseDraft);
+        } catch {
+          reconciliationFailed = true;
+        }
+      }
+      if (!isLiveScope(scope)) {
+        return;
+      }
+      const nextConfirmState = createConfirmAmbiguityState(responseDraft);
+      const nextFeedback = cancelOutcomeFeedback(
+        responseDraft,
+        reconciliationFailed,
+      );
+      if (applyDraft(responseDraft, authoritative.id, scope) === null) {
+        return;
+      }
+      updateCurrentState((state) => ({
+        ...state,
+        draft: responseDraft,
+        confirmState: nextConfirmState,
+        feedback: nextFeedback,
+      }));
+    } catch (error: unknown) {
+      if (!isLiveScope(scope)) {
+        return;
+      }
+      const failure = normalizeAIActionDraftApiError(
+        error,
+        'cancel',
+        Date.now(),
+        current.id,
+      );
+      if (failure.draft !== null) {
+        applyDraft(failure.draft, current.id, scope);
+      }
+      updateCurrentState((state) => ({
+        ...state,
+        feedback: failure.message,
+      }));
+    } finally {
+      finish(scope);
+    }
+  };
+
+  const checkStatus = async (): Promise<void> => {
+    const scope = begin('check');
+    if (scope === null) {
+      return;
+    }
+    try {
+      const next = await checkConfirmStatus({
+        dependencies: confirmDependencies,
+        tripId,
+        state: confirmState,
+        signal: scope.controller.signal,
+      });
+      applyConfirmState(next, confirmState.draft.id, scope);
+    } finally {
+      finish(scope);
+    }
+  };
+
+  useEffect(() => {
+    const previousDraft = previousIncomingDraftRef.current;
+    previousIncomingDraftRef.current = incomingDraft;
+    if (
+      previousDraft.status === 'CONFIRMED' ||
+      incomingDraft.status !== 'CONFIRMED'
+    ) {
+      return;
+    }
+    const reconciliation = reconcileConfirmedOnce(
+      previousDraft.status,
+      incomingDraft,
+    );
+    void reconciliation.catch(() => {
+      if (!mountedRef.current) {
+        return;
+      }
+      updateCurrentState((state) => ({
+        ...state,
+        feedback:
+          'The action was confirmed, but another trip screen could not refresh automatically.',
+      }));
+    });
+  }, [
+    incomingDraft,
+    incomingSourceIdentity,
+    reconcileConfirmedOnce,
+    updateCurrentState,
+  ]);
+
+  const visibleRetainedExpiredEdit =
+    draft.status === 'EXPIRED'
+      ? (retainedExpiredEdit ?? currentState.retainedExpiredEdit)
+      : currentState.retainedExpiredEdit;
+
+  return (
+    <ActionDraftCard
+      confirmOutcomeUnknown={confirmState.kind === 'unknown'}
+      confirmRetryAtMs={confirmState.confirmRetryAtMs}
+      draft={draft}
+      editableDraftEdit={draft.can_edit ? editor : null}
+      feedback={feedback}
+      fieldErrors={fieldErrors}
+      interactionDisabled={interactionDisabled}
+      nowMs={nowMs}
+      onCancel={cancel}
+      onCheckStatus={checkStatus}
+      onConfirm={confirm}
+      onEditableDraftEditChange={persistEditableDraft}
+      onPatch={patch}
+      pending={pending}
+      retainedExpiredEdit={visibleRetainedExpiredEdit}
+    />
+  );
+}
+
+export function AIActionDraftCardController(
+  props: AIActionDraftCardControllerProps,
+) {
+  const roomSessionStore =
+    useRoomAIActionDraftControllerSessionStore();
+  const resourceKey = controllerResourceKey(props.tripId, props.draft);
+  const sessionKey = canonicalResourceId(props.draft.id);
+  const fallbackSessionStore = useMemo(
+    () =>
+      createAIActionDraftControllerSessionStore(
+        `isolated:${resourceKey}`,
+      ),
+    [resourceKey],
+  );
+  const sessionStore = roomSessionStore ?? fallbackSessionStore;
+  const instanceKey = JSON.stringify([
+    sessionStore.resourceKey,
+    resourceKey,
+  ]);
+
+  return (
+    <AIActionDraftCardControllerResource
+      key={instanceKey}
+      {...props}
+      sessionKey={sessionKey}
+      sessionStore={sessionStore}
+    />
+  );
+}

--- a/mobile/src/features/chat/ai/components/AIMention.tsx
+++ b/mobile/src/features/chat/ai/components/AIMention.tsx
@@ -1,0 +1,170 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import {
+  GOPLAN_AI_MENTION,
+  GOPLAN_AI_PROMPT_LIMIT_PER_HOUR,
+  tokenizeGoPlanAIMention,
+} from '../mention';
+
+export interface GoPlanAIMentionTokenProps {
+  readonly tone?: 'default' | 'inverse';
+}
+
+export function GoPlanAIMentionToken({
+  tone = 'default',
+}: GoPlanAIMentionTokenProps) {
+  return (
+    <Text
+      accessibilityLabel="GoPlanAI mention"
+      style={[
+        styles.token,
+        tone === 'inverse' ? styles.inverseToken : styles.defaultToken,
+      ]}
+      testID="goplan-ai-mention-token"
+    >
+      {GOPLAN_AI_MENTION}
+    </Text>
+  );
+}
+
+export function GoPlanAIMentionMessageText(props: {
+  readonly content: string;
+  readonly inverse?: boolean;
+}) {
+  const segments = tokenizeGoPlanAIMention(props.content);
+  return (
+    <Text style={[styles.message, props.inverse ? styles.inverseText : null]}>
+      {segments.map((segment, index) =>
+        segment.kind === 'mention' ? (
+          <GoPlanAIMentionToken
+            key={`mention-${index}`}
+            tone={props.inverse ? 'inverse' : 'default'}
+          />
+        ) : (
+          <Text key={`text-${index}`}>{segment.text}</Text>
+        ),
+      )}
+    </Text>
+  );
+}
+
+export function GoPlanAIComposerIntent() {
+  return (
+    <View
+      accessibilityLabel={`Message will be sent to GoPlanAI. Limit ${GOPLAN_AI_PROMPT_LIMIT_PER_HOUR} prompts per hour.`}
+      style={styles.intent}
+      testID="goplan-ai-composer-intent"
+    >
+      <GoPlanAIMentionToken />
+      <Text style={styles.intentText}>
+        {GOPLAN_AI_PROMPT_LIMIT_PER_HOUR} prompts/hour
+      </Text>
+    </View>
+  );
+}
+
+export interface GoPlanAIMentionCommandMenuProps {
+  readonly open: boolean;
+  readonly disabled?: boolean;
+  readonly onSelect: () => void;
+}
+
+export function GoPlanAIMentionCommandMenu({
+  open,
+  disabled = false,
+  onSelect,
+}: GoPlanAIMentionCommandMenuProps) {
+  if (!open) {
+    return null;
+  }
+  return (
+    <View
+      accessibilityLabel="Mention suggestions"
+      accessibilityRole="menu"
+      style={styles.menu}
+    >
+      <Pressable
+        accessibilityHint="Inserts the exact GoPlanAI mention"
+        accessibilityLabel="Mention GoPlanAI"
+        accessibilityRole="button"
+        accessibilityState={{ disabled }}
+        disabled={disabled}
+        onPress={onSelect}
+        style={({ pressed }) => [
+          styles.menuItem,
+          pressed && !disabled ? styles.pressed : null,
+          disabled ? styles.disabled : null,
+        ]}
+      >
+        <GoPlanAIMentionToken />
+        <Text style={styles.menuDescription}>Ask GoPlanAI</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  token: {
+    ...typography.label,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xxs,
+    borderRadius: radii.full,
+    borderCurve: 'continuous',
+    overflow: 'hidden',
+  },
+  defaultToken: {
+    color: colors.primary,
+    backgroundColor: colors.primarySoft,
+  },
+  inverseToken: {
+    color: colors.background,
+    backgroundColor: colors.primaryPressed,
+  },
+  message: {
+    ...typography.body,
+    color: colors.text,
+  },
+  inverseText: { color: colors.background },
+  intent: {
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radii.md,
+    borderCurve: 'continuous',
+    backgroundColor: colors.primarySoft,
+  },
+  intentText: {
+    ...typography.caption,
+    color: colors.primary,
+    fontWeight: '600',
+  },
+  menu: {
+    padding: spacing.xs,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.lg,
+    borderCurve: 'continuous',
+    backgroundColor: colors.background,
+  },
+  menuItem: {
+    minHeight: 44,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.sm,
+    borderRadius: radii.md,
+    borderCurve: 'continuous',
+  },
+  menuDescription: {
+    ...typography.caption,
+    color: colors.textMuted,
+  },
+  pressed: { backgroundColor: colors.surface },
+  disabled: { opacity: 0.45 },
+});

--- a/mobile/src/features/chat/ai/components/AIMessageContent.tsx
+++ b/mobile/src/features/chat/ai/components/AIMessageContent.tsx
@@ -1,0 +1,154 @@
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  type StyleProp,
+  type TextStyle,
+} from 'react-native';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import {
+  parseConstrainedAIText,
+  type AIInlineSegment,
+} from '../constrainedText';
+
+function InlineText(props: {
+  readonly segments: readonly AIInlineSegment[];
+  readonly style?: StyleProp<TextStyle>;
+}) {
+  return (
+    <Text style={props.style}>
+      {props.segments.map((segment, index) => {
+        const style =
+          segment.kind === 'code'
+            ? styles.inlineCode
+            : segment.kind === 'strong'
+              ? styles.strong
+              : segment.kind === 'emphasis'
+                ? styles.emphasis
+                : null;
+        return (
+          <Text key={`${segment.kind}-${index}`} style={style}>
+            {segment.text}
+          </Text>
+        );
+      })}
+    </Text>
+  );
+}
+
+export function AIMessageContent({ content }: { readonly content: string }) {
+  const blocks = parseConstrainedAIText(content);
+  return (
+    <View
+      accessibilityLabel="GoPlanAI response"
+      style={styles.container}
+      testID="goplan-ai-message-content"
+    >
+      {blocks.map((block, index) => {
+        if (block.kind === 'code_block') {
+          const language = block.language || 'code';
+          return (
+            <View key={`code-${index}`} style={styles.codeBlock}>
+              <Text style={styles.codeLabel}>{language}</Text>
+              <ScrollView
+                accessibilityLabel={`${language} code block`}
+                contentContainerStyle={styles.codeScrollContent}
+                horizontal
+                showsHorizontalScrollIndicator
+              >
+                <Text selectable style={styles.codeText}>
+                  {block.code}
+                </Text>
+              </ScrollView>
+            </View>
+          );
+        }
+        if (block.kind === 'heading') {
+          return (
+            <InlineText
+              key={`heading-${index}`}
+              segments={block.segments}
+              style={styles.heading}
+            />
+          );
+        }
+        if (block.kind === 'list_item') {
+          return (
+            <View key={`list-${index}`} style={styles.listRow}>
+              <Text style={styles.listMarker}>
+                {block.ordered ? `${block.ordinal ?? 1}.` : '•'}
+              </Text>
+              <View style={styles.listContent}>
+                <InlineText
+                  segments={block.segments}
+                  style={styles.body}
+                />
+              </View>
+            </View>
+          );
+        }
+        return (
+          <InlineText
+            key={`paragraph-${index}`}
+            segments={block.segments}
+            style={styles.body}
+          />
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { gap: spacing.sm },
+  body: { ...typography.body, color: colors.text },
+  heading: {
+    ...typography.body,
+    color: colors.text,
+    fontWeight: '700',
+  },
+  strong: { fontWeight: '700' },
+  emphasis: { fontStyle: 'italic' },
+  inlineCode: {
+    color: colors.slate,
+    backgroundColor: colors.slateSoft,
+  },
+  listRow: {
+    minWidth: 0,
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.sm,
+  },
+  listMarker: {
+    ...typography.body,
+    minWidth: spacing.md,
+    color: colors.textMuted,
+    textAlign: 'right',
+  },
+  listContent: { minWidth: 0, flex: 1 },
+  codeBlock: {
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.lg,
+    borderCurve: 'continuous',
+    backgroundColor: colors.surface,
+  },
+  codeLabel: {
+    ...typography.label,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    color: colors.textMuted,
+    textTransform: 'uppercase',
+    backgroundColor: colors.slateSoft,
+  },
+  codeScrollContent: {
+    minWidth: '100%',
+    padding: spacing.md,
+  },
+  codeText: {
+    ...typography.caption,
+    color: colors.text,
+  },
+});

--- a/mobile/src/features/chat/ai/components/AITypingIndicator.tsx
+++ b/mobile/src/features/chat/ai/components/AITypingIndicator.tsx
@@ -1,0 +1,56 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+
+export function AITypingIndicator(props: {
+  readonly interactionId: string;
+}) {
+  return (
+    <View
+      accessibilityLabel="GoPlanAI is replying"
+      accessibilityLiveRegion="polite"
+      style={styles.row}
+      testID={`goplan-ai-typing-${props.interactionId}`}
+    >
+      <View accessibilityElementsHidden style={styles.avatar}>
+        <Text style={styles.avatarText}>AI</Text>
+      </View>
+      <View style={styles.bubble}>
+        <Text style={styles.label}>GoPlanAI is replying…</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: spacing.sm,
+  },
+  avatar: {
+    width: spacing.xl,
+    height: spacing.xl,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.full,
+    borderCurve: 'continuous',
+    backgroundColor: colors.slateSoft,
+  },
+  avatarText: {
+    ...typography.label,
+    color: colors.slate,
+  },
+  bubble: {
+    minHeight: 44,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radii.lg,
+    borderCurve: 'continuous',
+    backgroundColor: colors.surface,
+  },
+  label: {
+    ...typography.caption,
+    color: colors.textMuted,
+  },
+});

--- a/mobile/src/features/chat/ai/components/ActionDraftCard.tsx
+++ b/mobile/src/features/chat/ai/components/ActionDraftCard.tsx
@@ -1,0 +1,894 @@
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ComponentRef,
+  type ReactNode,
+} from 'react';
+import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import {
+  isKnownAIActionType,
+  aiActionDraftSourceIdentity,
+  type AIActionDraft,
+  type AIActionDraftStatus,
+} from '../drafts';
+import {
+  confirmationAuthorityText,
+  confirmationRestatement,
+  draftKicker,
+  draftTitle,
+  previewRows,
+} from '../presentation';
+import { useAIActionDraftExpiry } from '../useExpiryClock';
+import { useAIConfirmRetryClock } from '../useConfirmRetryClock';
+import { focusAccessibilityNode } from '../accessibilityFocus';
+import { DraftFieldEditor } from './DraftFieldEditor';
+import { ExpenseDraftDetails } from './renderers/ExpenseDraftDetails';
+import { GenericDraftDetails } from './renderers/GenericDraftDetails';
+import { SettlementDraftDetails } from './renderers/SettlementDraftDetails';
+import { DetailRows } from './renderers/shared';
+import { TimelineDraftDetails } from './renderers/TimelineDraftDetails';
+import { TransferDraftDetails } from './renderers/TransferDraftDetails';
+
+export type AIActionDraftPendingOperation =
+  | 'patch'
+  | 'confirm'
+  | 'cancel'
+  | 'check'
+  | null;
+
+export interface AIActionDraftSubmittedEdit {
+  readonly fields: AIActionDraft['missing_fields'];
+  readonly values: Readonly<Record<string, unknown>>;
+}
+
+export interface ActionDraftCardProps {
+  readonly draft: AIActionDraft;
+  readonly interactionDisabled?: boolean;
+  readonly pending?: AIActionDraftPendingOperation;
+  readonly feedback?: string | null;
+  readonly fieldErrors?: Readonly<Record<string, string>> | null;
+  readonly confirmOutcomeUnknown?: boolean;
+  readonly confirmRetryAtMs?: number | null;
+  readonly retainedExpiredEdit?: AIActionDraftSubmittedEdit | null;
+  readonly editableDraftEdit?: AIActionDraftSubmittedEdit | null;
+  readonly nowMs?: number;
+  readonly onPatch: (
+    draft: AIActionDraft,
+    payload: Readonly<Record<string, unknown>>,
+    submittedEdit: AIActionDraftSubmittedEdit,
+  ) => void | Promise<void>;
+  readonly onConfirm: (draft: AIActionDraft) => void | Promise<void>;
+  readonly onCancel: (draft: AIActionDraft) => void | Promise<void>;
+  readonly onCheckStatus: (draft: AIActionDraft) => void | Promise<void>;
+  readonly onEditableDraftEditChange?: (
+    edit: AIActionDraftSubmittedEdit | null,
+  ) => void;
+}
+
+type ReviewPanel = 'confirm' | 'cancel' | 'edit' | null;
+
+interface ReviewPanelState {
+  readonly panel: Exclude<ReviewPanel, null>;
+  readonly draftVersion: string;
+}
+
+const STATUS_LABELS: Readonly<Record<AIActionDraftStatus, string>> = {
+  NEEDS_INFO: 'Needs info',
+  READY: 'Ready',
+  CONFIRMED: 'Confirmed',
+  CANCELLED: 'Cancelled',
+  EXPIRED: 'Expired',
+  FAILED: 'Failed',
+};
+
+const STATUS_TONES: Readonly<
+  Record<
+    AIActionDraftStatus,
+    {
+      readonly pill: { readonly backgroundColor: string };
+      readonly text: { readonly color: string };
+    }
+  >
+> = {
+  NEEDS_INFO: {
+    pill: { backgroundColor: colors.warningSoft },
+    text: { color: colors.warning },
+  },
+  READY: {
+    pill: { backgroundColor: colors.successSoft },
+    text: { color: colors.success },
+  },
+  CONFIRMED: {
+    pill: { backgroundColor: colors.primarySoft },
+    text: { color: colors.primary },
+  },
+  CANCELLED: {
+    pill: { backgroundColor: colors.roseSoft },
+    text: { color: colors.rose },
+  },
+  EXPIRED: {
+    pill: { backgroundColor: colors.amberSoft },
+    text: { color: colors.amber },
+  },
+  FAILED: {
+    pill: { backgroundColor: colors.dangerSoft },
+    text: { color: colors.danger },
+  },
+};
+
+function ActionGlyph({ draft }: { readonly draft: AIActionDraft }) {
+  const glyph = draft.action_type.startsWith('timeline.')
+    ? 'T'
+    : draft.action_type.startsWith('expense.')
+      ? '$'
+      : draft.action_type.startsWith('settlement.transfer.')
+        ? '↔'
+        : draft.action_type.startsWith('settlement.')
+          ? 'S'
+          : 'AI';
+  return (
+    <View
+      accessibilityLabel={`${draftKicker(draft)} action`}
+      style={styles.icon}
+    >
+      <Text style={styles.iconText}>{glyph}</Text>
+    </View>
+  );
+}
+
+const StatusPill = forwardRef<
+  ComponentRef<typeof View>,
+  { readonly status: AIActionDraftStatus }
+>(function StatusPill({ status }, ref) {
+  const tone = STATUS_TONES[status];
+  return (
+    <View
+      accessibilityLabel={`Draft status: ${STATUS_LABELS[status]}`}
+      accessibilityRole="text"
+      ref={ref}
+      style={[styles.statusPill, tone.pill]}
+    >
+      <Text style={[styles.statusText, tone.text]}>
+        {STATUS_LABELS[status]}
+      </Text>
+    </View>
+  );
+});
+
+function StatusDetails(props: {
+  readonly draft: AIActionDraft;
+  readonly visualStatus: AIActionDraftStatus;
+}) {
+  const { draft, visualStatus } = props;
+  if (visualStatus === 'NEEDS_INFO') {
+    return (
+      <View style={styles.stateDetails}>
+        <Text style={styles.stateText}>Information is still required:</Text>
+        {draft.missing_fields.map((field) => (
+          <Text key={field.name} style={styles.missingField}>
+            • {field.label}
+          </Text>
+        ))}
+      </View>
+    );
+  }
+  if (visualStatus === 'READY') {
+    return (
+      <Text style={styles.stateText}>
+        Review every value before explicitly confirming this shared trip change.
+      </Text>
+    );
+  }
+  if (visualStatus === 'CONFIRMED') {
+    return (
+      <View style={styles.stateDetails}>
+        <Text style={styles.confirmedText}>The action was confirmed.</Text>
+        <DetailRows rows={previewRows(draft.result)} testID="ai-draft-result" />
+      </View>
+    );
+  }
+  if (visualStatus === 'CANCELLED') {
+    return <Text style={styles.stateText}>This draft was cancelled.</Text>;
+  }
+  if (visualStatus === 'EXPIRED') {
+    return (
+      <Text style={styles.stateText}>
+        This draft expired and can no longer be changed or confirmed.
+      </Text>
+    );
+  }
+  return (
+    <View style={styles.stateDetails}>
+      <Text style={styles.failedText}>The proposed action failed.</Text>
+      {draft.error_code.trim().length > 0 ? (
+        <Text style={styles.stateText}>Code: {draft.error_code}</Text>
+      ) : null}
+      {draft.error_detail.trim().length > 0 ? (
+        <Text style={styles.stateText}>{draft.error_detail}</Text>
+      ) : null}
+    </View>
+  );
+}
+
+function DraftSpecificDetails({ draft }: { readonly draft: AIActionDraft }) {
+  if (!isKnownAIActionType(draft.action_type)) {
+    return <GenericDraftDetails draft={draft} />;
+  }
+  if (draft.action_type.startsWith('timeline.activity.')) {
+    return <TimelineDraftDetails draft={draft} />;
+  }
+  if (draft.action_type.startsWith('expense.')) {
+    return <ExpenseDraftDetails draft={draft} />;
+  }
+  if (draft.action_type.startsWith('settlement.transfer.')) {
+    return <TransferDraftDetails draft={draft} />;
+  }
+  return <SettlementDraftDetails draft={draft} />;
+}
+
+interface ActionButtonProps {
+  readonly label: string;
+  readonly tone?: 'primary' | 'neutral' | 'danger';
+  readonly disabled: boolean;
+  readonly busy?: boolean;
+  readonly onPress: () => void;
+}
+
+const ActionButton = forwardRef<
+  ComponentRef<typeof Pressable>,
+  ActionButtonProps
+>(function ActionButton(props, ref) {
+  const tone = props.tone ?? 'neutral';
+  return (
+    <Pressable
+      accessibilityLabel={props.label}
+      accessibilityRole="button"
+      accessibilityState={{ disabled: props.disabled, busy: props.busy ?? false }}
+      disabled={props.disabled}
+      onPress={props.onPress}
+      ref={ref}
+      style={({ pressed }) => [
+        styles.actionButton,
+        tone === 'primary'
+          ? styles.primaryButton
+          : tone === 'danger'
+            ? styles.dangerButton
+            : styles.neutralButton,
+        pressed && !props.disabled ? styles.buttonPressed : null,
+        props.disabled ? styles.disabled : null,
+      ]}
+    >
+      <Text
+        style={[
+          styles.actionButtonText,
+          tone === 'primary'
+            ? styles.primaryButtonText
+            : tone === 'danger'
+              ? styles.dangerButtonText
+              : styles.neutralButtonText,
+        ]}
+      >
+        {props.label}
+      </Text>
+    </Pressable>
+  );
+});
+
+function ReviewModalShell(props: {
+  readonly dismissible: boolean;
+  readonly children: ReactNode;
+  readonly kind: 'confirm' | 'cancel';
+  readonly visible: boolean;
+  readonly onDismiss: () => void;
+  readonly onRequestClose: () => void;
+  readonly onShow: () => void;
+}) {
+  if (!props.visible) {
+    return null;
+  }
+  return (
+    <Modal
+      allowSwipeDismissal={props.dismissible}
+      animationType="slide"
+      onDismiss={props.onDismiss}
+      onRequestClose={props.onRequestClose}
+      onShow={props.onShow}
+      presentationStyle="formSheet"
+      testID={`ai-draft-${props.kind}-modal`}
+      visible
+    >
+      <SafeAreaView style={styles.modalSafeArea}>
+        <ScrollView
+          contentContainerStyle={styles.modalScrollContent}
+          contentInsetAdjustmentBehavior="automatic"
+        >
+          <View
+            accessibilityLabel={`${props.kind === 'confirm' ? 'Confirm' : 'Cancel'} AI action draft review`}
+            accessibilityViewIsModal
+            style={styles.reviewPanel}
+            testID={`ai-draft-${props.kind}-modal-content`}
+          >
+            {props.children}
+          </View>
+        </ScrollView>
+      </SafeAreaView>
+    </Modal>
+  );
+}
+
+export function ActionDraftCard({
+  draft,
+  interactionDisabled = false,
+  pending = null,
+  feedback = null,
+  fieldErrors = null,
+  confirmOutcomeUnknown = false,
+  confirmRetryAtMs = null,
+  retainedExpiredEdit = null,
+  editableDraftEdit = null,
+  nowMs,
+  onPatch,
+  onConfirm,
+  onCancel,
+  onCheckStatus,
+  onEditableDraftEditChange,
+}: ActionDraftCardProps) {
+  const [reviewState, setReviewState] = useState<ReviewPanelState | null>(null);
+  const actionLockRef = useRef<symbol | null>(null);
+  const interactionDisabledRef = useRef(interactionDisabled);
+  const confirmTriggerRef = useRef<ComponentRef<typeof Pressable>>(null);
+  const cancelTriggerRef = useRef<ComponentRef<typeof Pressable>>(null);
+  const confirmHeadingRef = useRef<ComponentRef<typeof Text>>(null);
+  const cancelHeadingRef = useRef<ComponentRef<typeof Text>>(null);
+  const statusPillRef = useRef<ComponentRef<typeof View>>(null);
+  const returnFocusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const returnFocusPanelRef = useRef<'confirm' | 'cancel' | null>(null);
+  const expiry = useAIActionDraftExpiry(draft, nowMs);
+  const confirmRetry = useAIConfirmRetryClock(confirmRetryAtMs, nowMs);
+  const busy = pending !== null;
+  const locallyDisabled = busy || expiry.isExpired || interactionDisabled;
+  const draftVersion = aiActionDraftSourceIdentity(draft);
+  const submittedFocusIntentRef = useRef<{
+    readonly panel: 'confirm' | 'cancel';
+    readonly draftVersion: string;
+  } | null>(null);
+  const reviewPanel: ReviewPanel =
+    reviewState?.draftVersion === draftVersion
+      ? reviewState.panel
+      : editableDraftEdit !== null && draft.can_edit
+        ? 'edit'
+        : null;
+
+  useLayoutEffect(() => {
+    interactionDisabledRef.current = interactionDisabled;
+  }, [interactionDisabled]);
+
+  const showPanel = (panel: Exclude<ReviewPanel, null>): void => {
+    if (interactionDisabledRef.current) {
+      return;
+    }
+    submittedFocusIntentRef.current = null;
+    if (panel === 'edit' && editableDraftEdit === null) {
+      onEditableDraftEditChange?.({
+        fields: draft.missing_fields,
+        values: {},
+      });
+    }
+    setReviewState({ panel, draftVersion });
+  };
+  const completeTriggerFocus = useCallback((): void => {
+    if (returnFocusTimerRef.current !== null) {
+      clearTimeout(returnFocusTimerRef.current);
+      returnFocusTimerRef.current = null;
+    }
+    const panel = returnFocusPanelRef.current;
+    returnFocusPanelRef.current = null;
+    if (panel === null) {
+      return;
+    }
+    const trigger =
+      panel === 'confirm'
+        ? confirmTriggerRef.current
+        : cancelTriggerRef.current;
+    focusAccessibilityNode(trigger ?? statusPillRef.current);
+    const submittedIntent = submittedFocusIntentRef.current;
+    if (
+      trigger === null &&
+      submittedIntent?.panel === panel
+    ) {
+      submittedFocusIntentRef.current = null;
+    }
+  }, []);
+  const scheduleTriggerFocus = (panel: 'confirm' | 'cancel'): void => {
+    returnFocusPanelRef.current = panel;
+    if (returnFocusTimerRef.current !== null) {
+      clearTimeout(returnFocusTimerRef.current);
+    }
+    returnFocusTimerRef.current = setTimeout(() => {
+      completeTriggerFocus();
+    }, 500);
+  };
+  const closePanel = (
+    panel: 'confirm' | 'cancel',
+    submitted = false,
+  ): void => {
+    if (submitted) {
+      submittedFocusIntentRef.current = { panel, draftVersion };
+    }
+    setReviewState(null);
+    scheduleTriggerFocus(panel);
+  };
+  const closeReview = (): void => {
+    if (!busy && (reviewPanel === 'confirm' || reviewPanel === 'cancel')) {
+      closePanel(reviewPanel);
+    }
+  };
+
+  const priorDraftVersionRef = useRef(draftVersion);
+  useLayoutEffect(() => {
+    if (priorDraftVersionRef.current === draftVersion) {
+      return;
+    }
+    const priorDraftVersion = priorDraftVersionRef.current;
+    priorDraftVersionRef.current = draftVersion;
+    actionLockRef.current = null;
+    const submittedIntent = submittedFocusIntentRef.current;
+    if (submittedIntent?.draftVersion === priorDraftVersion) {
+      if (returnFocusPanelRef.current !== submittedIntent.panel) {
+        const trigger =
+          submittedIntent.panel === 'confirm'
+            ? confirmTriggerRef.current
+            : cancelTriggerRef.current;
+        if (trigger === null) {
+          focusAccessibilityNode(statusPillRef.current);
+        }
+      }
+      submittedFocusIntentRef.current = null;
+    }
+    const stalePanel = reviewState?.panel ?? null;
+    setReviewState(null);
+    if (stalePanel === 'confirm' || stalePanel === 'cancel') {
+      returnFocusPanelRef.current = stalePanel;
+      if (returnFocusTimerRef.current !== null) {
+        clearTimeout(returnFocusTimerRef.current);
+      }
+      returnFocusTimerRef.current = setTimeout(() => {
+        completeTriggerFocus();
+      }, 500);
+    }
+  }, [draftVersion, reviewState, completeTriggerFocus]);
+
+  const priorPendingRef = useRef(pending);
+  useLayoutEffect(() => {
+    const priorPending = priorPendingRef.current;
+    priorPendingRef.current = pending;
+    if (
+      priorPending !== null &&
+      pending === null &&
+      submittedFocusIntentRef.current?.draftVersion === draftVersion
+    ) {
+      submittedFocusIntentRef.current = null;
+    }
+  }, [draftVersion, pending]);
+
+  useEffect(
+    () => () => {
+      if (returnFocusTimerRef.current !== null) {
+        clearTimeout(returnFocusTimerRef.current);
+        returnFocusTimerRef.current = null;
+      }
+      returnFocusPanelRef.current = null;
+      submittedFocusIntentRef.current = null;
+    },
+    [],
+  );
+
+  const save = async (
+    payload: Readonly<Record<string, unknown>>,
+    editedValues: Readonly<Record<string, unknown>>,
+  ): Promise<void> => {
+    if (
+      actionLockRef.current !== null ||
+      busy ||
+      interactionDisabledRef.current ||
+      expiry.isExpired ||
+      !draft.can_edit
+    ) {
+      return;
+    }
+    const lockOwner = Symbol('ai-draft-patch');
+    actionLockRef.current = lockOwner;
+    try {
+      await onPatch(draft, payload, {
+        fields: draft.missing_fields,
+        values: editedValues,
+      });
+    } finally {
+      if (actionLockRef.current === lockOwner) {
+        actionLockRef.current = null;
+      }
+    }
+  };
+
+  const runAction = async (
+    action: (current: AIActionDraft) => void | Promise<void>,
+    permitted: boolean,
+  ): Promise<void> => {
+    if (
+      actionLockRef.current !== null ||
+      busy ||
+      interactionDisabledRef.current ||
+      !permitted
+    ) {
+      return;
+    }
+    const lockOwner = Symbol('ai-draft-action');
+    actionLockRef.current = lockOwner;
+    try {
+      await action(draft);
+    } finally {
+      if (actionLockRef.current === lockOwner) {
+        actionLockRef.current = null;
+      }
+    }
+  };
+  const visibleEdit = retainedExpiredEdit ?? editableDraftEdit;
+  const editorDraft =
+    visibleEdit === null
+      ? draft
+      : { ...draft, missing_fields: visibleEdit.fields };
+
+  return (
+    <View
+      accessibilityLabel={`${draftKicker(draft)} draft, ${STATUS_LABELS[expiry.visualStatus]}`}
+      style={styles.card}
+      testID={`ai-action-draft-${draft.id}`}
+    >
+      <View style={styles.header}>
+        <ActionGlyph draft={draft} />
+        <View style={styles.headingBlock}>
+          <Text style={styles.kicker}>{draftKicker(draft)}</Text>
+          <Text style={styles.title}>{draftTitle(draft)}</Text>
+        </View>
+        <StatusPill ref={statusPillRef} status={expiry.visualStatus} />
+      </View>
+
+      <Text
+        accessibilityLabel={`Draft expiry: ${expiry.label}`}
+        style={styles.expiry}
+        testID="ai-draft-expiry"
+      >
+        {expiry.label}
+      </Text>
+
+      <DraftSpecificDetails draft={draft} />
+      <StatusDetails draft={draft} visualStatus={expiry.visualStatus} />
+
+      {feedback !== null ? (
+        <Text
+          accessibilityLiveRegion="polite"
+          accessibilityRole="alert"
+          style={styles.feedback}
+        >
+          {feedback}
+        </Text>
+      ) : null}
+
+      {visibleEdit !== null ||
+      (reviewPanel === 'edit' && draft.can_edit) ? (
+        <DraftFieldEditor
+          disabled={locallyDisabled || retainedExpiredEdit !== null}
+          disabledMessage={
+            retainedExpiredEdit !== null || expiry.isExpired
+              ? 'This draft expired. Your edits were not applied.'
+              : null
+          }
+          draft={editorDraft}
+          fieldErrors={fieldErrors}
+          initialValues={visibleEdit?.values}
+          onValuesChange={(values) =>
+            onEditableDraftEditChange?.({
+              fields: editorDraft.missing_fields,
+              values,
+            })
+          }
+          onSave={save}
+          pending={pending === 'patch'}
+        />
+      ) : null}
+
+      <ReviewModalShell
+        dismissible={!busy}
+        kind="confirm"
+        onDismiss={completeTriggerFocus}
+        onRequestClose={closeReview}
+        onShow={() => focusAccessibilityNode(confirmHeadingRef.current)}
+        visible={
+          reviewPanel === 'confirm' &&
+          draft.can_confirm &&
+          !confirmOutcomeUnknown
+        }
+      >
+          <Text
+            accessibilityRole="header"
+            ref={confirmHeadingRef}
+            style={styles.reviewTitle}
+          >
+            Confirm this action?
+          </Text>
+          <Text style={styles.reviewText}>{confirmationRestatement(draft)}</Text>
+          <Text style={styles.authorityText}>{confirmationAuthorityText(draft)}</Text>
+          {expiry.isExpired ? (
+            <Text accessibilityRole="alert" style={styles.feedback}>
+              This draft expired and cannot be confirmed.
+            </Text>
+          ) : null}
+          {confirmRetry.label !== null ? (
+            <Text accessibilityRole="alert" style={styles.retryText}>
+              {confirmRetry.label}. Close this review and wait before confirming.
+            </Text>
+          ) : null}
+          <View style={styles.reviewActions}>
+            <ActionButton
+              disabled={busy}
+              label="Back to review"
+              onPress={closeReview}
+            />
+            <ActionButton
+              busy={pending === 'confirm'}
+              disabled={locallyDisabled || confirmRetry.blocked}
+              label="Confirm this action"
+              onPress={() => {
+                closePanel('confirm', true);
+                void runAction(
+                  onConfirm,
+                  draft.can_confirm &&
+                    !expiry.isExpired &&
+                    !confirmRetry.blocked,
+                );
+              }}
+              tone="primary"
+            />
+          </View>
+      </ReviewModalShell>
+
+      <ReviewModalShell
+        dismissible={!busy}
+        kind="cancel"
+        onDismiss={completeTriggerFocus}
+        onRequestClose={closeReview}
+        onShow={() => focusAccessibilityNode(cancelHeadingRef.current)}
+        visible={reviewPanel === 'cancel' && draft.can_cancel}
+      >
+          <Text
+            accessibilityRole="header"
+            ref={cancelHeadingRef}
+            style={styles.reviewTitle}
+          >
+            Cancel this draft?
+          </Text>
+          <Text style={styles.reviewText}>
+            The proposal will be discarded and will not change trip data.
+          </Text>
+          {expiry.isExpired ? (
+            <Text accessibilityRole="alert" style={styles.feedback}>
+              This draft expired and cannot be cancelled.
+            </Text>
+          ) : null}
+          <View style={styles.reviewActions}>
+            <ActionButton
+              disabled={busy}
+              label="Keep reviewing"
+              onPress={closeReview}
+            />
+            <ActionButton
+              busy={pending === 'cancel'}
+              disabled={locallyDisabled}
+              label="Cancel this draft"
+              onPress={() => {
+                closePanel('cancel', true);
+                void runAction(
+                  onCancel,
+                  draft.can_cancel && !expiry.isExpired,
+                );
+              }}
+              tone="danger"
+            />
+          </View>
+      </ReviewModalShell>
+
+      {confirmOutcomeUnknown ? (
+        <View style={styles.unknownOutcome}>
+          <Text style={styles.unknownOutcomeText}>
+            Confirmation outcome is unknown. Do not confirm again.
+          </Text>
+          <ActionButton
+            busy={pending === 'check'}
+            disabled={busy || interactionDisabled}
+            label="Check status"
+            onPress={() => void runAction(onCheckStatus, true)}
+          />
+        </View>
+      ) : (
+        <View style={styles.actionSection}>
+          {draft.can_confirm && confirmRetry.label !== null ? (
+            <Text
+              accessibilityLiveRegion="polite"
+              style={styles.retryText}
+              testID="ai-confirm-retry-deadline"
+            >
+              {confirmRetry.label}
+            </Text>
+          ) : null}
+          <View style={styles.actions} testID="ai-draft-actions">
+          {draft.can_edit ? (
+            <ActionButton
+              disabled={locallyDisabled}
+              label="Edit draft"
+              onPress={() => showPanel('edit')}
+            />
+          ) : null}
+          {draft.can_cancel ? (
+            <ActionButton
+              disabled={locallyDisabled}
+              label="Cancel"
+              onPress={() => showPanel('cancel')}
+              ref={cancelTriggerRef}
+              tone="danger"
+            />
+          ) : null}
+          {draft.can_confirm ? (
+            <ActionButton
+              disabled={locallyDisabled || confirmRetry.blocked}
+              label="Confirm"
+              onPress={() => showPanel('confirm')}
+              ref={confirmTriggerRef}
+              tone="primary"
+            />
+          ) : null}
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    minWidth: 0,
+    width: '100%',
+    gap: spacing.md,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.lg,
+    borderCurve: 'continuous',
+    backgroundColor: colors.background,
+  },
+  header: {
+    minWidth: 0,
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.sm,
+  },
+  icon: {
+    width: spacing.xl,
+    minHeight: spacing.xl,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.md,
+    borderCurve: 'continuous',
+    backgroundColor: colors.primarySoft,
+  },
+  iconText: { ...typography.label, color: colors.primary },
+  headingBlock: { minWidth: 0, flex: 1, gap: spacing.xxs },
+  kicker: {
+    ...typography.caption,
+    color: colors.textMuted,
+    textTransform: 'uppercase',
+  },
+  title: {
+    ...typography.body,
+    minWidth: 0,
+    flexShrink: 1,
+    color: colors.text,
+    fontWeight: '700',
+  },
+  statusPill: {
+    minHeight: spacing.xl,
+    flexShrink: 0,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radii.full,
+    borderCurve: 'continuous',
+  },
+  statusText: { ...typography.label },
+  expiry: { ...typography.caption, color: colors.textMuted },
+  stateDetails: { gap: spacing.xs },
+  stateText: { ...typography.caption, color: colors.textMuted },
+  missingField: { ...typography.caption, color: colors.warning },
+  confirmedText: { ...typography.caption, color: colors.success },
+  failedText: { ...typography.caption, color: colors.danger, fontWeight: '600' },
+  feedback: { ...typography.caption, color: colors.danger },
+  actionSection: { gap: spacing.sm },
+  retryText: { ...typography.caption, color: colors.warning },
+  actions: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'flex-end',
+    gap: spacing.sm,
+    paddingTop: spacing.sm,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+  },
+  actionButton: {
+    minWidth: 44,
+    minHeight: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderWidth: 1,
+    borderRadius: radii.md,
+    borderCurve: 'continuous',
+  },
+  primaryButton: {
+    borderColor: colors.primary,
+    backgroundColor: colors.primary,
+  },
+  neutralButton: {
+    borderColor: colors.border,
+    backgroundColor: colors.background,
+  },
+  dangerButton: {
+    borderColor: colors.dangerBorder,
+    backgroundColor: colors.dangerSoft,
+  },
+  actionButtonText: { ...typography.label, textAlign: 'center' },
+  primaryButtonText: { color: colors.background },
+  neutralButtonText: { color: colors.text },
+  dangerButtonText: { color: colors.danger },
+  buttonPressed: { opacity: 0.62 },
+  disabled: { opacity: 0.45 },
+  reviewPanel: {
+    gap: spacing.sm,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.warning,
+    borderRadius: radii.md,
+    borderCurve: 'continuous',
+    backgroundColor: colors.warningSoft,
+  },
+  modalSafeArea: { flex: 1, backgroundColor: colors.background },
+  modalScrollContent: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    padding: spacing.md,
+  },
+  reviewTitle: { ...typography.body, color: colors.text, fontWeight: '700' },
+  reviewText: { ...typography.body, color: colors.text },
+  authorityText: { ...typography.caption, color: colors.textMuted },
+  reviewActions: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'flex-end',
+    gap: spacing.sm,
+  },
+  unknownOutcome: {
+    gap: spacing.sm,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.warning,
+    borderRadius: radii.md,
+    borderCurve: 'continuous',
+    backgroundColor: colors.warningSoft,
+  },
+  unknownOutcomeText: { ...typography.body, color: colors.text },
+});

--- a/mobile/src/features/chat/ai/components/DraftFieldEditor.tsx
+++ b/mobile/src/features/chat/ai/components/DraftFieldEditor.tsx
@@ -1,0 +1,391 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+import {
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import {
+  buildEditedDraftPayload,
+  createDraftEditingState,
+  rebaseDraftEditingState,
+  setDraftEditedValue,
+  type DraftEditingState,
+} from '../editing';
+import type {
+  AIActionDraft,
+  AIActionDraftMissingField,
+} from '../drafts';
+
+export interface DraftFieldEditorProps {
+  readonly draft: AIActionDraft;
+  readonly pending: boolean;
+  readonly disabled?: boolean;
+  readonly disabledMessage?: string | null;
+  readonly initialValues?: Readonly<Record<string, unknown>>;
+  readonly fieldErrors?: Readonly<Record<string, string>> | null;
+  readonly onValuesChange?: (
+    values: Readonly<Record<string, unknown>>,
+  ) => void;
+  readonly onSave: (
+    payload: Readonly<Record<string, unknown>>,
+    editedValues: Readonly<Record<string, unknown>>,
+  ) => void | Promise<void>;
+}
+
+function timeRangeNames(field: AIActionDraftMissingField): readonly [string, string] {
+  const pair = field.constraints?.pair;
+  if (
+    Array.isArray(pair) &&
+    pair.length === 2 &&
+    typeof pair[0] === 'string' &&
+    typeof pair[1] === 'string' &&
+    pair[0].length > 0 &&
+    pair[1].length > 0
+  ) {
+    return [pair[0], pair[1]];
+  }
+  return ['start_time', 'end_time'];
+}
+
+function InputError({ message }: { readonly message: string | null }) {
+  return message ? (
+    <Text accessibilityRole="alert" style={styles.errorText}>
+      {message}
+    </Text>
+  ) : null;
+}
+
+function SelectField(props: {
+  readonly field: AIActionDraftMissingField;
+  readonly value: unknown;
+  readonly disabled: boolean;
+  readonly error: string | null;
+  readonly onChange: (name: string, value: string) => void;
+}) {
+  const selected = typeof props.value === 'string' ? props.value : '';
+  return (
+    <View style={styles.fieldGroup}>
+      <Text style={styles.fieldLabel}>{props.field.label}</Text>
+      <View style={styles.options}>
+        {(props.field.options ?? []).map((option) => {
+          const isSelected = selected === option.value;
+          return (
+            <Pressable
+              key={option.value}
+              accessibilityLabel={`${props.field.label}: ${option.label}`}
+              accessibilityRole="button"
+              accessibilityState={{
+                disabled: props.disabled,
+                selected: isSelected,
+              }}
+              disabled={props.disabled}
+              onPress={() => props.onChange(props.field.name, option.value)}
+              style={({ pressed }) => [
+                styles.option,
+                isSelected ? styles.optionSelected : null,
+                pressed && !props.disabled ? styles.pressed : null,
+                props.disabled ? styles.disabled : null,
+              ]}
+            >
+              <Text
+                style={[
+                  styles.optionText,
+                  isSelected ? styles.optionTextSelected : null,
+                ]}
+              >
+                {option.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+      <InputError message={props.error} />
+    </View>
+  );
+}
+
+function TimeRangeField(props: {
+  readonly field: AIActionDraftMissingField;
+  readonly state: DraftEditingState;
+  readonly disabled: boolean;
+  readonly fieldErrors: Readonly<Record<string, string>>;
+  readonly onChange: (name: string, value: string) => void;
+}) {
+  const [startName, endName] = timeRangeNames(props.field);
+  const start = props.state.editedValues[startName];
+  const end = props.state.editedValues[endName];
+  return (
+    <View style={styles.fieldGroup}>
+      <Text style={styles.fieldLabel}>{props.field.label}</Text>
+      <View style={styles.timeRange}>
+        <View style={styles.timeInputBlock}>
+          <Text style={styles.inputCaption}>Start</Text>
+          <TextInput
+            accessibilityLabel={`${props.field.label} start`}
+            editable={!props.disabled}
+            onChangeText={(value) => props.onChange(startName, value)}
+            placeholder="HH:MM"
+            placeholderTextColor={colors.textMuted}
+            style={styles.input}
+            value={typeof start === 'string' ? start : ''}
+          />
+          <InputError message={props.fieldErrors[startName] ?? null} />
+        </View>
+        <View style={styles.timeInputBlock}>
+          <Text style={styles.inputCaption}>End</Text>
+          <TextInput
+            accessibilityLabel={`${props.field.label} end`}
+            editable={!props.disabled}
+            onChangeText={(value) => props.onChange(endName, value)}
+            placeholder="HH:MM"
+            placeholderTextColor={colors.textMuted}
+            style={styles.input}
+            value={typeof end === 'string' ? end : ''}
+          />
+          <InputError message={props.fieldErrors[endName] ?? null} />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function TextField(props: {
+  readonly field: AIActionDraftMissingField;
+  readonly value: unknown;
+  readonly disabled: boolean;
+  readonly error: string | null;
+  readonly onChange: (name: string, value: string) => void;
+}) {
+  return (
+    <View style={styles.fieldGroup}>
+      <Text style={styles.fieldLabel}>{props.field.label}</Text>
+      <TextInput
+        accessibilityLabel={props.field.label}
+        editable={!props.disabled}
+        keyboardType={props.field.type === 'money' ? 'decimal-pad' : 'default'}
+        multiline={props.field.type === 'json'}
+        onChangeText={(value) => props.onChange(props.field.name, value)}
+        placeholder={props.field.required ? 'Required' : 'Enter a value'}
+        placeholderTextColor={colors.textMuted}
+        style={[
+          styles.input,
+          props.field.type === 'json' ? styles.multilineInput : null,
+          props.error ? styles.inputError : null,
+        ]}
+        value={typeof props.value === 'string' ? props.value : ''}
+      />
+      <InputError message={props.error} />
+    </View>
+  );
+}
+
+export function DraftFieldEditor({
+  draft,
+  pending,
+  disabled = false,
+  disabledMessage = null,
+  initialValues = {},
+  fieldErrors: serverFieldErrors,
+  onValuesChange,
+  onSave,
+}: DraftFieldEditorProps) {
+  const [editing, setEditing] = useState(() => ({
+    ...createDraftEditingState(draft),
+    editedValues: { ...initialValues },
+  }));
+  const editingRef = useRef(editing);
+  const [localMessage, setLocalMessage] = useState<string | null>(null);
+  const currentEditing =
+    editing.draft.id === draft.id && editing.draft.updated_at === draft.updated_at
+      ? editing
+      : rebaseDraftEditingState(editing, draft);
+
+  useLayoutEffect(() => {
+    editingRef.current = currentEditing;
+  }, [currentEditing]);
+
+  const fieldErrors = serverFieldErrors ?? currentEditing.fieldErrors;
+  const controlsDisabled = disabled || pending;
+  const change = (name: string, value: string): void => {
+    const next = setDraftEditedValue(
+      rebaseDraftEditingState(editingRef.current, draft),
+      name,
+      value,
+    );
+    editingRef.current = next;
+    setEditing(next);
+    onValuesChange?.(next.editedValues);
+    setLocalMessage(null);
+  };
+
+  const save = async (): Promise<void> => {
+    const latestEditing = rebaseDraftEditingState(
+      editingRef.current,
+      draft,
+    );
+    const built = buildEditedDraftPayload(latestEditing);
+    if (!built.ok) {
+      setLocalMessage(built.message);
+      if (built.field !== null) {
+        const fieldName = built.field;
+        const next = {
+          ...latestEditing,
+          fieldErrors: {
+            ...latestEditing.fieldErrors,
+            [fieldName]: built.message,
+          },
+        };
+        editingRef.current = next;
+        setEditing(next);
+      }
+      return;
+    }
+    setLocalMessage(null);
+    await onSave(built.payload, latestEditing.editedValues);
+  };
+
+  return (
+    <View style={styles.editor} testID="ai-draft-field-editor">
+      {draft.missing_fields.map((field) => {
+        if (field.type === 'target') {
+          return (
+            <View key={field.name} style={styles.fieldGroup}>
+              <Text style={styles.fieldLabel}>{field.label}</Text>
+              <Text style={styles.targetHelp}>
+                Ask GoPlanAI to clarify this target. It cannot be guessed on the device.
+              </Text>
+            </View>
+          );
+        }
+        if (field.type === 'time_range') {
+          return (
+            <TimeRangeField
+              key={field.name}
+              disabled={controlsDisabled}
+              field={field}
+              fieldErrors={fieldErrors}
+              onChange={change}
+              state={currentEditing}
+            />
+          );
+        }
+        if (field.type === 'select' && (field.options?.length ?? 0) > 0) {
+          return (
+            <SelectField
+              key={field.name}
+              disabled={controlsDisabled}
+              error={fieldErrors[field.name] ?? null}
+              field={field}
+              onChange={change}
+              value={currentEditing.editedValues[field.name]}
+            />
+          );
+        }
+        return (
+          <TextField
+            key={field.name}
+            disabled={controlsDisabled}
+            error={fieldErrors[field.name] ?? null}
+            field={field}
+            onChange={change}
+            value={currentEditing.editedValues[field.name]}
+          />
+        );
+      })}
+      {disabledMessage !== null ? (
+        <Text accessibilityLiveRegion="polite" accessibilityRole="alert" style={styles.errorText}>
+          {disabledMessage}
+        </Text>
+      ) : null}
+      <InputError message={localMessage} />
+      <Pressable
+        accessibilityLabel="Save draft information"
+        accessibilityRole="button"
+        accessibilityState={{ disabled: controlsDisabled, busy: pending }}
+        disabled={controlsDisabled}
+        onPress={() => void save()}
+        style={({ pressed }) => [
+          styles.saveButton,
+          pressed && !controlsDisabled ? styles.primaryPressed : null,
+          controlsDisabled ? styles.disabled : null,
+        ]}
+      >
+        <Text style={styles.saveButtonText}>
+          {pending ? 'Saving…' : 'Save information'}
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  editor: {
+    gap: spacing.md,
+    paddingTop: spacing.md,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+  },
+  fieldGroup: { gap: spacing.xs },
+  fieldLabel: { ...typography.label, color: colors.text },
+  inputCaption: { ...typography.caption, color: colors.textMuted },
+  input: {
+    ...typography.body,
+    minHeight: 44,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    borderCurve: 'continuous',
+    color: colors.text,
+    backgroundColor: colors.background,
+  },
+  multilineInput: { minHeight: 88, textAlignVertical: 'top' },
+  inputError: { borderColor: colors.danger },
+  errorText: { ...typography.caption, color: colors.danger },
+  targetHelp: {
+    ...typography.caption,
+    padding: spacing.sm,
+    borderRadius: radii.md,
+    borderCurve: 'continuous',
+    color: colors.textMuted,
+    backgroundColor: colors.surface,
+  },
+  options: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm },
+  option: {
+    minHeight: 44,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.full,
+    borderCurve: 'continuous',
+    backgroundColor: colors.background,
+  },
+  optionSelected: {
+    borderColor: colors.primary,
+    backgroundColor: colors.primarySoft,
+  },
+  optionText: { ...typography.caption, color: colors.text },
+  optionTextSelected: { color: colors.primary, fontWeight: '600' },
+  timeRange: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm },
+  timeInputBlock: { minWidth: 120, flex: 1, gap: spacing.xs },
+  saveButton: {
+    minHeight: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radii.md,
+    borderCurve: 'continuous',
+    backgroundColor: colors.primary,
+  },
+  saveButtonText: { ...typography.label, color: colors.background },
+  primaryPressed: { backgroundColor: colors.primaryPressed },
+  pressed: { opacity: 0.62 },
+  disabled: { opacity: 0.45 },
+});

--- a/mobile/src/features/chat/ai/components/renderers/ExpenseDraftDetails.tsx
+++ b/mobile/src/features/chat/ai/components/renderers/ExpenseDraftDetails.tsx
@@ -1,0 +1,70 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { colors, spacing, typography } from '@/shared/theme/tokens';
+import type { AIActionDraft } from '../../drafts';
+import {
+  displayMetaRows,
+  readAIText,
+  safeAIValueText,
+  type AIDisplayMetaRow,
+} from '../../presentation';
+import { AmountHero, DetailRows } from './shared';
+
+function append(
+  rows: AIDisplayMetaRow[],
+  label: string,
+  value: string | null,
+): void {
+  if (value !== null && !rows.some((row) => row.label === label)) {
+    rows.push({ label, value });
+  }
+}
+
+function participantText(draft: AIActionDraft): string | null {
+  const participants =
+    draft.preview.participants ??
+    draft.preview.member_contributions ??
+    draft.preview.contributions;
+  if (participants === undefined) {
+    return null;
+  }
+  return safeAIValueText(participants);
+}
+
+export function ExpenseDraftDetails({ draft }: { readonly draft: AIActionDraft }) {
+  const rows: AIDisplayMetaRow[] = [];
+  append(
+    rows,
+    'Payer / collector',
+    readAIText(draft.preview, 'payer_name') ??
+      readAIText(draft.preview, 'collector_name') ??
+      readAIText(draft.preview, 'collector_id'),
+  );
+  append(rows, 'Participants', participantText(draft));
+  append(
+    rows,
+    'Split',
+    readAIText(draft.preview, 'split_type') ??
+      readAIText(draft.preview, 'split_method') ??
+      readAIText(draft.preview, 'scope'),
+  );
+  for (const meta of displayMetaRows(draft.display)) {
+    append(rows, meta.label, meta.value);
+  }
+
+  return (
+    <View style={styles.container} testID="ai-expense-draft-details">
+      <AmountHero draft={draft} />
+      <DetailRows rows={rows} />
+      {draft.action_type === 'expense.delete' ? (
+        <Text style={styles.destructive}>
+          This removes the expense from the shared trip.
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { gap: spacing.sm },
+  destructive: { ...typography.caption, color: colors.danger },
+});

--- a/mobile/src/features/chat/ai/components/renderers/GenericDraftDetails.tsx
+++ b/mobile/src/features/chat/ai/components/renderers/GenericDraftDetails.tsx
@@ -1,0 +1,22 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { colors, spacing, typography } from '@/shared/theme/tokens';
+import type { AIActionDraft } from '../../drafts';
+import { GenericPreview } from './shared';
+
+export function GenericDraftDetails({ draft }: { readonly draft: AIActionDraft }) {
+  return (
+    <View style={styles.container} testID="ai-generic-draft-details">
+      <Text style={styles.unknown}>Unknown action type: {draft.action_type}</Text>
+      {draft.summary.trim().length > 0 ? (
+        <Text style={styles.summary}>{draft.summary}</Text>
+      ) : null}
+      <GenericPreview draft={draft} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { gap: spacing.sm },
+  unknown: { ...typography.caption, color: colors.warning },
+  summary: { ...typography.body, color: colors.text },
+});

--- a/mobile/src/features/chat/ai/components/renderers/SettlementDraftDetails.tsx
+++ b/mobile/src/features/chat/ai/components/renderers/SettlementDraftDetails.tsx
@@ -1,0 +1,25 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { colors, spacing, typography } from '@/shared/theme/tokens';
+import type { AIActionDraft } from '../../drafts';
+import { DisplayMeta, GenericPreview } from './shared';
+
+export function SettlementDraftDetails({ draft }: { readonly draft: AIActionDraft }) {
+  const consequence =
+    draft.action_type === 'settlement.finalize'
+      ? 'Finalizing locks the current settlement calculation and creates the transfers needed to settle balances.'
+      : 'Reopening unlocks the settlement so expense balances may change again.';
+  return (
+    <View style={styles.container} testID="ai-settlement-draft-details">
+      <Text style={styles.consequence}>{consequence}</Text>
+      <DisplayMeta draft={draft} />
+      {Object.keys(draft.preview).length > 0 ? (
+        <GenericPreview draft={draft} />
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { gap: spacing.sm },
+  consequence: { ...typography.body, color: colors.text },
+});

--- a/mobile/src/features/chat/ai/components/renderers/TimelineDraftDetails.tsx
+++ b/mobile/src/features/chat/ai/components/renderers/TimelineDraftDetails.tsx
@@ -4,7 +4,6 @@ import { isAIRecord, type AIActionDraft } from '../../drafts';
 import {
   displayMetaRows,
   readAIText,
-  safeAIValueText,
   type AIDisplayMetaRow,
 } from '../../presentation';
 import { DetailRows } from './shared';
@@ -28,6 +27,9 @@ const ASSIGNEE_LABELS: Readonly<Record<string, string>> = {
 };
 
 function activityPreview(draft: AIActionDraft): Readonly<Record<string, unknown>> {
+  if (isAIRecord(draft.preview.resolved_data)) {
+    return draft.preview.resolved_data;
+  }
   return isAIRecord(draft.preview.data) ? draft.preview.data : draft.preview;
 }
 
@@ -63,6 +65,13 @@ function timeText(source: Readonly<Record<string, unknown>>): string | null {
 }
 
 function locationText(source: Readonly<Record<string, unknown>>): string | null {
+  const locationMode = firstText([source], ['location_mode']);
+  if (locationMode === 'STRUCTURED') {
+    const structuredPlace = source.place;
+    return isAIRecord(structuredPlace)
+      ? firstText([structuredPlace], ['title', 'address'])
+      : null;
+  }
   const direct = firstText([source], ['location_label', 'location']);
   if (direct !== null) {
     return direct;
@@ -87,17 +96,23 @@ export function TimelineDraftDetails({ draft }: { readonly draft: AIActionDraft 
   const activity = activityPreview(draft);
   const sources = [activity, draft.preview];
   const rows: AIDisplayMetaRow[] = [];
-  append(rows, 'Section', firstText(sources, ['section_label', 'section_title', 'section_id']));
+  append(rows, 'Section', firstText(sources, ['section_label', 'section_title']));
   append(rows, 'Date', firstText(sources, ['section_date', 'date']));
   append(rows, 'Time', timeText(activity));
+  const customType = firstText([activity], ['custom_type_label']);
   const systemType = firstText([activity], ['system_type']);
   append(
     rows,
     'Type',
-    systemType === null ? null : (SYSTEM_TYPE_LABELS[systemType] ?? systemType),
+    customType ?? (
+      systemType === null ? null : (SYSTEM_TYPE_LABELS[systemType] ?? systemType)
+    ),
   );
   append(rows, 'Location', locationText(activity));
-  const assignee = firstText([activity], ['assignee_name', 'assignee_scope']);
+  const assignee = firstText(
+    [activity],
+    ['assignee_label', 'assignee_name', 'assignee_scope'],
+  );
   append(
     rows,
     'Assignee',
@@ -107,14 +122,18 @@ export function TimelineDraftDetails({ draft }: { readonly draft: AIActionDraft 
     append(rows, meta.label, meta.value);
   }
   const title = firstText([activity, draft.display], ['title']);
+  const externalLink = readAIText(activity, 'external_link');
+  const hasExternalLinkMeta = rows.some(
+    (row) => row.label === 'External link',
+  );
 
   return (
     <View style={styles.container} testID="ai-timeline-draft-details">
       {title !== null ? <Text style={styles.title}>{title}</Text> : null}
       <DetailRows rows={rows} />
-      {activity.external_link !== undefined ? (
+      {externalLink !== null && !hasExternalLinkMeta ? (
         <Text style={styles.inertLink}>
-          Link (text only): {safeAIValueText(activity.external_link)}
+          Link (text only): {externalLink}
         </Text>
       ) : null}
     </View>

--- a/mobile/src/features/chat/ai/components/renderers/TimelineDraftDetails.tsx
+++ b/mobile/src/features/chat/ai/components/renderers/TimelineDraftDetails.tsx
@@ -1,0 +1,128 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { colors, spacing, typography } from '@/shared/theme/tokens';
+import { isAIRecord, type AIActionDraft } from '../../drafts';
+import {
+  displayMetaRows,
+  readAIText,
+  safeAIValueText,
+  type AIDisplayMetaRow,
+} from '../../presentation';
+import { DetailRows } from './shared';
+
+const SYSTEM_TYPE_LABELS: Readonly<Record<string, string>> = {
+  TRANSPORTATION: 'Transportation',
+  FOOD: 'Food',
+  CHECKIN_OUT: 'Check-in / Check-out',
+  FREE_TIME: 'Free time',
+  SIGHTSEEING: 'Sightseeing',
+  SHOPPING: 'Shopping',
+  ACCOMMODATION: 'Accommodation',
+  OTHER: 'Other',
+};
+
+const ASSIGNEE_LABELS: Readonly<Record<string, string>> = {
+  GROUP: 'Whole group',
+  EVERYONE: 'Whole group',
+  USER: 'Assigned member',
+  NONE: 'Unassigned',
+};
+
+function activityPreview(draft: AIActionDraft): Readonly<Record<string, unknown>> {
+  return isAIRecord(draft.preview.data) ? draft.preview.data : draft.preview;
+}
+
+function firstText(
+  sources: readonly Readonly<Record<string, unknown>>[],
+  keys: readonly string[],
+): string | null {
+  for (const source of sources) {
+    for (const key of keys) {
+      const value = readAIText(source, key);
+      if (value !== null) {
+        return value;
+      }
+    }
+  }
+  return null;
+}
+
+function timeText(source: Readonly<Record<string, unknown>>): string | null {
+  const start = firstText([source], ['start_time']);
+  const end = firstText([source], ['end_time']);
+  if (start !== null) {
+    return end === null ? start : `${start} – ${end}`;
+  }
+  const mode = firstText([source], ['time_mode']);
+  if (mode === 'ALL_DAY') {
+    return 'All day';
+  }
+  if (mode === 'FLEXIBLE') {
+    return 'Flexible';
+  }
+  return null;
+}
+
+function locationText(source: Readonly<Record<string, unknown>>): string | null {
+  const direct = firstText([source], ['location_label', 'location']);
+  if (direct !== null) {
+    return direct;
+  }
+  const place = source.place;
+  return isAIRecord(place)
+    ? firstText([place], ['title', 'address'])
+    : null;
+}
+
+function append(
+  rows: AIDisplayMetaRow[],
+  label: string,
+  value: string | null,
+): void {
+  if (value !== null && !rows.some((row) => row.label === label)) {
+    rows.push({ label, value });
+  }
+}
+
+export function TimelineDraftDetails({ draft }: { readonly draft: AIActionDraft }) {
+  const activity = activityPreview(draft);
+  const sources = [activity, draft.preview];
+  const rows: AIDisplayMetaRow[] = [];
+  append(rows, 'Section', firstText(sources, ['section_label', 'section_title', 'section_id']));
+  append(rows, 'Date', firstText(sources, ['section_date', 'date']));
+  append(rows, 'Time', timeText(activity));
+  const systemType = firstText([activity], ['system_type']);
+  append(
+    rows,
+    'Type',
+    systemType === null ? null : (SYSTEM_TYPE_LABELS[systemType] ?? systemType),
+  );
+  append(rows, 'Location', locationText(activity));
+  const assignee = firstText([activity], ['assignee_name', 'assignee_scope']);
+  append(
+    rows,
+    'Assignee',
+    assignee === null ? null : (ASSIGNEE_LABELS[assignee] ?? assignee),
+  );
+  for (const meta of displayMetaRows(draft.display)) {
+    append(rows, meta.label, meta.value);
+  }
+  const title = firstText([activity, draft.display], ['title']);
+
+  return (
+    <View style={styles.container} testID="ai-timeline-draft-details">
+      {title !== null ? <Text style={styles.title}>{title}</Text> : null}
+      <DetailRows rows={rows} />
+      {activity.external_link !== undefined ? (
+        <Text style={styles.inertLink}>
+          Link (text only): {safeAIValueText(activity.external_link)}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { gap: spacing.sm },
+  title: { ...typography.body, color: colors.text, fontWeight: '700' },
+  inertLink: { ...typography.caption, color: colors.textMuted },
+});

--- a/mobile/src/features/chat/ai/components/renderers/TransferDraftDetails.tsx
+++ b/mobile/src/features/chat/ai/components/renderers/TransferDraftDetails.tsx
@@ -1,0 +1,41 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { colors, spacing, typography } from '@/shared/theme/tokens';
+import type { AIActionDraft } from '../../drafts';
+import { displayMetaRows, readAIText } from '../../presentation';
+import { AmountHero, DetailRows } from './shared';
+
+export function TransferDraftDetails({ draft }: { readonly draft: AIActionDraft }) {
+  const meta = displayMetaRows(draft.display);
+  const from =
+    meta.find((row) => row.label.toLowerCase() === 'from')?.value ??
+    readAIText(draft.preview, 'from_name') ??
+    readAIText(draft.preview, 'payer_name') ??
+    'Payer';
+  const to =
+    meta.find((row) => row.label.toLowerCase() === 'to')?.value ??
+    readAIText(draft.preview, 'to_name') ??
+    readAIText(draft.preview, 'recipient_name') ??
+    'Recipient';
+  const assertion =
+    draft.action_type === 'settlement.transfer.mark_sent'
+      ? 'The payer is asserting that this transfer was sent.'
+      : 'The recipient is asserting that this transfer was received.';
+  return (
+    <View style={styles.container} testID="ai-transfer-draft-details">
+      <Text style={styles.direction}>{from} → {to}</Text>
+      <AmountHero draft={draft} />
+      <Text style={styles.assertion}>{assertion}</Text>
+      <DetailRows rows={meta} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { gap: spacing.sm },
+  direction: {
+    ...typography.body,
+    color: colors.text,
+    fontWeight: '700',
+  },
+  assertion: { ...typography.caption, color: colors.textMuted },
+});

--- a/mobile/src/features/chat/ai/components/renderers/shared.tsx
+++ b/mobile/src/features/chat/ai/components/renderers/shared.tsx
@@ -1,0 +1,87 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { colors, spacing, typography } from '@/shared/theme/tokens';
+import type { AIActionDraft } from '../../drafts';
+import {
+  displayAmount,
+  displayMetaRows,
+  previewRows,
+  type AIDisplayMetaRow,
+} from '../../presentation';
+
+export function AmountHero({ draft }: { readonly draft: AIActionDraft }) {
+  const amount = displayAmount(draft);
+  if (amount === null) {
+    return null;
+  }
+  return (
+    <View
+      accessibilityLabel={`Amount ${amount.value} ${amount.currency}`}
+      style={styles.amountRow}
+      testID="ai-draft-amount"
+    >
+      <Text style={styles.amountValue}>{amount.value}</Text>
+      <Text style={styles.amountCurrency}>{amount.currency}</Text>
+    </View>
+  );
+}
+
+export function DetailRows(props: {
+  readonly rows: readonly AIDisplayMetaRow[];
+  readonly testID?: string;
+}) {
+  if (props.rows.length === 0) {
+    return null;
+  }
+  return (
+    <View style={styles.rows} testID={props.testID}>
+      {props.rows.map((row, index) => (
+        <View key={`${row.label}-${index}`} style={styles.row}>
+          <Text style={styles.label}>{row.label}</Text>
+          <Text selectable style={styles.value}>
+            {row.value}
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+export function DisplayMeta({ draft }: { readonly draft: AIActionDraft }) {
+  return <DetailRows rows={displayMetaRows(draft.display)} />;
+}
+
+export function GenericPreview({ draft }: { readonly draft: AIActionDraft }) {
+  return (
+    <DetailRows rows={previewRows(draft.preview)} testID="ai-draft-preview" />
+  );
+}
+
+const styles = StyleSheet.create({
+  amountRow: {
+    minWidth: 0,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'baseline',
+    gap: spacing.sm,
+  },
+  amountValue: {
+    ...typography.heading,
+    flexShrink: 1,
+    color: colors.text,
+    fontWeight: '700',
+  },
+  amountCurrency: {
+    ...typography.label,
+    flexShrink: 0,
+    color: colors.textMuted,
+  },
+  rows: { gap: spacing.sm },
+  row: { minWidth: 0, gap: spacing.xs },
+  label: { ...typography.caption, color: colors.textMuted },
+  value: {
+    ...typography.body,
+    minWidth: 0,
+    flexShrink: 1,
+    color: colors.text,
+  },
+});

--- a/mobile/src/features/chat/ai/confirmController.ts
+++ b/mobile/src/features/chat/ai/confirmController.ts
@@ -1,0 +1,379 @@
+import {
+  confirmAIActionDraft,
+  getAIActionDraft,
+  isAmbiguousConfirmFailure,
+  normalizeAIActionDraftApiError,
+  type AIActionDraftApiFailure,
+} from './api';
+import {
+  requireMatchingAIActionDraft,
+  type AIActionDraft,
+  type AIActionDraftEnvelope,
+} from './drafts';
+import { reconcileNewlyConfirmedDraft } from './reconciliation';
+
+export type ConfirmResolutionKind =
+  | 'idle'
+  | 'confirmed'
+  | 'ready_for_explicit_confirmation'
+  | 'resolved'
+  | 'rejected'
+  | 'unknown';
+
+export interface ConfirmAmbiguityState {
+  readonly kind: ConfirmResolutionKind;
+  readonly draft: AIActionDraft;
+  readonly failure: AIActionDraftApiFailure | null;
+  readonly message: string | null;
+  readonly canCheckStatus: boolean;
+  readonly observedConfirmed: boolean;
+  readonly reconciliationFailed: boolean;
+  readonly confirmRetryAtMs: number | null;
+}
+
+export interface ConfirmControllerDependencies {
+  readonly confirm: (
+    tripId: string,
+    draftId: string,
+    signal?: AbortSignal,
+  ) => Promise<AIActionDraftEnvelope>;
+  readonly get: (
+    tripId: string,
+    draftId: string,
+    signal?: AbortSignal,
+  ) => Promise<AIActionDraftEnvelope>;
+  readonly normalizeError: (
+    error: unknown,
+    operation: 'confirm' | 'get',
+    requestedDraftId: string,
+  ) => AIActionDraftApiFailure;
+  readonly reconcile: (options: {
+    readonly tripId: string;
+    readonly previousDraft: AIActionDraft;
+    readonly nextDraft: AIActionDraft;
+  }) => Promise<void>;
+}
+
+export const DEFAULT_CONFIRM_CONTROLLER_DEPENDENCIES: ConfirmControllerDependencies = {
+  confirm: (tripId, draftId, signal) =>
+    confirmAIActionDraft(tripId, draftId, signal),
+  get: (tripId, draftId, signal) => getAIActionDraft(tripId, draftId, signal),
+  normalizeError: (error, operation, requestedDraftId) =>
+    normalizeAIActionDraftApiError(
+      error,
+      operation,
+      Date.now(),
+      requestedDraftId,
+    ),
+  reconcile: async ({ tripId, previousDraft, nextDraft }) => {
+    await reconcileNewlyConfirmedDraft({
+      tripId,
+      previousStatus: previousDraft.status,
+      draft: nextDraft,
+    });
+  },
+};
+
+export function createConfirmAmbiguityState(
+  draft: AIActionDraft,
+): ConfirmAmbiguityState {
+  return {
+    kind: 'idle',
+    draft,
+    failure: null,
+    message: null,
+    canCheckStatus: false,
+    observedConfirmed: draft.status === 'CONFIRMED',
+    reconciliationFailed: false,
+    confirmRetryAtMs: null,
+  };
+}
+
+function retryDeadlineMs(
+  failure: AIActionDraftApiFailure,
+  nowMs: number,
+): number | null {
+  if (failure.status !== 429 || failure.retryAfterMs === null) {
+    return null;
+  }
+  const deadline = nowMs + failure.retryAfterMs;
+  return Number.isSafeInteger(deadline) && deadline > nowMs ? deadline : null;
+}
+
+function confirmFailureContext(failure: AIActionDraftApiFailure): string {
+  if (failure.status !== 429 || failure.retryAfterMs === null) {
+    return failure.message;
+  }
+  const seconds = Math.ceil(failure.retryAfterMs / 1_000);
+  return `${failure.message} Retry-After: ${seconds} seconds.`;
+}
+
+function resolvedAmbiguousMessage(
+  failure: AIActionDraftApiFailure,
+  draft: AIActionDraft,
+  kind: ConfirmResolutionKind,
+): string {
+  const context = confirmFailureContext(failure);
+  if (kind === 'confirmed') {
+    return `${context} The status check shows that the action is confirmed.`;
+  }
+  if (kind === 'ready_for_explicit_confirmation') {
+    const retryInstruction =
+      failure.status === 429 && failure.retryAfterMs !== null
+        ? ' Wait for the Retry-After deadline.'
+        : '';
+    return `${context} The status check shows that the action is still ready. No confirmation was sent again.${retryInstruction} Review it before making a new explicit confirmation.`;
+  }
+  return `${context} The status check returned ${draft.status.toLowerCase()}. No confirmation was sent again.`;
+}
+
+function classifyResolvedDraft(draft: AIActionDraft): ConfirmResolutionKind {
+  if (draft.status === 'CONFIRMED') {
+    return 'confirmed';
+  }
+  if (draft.status === 'READY') {
+    return 'ready_for_explicit_confirmation';
+  }
+  return 'resolved';
+}
+
+async function applyObservedDraft(
+  tripId: string,
+  state: ConfirmAmbiguityState,
+  draft: AIActionDraft,
+  dependencies: ConfirmControllerDependencies,
+): Promise<ConfirmAmbiguityState> {
+  const matchingDraft = requireMatchingAIActionDraft(draft, state.draft.id);
+  let reconciliationFailed = state.reconciliationFailed;
+  if (!state.observedConfirmed && matchingDraft.status === 'CONFIRMED') {
+    try {
+      await dependencies.reconcile({
+        tripId,
+        previousDraft: state.draft,
+        nextDraft: matchingDraft,
+      });
+    } catch {
+      reconciliationFailed = true;
+    }
+  }
+  return {
+    ...state,
+    draft: matchingDraft,
+    observedConfirmed:
+      state.observedConfirmed || matchingDraft.status === 'CONFIRMED',
+    reconciliationFailed,
+  };
+}
+
+async function resolveWithFollowUpGet(
+  tripId: string,
+  state: ConfirmAmbiguityState,
+  confirmFailure: AIActionDraftApiFailure,
+  dependencies: ConfirmControllerDependencies,
+  signal?: AbortSignal,
+  nowMs: number = Date.now(),
+): Promise<ConfirmAmbiguityState> {
+  let nextState: ConfirmAmbiguityState = {
+    ...state,
+    confirmRetryAtMs: retryDeadlineMs(confirmFailure, nowMs),
+  };
+  if (confirmFailure.draft !== null) {
+    nextState = await applyObservedDraft(
+      tripId,
+      nextState,
+      confirmFailure.draft,
+      dependencies,
+    );
+  }
+
+  try {
+    const response = await dependencies.get(tripId, state.draft.id, signal);
+    nextState = await applyObservedDraft(
+      tripId,
+      nextState,
+      response.draft,
+      dependencies,
+    );
+    const kind = classifyResolvedDraft(response.draft);
+    return {
+      ...nextState,
+      kind,
+      failure: confirmFailure,
+      message: resolvedAmbiguousMessage(confirmFailure, response.draft, kind),
+      canCheckStatus: false,
+      confirmRetryAtMs:
+        kind === 'ready_for_explicit_confirmation'
+          ? nextState.confirmRetryAtMs
+          : null,
+    };
+  } catch (error: unknown) {
+    const getFailure = dependencies.normalizeError(error, 'get', state.draft.id);
+    if (getFailure.draft !== null) {
+      nextState = await applyObservedDraft(
+        tripId,
+        nextState,
+        getFailure.draft,
+        dependencies,
+      );
+    }
+    return {
+      ...nextState,
+      kind: 'unknown',
+      failure: confirmFailure,
+      message: `${confirmFailureContext(confirmFailure)} The confirmation outcome is unknown because the status check also failed. Use Check status; do not confirm again.`,
+      canCheckStatus: true,
+    };
+  }
+}
+
+/**
+ * Executes exactly one confirm POST after the UI has collected an explicit
+ * approval. It never invokes confirm again. Ambiguous responses immediately
+ * follow with GET and otherwise leave a Check status-only state.
+ */
+export async function confirmDraftAfterExplicitApproval(options: {
+  readonly tripId: string;
+  readonly state: ConfirmAmbiguityState;
+  readonly dependencies?: ConfirmControllerDependencies;
+  readonly signal?: AbortSignal;
+  readonly nowMs?: number;
+}): Promise<ConfirmAmbiguityState> {
+  const dependencies =
+    options.dependencies ?? DEFAULT_CONFIRM_CONTROLLER_DEPENDENCIES;
+  if (!options.state.draft.can_confirm) {
+    return {
+      ...options.state,
+      kind: 'rejected',
+      message: 'The server does not allow you to confirm this draft.',
+      canCheckStatus: false,
+      confirmRetryAtMs: null,
+    };
+  }
+
+  try {
+    const response = await dependencies.confirm(
+      options.tripId,
+      options.state.draft.id,
+      options.signal,
+    );
+    const nextState = await applyObservedDraft(
+      options.tripId,
+      options.state,
+      response.draft,
+      dependencies,
+    );
+    return {
+      ...nextState,
+      kind: classifyResolvedDraft(response.draft),
+      failure: null,
+      message: null,
+      canCheckStatus: false,
+      confirmRetryAtMs: null,
+    };
+  } catch (error: unknown) {
+    const failure = dependencies.normalizeError(
+      error,
+      'confirm',
+      options.state.draft.id,
+    );
+    if (isAmbiguousConfirmFailure(failure)) {
+      return resolveWithFollowUpGet(
+        options.tripId,
+        options.state,
+        failure,
+        dependencies,
+        options.signal,
+        options.nowMs,
+      );
+    }
+
+    const nextState =
+      failure.draft === null
+        ? options.state
+        : await applyObservedDraft(
+            options.tripId,
+            options.state,
+            failure.draft,
+            dependencies,
+          );
+    return {
+      ...nextState,
+      kind: 'rejected',
+      failure,
+      message: failure.message,
+      canCheckStatus: false,
+      confirmRetryAtMs: null,
+    };
+  }
+}
+
+/** GET-only recovery for an unknown outcome. It cannot execute the action. */
+export async function checkConfirmStatus(options: {
+  readonly tripId: string;
+  readonly state: ConfirmAmbiguityState;
+  readonly dependencies?: ConfirmControllerDependencies;
+  readonly signal?: AbortSignal;
+}): Promise<ConfirmAmbiguityState> {
+  const dependencies =
+    options.dependencies ?? DEFAULT_CONFIRM_CONTROLLER_DEPENDENCIES;
+  try {
+    const response = await dependencies.get(
+      options.tripId,
+      options.state.draft.id,
+      options.signal,
+    );
+    const nextState = await applyObservedDraft(
+      options.tripId,
+      options.state,
+      response.draft,
+      dependencies,
+    );
+    const kind = classifyResolvedDraft(response.draft);
+    const originatingFailure = options.state.failure;
+    return {
+      ...nextState,
+      kind,
+      failure: null,
+      message:
+        kind === 'ready_for_explicit_confirmation'
+          ? originatingFailure === null
+            ? 'The action is still ready. Review it again before confirming.'
+            : resolvedAmbiguousMessage(
+                originatingFailure,
+                response.draft,
+                kind,
+              )
+          : null,
+      canCheckStatus: false,
+      confirmRetryAtMs:
+        kind === 'ready_for_explicit_confirmation'
+          ? options.state.confirmRetryAtMs
+          : null,
+    };
+  } catch (error: unknown) {
+    const failure = dependencies.normalizeError(
+      error,
+      'get',
+      options.state.draft.id,
+    );
+    const nextState =
+      failure.draft === null
+        ? options.state
+        : await applyObservedDraft(
+            options.tripId,
+            options.state,
+            failure.draft,
+            dependencies,
+          );
+    return {
+      ...nextState,
+      kind: 'unknown',
+      failure: options.state.failure ?? failure,
+      message:
+        options.state.failure === null
+          ? 'The confirmation outcome is still unknown. Check status again later.'
+          : `${confirmFailureContext(options.state.failure)} The confirmation outcome is still unknown. Use Check status again later; do not confirm again.`,
+      canCheckStatus: true,
+    };
+  }
+}

--- a/mobile/src/features/chat/ai/constrainedText.ts
+++ b/mobile/src/features/chat/ai/constrainedText.ts
@@ -1,0 +1,151 @@
+export type AIInlineSegment = {
+  readonly kind: 'text' | 'code' | 'strong' | 'emphasis';
+  readonly text: string;
+};
+
+export type AITextBlock =
+  | {
+      readonly kind: 'heading';
+      readonly level: number;
+      readonly segments: readonly AIInlineSegment[];
+    }
+  | {
+      readonly kind: 'list_item';
+      readonly ordered: boolean;
+      readonly ordinal: number | null;
+      readonly segments: readonly AIInlineSegment[];
+    }
+  | {
+      readonly kind: 'paragraph';
+      readonly segments: readonly AIInlineSegment[];
+    }
+  | {
+      readonly kind: 'code_block';
+      readonly language: string;
+      readonly code: string;
+    };
+
+const INLINE_PATTERN = /(`[^`\n]+`|\*\*[^*\n]+\*\*|\*[^*\n]+\*)/g;
+
+export function parseAIInlineText(value: string): readonly AIInlineSegment[] {
+  const segments: AIInlineSegment[] = [];
+  let cursor = 0;
+  for (const match of value.matchAll(INLINE_PATTERN)) {
+    const index = match.index;
+    if (index > cursor) {
+      segments.push({ kind: 'text', text: value.slice(cursor, index) });
+    }
+    const token = match[0];
+    if (token.startsWith('`')) {
+      segments.push({ kind: 'code', text: token.slice(1, -1) });
+    } else if (token.startsWith('**')) {
+      segments.push({ kind: 'strong', text: token.slice(2, -2) });
+    } else {
+      segments.push({ kind: 'emphasis', text: token.slice(1, -1) });
+    }
+    cursor = index + token.length;
+  }
+  if (cursor < value.length) {
+    segments.push({ kind: 'text', text: value.slice(cursor) });
+  }
+  return segments.length > 0 ? segments : [{ kind: 'text', text: value }];
+}
+
+function isBlockStart(line: string): boolean {
+  return (
+    /^\s*```/.test(line) ||
+    /^\s{0,3}#{1,6}\s+/.test(line) ||
+    /^\s*[-*+]\s+/.test(line) ||
+    /^\s*\d+[.)]\s+/.test(line)
+  );
+}
+
+/**
+ * Small allowlist parser. HTML, links, images, directives, and every unknown
+ * syntax remain inert text; no output variant contains a URL or callback.
+ */
+export function parseConstrainedAIText(content: string): readonly AITextBlock[] {
+  const lines = content.replace(/\r\n?/g, '\n').split('\n');
+  const blocks: AITextBlock[] = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index];
+    if (line.trim().length === 0) {
+      index += 1;
+      continue;
+    }
+
+    const fence = /^\s*```([^`]*)$/.exec(line);
+    if (fence !== null) {
+      const language = fence[1].trim().slice(0, 40);
+      const codeLines: string[] = [];
+      index += 1;
+      while (index < lines.length && !/^\s*```\s*$/.test(lines[index])) {
+        codeLines.push(lines[index]);
+        index += 1;
+      }
+      if (index < lines.length) {
+        index += 1;
+      }
+      blocks.push({
+        kind: 'code_block',
+        language,
+        code: codeLines.join('\n'),
+      });
+      continue;
+    }
+
+    const heading = /^\s{0,3}(#{1,6})\s+(.+)$/.exec(line);
+    if (heading !== null) {
+      blocks.push({
+        kind: 'heading',
+        level: heading[1].length,
+        segments: parseAIInlineText(heading[2]),
+      });
+      index += 1;
+      continue;
+    }
+
+    const unordered = /^\s*[-*+]\s+(.+)$/.exec(line);
+    if (unordered !== null) {
+      blocks.push({
+        kind: 'list_item',
+        ordered: false,
+        ordinal: null,
+        segments: parseAIInlineText(unordered[1]),
+      });
+      index += 1;
+      continue;
+    }
+
+    const ordered = /^\s*(\d+)[.)]\s+(.+)$/.exec(line);
+    if (ordered !== null) {
+      const parsedOrdinal = Number(ordered[1]);
+      blocks.push({
+        kind: 'list_item',
+        ordered: true,
+        ordinal: Number.isSafeInteger(parsedOrdinal) ? parsedOrdinal : 1,
+        segments: parseAIInlineText(ordered[2]),
+      });
+      index += 1;
+      continue;
+    }
+
+    const paragraphLines = [line];
+    index += 1;
+    while (
+      index < lines.length &&
+      lines[index].trim().length > 0 &&
+      !isBlockStart(lines[index])
+    ) {
+      paragraphLines.push(lines[index]);
+      index += 1;
+    }
+    blocks.push({
+      kind: 'paragraph',
+      segments: parseAIInlineText(paragraphLines.join('\n')),
+    });
+  }
+  return blocks;
+}

--- a/mobile/src/features/chat/ai/controllerSession.ts
+++ b/mobile/src/features/chat/ai/controllerSession.ts
@@ -1,0 +1,67 @@
+import type { AIActionDraftSubmittedEdit } from './components/ActionDraftCard';
+import type { ConfirmAmbiguityState } from './confirmController';
+import type { AIActionDraft } from './drafts';
+
+export interface AIActionDraftControllerLocalState {
+  readonly sourceVersion: string;
+  readonly draft: AIActionDraft;
+  readonly feedback: string | null;
+  readonly fieldErrors: Readonly<Record<string, string>> | null;
+  readonly confirmState: ConfirmAmbiguityState;
+  readonly retainedExpiredEdit: AIActionDraftSubmittedEdit | null;
+}
+
+export interface AIActionDraftPersistedEdit
+  extends AIActionDraftSubmittedEdit {
+  readonly tripId: string;
+  readonly draftId: string;
+  readonly submittedSourceIdentity: string;
+}
+
+export type AIActionDraftRetainedExpiredEdit =
+  AIActionDraftPersistedEdit;
+
+export interface AIActionDraftControllerSession {
+  readonly localState: AIActionDraftControllerLocalState;
+  readonly retainedExpiredEdit: AIActionDraftRetainedExpiredEdit | null;
+  readonly editor: AIActionDraftPersistedEdit | null;
+}
+
+export interface AIActionDraftControllerSessionStore {
+  readonly resourceKey: string;
+  readonly get: (
+    draftResourceKey: string,
+  ) => AIActionDraftControllerSession | null;
+  readonly set: (
+    draftResourceKey: string,
+    session: AIActionDraftControllerSession,
+  ) => void;
+  readonly delete: (draftId: string) => void;
+  readonly setAmbiguousDraftIds: (draftIds: ReadonlySet<string>) => void;
+}
+
+export function createAIActionDraftControllerSessionStore(
+  resourceKey: string,
+): AIActionDraftControllerSessionStore {
+  const sessions = new Map<string, AIActionDraftControllerSession>();
+  const ambiguousDraftIds = new Set<string>();
+  return {
+    resourceKey,
+    get: (draftResourceKey) => sessions.get(draftResourceKey) ?? null,
+    set: (draftResourceKey, session) => {
+      if (!ambiguousDraftIds.has(draftResourceKey)) {
+        sessions.set(draftResourceKey, session);
+      }
+    },
+    delete: (draftId) => {
+      sessions.delete(draftId);
+    },
+    setAmbiguousDraftIds: (draftIds) => {
+      ambiguousDraftIds.clear();
+      for (const draftId of draftIds) {
+        ambiguousDraftIds.add(draftId);
+        sessions.delete(draftId);
+      }
+    },
+  };
+}

--- a/mobile/src/features/chat/ai/drafts.ts
+++ b/mobile/src/features/chat/ai/drafts.ts
@@ -1,0 +1,366 @@
+export const AI_ACTION_DRAFT_STATUSES = [
+  'NEEDS_INFO',
+  'READY',
+  'CONFIRMED',
+  'CANCELLED',
+  'EXPIRED',
+  'FAILED',
+] as const;
+
+export type AIActionDraftStatus = (typeof AI_ACTION_DRAFT_STATUSES)[number];
+
+export const KNOWN_AI_ACTION_TYPES = [
+  'timeline.activity.create',
+  'timeline.activity.update',
+  'timeline.activity.delete',
+  'timeline.activity.status.update',
+  'expense.create',
+  'expense.update',
+  'expense.delete',
+  'expense.contribution.set',
+  'settlement.finalize',
+  'settlement.reopen',
+  'settlement.transfer.mark_sent',
+  'settlement.transfer.confirm_received',
+] as const;
+
+export type KnownAIActionType = (typeof KNOWN_AI_ACTION_TYPES)[number];
+export type OpaqueAIValue = Readonly<Record<string, unknown>>;
+
+export type AIActionDraftOption = Readonly<Record<string, unknown>> & {
+  readonly label: string;
+  readonly value: string;
+};
+
+export type AIActionDraftPreset = Readonly<Record<string, unknown>> & {
+  readonly label: string;
+  readonly start: string;
+  readonly end: string;
+};
+
+export type AIActionDraftMissingField = Readonly<Record<string, unknown>> & {
+  readonly name: string;
+  readonly label: string;
+  readonly type?: string;
+  readonly required?: boolean;
+  readonly constraints?: OpaqueAIValue;
+  readonly options?: readonly AIActionDraftOption[];
+  readonly presets?: readonly AIActionDraftPreset[];
+};
+
+/**
+ * The server owns the action vocabulary and confirmation authority. Open
+ * strings and opaque presentation records are intentional: a future server
+ * value must remain visible instead of being stripped or crashing chat.
+ */
+export type AIActionDraft = Readonly<Record<string, unknown>> & {
+  readonly id: string;
+  readonly action_type: string;
+  readonly status: AIActionDraftStatus;
+  readonly required_confirmation: string;
+  readonly can_confirm: boolean;
+  readonly can_cancel: boolean;
+  readonly can_edit: boolean;
+  readonly display: OpaqueAIValue;
+  readonly summary: string;
+  readonly preview: OpaqueAIValue;
+  readonly missing_fields: readonly AIActionDraftMissingField[];
+  readonly result: OpaqueAIValue;
+  readonly error_code: string;
+  readonly error_detail: string;
+  readonly expires_at: string;
+  readonly created_at: string;
+  readonly updated_at: string;
+};
+
+export interface AIActionDraftEnvelope {
+  readonly draft: AIActionDraft;
+}
+
+export class AIActionDraftContractError extends Error {
+  constructor() {
+    super('The AI action draft server returned an invalid response.');
+    this.name = 'AIActionDraftContractError';
+  }
+}
+
+export function isAIRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function canonicalizeAIUuid(value: string): string | null {
+  const normalized = value.trim().toLowerCase();
+  return UUID_PATTERN.test(normalized) ? normalized : null;
+}
+
+/** Binds a parsed response draft to the resource requested by the caller. */
+export function requireMatchingAIActionDraft(
+  draft: AIActionDraft,
+  requestedDraftId: string,
+): AIActionDraft {
+  const expectedId = canonicalizeAIUuid(requestedDraftId);
+  const actualId = canonicalizeAIUuid(draft.id);
+  if (expectedId === null || actualId === null || actualId !== expectedId) {
+    throw new AIActionDraftContractError();
+  }
+  return actualId === draft.id ? draft : { ...draft, id: actualId };
+}
+
+function isTimestamp(value: unknown): value is string {
+  return isNonEmptyString(value) && Number.isFinite(Date.parse(value));
+}
+
+export function isAIActionDraftStatus(
+  value: unknown,
+): value is AIActionDraftStatus {
+  return AI_ACTION_DRAFT_STATUSES.some((status) => status === value);
+}
+
+export function isKnownAIActionType(
+  value: string,
+): value is KnownAIActionType {
+  return KNOWN_AI_ACTION_TYPES.some((actionType) => actionType === value);
+}
+
+/**
+ * Viewer permissions are computed outside the draft row and can change without
+ * advancing updated_at. Keep them in the UI source identity so revoked
+ * authority can never inherit stale local controls or review state.
+ */
+export function aiActionDraftSourceIdentity(draft: AIActionDraft): string {
+  return JSON.stringify([
+    draft.id,
+    draft.action_type,
+    draft.status,
+    draft.updated_at,
+    draft.expires_at,
+    draft.required_confirmation,
+    draft.can_confirm,
+    draft.can_cancel,
+    draft.can_edit,
+  ]);
+}
+
+function stableAIValueIdentity(value: unknown): string {
+  if (value === null) {
+    return 'null';
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableAIValueIdentity).join(',')}]`;
+  }
+  if (isAIRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map(
+        (key) =>
+          `${JSON.stringify(key)}:${stableAIValueIdentity(value[key])}`,
+      )
+      .join(',')}}`;
+  }
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return JSON.stringify(value);
+  }
+  return JSON.stringify(String(value));
+}
+
+/**
+ * Security identity for an explicit mutation review. Unlike the lightweight
+ * UI source identity, this includes every parsed server field (including
+ * opaque future fields), so a preflight GET can never continue an approval
+ * against changed content merely because the row timestamp stayed equal.
+ */
+export function aiActionDraftMutationSnapshotIdentity(
+  draft: AIActionDraft,
+): string {
+  return stableAIValueIdentity(draft);
+}
+
+function parseOption(value: unknown): AIActionDraftOption | null {
+  if (
+    !isAIRecord(value) ||
+    typeof value.label !== 'string' ||
+    typeof value.value !== 'string'
+  ) {
+    return null;
+  }
+  return { ...value, label: value.label, value: value.value };
+}
+
+function parsePreset(value: unknown): AIActionDraftPreset | null {
+  if (
+    !isAIRecord(value) ||
+    typeof value.label !== 'string' ||
+    typeof value.start !== 'string' ||
+    typeof value.end !== 'string'
+  ) {
+    return null;
+  }
+  return {
+    ...value,
+    label: value.label,
+    start: value.start,
+    end: value.end,
+  };
+}
+
+function parseOptionalList<T>(
+  value: unknown,
+  parseItem: (candidate: unknown) => T | null,
+): readonly T[] | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const parsed: T[] = [];
+  for (const candidate of value) {
+    const item = parseItem(candidate);
+    if (item === null) {
+      return null;
+    }
+    parsed.push(item);
+  }
+  return parsed;
+}
+
+function parseMissingField(value: unknown): AIActionDraftMissingField | null {
+  if (
+    !isAIRecord(value) ||
+    !isNonEmptyString(value.name) ||
+    !isNonEmptyString(value.label) ||
+    (value.type !== undefined && typeof value.type !== 'string') ||
+    (value.required !== undefined && typeof value.required !== 'boolean') ||
+    (value.constraints !== undefined && !isAIRecord(value.constraints))
+  ) {
+    return null;
+  }
+
+  const options = parseOptionalList(value.options, parseOption);
+  const presets = parseOptionalList(value.presets, parsePreset);
+  if (options === null || presets === null) {
+    return null;
+  }
+
+  return {
+    ...value,
+    name: value.name,
+    label: value.label,
+    ...(typeof value.type === 'string' ? { type: value.type } : {}),
+    ...(typeof value.required === 'boolean'
+      ? { required: value.required }
+      : {}),
+    ...(isAIRecord(value.constraints)
+      ? { constraints: { ...value.constraints } }
+      : {}),
+    ...(options !== undefined ? { options } : {}),
+    ...(presets !== undefined ? { presets } : {}),
+  };
+}
+
+function parseMissingFields(
+  value: unknown,
+): readonly AIActionDraftMissingField[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const fields: AIActionDraftMissingField[] = [];
+  const names = new Set<string>();
+  for (const candidate of value) {
+    const field = parseMissingField(candidate);
+    if (field === null || names.has(field.name)) {
+      return null;
+    }
+    names.add(field.name);
+    fields.push(field);
+  }
+  return fields;
+}
+
+export function parseAIActionDraft(value: unknown): AIActionDraft | null {
+  if (!isAIRecord(value)) {
+    return null;
+  }
+  const missingFields = parseMissingFields(value.missing_fields);
+  const id = typeof value.id === 'string' ? canonicalizeAIUuid(value.id) : null;
+  if (
+    id === null ||
+    !isNonEmptyString(value.action_type) ||
+    !isAIActionDraftStatus(value.status) ||
+    typeof value.required_confirmation !== 'string' ||
+    typeof value.can_confirm !== 'boolean' ||
+    typeof value.can_cancel !== 'boolean' ||
+    typeof value.can_edit !== 'boolean' ||
+    !isAIRecord(value.display) ||
+    typeof value.summary !== 'string' ||
+    !isAIRecord(value.preview) ||
+    missingFields === null ||
+    !isAIRecord(value.result) ||
+    typeof value.error_code !== 'string' ||
+    typeof value.error_detail !== 'string' ||
+    !isTimestamp(value.expires_at) ||
+    !isTimestamp(value.created_at) ||
+    !isTimestamp(value.updated_at)
+  ) {
+    return null;
+  }
+
+  return {
+    ...value,
+    id,
+    action_type: value.action_type,
+    status: value.status,
+    required_confirmation: value.required_confirmation,
+    can_confirm: value.can_confirm,
+    can_cancel: value.can_cancel,
+    can_edit: value.can_edit,
+    display: { ...value.display },
+    summary: value.summary,
+    preview: { ...value.preview },
+    missing_fields: missingFields,
+    result: { ...value.result },
+    error_code: value.error_code,
+    error_detail: value.error_detail,
+    expires_at: value.expires_at,
+    created_at: value.created_at,
+    updated_at: value.updated_at,
+  };
+}
+
+export function requireAIActionDraft(value: unknown): AIActionDraft {
+  const draft = parseAIActionDraft(value);
+  if (draft === null) {
+    throw new AIActionDraftContractError();
+  }
+  return draft;
+}
+
+export function requireAIActionDraftEnvelope(
+  value: unknown,
+): AIActionDraftEnvelope {
+  if (!isAIRecord(value)) {
+    throw new AIActionDraftContractError();
+  }
+  return { draft: requireAIActionDraft(value.draft) };
+}
+
+export function requireMatchingAIActionDraftEnvelope(
+  value: unknown,
+  requestedDraftId: string,
+): AIActionDraftEnvelope {
+  const envelope = requireAIActionDraftEnvelope(value);
+  return {
+    draft: requireMatchingAIActionDraft(envelope.draft, requestedDraftId),
+  };
+}

--- a/mobile/src/features/chat/ai/editing.ts
+++ b/mobile/src/features/chat/ai/editing.ts
@@ -1,0 +1,291 @@
+import {
+  normalizeAIActionDraftApiError,
+  patchAIActionDraft,
+  type AIActionDraftApiFailure,
+} from './api';
+import {
+  requireMatchingAIActionDraft,
+  type AIActionDraft,
+  type AIActionDraftEnvelope,
+  type AIActionDraftMissingField,
+} from './drafts';
+
+export interface DraftEditingState {
+  readonly draft: AIActionDraft;
+  readonly editedValues: Readonly<Record<string, unknown>>;
+  readonly fieldErrors: Readonly<Record<string, string>>;
+  readonly message: string | null;
+  readonly expiredWithUnsavedEdits: boolean;
+}
+
+export type BuildDraftPatchResult =
+  | { readonly ok: true; readonly payload: Readonly<Record<string, unknown>> }
+  | {
+      readonly ok: false;
+      readonly field: string | null;
+      readonly message: string;
+    };
+
+export interface DraftEditingDependencies {
+  readonly patch: (
+    tripId: string,
+    draftId: string,
+    payload: Readonly<Record<string, unknown>>,
+  ) => Promise<AIActionDraftEnvelope>;
+  readonly normalizeError: (
+    error: unknown,
+    requestedDraftId: string,
+  ) => AIActionDraftApiFailure;
+}
+
+export interface DraftPatchOutcome {
+  readonly state: DraftEditingState;
+  readonly failure: AIActionDraftApiFailure | null;
+  readonly applied: boolean;
+}
+
+export const DEFAULT_DRAFT_EDITING_DEPENDENCIES: DraftEditingDependencies = {
+  patch: (tripId, draftId, payload) =>
+    patchAIActionDraft(tripId, draftId, payload),
+  normalizeError: (error, requestedDraftId) =>
+    normalizeAIActionDraftApiError(
+      error,
+      'patch',
+      Date.now(),
+      requestedDraftId,
+    ),
+};
+
+function payloadNamesForField(
+  field: AIActionDraftMissingField,
+): readonly string[] {
+  if (field.type === 'target') {
+    return [];
+  }
+  if (field.type !== 'time_range') {
+    return [field.name];
+  }
+  const pair = field.constraints?.pair;
+  if (
+    Array.isArray(pair) &&
+    pair.length === 2 &&
+    pair.every(
+      (name): name is string => typeof name === 'string' && name.length > 0,
+    )
+  ) {
+    return pair;
+  }
+  return ['start_time', 'end_time'];
+}
+
+export function editablePayloadNames(
+  fields: readonly AIActionDraftMissingField[],
+): ReadonlySet<string> {
+  return new Set(fields.flatMap(payloadNamesForField));
+}
+
+function fieldForPayloadName(
+  fields: readonly AIActionDraftMissingField[],
+  payloadName: string,
+): AIActionDraftMissingField | null {
+  return (
+    fields.find((field) => payloadNamesForField(field).includes(payloadName)) ??
+    null
+  );
+}
+
+export function createDraftEditingState(
+  draft: AIActionDraft,
+): DraftEditingState {
+  return {
+    draft,
+    editedValues: {},
+    fieldErrors: {},
+    message: null,
+    expiredWithUnsavedEdits: false,
+  };
+}
+
+export function setDraftEditedValue(
+  state: DraftEditingState,
+  name: string,
+  value: unknown,
+): DraftEditingState {
+  if (!editablePayloadNames(state.draft.missing_fields).has(name)) {
+    return state;
+  }
+  const fieldErrors = { ...state.fieldErrors };
+  delete fieldErrors[name];
+  return {
+    ...state,
+    editedValues: { ...state.editedValues, [name]: value },
+    fieldErrors,
+    message: null,
+  };
+}
+
+function isBlank(value: unknown): boolean {
+  return (
+    value === null ||
+    value === undefined ||
+    (typeof value === 'string' && value.trim().length === 0)
+  );
+}
+
+export function buildEditedDraftPayload(
+  state: DraftEditingState,
+): BuildDraftPatchResult {
+  const allowed = editablePayloadNames(state.draft.missing_fields);
+  const payload: Record<string, unknown> = {};
+  for (const [name, value] of Object.entries(state.editedValues)) {
+    if (!allowed.has(name) || isBlank(value)) {
+      continue;
+    }
+    const field = fieldForPayloadName(state.draft.missing_fields, name);
+    if (field?.type === 'json' && typeof value === 'string') {
+      try {
+        const parsed: unknown = JSON.parse(value);
+        payload[name] = parsed;
+      } catch {
+        return {
+          ok: false,
+          field: name,
+          message: 'Enter valid JSON.',
+        };
+      }
+    } else {
+      payload[name] = value;
+    }
+  }
+  if (Object.keys(payload).length === 0) {
+    return {
+      ok: false,
+      field: null,
+      message: 'Enter at least one field before saving.',
+    };
+  }
+  return { ok: true, payload };
+}
+
+export function rebaseDraftEditingState(
+  state: DraftEditingState,
+  draft: AIActionDraft,
+): DraftEditingState {
+  const stillEditable = editablePayloadNames(draft.missing_fields);
+  const editedValues: Record<string, unknown> = {};
+  const fieldErrors: Record<string, string> = {};
+  for (const [name, value] of Object.entries(state.editedValues)) {
+    if (stillEditable.has(name)) {
+      editedValues[name] = value;
+    }
+  }
+  for (const [name, message] of Object.entries(state.fieldErrors)) {
+    if (stillEditable.has(name)) {
+      fieldErrors[name] = message;
+    }
+  }
+  return {
+    ...state,
+    draft,
+    editedValues,
+    fieldErrors,
+  };
+}
+
+export async function saveDraftEdits(options: {
+  readonly tripId: string;
+  readonly state: DraftEditingState;
+  readonly dependencies?: DraftEditingDependencies;
+}): Promise<DraftPatchOutcome> {
+  if (!options.state.draft.can_edit) {
+    return {
+      applied: false,
+      failure: null,
+      state: {
+        ...options.state,
+        message: 'The server does not allow you to edit this draft.',
+      },
+    };
+  }
+  const built = buildEditedDraftPayload(options.state);
+  if (!built.ok) {
+    return {
+      applied: false,
+      failure: null,
+      state: {
+        ...options.state,
+        message: built.message,
+        fieldErrors:
+          built.field === null
+            ? options.state.fieldErrors
+            : { ...options.state.fieldErrors, [built.field]: built.message },
+      },
+    };
+  }
+
+  const dependencies =
+    options.dependencies ?? DEFAULT_DRAFT_EDITING_DEPENDENCIES;
+  try {
+    const response = await dependencies.patch(
+      options.tripId,
+      options.state.draft.id,
+      built.payload,
+    );
+    const responseDraft = requireMatchingAIActionDraft(
+      response.draft,
+      options.state.draft.id,
+    );
+    return {
+      applied: true,
+      failure: null,
+      state: {
+        ...rebaseDraftEditingState(options.state, responseDraft),
+        message: 'Draft updated.',
+        expiredWithUnsavedEdits: false,
+      },
+    };
+  } catch (error: unknown) {
+    const normalizedFailure = dependencies.normalizeError(
+      error,
+      options.state.draft.id,
+    );
+    let failure = normalizedFailure;
+    if (normalizedFailure.draft !== null) {
+      try {
+        failure = {
+          ...normalizedFailure,
+          draft: requireMatchingAIActionDraft(
+            normalizedFailure.draft,
+            options.state.draft.id,
+          ),
+        };
+      } catch {
+        failure = { ...normalizedFailure, draft: null };
+      }
+    }
+    const expired =
+      failure.errorCode === 'AI_DRAFT_EXPIRED' ||
+      failure.draft?.status === 'EXPIRED';
+    const currentState =
+      failure.draft === null
+        ? options.state
+        : expired
+          ? { ...options.state, draft: failure.draft }
+          : rebaseDraftEditingState(options.state, failure.draft);
+    return {
+      applied: false,
+      failure,
+      state: {
+        ...currentState,
+        fieldErrors: failure.fieldErrors ?? currentState.fieldErrors,
+        message: expired
+          ? 'This draft expired. Your edits were not applied.'
+          : failure.errorCode === 'AI_DRAFT_PATCH_FIELD_NOT_ALLOWED'
+            ? failure.message || 'That field cannot be edited for this draft.'
+            : failure.message,
+        expiredWithUnsavedEdits:
+          expired && Object.keys(options.state.editedValues).length > 0,
+      },
+    };
+  }
+}

--- a/mobile/src/features/chat/ai/expiry.ts
+++ b/mobile/src/features/chat/ai/expiry.ts
@@ -1,0 +1,65 @@
+import type { AIActionDraft, AIActionDraftStatus } from './drafts';
+
+const ACTIVE_STATUSES = new Set<AIActionDraftStatus>([
+  'NEEDS_INFO',
+  'READY',
+]);
+
+export interface AIActionDraftExpiry {
+  readonly isExpired: boolean;
+  readonly remainingMs: number;
+  readonly visualStatus: AIActionDraftStatus;
+  readonly label: string;
+}
+
+export function isLocallyExpired(
+  draft: Pick<AIActionDraft, 'status' | 'expires_at'>,
+  nowMs: number,
+): boolean {
+  return (
+    ACTIVE_STATUSES.has(draft.status) && Date.parse(draft.expires_at) <= nowMs
+  );
+}
+
+export function getAIActionDraftExpiry(
+  draft: Pick<AIActionDraft, 'status' | 'expires_at'>,
+  nowMs: number,
+): AIActionDraftExpiry {
+  const expiresAtMs = Date.parse(draft.expires_at);
+  const remainingMs = Math.max(0, expiresAtMs - nowMs);
+  const localExpiry = isLocallyExpired(draft, nowMs);
+  if (draft.status === 'EXPIRED' || localExpiry) {
+    return {
+      isExpired: true,
+      remainingMs: 0,
+      visualStatus: 'EXPIRED',
+      label: 'Expired',
+    };
+  }
+
+  if (!ACTIVE_STATUSES.has(draft.status)) {
+    return {
+      isExpired: false,
+      remainingMs,
+      visualStatus: draft.status,
+      label: 'Closed',
+    };
+  }
+
+  const seconds = Math.ceil(remainingMs / 1_000);
+  if (seconds < 60) {
+    return {
+      isExpired: false,
+      remainingMs,
+      visualStatus: draft.status,
+      label: `Expires in ${seconds}s`,
+    };
+  }
+  const minutes = Math.ceil(seconds / 60);
+  return {
+    isExpired: false,
+    remainingMs,
+    visualStatus: draft.status,
+    label: `Expires in ${minutes}m`,
+  };
+}

--- a/mobile/src/features/chat/ai/expiryClock.ts
+++ b/mobile/src/features/chat/ai/expiryClock.ts
@@ -1,0 +1,107 @@
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+export interface AIExpiryClockScheduler {
+  readonly set: (callback: () => void, delayMs: number) => unknown;
+  readonly clear: (handle: unknown) => void;
+}
+
+export interface AIExpiryDeadlineClock {
+  readonly subscribe: (
+    expiresAtMs: number,
+    listener: (nowMs: number) => void,
+  ) => () => void;
+}
+
+interface DeadlineSubscriber {
+  readonly expiresAtMs: number;
+  readonly listener: (nowMs: number) => void;
+  nextUpdateAtMs: number;
+}
+
+function nextLabelUpdateAt(expiresAtMs: number, nowMs: number): number {
+  const remainingMs = expiresAtMs - nowMs;
+  if (remainingMs <= 0) {
+    return Number.POSITIVE_INFINITY;
+  }
+  const seconds = Math.ceil(remainingMs / 1_000);
+  if (seconds < 60) {
+    return expiresAtMs - (seconds - 1) * 1_000;
+  }
+  const minutes = Math.ceil(seconds / 60);
+  return minutes === 1
+    ? expiresAtMs - 59_000
+    : expiresAtMs - (minutes - 1) * 60_000;
+}
+
+export function createAIExpiryDeadlineClock(options: {
+  readonly now: () => number;
+  readonly scheduler: AIExpiryClockScheduler;
+}): AIExpiryDeadlineClock {
+  const subscribers = new Set<DeadlineSubscriber>();
+  let timeoutHandle: unknown = null;
+
+  const cancelScheduledTick = (): void => {
+    if (timeoutHandle !== null) {
+      options.scheduler.clear(timeoutHandle);
+      timeoutHandle = null;
+    }
+  };
+
+  const schedule = (): void => {
+    cancelScheduledTick();
+    if (subscribers.size === 0) {
+      return;
+    }
+    const nextUpdateAtMs = [...subscribers].reduce(
+      (earliest, subscriber) => Math.min(earliest, subscriber.nextUpdateAtMs),
+      Number.POSITIVE_INFINITY,
+    );
+    if (!Number.isFinite(nextUpdateAtMs)) {
+      return;
+    }
+    const delayMs = Math.min(
+      MAX_TIMER_DELAY_MS,
+      Math.max(1, nextUpdateAtMs - options.now()),
+    );
+    timeoutHandle = options.scheduler.set(() => {
+      timeoutHandle = null;
+      const nowMs = options.now();
+      for (const subscriber of [...subscribers]) {
+        if (subscriber.nextUpdateAtMs <= nowMs) {
+          subscriber.nextUpdateAtMs = nextLabelUpdateAt(
+            subscriber.expiresAtMs,
+            nowMs,
+          );
+          subscriber.listener(nowMs);
+        }
+      }
+      schedule();
+    }, delayMs);
+  };
+
+  return {
+    subscribe: (expiresAtMs, listener) => {
+      const nowMs = options.now();
+      const subscriber: DeadlineSubscriber = {
+        expiresAtMs,
+        listener,
+        nextUpdateAtMs: nextLabelUpdateAt(expiresAtMs, nowMs),
+      };
+      subscribers.add(subscriber);
+      listener(nowMs);
+      schedule();
+      return () => {
+        subscribers.delete(subscriber);
+        schedule();
+      };
+    },
+  };
+}
+
+export const sharedAIExpiryDeadlineClock = createAIExpiryDeadlineClock({
+  now: () => Date.now(),
+  scheduler: {
+    set: (callback, delayMs) => setTimeout(callback, delayMs),
+    clear: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+  },
+});

--- a/mobile/src/features/chat/ai/index.ts
+++ b/mobile/src/features/chat/ai/index.ts
@@ -1,0 +1,88 @@
+export {
+  AIActionDraftContractError,
+  AI_ACTION_DRAFT_STATUSES,
+  KNOWN_AI_ACTION_TYPES,
+  aiActionDraftSourceIdentity,
+  canonicalizeAIUuid,
+  isAIActionDraftStatus,
+  isKnownAIActionType,
+  parseAIActionDraft,
+  requireAIActionDraft,
+  requireAIActionDraftEnvelope,
+  requireMatchingAIActionDraft,
+  requireMatchingAIActionDraftEnvelope,
+  type AIActionDraft,
+  type AIActionDraftEnvelope,
+  type AIActionDraftMissingField,
+  type AIActionDraftStatus,
+} from './drafts';
+export {
+  GOPLAN_AI_MENTION,
+  GOPLAN_AI_PROMPT_LIMIT_PER_HOUR,
+  GOPLAN_AI_RATE_LIMIT_MESSAGE,
+  goPlanAISendFailureMessage,
+  insertGoPlanAIMention,
+  isGoPlanAIThrottledSend,
+  parseGoPlanAIMention,
+  shouldOfferGoPlanAICommand,
+  tokenizeGoPlanAIMention,
+} from './mention';
+export {
+  aiActionDraftPath,
+  cancelAIActionDraft,
+  confirmAIActionDraft,
+  getAIActionDraft,
+  isAmbiguousConfirmFailure,
+  normalizeAIActionDraftApiError,
+  parseRetryAfterMs,
+  patchAIActionDraft,
+  type AIActionDraftApiFailure,
+} from './api';
+export {
+  AI_TYPING_VISUAL_TIMEOUT_MS,
+  createAITypingVisualController,
+  reduceAITypingState,
+  type AITypingState,
+} from './typingState';
+export { getAIActionDraftExpiry, isLocallyExpired } from './expiry';
+export {
+  checkConfirmStatus,
+  confirmDraftAfterExplicitApproval,
+  createConfirmAmbiguityState,
+  type ConfirmAmbiguityState,
+  type ConfirmControllerDependencies,
+} from './confirmController';
+export {
+  buildEditedDraftPayload,
+  createDraftEditingState,
+  editablePayloadNames,
+  rebaseDraftEditingState,
+  saveDraftEdits,
+  setDraftEditedValue,
+  type DraftEditingState,
+} from './editing';
+export {
+  reconcileNewlyConfirmedDraft,
+  reconciliationChannelForAction,
+  type AIReconciliationPublishers,
+} from './reconciliation';
+export {
+  confirmationAuthorityText,
+  confirmationRestatement,
+  safeAIValueText,
+} from './presentation';
+export {
+  parseAIInlineText,
+  parseConstrainedAIText,
+  type AITextBlock,
+} from './constrainedText';
+export { ActionDraftCard } from './components/ActionDraftCard';
+export { AIActionDraftCardController } from './components/AIActionDraftCardController';
+export { AIMessageContent } from './components/AIMessageContent';
+export { AITypingIndicator } from './components/AITypingIndicator';
+export {
+  GoPlanAIComposerIntent,
+  GoPlanAIMentionCommandMenu,
+  GoPlanAIMentionMessageText,
+  GoPlanAIMentionToken,
+} from './components/AIMention';

--- a/mobile/src/features/chat/ai/mention.ts
+++ b/mobile/src/features/chat/ai/mention.ts
@@ -1,0 +1,86 @@
+export const GOPLAN_AI_MENTION = '@GoPlanAI';
+export const GOPLAN_AI_PROMPT_LIMIT_PER_HOUR = 20;
+export const GOPLAN_AI_RATE_LIMIT_MESSAGE =
+  'GoPlanAI allows 20 prompts per hour. Your prompt was not sent; try again later.';
+
+const GOPLAN_AI_PATTERN = /@GoPlanAI\b/gi;
+const TRAILING_COMMAND_TRIGGER_PATTERN = /@\s*$/;
+
+export interface GoPlanAIMentionParseResult {
+  readonly hasMention: boolean;
+  readonly prompt: string;
+  readonly displayContent: string;
+}
+
+/** Kept byte-for-byte equivalent to the web parser contract. */
+export function parseGoPlanAIMention(
+  value: string,
+): GoPlanAIMentionParseResult {
+  const hasMention = GOPLAN_AI_PATTERN.test(value);
+  GOPLAN_AI_PATTERN.lastIndex = 0;
+  const normalized = value.trim().replace(/\s+/g, ' ');
+  if (!hasMention) {
+    return { hasMention: false, prompt: normalized, displayContent: normalized };
+  }
+  const prompt = value
+    .replace(GOPLAN_AI_PATTERN, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+  return {
+    hasMention: true,
+    prompt,
+    displayContent: prompt ? `${GOPLAN_AI_MENTION} ${prompt}` : GOPLAN_AI_MENTION,
+  };
+}
+
+export function shouldOfferGoPlanAICommand(value: string): boolean {
+  return /(^|\s)@$/.test(value);
+}
+
+export function insertGoPlanAIMention(value: string): GoPlanAIMentionParseResult {
+  const prompt = value.replace(TRAILING_COMMAND_TRIGGER_PATTERN, '').trim();
+  return parseGoPlanAIMention(
+    prompt.length > 0 ? `${GOPLAN_AI_MENTION} ${prompt}` : GOPLAN_AI_MENTION,
+  );
+}
+
+export type GoPlanAIMessageSegment =
+  | { readonly kind: 'mention'; readonly text: typeof GOPLAN_AI_MENTION }
+  | { readonly kind: 'text'; readonly text: string };
+
+/**
+ * Returns display-only segments. A mention segment has no callback or URL, so
+ * server-rewritten content can be styled without becoming an executable token.
+ */
+export function tokenizeGoPlanAIMention(
+  content: string,
+): readonly GoPlanAIMessageSegment[] {
+  const parsed = parseGoPlanAIMention(content);
+  if (!parsed.hasMention) {
+    return parsed.displayContent
+      ? [{ kind: 'text', text: parsed.displayContent }]
+      : [];
+  }
+  return parsed.prompt
+    ? [
+        { kind: 'mention', text: GOPLAN_AI_MENTION },
+        { kind: 'text', text: ` ${parsed.prompt}` },
+      ]
+    : [{ kind: 'mention', text: GOPLAN_AI_MENTION }];
+}
+
+export function isGoPlanAIThrottledSend(
+  content: string,
+  status: number | null,
+): boolean {
+  return status === 429 && parseGoPlanAIMention(content).hasMention;
+}
+
+export function goPlanAISendFailureMessage(
+  content: string,
+  failure: { readonly status: number | null; readonly message: string },
+): string {
+  return isGoPlanAIThrottledSend(content, failure.status)
+    ? GOPLAN_AI_RATE_LIMIT_MESSAGE
+    : failure.message;
+}

--- a/mobile/src/features/chat/ai/presentation.ts
+++ b/mobile/src/features/chat/ai/presentation.ts
@@ -1,0 +1,217 @@
+import {
+  isAIRecord,
+  type AIActionDraft,
+  type OpaqueAIValue,
+} from './drafts';
+
+export interface AIDisplayMetaRow {
+  readonly label: string;
+  readonly value: string;
+}
+
+export interface AIAmountPresentation {
+  readonly value: string;
+  readonly currency: string;
+}
+
+export function readAIText(
+  source: Readonly<Record<string, unknown>>,
+  key: string,
+): string | null {
+  const value = source[key];
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function primitiveText(value: unknown): string | null {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+  if (value === null) {
+    return 'null';
+  }
+  return null;
+}
+
+function stringifyAIValue(
+  value: unknown,
+  seen: Set<object>,
+  depth: number,
+): string {
+  const primitive = primitiveText(value);
+  if (primitive !== null) {
+    return primitive;
+  }
+  if (depth >= 4) {
+    return '[nested value]';
+  }
+  if (Array.isArray(value)) {
+    if (seen.has(value)) {
+      return '[circular value]';
+    }
+    seen.add(value);
+    const text = `[${value
+      .slice(0, 30)
+      .map((item) => stringifyAIValue(item, seen, depth + 1))
+      .join(', ')}${value.length > 30 ? ', …' : ''}]`;
+    seen.delete(value);
+    return text;
+  }
+  if (isAIRecord(value)) {
+    if (seen.has(value)) {
+      return '[circular value]';
+    }
+    seen.add(value);
+    const entries = Object.entries(value);
+    const text = `{${entries
+      .slice(0, 30)
+      .map(
+        ([key, entry]) =>
+          `${key}: ${stringifyAIValue(entry, seen, depth + 1)}`,
+      )
+      .join(', ')}${entries.length > 30 ? ', …' : ''}}`;
+    seen.delete(value);
+    return text;
+  }
+  return '[unsupported value]';
+}
+
+/** Converts unknown JSON to inert text; it never returns a React node or URL. */
+export function safeAIValueText(value: unknown): string {
+  return stringifyAIValue(value, new Set<object>(), 0);
+}
+
+export function humanizeAIKey(value: string): string {
+  const words = value.replace(/[._-]+/g, ' ').trim();
+  return words.length > 0
+    ? `${words.charAt(0).toUpperCase()}${words.slice(1)}`
+    : 'Value';
+}
+
+export function draftTitle(draft: AIActionDraft): string {
+  return (
+    readAIText(draft.display, 'title') ??
+    (draft.summary.trim().length > 0 ? draft.summary.trim() : null) ??
+    humanizeAIKey(draft.action_type)
+  );
+}
+
+export function draftKicker(draft: AIActionDraft): string {
+  return (
+    readAIText(draft.display, 'kicker') ?? humanizeAIKey(draft.action_type)
+  );
+}
+
+export function displayMetaRows(display: OpaqueAIValue): readonly AIDisplayMetaRow[] {
+  const meta = display.meta;
+  if (!Array.isArray(meta)) {
+    return [];
+  }
+  const rows: AIDisplayMetaRow[] = [];
+  for (const candidate of meta) {
+    if (!isAIRecord(candidate) || typeof candidate.label !== 'string') {
+      continue;
+    }
+    const label = candidate.label.trim();
+    const value = primitiveText(candidate.value);
+    if (label.length > 0 && value !== null && value.trim().length > 0) {
+      rows.push({ label, value: value.trim() });
+    }
+  }
+  return rows;
+}
+
+export function displayAmount(
+  draft: AIActionDraft,
+): AIAmountPresentation | null {
+  const hero = draft.display.hero;
+  if (isAIRecord(hero) && hero.kind === 'amount') {
+    const value = primitiveText(hero.value);
+    const currency = primitiveText(hero.currency);
+    if (value !== null && currency !== null) {
+      return { value, currency };
+    }
+  }
+  const amount =
+    primitiveText(draft.preview.total_amount) ??
+    primitiveText(draft.preview.amount);
+  const currency =
+    primitiveText(draft.preview.currency_code) ??
+    primitiveText(draft.preview.currency);
+  return amount !== null && currency !== null ? { value: amount, currency } : null;
+}
+
+export function previewRows(
+  preview: OpaqueAIValue,
+): readonly AIDisplayMetaRow[] {
+  return Object.entries(preview).map(([key, value]) => ({
+    label: humanizeAIKey(key),
+    value: safeAIValueText(value),
+  }));
+}
+
+function quotedTitle(draft: AIActionDraft): string {
+  return `“${draftTitle(draft)}”`;
+}
+
+function amountSuffix(draft: AIActionDraft): string {
+  const amount = displayAmount(draft);
+  return amount === null ? '' : ` for ${amount.value} ${amount.currency}`;
+}
+
+export function confirmationRestatement(draft: AIActionDraft): string {
+  switch (draft.action_type) {
+    case 'timeline.activity.create':
+      return `Create timeline activity ${quotedTitle(draft)}.`;
+    case 'timeline.activity.update':
+      return `Update timeline activity ${quotedTitle(draft)} with the reviewed values.`;
+    case 'timeline.activity.delete':
+      return `Delete timeline activity ${quotedTitle(draft)} from the shared trip.`;
+    case 'timeline.activity.status.update':
+      return `Change the status of timeline activity ${quotedTitle(draft)}.`;
+    case 'expense.create':
+      return `Create expense ${quotedTitle(draft)}${amountSuffix(draft)}.`;
+    case 'expense.update':
+      return `Update expense ${quotedTitle(draft)}${amountSuffix(draft)}.`;
+    case 'expense.delete':
+      return `Delete expense ${quotedTitle(draft)} from the shared trip.`;
+    case 'expense.contribution.set':
+      return `Change participant contributions for ${quotedTitle(draft)}.`;
+    case 'settlement.finalize':
+      return 'Finalize the settlement and lock the current expense calculation.';
+    case 'settlement.reopen':
+      return 'Reopen the finalized settlement so expense balances can change again.';
+    case 'settlement.transfer.mark_sent':
+      return `Mark this settlement transfer${amountSuffix(draft)} as sent by the payer.`;
+    case 'settlement.transfer.confirm_received':
+      return `Confirm that this settlement transfer${amountSuffix(draft)} was received by the recipient.`;
+    default:
+      return `Execute this AI-proposed action: ${quotedTitle(draft)}.`;
+  }
+}
+
+export function confirmationAuthorityText(draft: AIActionDraft): string {
+  switch (draft.required_confirmation) {
+    case 'CAPTAIN':
+      return 'The server requires an active trip captain.';
+    case 'TIMELINE_ACTIVITY_STATUS':
+      return 'The server requires permission to update this activity status.';
+    case 'TRANSFER_PAYER':
+      return 'The server requires the transfer payer.';
+    case 'TRANSFER_RECIPIENT':
+      return 'The server requires the transfer recipient.';
+    case '':
+      return 'The server will verify your permission when you confirm.';
+    default:
+      return `Server confirmation rule: ${draft.required_confirmation}.`;
+  }
+}

--- a/mobile/src/features/chat/ai/presentation.ts
+++ b/mobile/src/features/chat/ai/presentation.ts
@@ -168,12 +168,163 @@ function amountSuffix(draft: AIActionDraft): string {
   return amount === null ? '' : ` for ${amount.value} ${amount.currency}`;
 }
 
+function timelineActivityPreview(
+  draft: AIActionDraft,
+): Readonly<Record<string, unknown>> {
+  if (isAIRecord(draft.preview.resolved_data)) {
+    return draft.preview.resolved_data;
+  }
+  return isAIRecord(draft.preview.data) ? draft.preview.data : draft.preview;
+}
+
+function timelineDisplayText(
+  draft: AIActionDraft,
+  label: 'Target' | 'Date' | 'Time' | 'Location',
+): string | null {
+  const meta = draft.display.meta;
+  if (!Array.isArray(meta)) {
+    return null;
+  }
+  for (const candidate of meta) {
+    if (
+      !isAIRecord(candidate) ||
+      candidate.label !== label ||
+      typeof candidate.value !== 'string'
+    ) {
+      continue;
+    }
+    const value = candidate.value.trim();
+    if (value.length > 0) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function firstTimelineText(
+  sources: readonly Readonly<Record<string, unknown>>[],
+  keys: readonly string[],
+): string | null {
+  for (const source of sources) {
+    for (const key of keys) {
+      const value = readAIText(source, key);
+      if (value !== null) {
+        return value;
+      }
+    }
+  }
+  return null;
+}
+
+function timelineTimeText(
+  activity: Readonly<Record<string, unknown>>,
+): string | null {
+  const start = firstTimelineText([activity], ['start_time']);
+  const end = firstTimelineText([activity], ['end_time']);
+  if (start !== null) {
+    return end === null ? start : `${start} – ${end}`;
+  }
+  const mode = firstTimelineText([activity], ['time_mode']);
+  if (mode === 'ALL_DAY') {
+    return 'All day';
+  }
+  if (mode === 'FLEXIBLE') {
+    return 'Flexible';
+  }
+  return null;
+}
+
+function timelineLocationText(
+  activity: Readonly<Record<string, unknown>>,
+): string | null {
+  const locationMode = firstTimelineText([activity], ['location_mode']);
+  if (locationMode === 'STRUCTURED') {
+    return isAIRecord(activity.place)
+      ? firstTimelineText([activity.place], ['title', 'address'])
+      : null;
+  }
+  const direct = firstTimelineText(
+    [activity],
+    ['location_label', 'location'],
+  );
+  if (direct !== null) {
+    return direct;
+  }
+  return isAIRecord(activity.place)
+    ? firstTimelineText([activity.place], ['title', 'address'])
+    : null;
+}
+
+const TIMELINE_CONFIRMATION_DETAIL_LABELS = new Set([
+  'Type',
+  'Custom type',
+  'Assignee',
+  'Assigned member',
+  'Booking reference',
+  'Contact name',
+  'Contact phone',
+  'External link',
+  'Location note',
+  'Meeting point',
+  'Note',
+  'Reminders',
+]);
+
+function timelineConfirmationMetaDetails(draft: AIActionDraft): string[] {
+  return displayMetaRows(draft.display)
+    .filter(({ label }) => TIMELINE_CONFIRMATION_DETAIL_LABELS.has(label))
+    .map(({ label, value }) => `${label}: ${value}.`);
+}
+
+function timelineConfirmationDetails(draft: AIActionDraft): string {
+  const activity = timelineActivityPreview(draft);
+  const sectionLabel = firstTimelineText([draft.preview], ['section_label']);
+  const sectionDate = firstTimelineText(
+    [draft.preview],
+    ['section_date', 'date'],
+  );
+  const fallbackDate =
+    sectionLabel !== null && sectionDate !== null
+      ? `${sectionLabel} · ${sectionDate}`
+      : (sectionDate ?? sectionLabel);
+  const date = timelineDisplayText(draft, 'Date') ?? fallbackDate;
+  const time = timelineDisplayText(draft, 'Time') ?? timelineTimeText(activity);
+  const location =
+    timelineDisplayText(draft, 'Location') ?? timelineLocationText(activity);
+  const details = [
+    date === null ? null : `Date: ${date}.`,
+    time === null ? null : `Time: ${time}.`,
+    location === null ? null : `Location: ${location}.`,
+    ...timelineConfirmationMetaDetails(draft),
+  ].filter((detail): detail is string => detail !== null);
+  return details.length === 0 ? '' : ` ${details.join(' ')}`;
+}
+
+function quotedTimelineUpdateTarget(draft: AIActionDraft): string {
+  const target =
+    timelineDisplayText(draft, 'Target') ??
+    firstTimelineText([draft.preview], ['target_title']) ??
+    draftTitle(draft);
+  return `“${target}”`;
+}
+
+function timelineUpdateTitleSuffix(draft: AIActionDraft): string {
+  const target =
+    timelineDisplayText(draft, 'Target') ??
+    firstTimelineText([draft.preview], ['target_title']) ??
+    draftTitle(draft);
+  const resolvedTitle =
+    firstTimelineText([timelineActivityPreview(draft)], ['title']) ??
+    draftTitle(draft);
+  return resolvedTitle === target ? '' : ` to “${resolvedTitle}”`;
+}
+
 export function confirmationRestatement(draft: AIActionDraft): string {
   switch (draft.action_type) {
     case 'timeline.activity.create':
-      return `Create timeline activity ${quotedTitle(draft)}.`;
+      return `Create timeline activity ${quotedTitle(draft)}.${timelineConfirmationDetails(draft)}`;
     case 'timeline.activity.update':
-      return `Update timeline activity ${quotedTitle(draft)} with the reviewed values.`;
+      return `Update timeline activity ${quotedTimelineUpdateTarget(draft)}${timelineUpdateTitleSuffix(draft)}.${timelineConfirmationDetails(draft)}`;
     case 'timeline.activity.delete':
       return `Delete timeline activity ${quotedTitle(draft)} from the shared trip.`;
     case 'timeline.activity.status.update':

--- a/mobile/src/features/chat/ai/reconciliation.ts
+++ b/mobile/src/features/chat/ai/reconciliation.ts
@@ -1,0 +1,150 @@
+import { publishExpenseEvent } from '@/features/expenses/expenseEvents';
+import { publishTimelineEvent } from '@/features/timeline/timelineEvents';
+import {
+  canonicalizeAIUuid,
+  isKnownAIActionType,
+  type AIActionDraft,
+  type AIActionDraftStatus,
+  type KnownAIActionType,
+} from './drafts';
+
+export type AIReconciliationChannel = 'timeline' | 'expenses';
+
+const CHANNEL_BY_ACTION: Readonly<
+  Record<KnownAIActionType, AIReconciliationChannel>
+> = {
+  'timeline.activity.create': 'timeline',
+  'timeline.activity.update': 'timeline',
+  'timeline.activity.delete': 'timeline',
+  'timeline.activity.status.update': 'timeline',
+  'expense.create': 'expenses',
+  'expense.update': 'expenses',
+  'expense.delete': 'expenses',
+  'expense.contribution.set': 'expenses',
+  'settlement.finalize': 'expenses',
+  'settlement.reopen': 'expenses',
+  'settlement.transfer.mark_sent': 'expenses',
+  'settlement.transfer.confirm_received': 'expenses',
+};
+
+export interface AIReconciliationPublishers {
+  readonly timeline: (tripId: string) => void | Promise<void>;
+  readonly expenses: (tripId: string) => void | Promise<void>;
+}
+
+const DEFAULT_PUBLISHERS: AIReconciliationPublishers = {
+  timeline: async (tripId) => {
+    await publishTimelineEvent({ type: 'timelineChanged', tripId });
+  },
+  expenses: async (tripId) => {
+    await publishExpenseEvent({ type: 'expensesChanged', tripId });
+  },
+};
+
+export function reconciliationChannelForAction(
+  actionType: string,
+): AIReconciliationChannel | null {
+  return isKnownAIActionType(actionType)
+    ? CHANNEL_BY_ACTION[actionType]
+    : null;
+}
+
+export async function reconcileNewlyConfirmedDraft(options: {
+  readonly tripId: string;
+  readonly previousStatus: AIActionDraftStatus;
+  readonly draft: AIActionDraft;
+  readonly publishers?: AIReconciliationPublishers;
+}): Promise<AIReconciliationChannel | null> {
+  if (
+    options.previousStatus === 'CONFIRMED' ||
+    options.draft.status !== 'CONFIRMED'
+  ) {
+    return null;
+  }
+  const channel = reconciliationChannelForAction(options.draft.action_type);
+  if (channel === null) {
+    return null;
+  }
+  const publishers = options.publishers ?? DEFAULT_PUBLISHERS;
+  await publishers[channel](options.tripId);
+  return channel;
+}
+
+export interface AIReconciliationCoordinator {
+  readonly resourceKey: string;
+  readonly tripId: string;
+  readonly seedConfirmedDrafts: (
+    drafts: readonly AIActionDraft[],
+  ) => void;
+  readonly reconcile: (options: {
+    readonly previousStatus: AIActionDraftStatus | null;
+    readonly draft: AIActionDraft;
+  }) => Promise<AIReconciliationChannel | null>;
+}
+
+export function createAIReconciliationCoordinator(options: {
+  readonly tripId: string;
+  readonly resourceKey?: string;
+  readonly publishers?: AIReconciliationPublishers;
+  readonly reconcile?: typeof reconcileNewlyConfirmedDraft;
+}): AIReconciliationCoordinator {
+  const claims = new Map<
+    string,
+    Promise<AIReconciliationChannel | null>
+  >();
+
+  const canonicalDraftId = (draft: AIActionDraft): string =>
+    canonicalizeAIUuid(draft.id) ?? draft.id.trim().toLowerCase();
+
+  return {
+    resourceKey: options.resourceKey ?? options.tripId,
+    tripId: options.tripId,
+    seedConfirmedDrafts: (drafts) => {
+      for (const draft of drafts) {
+        if (draft.status !== 'CONFIRMED') {
+          continue;
+        }
+        const draftId = canonicalDraftId(draft);
+        if (!claims.has(draftId)) {
+          claims.set(draftId, Promise.resolve(null));
+        }
+      }
+    },
+    reconcile: ({ previousStatus, draft }) => {
+      if (previousStatus === 'CONFIRMED' || draft.status !== 'CONFIRMED') {
+        return Promise.resolve(null);
+      }
+      const draftId = canonicalDraftId(draft);
+      const existing = claims.get(draftId);
+      if (existing !== undefined) {
+        return existing;
+      }
+
+      let resolveClaim: (
+        channel: AIReconciliationChannel | null,
+      ) => void = () => undefined;
+      let rejectClaim: (error: unknown) => void = () => undefined;
+      const claim = new Promise<AIReconciliationChannel | null>(
+        (resolve, reject) => {
+          resolveClaim = resolve;
+          rejectClaim = reject;
+        },
+      );
+      // Claim before invoking a publisher. A synchronous publisher callback
+      // can therefore observe and reuse this exact in-flight Promise.
+      claims.set(draftId, claim);
+      const reconcile = options.reconcile ?? reconcileNewlyConfirmedDraft;
+      void Promise.resolve()
+        .then(() =>
+          reconcile({
+            tripId: options.tripId,
+            previousStatus: previousStatus ?? 'READY',
+            draft,
+            publishers: options.publishers,
+          }),
+        )
+        .then(resolveClaim, rejectClaim);
+      return claim;
+    },
+  };
+}

--- a/mobile/src/features/chat/ai/reconciliation.ts
+++ b/mobile/src/features/chat/ai/reconciliation.ts
@@ -1,5 +1,6 @@
 import { publishExpenseEvent } from '@/features/expenses/expenseEvents';
 import { publishTimelineEvent } from '@/features/timeline/timelineEvents';
+import type { ChatApiFailure } from '../types';
 import {
   canonicalizeAIUuid,
   isKnownAIActionType,
@@ -80,6 +81,11 @@ export interface AIReconciliationCoordinator {
     readonly previousStatus: AIActionDraftStatus | null;
     readonly draft: AIActionDraft;
   }) => Promise<AIReconciliationChannel | null>;
+  /** Escalates room-level access/terminal authority discovered by a draft API. */
+  readonly reportAuthoritativeFailure: (failure: ChatApiFailure) => void;
+  readonly setAuthoritativeFailureReporter: (
+    reporter: ((failure: ChatApiFailure) => void) | null,
+  ) => void;
 }
 
 export function createAIReconciliationCoordinator(options: {
@@ -87,11 +93,14 @@ export function createAIReconciliationCoordinator(options: {
   readonly resourceKey?: string;
   readonly publishers?: AIReconciliationPublishers;
   readonly reconcile?: typeof reconcileNewlyConfirmedDraft;
+  readonly reportAuthoritativeFailure?: (failure: ChatApiFailure) => void;
 }): AIReconciliationCoordinator {
   const claims = new Map<
     string,
     Promise<AIReconciliationChannel | null>
   >();
+  let authoritativeFailureReporter =
+    options.reportAuthoritativeFailure ?? (() => undefined);
 
   const canonicalDraftId = (draft: AIActionDraft): string =>
     canonicalizeAIUuid(draft.id) ?? draft.id.trim().toLowerCase();
@@ -99,6 +108,11 @@ export function createAIReconciliationCoordinator(options: {
   return {
     resourceKey: options.resourceKey ?? options.tripId,
     tripId: options.tripId,
+    reportAuthoritativeFailure: (failure) =>
+      authoritativeFailureReporter(failure),
+    setAuthoritativeFailureReporter: (reporter) => {
+      authoritativeFailureReporter = reporter ?? (() => undefined);
+    },
     seedConfirmedDrafts: (drafts) => {
       for (const draft of drafts) {
         if (draft.status !== 'CONFIRMED') {

--- a/mobile/src/features/chat/ai/reconciliationContext.tsx
+++ b/mobile/src/features/chat/ai/reconciliationContext.tsx
@@ -1,0 +1,49 @@
+import {
+  createContext,
+  type PropsWithChildren,
+  useContext,
+  useMemo,
+} from 'react';
+import {
+  createAIActionDraftControllerSessionStore,
+  type AIActionDraftControllerSessionStore,
+} from './controllerSession';
+import type { AIReconciliationCoordinator } from './reconciliation';
+
+const AIReconciliationCoordinatorContext =
+  createContext<AIReconciliationCoordinator | null>(null);
+const AIActionDraftControllerSessionContext =
+  createContext<AIActionDraftControllerSessionStore | null>(null);
+
+export function AIReconciliationCoordinatorProvider({
+  children,
+  value,
+}: PropsWithChildren<{
+  readonly value: AIReconciliationCoordinator | null;
+}>) {
+  const resourceKey = value?.resourceKey ?? null;
+  const controllerSessionStore = useMemo(
+    () =>
+      resourceKey === null
+        ? null
+        : createAIActionDraftControllerSessionStore(resourceKey),
+    [resourceKey],
+  );
+  return (
+    <AIReconciliationCoordinatorContext.Provider value={value}>
+      <AIActionDraftControllerSessionContext.Provider
+        value={controllerSessionStore}
+      >
+        {children}
+      </AIActionDraftControllerSessionContext.Provider>
+    </AIReconciliationCoordinatorContext.Provider>
+  );
+}
+
+export function useRoomAIReconciliationCoordinator(): AIReconciliationCoordinator | null {
+  return useContext(AIReconciliationCoordinatorContext);
+}
+
+export function useRoomAIActionDraftControllerSessionStore(): AIActionDraftControllerSessionStore | null {
+  return useContext(AIActionDraftControllerSessionContext);
+}

--- a/mobile/src/features/chat/ai/typingState.ts
+++ b/mobile/src/features/chat/ai/typingState.ts
@@ -1,0 +1,142 @@
+export const AI_TYPING_VISUAL_TIMEOUT_MS = 120_000;
+
+export interface AITypingInteraction {
+  readonly interactionId: string;
+  readonly requestedByUserId: string | null;
+  readonly startedAtMs: number;
+  readonly visualExpiresAtMs: number;
+}
+
+export interface AITypingState {
+  readonly active: AITypingInteraction | null;
+}
+
+export type AITypingEvent =
+  | {
+      readonly type: 'started';
+      readonly interactionId: string;
+      readonly requestedByUserId: string | null;
+      readonly nowMs: number;
+    }
+  | {
+      readonly type: 'stopped';
+      readonly interactionId: string;
+    }
+  | {
+      readonly type: 'visual_timeout';
+      readonly interactionId: string;
+      readonly nowMs: number;
+    };
+
+export const EMPTY_AI_TYPING_STATE: AITypingState = { active: null };
+
+export function reduceAITypingState(
+  state: AITypingState,
+  event: AITypingEvent,
+): AITypingState {
+  if (event.type === 'started') {
+    return {
+      active: {
+        interactionId: event.interactionId,
+        requestedByUserId: event.requestedByUserId,
+        startedAtMs: event.nowMs,
+        visualExpiresAtMs: event.nowMs + AI_TYPING_VISUAL_TIMEOUT_MS,
+      },
+    };
+  }
+
+  if (state.active?.interactionId !== event.interactionId) {
+    return state;
+  }
+
+  if (event.type === 'stopped') {
+    return EMPTY_AI_TYPING_STATE;
+  }
+
+  return event.nowMs >= state.active.visualExpiresAtMs
+    ? EMPTY_AI_TYPING_STATE
+    : state;
+}
+
+export interface AITypingTimerScheduler {
+  readonly set: (callback: () => void, delayMs: number) => unknown;
+  readonly clear: (handle: unknown) => void;
+}
+
+export interface AITypingVisualController {
+  readonly getState: () => AITypingState;
+  readonly start: (
+    interactionId: string,
+    requestedByUserId: string | null,
+  ) => void;
+  readonly stop: (interactionId: string) => void;
+  readonly dispose: () => void;
+}
+
+/**
+ * Timer and clock injection make correlation and the 120-second fallback fully
+ * deterministic. The fallback changes visual state only; it never calls a
+ * server API or emits a stopped event.
+ */
+export function createAITypingVisualController(options: {
+  readonly scheduler: AITypingTimerScheduler;
+  readonly now: () => number;
+  readonly onChange: (state: AITypingState) => void;
+}): AITypingVisualController {
+  let state = EMPTY_AI_TYPING_STATE;
+  let timeoutHandle: unknown = null;
+
+  const cancelTimeout = (): void => {
+    if (timeoutHandle !== null) {
+      options.scheduler.clear(timeoutHandle);
+      timeoutHandle = null;
+    }
+  };
+
+  const publish = (next: AITypingState): void => {
+    if (next === state) {
+      return;
+    }
+    state = next;
+    options.onChange(state);
+  };
+
+  return {
+    getState: () => state,
+    start: (interactionId, requestedByUserId) => {
+      cancelTimeout();
+      const nowMs = options.now();
+      publish(
+        reduceAITypingState(state, {
+          type: 'started',
+          interactionId,
+          requestedByUserId,
+          nowMs,
+        }),
+      );
+      timeoutHandle = options.scheduler.set(() => {
+        timeoutHandle = null;
+        publish(
+          reduceAITypingState(state, {
+            type: 'visual_timeout',
+            interactionId,
+            nowMs: options.now(),
+          }),
+        );
+      }, AI_TYPING_VISUAL_TIMEOUT_MS);
+    },
+    stop: (interactionId) => {
+      const next = reduceAITypingState(state, {
+        type: 'stopped',
+        interactionId,
+      });
+      if (next !== state) {
+        cancelTimeout();
+        publish(next);
+      }
+    },
+    dispose: () => {
+      cancelTimeout();
+    },
+  };
+}

--- a/mobile/src/features/chat/ai/useConfirmRetryClock.ts
+++ b/mobile/src/features/chat/ai/useConfirmRetryClock.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { sharedAIExpiryDeadlineClock } from './expiryClock';
+
+export interface AIConfirmRetryProjection {
+  readonly blocked: boolean;
+  readonly label: string | null;
+  readonly remainingMs: number;
+}
+
+function retryLabel(remainingMs: number): string {
+  const seconds = Math.max(1, Math.ceil(remainingMs / 1_000));
+  if (seconds < 60) {
+    return `Confirmation available in ${seconds}s`;
+  }
+  return `Confirmation available in ${Math.ceil(seconds / 60)} min`;
+}
+
+export function useAIConfirmRetryClock(
+  retryAtMs: number | null,
+  nowOverrideMs?: number,
+): AIConfirmRetryProjection {
+  const [clockMs, setClockMs] = useState(() => Date.now());
+  const nowMs = nowOverrideMs ?? clockMs;
+  const safeDeadline =
+    retryAtMs !== null && Number.isSafeInteger(retryAtMs) ? retryAtMs : null;
+  const remainingMs =
+    safeDeadline === null ? 0 : Math.max(0, safeDeadline - nowMs);
+  const blocked = remainingMs > 0;
+
+  useEffect(() => {
+    if (nowOverrideMs !== undefined || safeDeadline === null || !blocked) {
+      return undefined;
+    }
+    return sharedAIExpiryDeadlineClock.subscribe(safeDeadline, setClockMs);
+  }, [blocked, nowOverrideMs, safeDeadline]);
+
+  return {
+    blocked,
+    label: blocked ? retryLabel(remainingMs) : null,
+    remainingMs,
+  };
+}

--- a/mobile/src/features/chat/ai/useExpiryClock.ts
+++ b/mobile/src/features/chat/ai/useExpiryClock.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import type { AIActionDraft } from './drafts';
+import { getAIActionDraftExpiry } from './expiry';
+import { sharedAIExpiryDeadlineClock } from './expiryClock';
+
+export function useAIActionDraftExpiry(
+  draft: Pick<AIActionDraft, 'status' | 'expires_at'>,
+  nowOverrideMs?: number,
+) {
+  const [clockMs, setClockMs] = useState(() => Date.now());
+  const expiresAtMs = Date.parse(draft.expires_at);
+  const renderedClockMs = nowOverrideMs ?? clockMs;
+  const projection = getAIActionDraftExpiry(draft, renderedClockMs);
+  const activeStatus = draft.status === 'NEEDS_INFO' || draft.status === 'READY';
+
+  useEffect(() => {
+    if (
+      nowOverrideMs !== undefined ||
+      !activeStatus ||
+      projection.isExpired
+    ) {
+      return undefined;
+    }
+    return sharedAIExpiryDeadlineClock.subscribe(expiresAtMs, setClockMs);
+  }, [activeStatus, expiresAtMs, nowOverrideMs, projection.isExpired]);
+
+  return projection;
+}

--- a/mobile/src/features/chat/application/transcriptReducer.ts
+++ b/mobile/src/features/chat/application/transcriptReducer.ts
@@ -3,6 +3,11 @@ import type {
   ChatMessage,
   ReactionSummary,
 } from '../types';
+import {
+  aiActionDraftSourceIdentity,
+  parseAIActionDraft,
+  type AIActionDraft,
+} from '../ai/drafts';
 
 export type ChatRoomStatus = 'idle' | 'loading' | 'ready' | 'error' | 'kicked';
 
@@ -20,6 +25,13 @@ export interface TranscriptReactionOverlay {
 export interface TranscriptMutationError {
   readonly messageId: string | null;
   readonly error: ChatApiFailure;
+}
+
+export interface TranscriptAIDraftOverlay {
+  readonly draft: AIActionDraft;
+  readonly projectedIdentity: string;
+  readonly priorSourceIdentities: ReadonlySet<string>;
+  readonly lastAuthoritativeSequence: number;
 }
 
 export interface TranscriptState {
@@ -49,6 +61,15 @@ export interface TranscriptState {
   readonly reactionOverlays: ReadonlyMap<
     string,
     TranscriptReactionOverlay
+  >;
+  /**
+   * Immediate HTTP draft projections. Full chat rows remain authoritative and
+   * retain their server-authored change_sequence; this overlay is reconciled
+   * separately when a newer full row arrives.
+   */
+  readonly aiDraftOverlays: ReadonlyMap<
+    string,
+    ReadonlyMap<string, TranscriptAIDraftOverlay>
   >;
   readonly hasMoreOlder: boolean;
   readonly nextOlderCursor: string | null;
@@ -104,6 +125,13 @@ export type TranscriptAction =
       readonly messages: readonly ChatMessage[];
       /** Required for REST data; omitted only for a live authoritative push. */
       readonly requestVersion?: number;
+    })
+  | (ResourceScopedAction & {
+      readonly type: 'AI_DRAFT_LOCAL_SNAPSHOT';
+      readonly messageId: string;
+      readonly draftId: string;
+      readonly expectedSourceIdentity: string;
+      readonly draft: AIActionDraft;
     })
   | (ResourceScopedAction & {
       readonly type: 'REACTION_PATCH';
@@ -227,6 +255,7 @@ export function createTranscriptState(resourceKey: string): TranscriptState {
     hidden: new Set(),
     reactionBase: new Map(),
     reactionOverlays: new Map(),
+    aiDraftOverlays: new Map(),
     hasMoreOlder: false,
     nextOlderCursor: null,
     isLoadingOlder: false,
@@ -242,6 +271,47 @@ export function createTranscriptState(resourceKey: string): TranscriptState {
 }
 
 type MergeMode = 'upsert' | 'patch-known';
+
+function parsedDraftById(
+  message: ChatMessage,
+  draftId: string,
+): AIActionDraft | null {
+  for (const candidate of message.action_drafts) {
+    const parsed = parseAIActionDraft(candidate);
+    if (parsed?.id === draftId) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function reconcileAIDraftOverlaysForFullMessage(
+  overlays: ReadonlyMap<string, TranscriptAIDraftOverlay>,
+  message: ChatMessage,
+): ReadonlyMap<string, TranscriptAIDraftOverlay> | null {
+  if (message.is_deleted_for_everyone) {
+    return null;
+  }
+
+  const next = new Map<string, TranscriptAIDraftOverlay>();
+  for (const [draftId, overlay] of overlays) {
+    const incomingDraft = parsedDraftById(message, draftId);
+    if (incomingDraft === null) {
+      continue;
+    }
+    const incomingIdentity = aiActionDraftSourceIdentity(incomingDraft);
+    if (incomingIdentity === overlay.projectedIdentity) {
+      continue;
+    }
+    if (overlay.priorSourceIdentities.has(incomingIdentity)) {
+      next.set(draftId, {
+        ...overlay,
+        lastAuthoritativeSequence: message.change_sequence,
+      });
+    }
+  }
+  return next.size > 0 ? next : null;
+}
 
 function mergeMessages(
   state: TranscriptState,
@@ -287,6 +357,7 @@ function mergeMessages(
   const failedByClientId = new Map(state.failedByClientId);
   const reactionBase = new Map(state.reactionBase);
   const reactionOverlays = new Map(state.reactionOverlays);
+  const aiDraftOverlays = new Map(state.aiDraftOverlays);
   const pendingReactionMessageIds = new Set(
     state.pendingReactionMessageIds,
   );
@@ -303,6 +374,19 @@ function mergeMessages(
     if (message.is_deleted_for_everyone) {
       reactionOverlays.delete(message.id);
       pendingReactionMessageIds.delete(message.id);
+    }
+
+    const messageDraftOverlays = aiDraftOverlays.get(message.id);
+    if (messageDraftOverlays !== undefined) {
+      const reconciled = reconcileAIDraftOverlaysForFullMessage(
+        messageDraftOverlays,
+        message,
+      );
+      if (reconciled === null) {
+        aiDraftOverlays.delete(message.id);
+      } else {
+        aiDraftOverlays.set(message.id, reconciled);
+      }
     }
 
     const cid = message.client_message_id;
@@ -329,6 +413,7 @@ function mergeMessages(
     failedByClientId,
     reactionBase,
     reactionOverlays,
+    aiDraftOverlays,
     pendingReactionMessageIds,
   };
 }
@@ -528,6 +613,54 @@ export function transcriptReducer(
         action.requestVersion,
       );
 
+    case 'AI_DRAFT_LOCAL_SNAPSHOT': {
+      const message = state.confirmed.get(action.messageId);
+      if (
+        message === undefined ||
+        message.sender_kind !== 'AI' ||
+        message.is_deleted_for_everyone ||
+        state.hidden.has(action.messageId) ||
+        action.draft.id !== action.draftId
+      ) {
+        return state;
+      }
+
+      const messageOverlays = state.aiDraftOverlays.get(action.messageId);
+      const currentOverlay = messageOverlays?.get(action.draftId);
+      const currentDraft =
+        currentOverlay?.draft ?? parsedDraftById(message, action.draftId);
+      if (
+        currentDraft === null ||
+        aiActionDraftSourceIdentity(currentDraft) !==
+          action.expectedSourceIdentity
+      ) {
+        return state;
+      }
+
+      const nextVersion = state.version + 1;
+      const priorSourceIdentities = new Set(
+        currentOverlay?.priorSourceIdentities ?? [],
+      );
+      priorSourceIdentities.add(action.expectedSourceIdentity);
+      const nextMessageOverlays = new Map(messageOverlays ?? []);
+      nextMessageOverlays.set(action.draftId, {
+        draft: action.draft,
+        projectedIdentity: aiActionDraftSourceIdentity(action.draft),
+        priorSourceIdentities,
+        lastAuthoritativeSequence: message.change_sequence,
+      });
+      const aiDraftOverlays = new Map(state.aiDraftOverlays);
+      aiDraftOverlays.set(action.messageId, nextMessageOverlays);
+      const messageVersions = new Map(state.messageVersions);
+      messageVersions.set(action.messageId, nextVersion);
+      return {
+        ...state,
+        version: nextVersion,
+        messageVersions,
+        aiDraftOverlays,
+      };
+    }
+
     case 'REACTION_PATCH': {
       const message = state.confirmed.get(action.messageId);
       if (
@@ -674,6 +807,7 @@ export function transcriptReducer(
       const hidden = new Set(state.hidden);
       const reactionBase = new Map(state.reactionBase);
       const reactionOverlays = new Map(state.reactionOverlays);
+      const aiDraftOverlays = new Map(state.aiDraftOverlays);
       const pendingReactionMessageIds = new Set(
         state.pendingReactionMessageIds,
       );
@@ -687,6 +821,7 @@ export function transcriptReducer(
         reactionLiveVersions.delete(messageId);
         reactionBase.delete(messageId);
         reactionOverlays.delete(messageId);
+        aiDraftOverlays.delete(messageId);
         pendingReactionMessageIds.delete(messageId);
         pendingDeleteMessageIds.delete(messageId);
 
@@ -717,6 +852,7 @@ export function transcriptReducer(
         hidden,
         reactionBase,
         reactionOverlays,
+        aiDraftOverlays,
         pendingReactionMessageIds,
         pendingDeleteMessageIds,
         mutationError: null,
@@ -910,6 +1046,7 @@ export function transcriptReducer(
       const reactionLiveVersions = new Map(state.reactionLiveVersions);
       const reactionBase = new Map(state.reactionBase);
       const reactionOverlays = new Map(state.reactionOverlays);
+      const aiDraftOverlays = new Map(state.aiDraftOverlays);
       const pendingReactionMessageIds = new Set(
         state.pendingReactionMessageIds,
       );
@@ -927,6 +1064,9 @@ export function transcriptReducer(
       reactionLiveVersions.delete(message.id);
       reactionBase.set(message.id, authoritative.reactions);
       reactionOverlays.delete(message.id);
+      if (authoritative.is_deleted_for_everyone) {
+        aiDraftOverlays.delete(message.id);
+      }
       pendingReactionMessageIds.delete(message.id);
       pendingDeleteMessageIds.delete(message.id);
 
@@ -939,6 +1079,7 @@ export function transcriptReducer(
         reactionLiveVersions,
         reactionBase,
         reactionOverlays,
+        aiDraftOverlays,
         pendingReactionMessageIds,
         pendingDeleteMessageIds,
         mutationError: null,
@@ -1013,6 +1154,42 @@ function withEffectiveReactions(
   return message;
 }
 
+function withEffectiveAIDrafts(
+  state: TranscriptState,
+  message: ChatMessage,
+): ChatMessage {
+  const overlays = state.aiDraftOverlays.get(message.id);
+  if (
+    overlays === undefined ||
+    overlays.size === 0 ||
+    message.is_deleted_for_everyone
+  ) {
+    return message;
+  }
+
+  let changed = false;
+  const actionDrafts = message.action_drafts.map((candidate) => {
+    const parsed = parseAIActionDraft(candidate);
+    if (parsed === null) {
+      return candidate;
+    }
+    const overlay = overlays.get(parsed.id);
+    if (overlay === undefined) {
+      return candidate;
+    }
+    changed = true;
+    return overlay.draft;
+  });
+  return changed ? { ...message, action_drafts: actionDrafts } : message;
+}
+
+function withEffectiveMessage(
+  state: TranscriptState,
+  message: ChatMessage,
+): ChatMessage {
+  return withEffectiveAIDrafts(state, withEffectiveReactions(state, message));
+}
+
 /** Confirmed and optimistic messages ordered by `(created_at, id)` ascending. */
 export function selectTranscriptMessages(
   state: TranscriptState,
@@ -1024,7 +1201,7 @@ export function selectTranscriptMessages(
     if (state.hidden.has(message.id)) {
       continue;
     }
-    messages.push(withEffectiveReactions(state, message));
+    messages.push(withEffectiveMessage(state, message));
     if (message.client_message_id !== null) {
       confirmedClientIds.add(message.client_message_id);
     }
@@ -1049,7 +1226,7 @@ export function selectMessageById(
 ): ChatMessage | null {
   const confirmed = state.confirmed.get(id);
   if (confirmed !== undefined && !state.hidden.has(id)) {
-    return withEffectiveReactions(state, confirmed);
+    return withEffectiveMessage(state, confirmed);
   }
   for (const message of state.pending.values()) {
     if (message.id === id && !state.hidden.has(id)) {

--- a/mobile/src/features/chat/application/transcriptReducer.ts
+++ b/mobile/src/features/chat/application/transcriptReducer.ts
@@ -34,12 +34,29 @@ export interface TranscriptAIDraftOverlay {
   readonly lastAuthoritativeSequence: number;
 }
 
+interface DeferredFullMessagePatch {
+  readonly message: ChatMessage;
+  readonly live: boolean;
+}
+
+interface DeferredReactionPatch {
+  readonly reactions: readonly ReactionSummary[];
+  readonly changeSequence: number;
+  readonly updatedAt: string;
+}
+
+interface DeferredAuthoritativePatch {
+  readonly fullMessage: DeferredFullMessagePatch | null;
+  readonly reaction: DeferredReactionPatch | null;
+}
+
 export interface TranscriptState {
   readonly resourceKey: string;
   /** Shared logical clock captured before starting REST requests. */
   readonly version: number;
   readonly roomStatus: ChatRoomStatus;
   readonly roomError: ChatApiFailure | null;
+  readonly isLoadingInitial: boolean;
   readonly confirmed: ReadonlyMap<string, ChatMessage>;
   /** Last transcript mutation version for each confirmed server id. */
   readonly messageVersions: ReadonlyMap<string, number>;
@@ -70,6 +87,11 @@ export interface TranscriptState {
   readonly aiDraftOverlays: ReadonlyMap<
     string,
     ReadonlyMap<string, TranscriptAIDraftOverlay>
+  >;
+  /** Newer authority retained until an unloaded paginated row materializes. */
+  readonly deferredAuthoritativePatches: ReadonlyMap<
+    string,
+    DeferredAuthoritativePatch
   >;
   readonly hasMoreOlder: boolean;
   readonly nextOlderCursor: string | null;
@@ -243,6 +265,7 @@ export function createTranscriptState(resourceKey: string): TranscriptState {
     version: 0,
     roomStatus: 'idle',
     roomError: null,
+    isLoadingInitial: false,
     confirmed: new Map(),
     messageVersions: new Map(),
     reactionBaseVersions: new Map(),
@@ -256,6 +279,7 @@ export function createTranscriptState(resourceKey: string): TranscriptState {
     reactionBase: new Map(),
     reactionOverlays: new Map(),
     aiDraftOverlays: new Map(),
+    deferredAuthoritativePatches: new Map(),
     hasMoreOlder: false,
     nextOlderCursor: null,
     isLoadingOlder: false,
@@ -271,6 +295,103 @@ export function createTranscriptState(resourceKey: string): TranscriptState {
 }
 
 type MergeMode = 'upsert' | 'patch-known';
+
+function shouldReplaceFullMessage(
+  current: ChatMessage,
+  incoming: ChatMessage,
+): boolean {
+  if (current.is_deleted_for_everyone && !incoming.is_deleted_for_everyone) {
+    return false;
+  }
+  return (
+    incoming.change_sequence > current.change_sequence ||
+    (incoming.change_sequence === current.change_sequence &&
+      incoming.is_deleted_for_everyone &&
+      !current.is_deleted_for_everyone)
+  );
+}
+
+/** Returns the deferred full row only when it will supersede this raw page row. */
+export function selectDeferredFullAuthorityForMaterialization(
+  state: TranscriptState,
+  incoming: ChatMessage,
+): ChatMessage | null {
+  const deferred = state.deferredAuthoritativePatches.get(incoming.id)
+    ?.fullMessage?.message;
+  return deferred !== undefined && shouldReplaceFullMessage(incoming, deferred)
+    ? deferred
+    : null;
+}
+
+function retainDeferredFullMessage(
+  current: DeferredAuthoritativePatch | undefined,
+  message: ChatMessage,
+  live: boolean,
+): DeferredAuthoritativePatch | null {
+  const currentFullMessage = current?.fullMessage?.message;
+  if (
+    currentFullMessage !== undefined &&
+    !shouldReplaceFullMessage(currentFullMessage, message)
+  ) {
+    return null;
+  }
+  return {
+    fullMessage: { message, live },
+    reaction: message.is_deleted_for_everyone ? null : current?.reaction ?? null,
+  };
+}
+
+function retainDeferredReaction(
+  current: DeferredAuthoritativePatch | undefined,
+  reaction: DeferredReactionPatch,
+): DeferredAuthoritativePatch | null {
+  if (
+    current?.fullMessage?.message.is_deleted_for_everyone ||
+    (current?.fullMessage !== null &&
+      current?.fullMessage !== undefined &&
+      current.fullMessage.message.change_sequence >= reaction.changeSequence) ||
+    (current?.reaction !== null &&
+      current?.reaction !== undefined &&
+      current.reaction.changeSequence >= reaction.changeSequence)
+  ) {
+    return null;
+  }
+  return {
+    fullMessage: current?.fullMessage ?? null,
+    reaction,
+  };
+}
+
+function materializeDeferredPatch(
+  message: ChatMessage,
+  deferred: DeferredAuthoritativePatch,
+): { readonly message: ChatMessage; readonly live: boolean } {
+  let resolved = message;
+  let live = false;
+  const fullMessage = deferred.fullMessage;
+  if (
+    fullMessage !== null &&
+    shouldReplaceFullMessage(resolved, fullMessage.message)
+  ) {
+    resolved = fullMessage.message;
+    live = fullMessage.live;
+  }
+  const reaction = deferred.reaction;
+  if (
+    reaction !== null &&
+    !resolved.is_deleted_for_everyone &&
+    reaction.changeSequence > resolved.change_sequence
+  ) {
+    resolved = {
+      ...resolved,
+      reactions: reaction.reactions,
+      change_sequence: reaction.changeSequence,
+      updated_at: reaction.updatedAt,
+    };
+    live = true;
+  }
+  return { message: resolved, live };
+}
 
 function parsedDraftById(
   message: ChatMessage,
@@ -319,30 +440,67 @@ function mergeMessages(
   mode: MergeMode,
   _requestVersion: number | undefined,
 ): TranscriptState {
-  const eligible = new Map<string, ChatMessage>();
+  const eligible = new Map<
+    string,
+    { readonly message: ChatMessage; readonly live: boolean }
+  >();
+  let deferredAuthoritativePatches = state.deferredAuthoritativePatches;
+  let deferredChanged = false;
 
-  for (const message of messages) {
-    if (state.hidden.has(message.id)) {
+  const mutableDeferredPatches = () => {
+    if (!deferredChanged) {
+      deferredAuthoritativePatches = new Map(deferredAuthoritativePatches);
+      deferredChanged = true;
+    }
+    return deferredAuthoritativePatches as Map<
+      string,
+      DeferredAuthoritativePatch
+    >;
+  };
+
+  for (const incoming of messages) {
+    if (state.hidden.has(incoming.id)) {
       continue;
     }
-    if (mode === 'patch-known' && !state.confirmed.has(message.id)) {
+    const current = state.confirmed.get(incoming.id);
+    if (mode === 'patch-known' && current === undefined) {
+      const retained = retainDeferredFullMessage(
+        deferredAuthoritativePatches.get(incoming.id),
+        incoming,
+        _requestVersion === undefined,
+      );
+      if (retained !== null) {
+        mutableDeferredPatches().set(incoming.id, retained);
+      }
       continue;
     }
 
-    const current = state.confirmed.get(message.id);
+    let message = incoming;
+    let live = _requestVersion === undefined;
+    const deferred = deferredAuthoritativePatches.get(message.id);
+    if (current === undefined && deferred !== undefined) {
+      const materialized = materializeDeferredPatch(message, deferred);
+      message = materialized.message;
+      live = live || materialized.live;
+      mutableDeferredPatches().delete(message.id);
+    }
     if (
       current !== undefined &&
-      (message.change_sequence <= current.change_sequence ||
-        (current.is_deleted_for_everyone &&
-          !message.is_deleted_for_everyone))
+      !shouldReplaceFullMessage(current, message)
     ) {
       continue;
     }
-    eligible.set(message.id, message);
+    eligible.set(message.id, { message, live });
   }
 
   if (eligible.size === 0) {
-    return state;
+    return deferredChanged
+      ? {
+          ...state,
+          version: state.version + 1,
+          deferredAuthoritativePatches,
+        }
+      : state;
   }
 
   const nextVersion = state.version + 1;
@@ -362,12 +520,12 @@ function mergeMessages(
     state.pendingReactionMessageIds,
   );
 
-  for (const message of eligible.values()) {
+  for (const { message, live } of eligible.values()) {
     confirmed.set(message.id, message);
     messageVersions.set(message.id, nextVersion);
     reactionBase.set(message.id, message.reactions);
     reactionBaseVersions.set(message.id, nextVersion);
-    if (_requestVersion === undefined) {
+    if (live) {
       reactionLiveVersions.set(message.id, nextVersion);
     }
 
@@ -414,6 +572,7 @@ function mergeMessages(
     reactionBase,
     reactionOverlays,
     aiDraftOverlays,
+    deferredAuthoritativePatches,
     pendingReactionMessageIds,
   };
 }
@@ -546,7 +705,18 @@ export function transcriptReducer(
 
   switch (action.type) {
     case 'INIT_START':
-      return { ...state, roomStatus: 'loading', roomError: null };
+      if (state.isLoadingInitial) {
+        return state;
+      }
+      if (state.terminalLocked) {
+        return { ...state, isLoadingInitial: true, roomError: null };
+      }
+      return {
+        ...state,
+        roomStatus: 'loading',
+        roomError: null,
+        isLoadingInitial: true,
+      };
 
     case 'INIT_RESOLVED': {
       const merged = mergeMessages(
@@ -559,15 +729,32 @@ export function transcriptReducer(
         ...merged,
         roomStatus: 'ready',
         roomError: null,
+        isLoadingInitial: false,
         nextOlderCursor: action.nextCursor,
         hasMoreOlder: action.nextCursor !== null,
       };
     }
 
     case 'INIT_FAILED':
-      return { ...state, roomStatus: 'error', roomError: action.error };
+      if (state.terminalLocked) {
+        return {
+          ...state,
+          roomStatus: 'ready',
+          roomError: action.error,
+          isLoadingInitial: false,
+        };
+      }
+      return {
+        ...state,
+        roomStatus: 'error',
+        roomError: action.error,
+        isLoadingInitial: false,
+      };
 
     case 'OLDER_START':
+      if (state.isLoadingOlder) {
+        return state;
+      }
       return {
         ...state,
         isLoadingOlder: true,
@@ -663,8 +850,32 @@ export function transcriptReducer(
 
     case 'REACTION_PATCH': {
       const message = state.confirmed.get(action.messageId);
+      if (message === undefined) {
+        if (state.hidden.has(action.messageId)) {
+          return state;
+        }
+        const retained = retainDeferredReaction(
+          state.deferredAuthoritativePatches.get(action.messageId),
+          {
+            reactions: action.reactions,
+            changeSequence: action.changeSequence,
+            updatedAt: action.updatedAt,
+          },
+        );
+        if (retained === null) {
+          return state;
+        }
+        const deferredAuthoritativePatches = new Map(
+          state.deferredAuthoritativePatches,
+        );
+        deferredAuthoritativePatches.set(action.messageId, retained);
+        return {
+          ...state,
+          version: state.version + 1,
+          deferredAuthoritativePatches,
+        };
+      }
       if (
-        message === undefined ||
         message.is_deleted_for_everyone ||
         state.hidden.has(action.messageId) ||
         action.changeSequence <= message.change_sequence
@@ -808,6 +1019,9 @@ export function transcriptReducer(
       const reactionBase = new Map(state.reactionBase);
       const reactionOverlays = new Map(state.reactionOverlays);
       const aiDraftOverlays = new Map(state.aiDraftOverlays);
+      const deferredAuthoritativePatches = new Map(
+        state.deferredAuthoritativePatches,
+      );
       const pendingReactionMessageIds = new Set(
         state.pendingReactionMessageIds,
       );
@@ -822,6 +1036,7 @@ export function transcriptReducer(
         reactionBase.delete(messageId);
         reactionOverlays.delete(messageId);
         aiDraftOverlays.delete(messageId);
+        deferredAuthoritativePatches.delete(messageId);
         pendingReactionMessageIds.delete(messageId);
         pendingDeleteMessageIds.delete(messageId);
 
@@ -853,6 +1068,7 @@ export function transcriptReducer(
         reactionBase,
         reactionOverlays,
         aiDraftOverlays,
+        deferredAuthoritativePatches,
         pendingReactionMessageIds,
         pendingDeleteMessageIds,
         mutationError: null,
@@ -871,6 +1087,7 @@ export function transcriptReducer(
     case 'TERMINAL_LOCK': {
       if (
         state.terminalLocked &&
+        state.roomStatus === 'ready' &&
         state.pending.size === 0 &&
         state.reactionOverlays.size === 0 &&
         state.pendingDeleteMessageIds.size === 0 &&
@@ -894,9 +1111,11 @@ export function transcriptReducer(
         failedClientIds: new Set(),
         failedByClientId: new Map(),
         reactionOverlays: new Map(),
+        roomStatus: 'ready',
         terminalLocked: true,
         pendingReactionMessageIds: new Set(),
         pendingDeleteMessageIds: new Set(),
+        olderLoadError: null,
         isHidingMessages: false,
         mutationError: null,
       };
@@ -915,6 +1134,7 @@ export function transcriptReducer(
       const hadBusyState =
         activeSendClientIds.length > 0 ||
         interruptedMutation ||
+        state.isLoadingInitial ||
         state.isLoadingOlder ||
         state.isGapFilling ||
         state.isUpdating;
@@ -951,6 +1171,7 @@ export function transcriptReducer(
         reactionOverlays: new Map(),
         pendingReactionMessageIds: new Set(),
         pendingDeleteMessageIds: new Set(),
+        isLoadingInitial: false,
         isLoadingOlder: false,
         isGapFilling: false,
         isUpdating: false,

--- a/mobile/src/features/chat/components/ChatComposer.tsx
+++ b/mobile/src/features/chat/components/ChatComposer.tsx
@@ -9,6 +9,15 @@ import {
   View,
 } from 'react-native';
 import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import {
+  GoPlanAIComposerIntent,
+  GoPlanAIMentionCommandMenu,
+} from '../ai/components/AIMention';
+import {
+  insertGoPlanAIMention,
+  parseGoPlanAIMention,
+  shouldOfferGoPlanAICommand,
+} from '../ai/mention';
 
 export const CHAT_MESSAGE_MAX_LENGTH = 2000;
 
@@ -37,7 +46,13 @@ export function ChatComposer({
   const [feedback, setFeedback] = useState<string | null>(null);
   const trimmedDraft = draft.trim();
   const busy = sending || localSending;
-  const canSend = !disabled && !busy && trimmedDraft.length > 0;
+  const parsedAIMention = parseGoPlanAIMention(draft);
+  const hasAIMention = parsedAIMention.hasMention;
+  const missingAIPrompt = hasAIMention && parsedAIMention.prompt.length === 0;
+  const canSend =
+    !disabled && !busy && trimmedDraft.length > 0 && !missingAIPrompt;
+  const showAIMentionMenu =
+    !disabled && !busy && shouldOfferGoPlanAICommand(draft);
 
   useEffect(() => {
     if (hidden) {
@@ -49,6 +64,20 @@ export function ChatComposer({
     setDraft(value);
     setFeedback(null);
   }, []);
+
+  const insertAIMention = useCallback(() => {
+    const inserted = insertGoPlanAIMention(draft).displayContent;
+    if (inserted.length > CHAT_MESSAGE_MAX_LENGTH) {
+      setFeedback(
+        'GoPlanAI mention cannot be inserted because this message would exceed 2,000 characters.',
+      );
+      inputRef.current?.focus();
+      return;
+    }
+    setDraft(inserted);
+    setFeedback(null);
+    inputRef.current?.focus();
+  }, [draft]);
 
   const submit = useCallback(async () => {
     if (!canSend || submittingRef.current) {
@@ -79,6 +108,12 @@ export function ChatComposer({
       style={[styles.shell, hidden ? styles.hidden : null]}
       testID="chat-composer"
     >
+      <GoPlanAIMentionCommandMenu
+        disabled={disabled || busy}
+        onSelect={insertAIMention}
+        open={showAIMentionMenu}
+      />
+      {hasAIMention ? <GoPlanAIComposerIntent /> : null}
       <View style={styles.composerRow}>
         <TextInput
           ref={inputRef}
@@ -131,6 +166,16 @@ export function ChatComposer({
           {feedback}
         </Text>
       ) : null}
+      {missingAIPrompt ? (
+        <Text
+          accessibilityLiveRegion="polite"
+          accessibilityRole="alert"
+          style={styles.promptHint}
+          testID="goplan-ai-prompt-hint"
+        >
+          Add a prompt for GoPlanAI before sending.
+        </Text>
+      ) : null}
     </View>
   );
 }
@@ -176,5 +221,6 @@ const styles = StyleSheet.create({
   sendButtonPressed: { backgroundColor: colors.primaryPressed },
   sendButtonDisabled: { opacity: 0.38 },
   feedback: { ...typography.caption, color: colors.danger },
+  promptHint: { ...typography.caption, color: colors.warning },
   hidden: { display: 'none' },
 });

--- a/mobile/src/features/chat/components/ChatConnectionBanner.tsx
+++ b/mobile/src/features/chat/components/ChatConnectionBanner.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react';
-import { StyleSheet, Text } from 'react-native';
-import type { RealtimeStatus } from '@/features/realtime/types';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import type {
+  RealtimeDiagnostics,
+  RealtimeStatus,
+} from '@/features/realtime/types';
 import { colors, spacing, typography } from '@/shared/theme/tokens';
 import type { ChatSubscriptionStatus } from '../hooks/useTripChat';
 
@@ -12,15 +15,37 @@ type VisibleConnectionState = 'connecting' | 'reconnecting' | 'disconnected';
 const CONNECTION_COPY: Record<VisibleConnectionState, string> = {
   connecting: 'Connecting to live chat…',
   reconnecting: 'Reconnecting. You can keep reading; missed messages will catch up.',
-  disconnected: 'Disconnected. Trying again shortly.',
+  disconnected: 'Live chat is disconnected. New messages may be delayed.',
 };
+
+function disconnectedCopy(
+  diagnostics: RealtimeDiagnostics | undefined,
+): string {
+  if (!diagnostics?.terminal) {
+    return CONNECTION_COPY.disconnected;
+  }
+  switch (diagnostics.reason) {
+    case 'authentication_failed':
+      return 'Live chat stopped because your session could not be authenticated.';
+    case 'invalid_configuration':
+      return 'Live chat is unavailable because the app configuration is invalid.';
+    case 'retry_exhausted':
+      return 'Live chat stopped after repeated connection failures. Check your connection and try again later.';
+    default:
+      return 'Live chat is unavailable and will not retry automatically.';
+  }
+}
 
 export function ChatConnectionBanner({
   status,
   subscriptionStatus,
+  diagnostics,
+  onRetry,
 }: {
   status: RealtimeStatus;
   subscriptionStatus?: ChatSubscriptionStatus;
+  diagnostics?: RealtimeDiagnostics;
+  onRetry?: () => void;
 }) {
   const visibleStatus: VisibleConnectionState | null =
     status === 'connecting' ||
@@ -35,13 +60,35 @@ export function ChatConnectionBanner({
     return null;
   }
 
-  return <NonConnectedBanner key={visibleStatus} status={visibleStatus} />;
+  const copy =
+    visibleStatus === 'disconnected'
+      ? disconnectedCopy(diagnostics)
+      : CONNECTION_COPY[visibleStatus];
+  const terminal =
+    visibleStatus === 'disconnected' && diagnostics?.terminal === true;
+
+  return (
+    <NonConnectedBanner
+      copy={copy}
+      key={`${visibleStatus}:${copy}`}
+      onRetry={
+        terminal && diagnostics?.reason === 'retry_exhausted'
+          ? onRetry
+          : undefined
+      }
+      terminal={terminal}
+    />
+  );
 }
 
 function NonConnectedBanner({
-  status,
+  copy,
+  onRetry,
+  terminal,
 }: {
-  status: VisibleConnectionState;
+  copy: string;
+  onRetry?: () => void;
+  terminal: boolean;
 }) {
   const [visible, setVisible] = useState(false);
   const [escalated, setEscalated] = useState(false);
@@ -65,28 +112,80 @@ function NonConnectedBanner({
     return null;
   }
 
-  return (
+  const text = (
     <Text
       accessibilityLiveRegion="polite"
       accessibilityRole="alert"
-      style={[styles.banner, escalated ? styles.bannerEscalated : null]}
+      style={[
+        styles.bannerText,
+        escalated || terminal ? styles.bannerTextEscalated : null,
+      ]}
+    >
+      {copy}
+    </Text>
+  );
+
+  if (!onRetry) {
+    return (
+      <View
+        style={[
+          styles.banner,
+          escalated || terminal ? styles.bannerEscalated : null,
+        ]}
+        testID="chat-connection-banner"
+      >
+        {text}
+      </View>
+    );
+  }
+
+  return (
+    <View
+      style={[styles.banner, styles.actionBanner, styles.bannerEscalated]}
       testID="chat-connection-banner"
     >
-      {CONNECTION_COPY[status]}
-    </Text>
+      {text}
+      <Pressable
+        accessibilityLabel="Retry live connection"
+        accessibilityRole="button"
+        onPress={onRetry}
+        style={({ pressed }) => [
+          styles.retryButton,
+          pressed ? styles.retryButtonPressed : null,
+        ]}
+      >
+        <Text style={styles.retryButtonText}>Retry</Text>
+      </Pressable>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
   banner: {
-    ...typography.caption,
+    minHeight: 44,
+    justifyContent: 'center',
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.sm,
-    color: colors.textMuted,
     backgroundColor: colors.completedSoft,
   },
+  actionBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingRight: spacing.sm,
+  },
   bannerEscalated: {
-    color: colors.warning,
     backgroundColor: colors.warningSoft,
   },
+  bannerText: { ...typography.caption, flex: 1, color: colors.textMuted },
+  bannerTextEscalated: { color: colors.warning },
+  retryButton: {
+    minHeight: 44,
+    minWidth: 72,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.sm,
+  },
+  retryButtonPressed: { opacity: 0.58 },
+  retryButtonText: { ...typography.label, color: colors.primary },
 });

--- a/mobile/src/features/chat/components/ChatMessageActionsModal.tsx
+++ b/mobile/src/features/chat/components/ChatMessageActionsModal.tsx
@@ -1,8 +1,15 @@
-import { Ionicons } from '@expo/vector-icons';
-import { type ComponentProps, memo, useCallback } from 'react';
+import { FontAwesome6, Ionicons } from '@expo/vector-icons';
+import {
+  type ComponentProps,
+  memo,
+  useCallback,
+  useEffect,
+  useRef,
+} from 'react';
 import {
   Alert,
   Modal,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -15,6 +22,7 @@ import {
   ALLOWED_REACTION_EMOJIS,
   type AllowedReactionEmoji,
 } from '../types';
+import { ChatReactionIcon } from './ChatReactionIcon';
 import { REACTION_ACCESSIBILITY_LABELS } from './ChatReactionBar';
 
 interface ChatMessageActionsModalProps {
@@ -26,6 +34,8 @@ interface ChatMessageActionsModalProps {
   canSelect: boolean;
   busy?: boolean;
   onClose: () => void;
+  onCloseWithoutFocus?: () => void;
+  onDismiss?: () => void;
   onReact: (emoji: AllowedReactionEmoji) => void;
   onHide: () => void;
   onDeleteForEveryone: () => void;
@@ -50,6 +60,9 @@ const ReactionOption = memo(function ReactionOption({
     <Pressable
       accessibilityRole="button"
       accessibilityLabel={`React with ${REACTION_ACCESSIBILITY_LABELS[emoji].toLowerCase()}`}
+      accessibilityHint={
+        selected ? 'Removes your reaction' : 'Adds this reaction'
+      }
       accessibilityState={{ selected, disabled }}
       disabled={disabled}
       onPress={select}
@@ -61,7 +74,22 @@ const ReactionOption = memo(function ReactionOption({
       ]}
       testID={`chat-reaction-option-${emoji}`}
     >
-      <Text style={styles.reactionEmoji}>{emoji}</Text>
+      <ChatReactionIcon emoji={emoji} size={22} />
+      {selected ? (
+        <View
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+          style={styles.reactionSelectedBadge}
+          testID={`chat-reaction-option-selected-${emoji}`}
+        >
+          <FontAwesome6
+            color={colors.background}
+            name="check"
+            size={9}
+            solid
+          />
+        </View>
+      ) : null}
     </Pressable>
   );
 });
@@ -75,52 +103,145 @@ export function ChatMessageActionsModal({
   canSelect,
   busy = false,
   onClose,
+  onCloseWithoutFocus,
+  onDismiss,
   onReact,
   onHide,
   onDeleteForEveryone,
   onSelect,
 }: ChatMessageActionsModalProps) {
-  const selectReaction = useCallback(
-    (emoji: AllowedReactionEmoji) => {
-      onClose();
-      onReact(emoji);
-    },
-    [onClose, onReact],
+  const reactionSelectionLockedRef = useRef(false);
+  const dismissHandoffRef = useRef<(() => void) | null>(null);
+  const dismissHandoffTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const androidDismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
   );
 
-  const confirmHide = useCallback(() => {
+  useEffect(() => {
+    if (!visible) {
+      reactionSelectionLockedRef.current = false;
+      return;
+    }
+    if (androidDismissTimerRef.current !== null) {
+      clearTimeout(androidDismissTimerRef.current);
+      androidDismissTimerRef.current = null;
+    }
+  }, [visible]);
+
+  useEffect(
+    () => () => {
+      if (dismissHandoffTimerRef.current !== null) {
+        clearTimeout(dismissHandoffTimerRef.current);
+        dismissHandoffTimerRef.current = null;
+      }
+      if (androidDismissTimerRef.current !== null) {
+        clearTimeout(androidDismissTimerRef.current);
+        androidDismissTimerRef.current = null;
+      }
+      dismissHandoffRef.current = null;
+    },
+    [],
+  );
+
+  const closeWithFocusRestore = useCallback(() => {
     onClose();
-    Alert.alert(
-      'Hide this message?',
-      'It will disappear only from your chat history. This cannot be undone.',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        { text: 'Hide', style: 'destructive', onPress: onHide },
-      ],
+    if (
+      Platform.OS === 'android' &&
+      androidDismissTimerRef.current === null
+    ) {
+      // Android does not publish Modal.onDismiss. Wait until the visibility
+      // update has removed the native modal host before handing focus back.
+      androidDismissTimerRef.current = setTimeout(() => {
+        androidDismissTimerRef.current = null;
+        onDismiss?.();
+      }, 0);
+    }
+  }, [onClose, onDismiss]);
+
+  const selectReaction = useCallback(
+    (emoji: AllowedReactionEmoji) => {
+      if (!canReact || busy || reactionSelectionLockedRef.current) {
+        return;
+      }
+      reactionSelectionLockedRef.current = true;
+      closeWithFocusRestore();
+      onReact(emoji);
+    },
+    [busy, canReact, closeWithFocusRestore, onReact],
+  );
+
+  const closeWithDismissHandoff = useCallback(
+    (handoff: () => void) => {
+      if (Platform.OS === 'ios') {
+        dismissHandoffRef.current = handoff;
+      }
+      (onCloseWithoutFocus ?? onClose)();
+
+      // React Native only exposes Modal.onDismiss on iOS. Android must not
+      // wait for a callback that will never arrive.
+      if (Platform.OS !== 'ios') {
+        handoff();
+      }
+    },
+    [onClose, onCloseWithoutFocus],
+  );
+
+  const handleDismiss = useCallback(() => {
+    const handoff = dismissHandoffRef.current;
+    dismissHandoffRef.current = null;
+    onDismiss?.();
+    if (handoff) {
+      if (dismissHandoffTimerRef.current !== null) {
+        clearTimeout(dismissHandoffTimerRef.current);
+      }
+      // Fabric emits onDismiss immediately before completing its native focus
+      // restoration. Move the alert to the next task so VoiceOver stays on the
+      // confirmation instead of being pulled back to the old sheet trigger.
+      dismissHandoffTimerRef.current = setTimeout(() => {
+        dismissHandoffTimerRef.current = null;
+        handoff();
+      }, 0);
+    }
+  }, [onDismiss]);
+
+  const confirmHide = useCallback(() => {
+    closeWithDismissHandoff(
+      () => Alert.alert(
+        'Hide this message?',
+        'It will disappear only from your chat history. This cannot be undone.',
+        [
+          { text: 'Cancel', style: 'cancel' },
+          { text: 'Hide', style: 'destructive', onPress: onHide },
+        ],
+      ),
     );
-  }, [onClose, onHide]);
+  }, [closeWithDismissHandoff, onHide]);
 
   const confirmDeleteForEveryone = useCallback(() => {
-    onClose();
-    Alert.alert(
-      'Remove this message for everyone?',
-      'Its content will be replaced with a removal notice for every trip member.',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        { text: 'Remove', style: 'destructive', onPress: onDeleteForEveryone },
-      ],
+    closeWithDismissHandoff(
+      () => Alert.alert(
+        'Remove this message for everyone?',
+        'Its content will be replaced with a removal notice for every trip member.',
+        [
+          { text: 'Cancel', style: 'cancel' },
+          { text: 'Remove', style: 'destructive', onPress: onDeleteForEveryone },
+        ],
+      ),
     );
-  }, [onClose, onDeleteForEveryone]);
+  }, [closeWithDismissHandoff, onDeleteForEveryone]);
 
   const startSelection = useCallback(() => {
-    onClose();
+    closeWithFocusRestore();
     onSelect();
-  }, [onClose, onSelect]);
+  }, [closeWithFocusRestore, onSelect]);
 
   return (
     <Modal
       animationType="slide"
-      onRequestClose={onClose}
+      onDismiss={handleDismiss}
+      onRequestClose={closeWithFocusRestore}
       presentationStyle="pageSheet"
       visible={visible}
     >
@@ -141,7 +262,7 @@ export function ChatMessageActionsModal({
             <Pressable
               accessibilityRole="button"
               accessibilityLabel="Close message actions"
-              onPress={onClose}
+              onPress={closeWithFocusRestore}
               style={({ pressed }) => [
                 styles.closeButton,
                 pressed ? styles.pressed : null,
@@ -288,6 +409,7 @@ const styles = StyleSheet.create({
     rowGap: spacing.xs,
   },
   reactionOption: {
+    position: 'relative',
     minWidth: 44,
     minHeight: 44,
     alignItems: 'center',
@@ -297,8 +419,23 @@ const styles = StyleSheet.create({
     borderRadius: radii.full,
     borderCurve: 'continuous',
   },
-  reactionOptionSelected: { backgroundColor: colors.primarySoft },
-  reactionEmoji: { ...typography.heading },
+  reactionOptionSelected: {
+    borderWidth: 2,
+    borderColor: colors.primary,
+    backgroundColor: colors.primarySoft,
+  },
+  reactionSelectedBadge: {
+    position: 'absolute',
+    right: -2,
+    bottom: -2,
+    width: 18,
+    height: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.full,
+    borderCurve: 'continuous',
+    backgroundColor: colors.primary,
+  },
   actions: {
     overflow: 'hidden',
     borderWidth: 1,

--- a/mobile/src/features/chat/components/ChatMessageBubble.tsx
+++ b/mobile/src/features/chat/components/ChatMessageBubble.tsx
@@ -11,6 +11,17 @@ import {
 } from 'react-native';
 import { UserAvatar } from '@/features/auth/components/UserAvatar';
 import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
+import { AIActionDraftCardController } from '../ai/components/AIActionDraftCardController';
+import {
+  GoPlanAIMentionMessageText,
+} from '../ai/components/AIMention';
+import { AIMessageContent } from '../ai/components/AIMessageContent';
+import {
+  aiActionDraftSourceIdentity,
+  parseAIActionDraft,
+  type AIActionDraft,
+} from '../ai/drafts';
+import { parseGoPlanAIMention } from '../ai/mention';
 import type {
   AllowedReactionEmoji,
   ChatApiFailure,
@@ -28,6 +39,19 @@ const accessibleTimeFormatter = new Intl.DateTimeFormat(undefined, {
   timeStyle: 'short',
 });
 
+const EMPTY_DRAFT_ID_SET: ReadonlySet<string> = new Set();
+
+export interface ApplyMessageAIDraftSnapshotInput {
+  readonly messageId: string;
+  readonly draftId: string;
+  readonly expectedSourceIdentity: string;
+  readonly draft: AIActionDraft;
+}
+
+export type ApplyMessageAIDraftSnapshot = (
+  input: ApplyMessageAIDraftSnapshotInput,
+) => Promise<void>;
+
 interface ChatMessageBubbleProps {
   message: ChatMessage;
   currentUserId: string;
@@ -41,12 +65,14 @@ interface ChatMessageBubbleProps {
   deleting: boolean;
   reactionBusy: boolean;
   actionsEnabled: boolean;
+  ambiguousAIDraftIds?: ReadonlySet<string>;
   selectionMode: boolean;
   selected: boolean;
   onOpenActions: (messageId: string) => void;
   onToggleSelection: (messageId: string) => void;
   onRetry: (clientMessageId: string) => void;
   onToggleReaction: (messageId: string, emoji: AllowedReactionEmoji) => void;
+  onApplyAIDraftSnapshot: ApplyMessageAIDraftSnapshot;
 }
 
 function senderLabel(message: ChatMessage): string {
@@ -75,7 +101,9 @@ function messageAccessibilityLabel(
   const sender = isOwn ? 'You' : senderLabel(message);
   const content = message.is_deleted_for_everyone
     ? 'Message removed for everyone'
-    : message.content || 'Message with no text';
+    : message.sender_kind === 'AI' && message.ai_status === 'ERROR'
+      ? `GoPlanAI could not complete this request. ${message.content || 'No error detail was provided.'}`
+      : message.content || 'Message with no text';
   const time = formatMessageTime(message.created_at, true);
   const delivery = failed
     ? 'Not sent'
@@ -124,6 +152,47 @@ function SenderAvatar({ message }: { message: ChatMessage }) {
   );
 }
 
+interface AIDraftCardAdapterProps {
+  readonly draft: AIActionDraft;
+  readonly interactionDisabled: boolean;
+  readonly messageId: string;
+  readonly tripId: string;
+  readonly onApplyAIDraftSnapshot: ApplyMessageAIDraftSnapshot;
+}
+
+const AIDraftCardAdapter = memo(function AIDraftCardAdapter({
+  draft,
+  interactionDisabled,
+  messageId,
+  tripId,
+  onApplyAIDraftSnapshot,
+}: AIDraftCardAdapterProps) {
+  const expectedSourceIdentity = useMemo(
+    () => aiActionDraftSourceIdentity(draft),
+    [draft],
+  );
+  const applySnapshot = useCallback(
+    (nextDraft: AIActionDraft) =>
+      onApplyAIDraftSnapshot({
+        messageId,
+        draftId: draft.id,
+        expectedSourceIdentity,
+        draft: nextDraft,
+      }),
+    [draft.id, expectedSourceIdentity, messageId, onApplyAIDraftSnapshot],
+  );
+
+  return (
+    <AIActionDraftCardController
+      draft={draft}
+      interactionDisabled={interactionDisabled}
+      onDraftChanged={applySnapshot}
+      tripId={tripId}
+    />
+  );
+});
+AIDraftCardAdapter.displayName = 'AIDraftCardAdapter';
+
 function ChatMessageBubbleComponent({
   message,
   currentUserId,
@@ -137,18 +206,61 @@ function ChatMessageBubbleComponent({
   deleting,
   reactionBusy,
   actionsEnabled,
+  ambiguousAIDraftIds = EMPTY_DRAFT_ID_SET,
   selectionMode,
   selected,
   onOpenActions,
   onToggleSelection,
   onRetry,
   onToggleReaction,
+  onApplyAIDraftSnapshot,
 }: ChatMessageBubbleProps) {
   const canSelect = !pending && !failed && !deleting;
   const canOpenActions = actionsEnabled && canSelect && !selectionMode;
   const canRetry = Boolean(actionsEnabled && failed && message.client_message_id);
   const time = formatMessageTime(message.created_at);
   const label = senderLabel(message);
+  const userHasAIMention = useMemo(
+    () =>
+      message.sender_kind === 'USER' &&
+      parseGoPlanAIMention(message.content).hasMention,
+    [message.content, message.sender_kind],
+  );
+  const parsedDrafts = useMemo(() => {
+    if (
+      message.sender_kind !== 'AI' ||
+      message.is_deleted_for_everyone
+    ) {
+      return { drafts: [] as readonly AIActionDraft[], malformedCount: 0 };
+    }
+    const parsedCandidates = message.action_drafts.map(parseAIActionDraft);
+    const idCounts = new Map<string, number>();
+    for (const parsed of parsedCandidates) {
+      if (parsed !== null) {
+        idCounts.set(parsed.id, (idCounts.get(parsed.id) ?? 0) + 1);
+      }
+    }
+    const drafts: AIActionDraft[] = [];
+    let malformedCount = 0;
+    for (const parsed of parsedCandidates) {
+      if (parsed === null) {
+        malformedCount += 1;
+      } else if (
+        (idCounts.get(parsed.id) ?? 0) !== 1 ||
+        ambiguousAIDraftIds.has(parsed.id)
+      ) {
+        malformedCount += 1;
+      } else {
+        drafts.push(parsed);
+      }
+    }
+    return { drafts, malformedCount };
+  }, [
+    ambiguousAIDraftIds,
+    message.action_drafts,
+    message.is_deleted_for_everyone,
+    message.sender_kind,
+  ]);
   const accessibilityActions = useMemo<AccessibilityActionInfo[]>(() => {
     if (selectionMode && canSelect) {
       return [
@@ -203,6 +315,28 @@ function ChatMessageBubbleComponent({
     [openActions, retry, toggleSelection],
   );
 
+  const content = message.sender_kind === 'AI' ? (
+    <View style={styles.aiContent}>
+      {message.ai_status === 'ERROR' ? (
+        <Text
+          accessibilityLiveRegion="polite"
+          accessibilityRole="alert"
+          style={styles.aiErrorText}
+          testID={`chat-ai-error-${message.id}`}
+        >
+          GoPlanAI could not complete this request.
+        </Text>
+      ) : null}
+      <AIMessageContent content={message.content} />
+    </View>
+  ) : userHasAIMention ? (
+    <GoPlanAIMentionMessageText content={message.content} inverse={isOwn} />
+  ) : (
+    <Text style={[styles.messageText, isOwn ? styles.ownMessageText : null]}>
+      {message.content}
+    </Text>
+  );
+
   const bubble = (
     <Pressable
       accessible
@@ -238,12 +372,35 @@ function ChatMessageBubbleComponent({
       {message.is_deleted_for_everyone ? (
         <Text style={styles.tombstoneText}>Message removed for everyone</Text>
       ) : (
-        <Text style={[styles.messageText, isOwn ? styles.ownMessageText : null]}>
-          {message.content}
-        </Text>
+        content
       )}
     </Pressable>
   );
+
+  const actionDraftCards =
+    parsedDrafts.drafts.length > 0 || parsedDrafts.malformedCount > 0 ? (
+      <View style={styles.actionDrafts} testID={`chat-ai-drafts-${message.id}`}>
+        {parsedDrafts.drafts.map((draft) => (
+          <AIDraftCardAdapter
+            draft={draft}
+            interactionDisabled={!actionsEnabled || selectionMode}
+            key={draft.id}
+            messageId={message.id}
+            onApplyAIDraftSnapshot={onApplyAIDraftSnapshot}
+            tripId={message.trip_id}
+          />
+        ))}
+        {parsedDrafts.malformedCount > 0 ? (
+          <Text
+            accessibilityRole="alert"
+            style={styles.malformedDraftText}
+            testID={`chat-ai-draft-malformed-${message.id}`}
+          >
+            An AI action draft could not be displayed safely.
+          </Text>
+        ) : null}
+      </View>
+    ) : null;
 
   const meta = showMeta || pending || failed || deleting ? (
     <View style={[styles.metaRow, isOwn ? styles.metaRowOwn : null]}>
@@ -296,6 +453,7 @@ function ChatMessageBubbleComponent({
       <View style={[styles.row, styles.ownRow, selected ? styles.selectedRow : null]}>
         <View style={[styles.messageColumn, styles.ownColumn]}>
           {bubble}
+          {actionDraftCards}
           {reactions}
           {meta}
         </View>
@@ -308,7 +466,13 @@ function ChatMessageBubbleComponent({
     <View style={[styles.row, styles.otherRow, selected ? styles.selectedRow : null]}>
       {selectionMode && canSelect ? <SelectionIndicator selected={selected} /> : null}
       <View style={styles.avatarGutter}>{showAvatar ? <SenderAvatar message={message} /> : null}</View>
-      <View style={[styles.messageColumn, styles.otherColumn]}>
+      <View
+        style={[
+          styles.messageColumn,
+          styles.otherColumn,
+          message.sender_kind === 'AI' ? styles.aiColumn : null,
+        ]}
+      >
         {showSender ? (
           <View style={styles.senderRow}>
             <Text style={[styles.senderName, message.sender_kind === 'AI' ? styles.aiSender : null]}>
@@ -320,6 +484,7 @@ function ChatMessageBubbleComponent({
           </View>
         ) : null}
         {bubble}
+        {actionDraftCards}
         {reactions}
         {meta}
       </View>
@@ -351,6 +516,7 @@ const styles = StyleSheet.create({
   messageColumn: { minWidth: 0, gap: spacing.xs },
   ownColumn: { maxWidth: '82%', alignItems: 'flex-end' },
   otherColumn: { maxWidth: '82%', alignItems: 'flex-start' },
+  aiColumn: { maxWidth: '100%', flex: 1, alignItems: 'stretch' },
   avatarGutter: { width: 32, minHeight: 32, justifyContent: 'flex-end' },
   aiAvatar: {
     width: 32,
@@ -400,6 +566,13 @@ const styles = StyleSheet.create({
   pressed: { opacity: 0.58 },
   messageText: { ...typography.body, color: colors.text },
   ownMessageText: { color: colors.background },
+  aiContent: { minWidth: 0, gap: spacing.sm },
+  aiErrorText: { ...typography.label, color: colors.danger },
+  actionDrafts: { width: '100%', minWidth: 0, gap: spacing.sm },
+  malformedDraftText: {
+    ...typography.caption,
+    color: colors.danger,
+  },
   tombstoneText: { ...typography.caption, color: colors.textMuted, fontStyle: 'italic' },
   metaRow: {
     minHeight: 20,

--- a/mobile/src/features/chat/components/ChatMessageBubble.tsx
+++ b/mobile/src/features/chat/components/ChatMessageBubble.tsx
@@ -1,5 +1,11 @@
-import { Ionicons } from '@expo/vector-icons';
-import { memo, useCallback, useMemo } from 'react';
+import { FontAwesome6, Ionicons } from '@expo/vector-icons';
+import {
+  type ComponentRef,
+  memo,
+  useCallback,
+  useMemo,
+  useRef,
+} from 'react';
 import {
   ActivityIndicator,
   type AccessibilityActionEvent,
@@ -22,6 +28,7 @@ import {
   type AIActionDraft,
 } from '../ai/drafts';
 import { parseGoPlanAIMention } from '../ai/mention';
+import type { AccessibilityFocusTarget } from '../ai/accessibilityFocus';
 import type {
   AllowedReactionEmoji,
   ChatApiFailure,
@@ -52,6 +59,8 @@ export type ApplyMessageAIDraftSnapshot = (
   input: ApplyMessageAIDraftSnapshotInput,
 ) => Promise<void>;
 
+export type ChatMessageActionFocusResolver = () => AccessibilityFocusTarget;
+
 interface ChatMessageBubbleProps {
   message: ChatMessage;
   currentUserId: string;
@@ -65,10 +74,14 @@ interface ChatMessageBubbleProps {
   deleting: boolean;
   reactionBusy: boolean;
   actionsEnabled: boolean;
+  showReactionAffordance?: boolean;
   ambiguousAIDraftIds?: ReadonlySet<string>;
   selectionMode: boolean;
   selected: boolean;
-  onOpenActions: (messageId: string) => void;
+  onOpenActions: (
+    messageId: string,
+    resolveFocusTarget: ChatMessageActionFocusResolver,
+  ) => void;
   onToggleSelection: (messageId: string) => void;
   onRetry: (clientMessageId: string) => void;
   onToggleReaction: (messageId: string, emoji: AllowedReactionEmoji) => void;
@@ -206,6 +219,7 @@ function ChatMessageBubbleComponent({
   deleting,
   reactionBusy,
   actionsEnabled,
+  showReactionAffordance = false,
   ambiguousAIDraftIds = EMPTY_DRAFT_ID_SET,
   selectionMode,
   selected,
@@ -215,8 +229,11 @@ function ChatMessageBubbleComponent({
   onToggleReaction,
   onApplyAIDraftSnapshot,
 }: ChatMessageBubbleProps) {
+  const bubbleRef = useRef<ComponentRef<typeof Pressable>>(null);
+  const reactionAffordanceRef = useRef<ComponentRef<typeof Pressable>>(null);
   const canSelect = !pending && !failed && !deleting;
-  const canOpenActions = actionsEnabled && canSelect && !selectionMode;
+  const canOpenActions =
+    actionsEnabled && canSelect && !reactionBusy && !selectionMode;
   const canRetry = Boolean(actionsEnabled && failed && message.client_message_id);
   const time = formatMessageTime(message.created_at);
   const label = senderLabel(message);
@@ -279,9 +296,18 @@ function ChatMessageBubbleComponent({
     return [];
   }, [canOpenActions, canRetry, canSelect, selected, selectionMode]);
 
-  const openActions = useCallback(() => {
+  const openBubbleActions = useCallback(() => {
     if (canOpenActions) {
-      onOpenActions(message.id);
+      onOpenActions(message.id, () => bubbleRef.current);
+    }
+  }, [canOpenActions, message.id, onOpenActions]);
+
+  const openReactionActions = useCallback(() => {
+    if (canOpenActions) {
+      onOpenActions(
+        message.id,
+        () => reactionAffordanceRef.current ?? bubbleRef.current,
+      );
     }
   }, [canOpenActions, message.id, onOpenActions]);
 
@@ -305,14 +331,14 @@ function ChatMessageBubbleComponent({
   const handleAccessibilityAction = useCallback(
     (event: AccessibilityActionEvent) => {
       if (event.nativeEvent.actionName === 'openMessageActions') {
-        openActions();
+        openBubbleActions();
       } else if (event.nativeEvent.actionName === 'toggleSelection') {
         toggleSelection();
       } else if (event.nativeEvent.actionName === 'retrySend') {
         retry();
       }
     },
-    [openActions, retry, toggleSelection],
+    [openBubbleActions, retry, toggleSelection],
   );
 
   const content = message.sender_kind === 'AI' ? (
@@ -339,6 +365,7 @@ function ChatMessageBubbleComponent({
 
   const bubble = (
     <Pressable
+      ref={bubbleRef}
       accessible
       accessibilityRole={canOpenActions || (selectionMode && canSelect) ? 'button' : undefined}
       accessibilityLabel={messageAccessibilityLabel(message, isOwn, pending, failed, deleting)}
@@ -356,7 +383,7 @@ function ChatMessageBubbleComponent({
       accessibilityActions={accessibilityActions}
       delayLongPress={400}
       onAccessibilityAction={handleAccessibilityAction}
-      onLongPress={canOpenActions ? openActions : undefined}
+      onLongPress={canOpenActions ? openBubbleActions : undefined}
       onPress={selectionMode && canSelect ? toggleSelection : undefined}
       style={({ pressed }) => [
         styles.bubble,
@@ -448,11 +475,64 @@ function ChatMessageBubbleComponent({
     />
   );
 
+  const reactionAffordance =
+    showReactionAffordance && actionsEnabled && canSelect && !selectionMode ? (
+      <Pressable
+        ref={reactionAffordanceRef}
+        accessibilityRole="button"
+        accessibilityLabel="React to this message"
+        accessibilityHint="Opens reactions and other message actions"
+        accessibilityState={{ disabled: reactionBusy, busy: reactionBusy }}
+        disabled={reactionBusy}
+        onPress={openReactionActions}
+        style={({ pressed }) => [
+          styles.reactionAffordance,
+          pressed && !reactionBusy ? styles.pressed : null,
+          reactionBusy ? styles.reactionAffordanceBusy : null,
+        ]}
+        testID={`chat-reaction-affordance-${message.id}`}
+      >
+        <FontAwesome6
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+          color={colors.textMuted}
+          name="face-smile"
+          size={17}
+          solid
+        />
+        <View
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+          style={styles.reactionAffordanceBadge}
+        >
+          <FontAwesome6
+            color={colors.background}
+            name="plus"
+            size={8}
+            solid
+          />
+        </View>
+      </Pressable>
+    ) : null;
+
+  const bubbleActionRow = (
+    <View
+      style={[styles.bubbleActionRow, isOwn ? styles.bubbleActionRowOwn : null]}
+      testID={`chat-bubble-action-row-${message.id}`}
+    >
+      {bubble}
+      {reactionAffordance}
+    </View>
+  );
+
   if (isOwn) {
     return (
       <View style={[styles.row, styles.ownRow, selected ? styles.selectedRow : null]}>
-        <View style={[styles.messageColumn, styles.ownColumn]}>
-          {bubble}
+        <View
+          style={[styles.messageColumn, styles.ownColumn]}
+          testID={`chat-column-${message.id}`}
+        >
+          {bubbleActionRow}
           {actionDraftCards}
           {reactions}
           {meta}
@@ -472,6 +552,7 @@ function ChatMessageBubbleComponent({
           styles.otherColumn,
           message.sender_kind === 'AI' ? styles.aiColumn : null,
         ]}
+        testID={`chat-column-${message.id}`}
       >
         {showSender ? (
           <View style={styles.senderRow}>
@@ -483,7 +564,7 @@ function ChatMessageBubbleComponent({
             ) : null}
           </View>
         ) : null}
-        {bubble}
+        {bubbleActionRow}
         {actionDraftCards}
         {reactions}
         {meta}
@@ -513,9 +594,9 @@ const styles = StyleSheet.create({
     gap: spacing.sm,
   },
   selectedRow: { backgroundColor: colors.primarySoft },
-  messageColumn: { minWidth: 0, gap: spacing.xs },
-  ownColumn: { maxWidth: '82%', alignItems: 'flex-end' },
-  otherColumn: { maxWidth: '82%', alignItems: 'flex-start' },
+  messageColumn: { minWidth: 0, flexShrink: 1, gap: spacing.xs },
+  ownColumn: { maxWidth: '94%', alignItems: 'flex-end' },
+  otherColumn: { maxWidth: '88%', alignItems: 'flex-start' },
   aiColumn: { maxWidth: '100%', flex: 1, alignItems: 'stretch' },
   avatarGutter: { width: 32, minHeight: 32, justifyContent: 'flex-end' },
   aiAvatar: {
@@ -537,6 +618,7 @@ const styles = StyleSheet.create({
   senderTag: { ...typography.caption, color: colors.textMuted },
   aiSender: { color: colors.violet },
   bubble: {
+    flexShrink: 1,
     minHeight: 44,
     minWidth: 48,
     justifyContent: 'center',
@@ -564,6 +646,35 @@ const styles = StyleSheet.create({
   },
   pendingBubble: { opacity: 0.68 },
   pressed: { opacity: 0.58 },
+  reactionAffordance: {
+    position: 'relative',
+    width: 44,
+    minHeight: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.full,
+    borderCurve: 'continuous',
+  },
+  reactionAffordanceBusy: { opacity: 0.55 },
+  reactionAffordanceBadge: {
+    position: 'absolute',
+    right: 7,
+    bottom: 7,
+    width: 14,
+    height: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.full,
+    borderCurve: 'continuous',
+    backgroundColor: colors.primary,
+  },
+  bubbleActionRow: {
+    maxWidth: '100%',
+    minHeight: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  bubbleActionRowOwn: { flexDirection: 'row-reverse' },
   messageText: { ...typography.body, color: colors.text },
   ownMessageText: { color: colors.background },
   aiContent: { minWidth: 0, gap: spacing.sm },

--- a/mobile/src/features/chat/components/ChatMessageList.tsx
+++ b/mobile/src/features/chat/components/ChatMessageList.tsx
@@ -17,9 +17,14 @@ import {
   StyleSheet,
   Text,
   View,
+  type ViewProps,
 } from 'react-native';
 import { colors, spacing, typography } from '@/shared/theme/tokens';
 import { AITypingIndicator } from '../ai/components/AITypingIndicator';
+import {
+  focusAccessibilityNode,
+  type AccessibilityFocusTarget,
+} from '../ai/accessibilityFocus';
 import { useRoomAIActionDraftControllerSessionStore } from '../ai/reconciliationContext';
 import type {
   AllowedReactionEmoji,
@@ -30,6 +35,7 @@ import type {
 import { ChatMessageActionsModal } from './ChatMessageActionsModal';
 import {
   ChatMessageBubble,
+  type ChatMessageActionFocusResolver,
   type ApplyMessageAIDraftSnapshot,
 } from './ChatMessageBubble';
 import { ChatSelectionToolbar } from './ChatSelectionToolbar';
@@ -37,7 +43,13 @@ import { ChatSelectionToolbar } from './ChatSelectionToolbar';
 const MESSAGE_GROUP_WINDOW_MS = 5 * 60 * 1000;
 export const CHAT_HIDE_SELECTION_LIMIT = 100;
 const MAX_TIMER_DELAY_MS = 2_147_483_647;
-const MAINTAIN_VISIBLE_CONTENT_POSITION = { minIndexForVisible: 0 } as const;
+const MAINTAIN_VISIBLE_CONTENT_POSITION = {
+  minIndexForVisible: 0,
+  // An inverted list's native "top" is the visual newest edge. Keep readers
+  // anchored while they browse older messages, but reveal an incoming message
+  // when they are already within roughly one row of the live edge.
+  autoscrollToTopThreshold: 80,
+} as const;
 
 export interface ChatListMutationResult {
   applied: boolean;
@@ -177,9 +189,13 @@ function useDeleteDeadlineClock(messages: readonly ChatMessage[]): number {
   return nowMs;
 }
 
-function EmptyChatState() {
+function EmptyChatState({ onLayout, style }: Pick<ViewProps, 'onLayout' | 'style'>) {
   return (
-    <View style={styles.emptyState}>
+    <View
+      onLayout={onLayout}
+      style={[styles.emptyState, style]}
+      testID="chat-empty-state"
+    >
       <Ionicons name="chatbubbles-outline" size={44} color={colors.textMuted} />
       <Text accessibilityRole="header" style={styles.emptyTitle}>
         No messages yet
@@ -220,6 +236,11 @@ export function ChatMessageList({
   const userInteractedRef = useRef(false);
   const actionsEnabledRef = useRef(actionsEnabled);
   const messagesRef = useRef(messages);
+  const actionOriginFocusResolverRef =
+    useRef<ChatMessageActionFocusResolver | null>(null);
+  const actionFocusRestoreGenerationRef = useRef(0);
+  const actionFocusRestoreTimerRef =
+    useRef<ReturnType<typeof setTimeout> | null>(null);
   const [activeMessageId, setActiveMessageId] = useState<string | null>(null);
   const [selectedMessageIds, setSelectedMessageIds] = useState<ReadonlySet<string>>(
     () => new Set(),
@@ -284,19 +305,72 @@ export function ChatMessageList({
     Keyboard.dismiss();
   }, [markUserInteraction]);
 
+  const clearActionFocusRestoreTimer = useCallback(() => {
+    const timer = actionFocusRestoreTimerRef.current;
+    actionFocusRestoreTimerRef.current = null;
+    if (timer !== null) {
+      clearTimeout(timer);
+    }
+  }, []);
+
+  useEffect(
+    () => () => {
+      actionFocusRestoreGenerationRef.current += 1;
+      actionOriginFocusResolverRef.current = null;
+      clearActionFocusRestoreTimer();
+    },
+    [clearActionFocusRestoreTimer],
+  );
+
   const loadOlderFromScroll = useCallback(() => {
     if (userInteractedRef.current && hasMoreOlder && !isLoadingOlder) {
       onLoadOlder();
     }
   }, [hasMoreOlder, isLoadingOlder, onLoadOlder]);
 
-  const openActions = useCallback((messageId: string) => {
-    setActiveMessageId(messageId);
-  }, []);
+  const openActions = useCallback(
+    (
+      messageId: string,
+      resolveFocusTarget: () => AccessibilityFocusTarget,
+    ) => {
+      actionFocusRestoreGenerationRef.current += 1;
+      clearActionFocusRestoreTimer();
+      actionOriginFocusResolverRef.current = resolveFocusTarget;
+      setActiveMessageId(messageId);
+    },
+    [clearActionFocusRestoreTimer],
+  );
 
   const closeActions = useCallback(() => {
     setActiveMessageId(null);
   }, []);
+
+  const closeActionsWithoutFocus = useCallback(() => {
+    actionFocusRestoreGenerationRef.current += 1;
+    clearActionFocusRestoreTimer();
+    actionOriginFocusResolverRef.current = null;
+    setActiveMessageId(null);
+  }, [clearActionFocusRestoreTimer]);
+
+  const restoreActionOriginFocus = useCallback(() => {
+    const resolveFocusTarget = actionOriginFocusResolverRef.current;
+    actionOriginFocusResolverRef.current = null;
+    clearActionFocusRestoreTimer();
+    if (resolveFocusTarget === null) return;
+
+    const generation = actionFocusRestoreGenerationRef.current;
+    // Fabric publishes Modal.onDismiss immediately before its own native focus
+    // restoration. Restore the originating control on the next task so the
+    // native completion cannot overwrite it.
+    actionFocusRestoreTimerRef.current = setTimeout(() => {
+      actionFocusRestoreTimerRef.current = null;
+      if (actionFocusRestoreGenerationRef.current !== generation) return;
+      const focusTarget = resolveFocusTarget();
+      if (focusTarget !== null) {
+        focusAccessibilityNode(focusTarget);
+      }
+    }, 0);
+  }, [clearActionFocusRestoreTimer]);
 
   const toggleSelection = useCallback(
     (messageId: string) => {
@@ -398,6 +472,13 @@ export function ChatMessageList({
           deleting={pendingDeleteMessageIds.has(item.id)}
           reactionBusy={pendingReactionMessageIds.has(item.id)}
           actionsEnabled={actionsEnabled}
+          showReactionAffordance={
+            actionsEnabled &&
+            !pending &&
+            !failed &&
+            !pendingDeleteMessageIds.has(item.id) &&
+            !item.is_deleted_for_everyone
+          }
           ambiguousAIDraftIds={ambiguousAIDraftIds}
           selectionMode={selectionMode}
           selected={visibleSelectedIds.has(item.id)}
@@ -525,6 +606,8 @@ export function ChatMessageList({
         canSelect={activeMessageCanMutate}
         busy={activeBusy}
         onClose={closeActions}
+        onCloseWithoutFocus={closeActionsWithoutFocus}
+        onDismiss={restoreActionOriginFocus}
         onReact={reactToActiveMessage}
         onHide={hideActiveMessage}
         onDeleteForEveryone={deleteActiveMessageForEveryone}

--- a/mobile/src/features/chat/components/ChatMessageList.tsx
+++ b/mobile/src/features/chat/components/ChatMessageList.tsx
@@ -18,6 +18,8 @@ import {
   View,
 } from 'react-native';
 import { colors, spacing, typography } from '@/shared/theme/tokens';
+import { AITypingIndicator } from '../ai/components/AITypingIndicator';
+import { useRoomAIActionDraftControllerSessionStore } from '../ai/reconciliationContext';
 import type {
   AllowedReactionEmoji,
   ChatApiFailure,
@@ -25,7 +27,10 @@ import type {
   DeleteChatMessageMode,
 } from '../types';
 import { ChatMessageActionsModal } from './ChatMessageActionsModal';
-import { ChatMessageBubble } from './ChatMessageBubble';
+import {
+  ChatMessageBubble,
+  type ApplyMessageAIDraftSnapshot,
+} from './ChatMessageBubble';
 import { ChatSelectionToolbar } from './ChatSelectionToolbar';
 
 const MESSAGE_GROUP_WINDOW_MS = 5 * 60 * 1000;
@@ -66,6 +71,8 @@ interface ChatMessageListProps {
   isLoadingOlder: boolean;
   olderLoadError: string | null;
   actionsEnabled: boolean;
+  ambiguousAIDraftIds: ReadonlySet<string>;
+  aiTypingInteractionId: string | null;
   isHidingMessages: boolean;
   bottomAccessory: ReactNode;
   onLoadOlder: () => void;
@@ -73,6 +80,7 @@ interface ChatMessageListProps {
   onToggleReaction: (messageId: string, emoji: AllowedReactionEmoji) => void;
   onDeleteMessage: (messageId: string, mode: DeleteChatMessageMode) => void;
   onHideMessagesForMe: (messageIds: readonly string[]) => Promise<ChatListMutationResult>;
+  onApplyAIDraftSnapshot: ApplyMessageAIDraftSnapshot;
 }
 
 function chatMessageKey(message: ChatMessage): string {
@@ -194,6 +202,8 @@ export function ChatMessageList({
   isLoadingOlder,
   olderLoadError,
   actionsEnabled,
+  ambiguousAIDraftIds,
+  aiTypingInteractionId,
   isHidingMessages,
   bottomAccessory,
   onLoadOlder,
@@ -201,7 +211,10 @@ export function ChatMessageList({
   onToggleReaction,
   onDeleteMessage,
   onHideMessagesForMe,
+  onApplyAIDraftSnapshot,
 }: ChatMessageListProps) {
+  const aiControllerSessionStore =
+    useRoomAIActionDraftControllerSessionStore();
   const nowMs = useDeleteDeadlineClock(messages);
   const userInteractedRef = useRef(false);
   const actionsEnabledRef = useRef(actionsEnabled);
@@ -212,6 +225,12 @@ export function ChatMessageList({
   );
   const [selectionFeedback, setSelectionFeedback] = useState<string | null>(null);
   const newestFirstMessages = useMemo(() => [...messages].reverse(), [messages]);
+  useLayoutEffect(() => {
+    if (aiControllerSessionStore === null) {
+      return;
+    }
+    aiControllerSessionStore.setAmbiguousDraftIds(ambiguousAIDraftIds);
+  }, [aiControllerSessionStore, ambiguousAIDraftIds]);
   const visibleMessageIds = useMemo(
     () => new Set(messages.map((message) => message.id)),
     [messages],
@@ -240,6 +259,15 @@ export function ChatMessageList({
     ? pendingReactionMessageIds.has(activeMessage.id) ||
       pendingDeleteMessageIds.has(activeMessage.id)
     : false;
+  const typingHeader = useMemo(
+    () =>
+      aiTypingInteractionId === null ? null : (
+        <View style={styles.typingHeader}>
+          <AITypingIndicator interactionId={aiTypingInteractionId} />
+        </View>
+      ),
+    [aiTypingInteractionId],
+  );
 
   useLayoutEffect(() => {
     actionsEnabledRef.current = actionsEnabled;
@@ -364,23 +392,27 @@ export function ChatMessageList({
           deleting={pendingDeleteMessageIds.has(item.id)}
           reactionBusy={pendingReactionMessageIds.has(item.id)}
           actionsEnabled={actionsEnabled}
+          ambiguousAIDraftIds={ambiguousAIDraftIds}
           selectionMode={selectionMode}
           selected={visibleSelectedIds.has(item.id)}
           onOpenActions={openActions}
           onToggleSelection={toggleSelection}
           onRetry={onRetry}
           onToggleReaction={onToggleReaction}
+          onApplyAIDraftSnapshot={onApplyAIDraftSnapshot}
         />
       );
     },
     [
       actionsEnabled,
+      ambiguousAIDraftIds,
       currentUserId,
       failedClientIds,
       failedByClientId,
       newestFirstMessages,
       onRetry,
       onToggleReaction,
+      onApplyAIDraftSnapshot,
       openActions,
       pendingClientIds,
       pendingDeleteMessageIds,
@@ -453,6 +485,7 @@ export function ChatMessageList({
           newestFirstMessages.length === 0 ? styles.emptyContent : styles.listContent
         }
         ListEmptyComponent={<EmptyChatState />}
+        ListHeaderComponent={typingHeader}
         ListFooterComponent={paginationFooter}
         testID="chat-message-list"
       />
@@ -499,6 +532,10 @@ const styles = StyleSheet.create({
   shell: { flex: 1, backgroundColor: colors.surface },
   listContent: { paddingVertical: spacing.sm },
   emptyContent: { flexGrow: 1, justifyContent: 'center' },
+  typingHeader: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+  },
   emptyState: {
     flex: 1,
     alignItems: 'center',

--- a/mobile/src/features/chat/components/ChatMessageList.tsx
+++ b/mobile/src/features/chat/components/ChatMessageList.tsx
@@ -11,6 +11,7 @@ import {
 import {
   ActivityIndicator,
   FlatList,
+  Keyboard,
   type ListRenderItemInfo,
   Pressable,
   StyleSheet,
@@ -278,6 +279,11 @@ export function ChatMessageList({
     userInteractedRef.current = true;
   }, []);
 
+  const beginTranscriptDrag = useCallback(() => {
+    markUserInteraction();
+    Keyboard.dismiss();
+  }, [markUserInteraction]);
+
   const loadOlderFromScroll = useCallback(() => {
     if (userInteractedRef.current && hasMoreOlder && !isLoadingOlder) {
       onLoadOlder();
@@ -472,13 +478,13 @@ export function ChatMessageList({
         inverted
         initialNumToRender={20}
         keyExtractor={chatMessageKey}
-        keyboardDismissMode="interactive"
+        keyboardDismissMode="on-drag"
         keyboardShouldPersistTaps="handled"
         maintainVisibleContentPosition={MAINTAIN_VISIBLE_CONTENT_POSITION}
         onEndReached={loadOlderFromScroll}
         onEndReachedThreshold={0.25}
         onMomentumScrollBegin={markUserInteraction}
-        onScrollBeginDrag={markUserInteraction}
+        onScrollBeginDrag={beginTranscriptDrag}
         renderItem={renderMessage}
         contentInsetAdjustmentBehavior="automatic"
         contentContainerStyle={

--- a/mobile/src/features/chat/components/ChatReactionBar.tsx
+++ b/mobile/src/features/chat/components/ChatReactionBar.tsx
@@ -1,3 +1,4 @@
+import { FontAwesome6 } from '@expo/vector-icons';
 import { memo, useCallback, useMemo } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { colors, radii, spacing, typography } from '@/shared/theme/tokens';
@@ -6,6 +7,7 @@ import {
   type AllowedReactionEmoji,
   type ReactionSummary,
 } from '../types';
+import { ChatReactionIcon } from './ChatReactionIcon';
 
 export const REACTION_ACCESSIBILITY_LABELS: Record<AllowedReactionEmoji, string> = {
   '❤️': 'Heart',
@@ -52,8 +54,19 @@ const ReactionChip = memo(function ReactionChip({
   }${reactedByMe ? ', you reacted' : ''}`;
   const content = (
     <>
-      <Text style={styles.emoji}>{emoji}</Text>
+      <ChatReactionIcon emoji={emoji} />
       <Text style={styles.count}>{formatReactionCount(count)}</Text>
+      {reactedByMe ? (
+        <FontAwesome6
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+          color={colors.primary}
+          name="check"
+          size={11}
+          solid
+          testID={`chat-reaction-selected-${emoji}`}
+        />
+      ) : null}
     </>
   );
 
@@ -150,6 +163,5 @@ const styles = StyleSheet.create({
   },
   chipPressed: { opacity: 0.58 },
   chipBusy: { opacity: 0.55 },
-  emoji: { ...typography.body },
   count: { ...typography.caption, color: colors.text },
 });

--- a/mobile/src/features/chat/components/ChatReactionIcon.tsx
+++ b/mobile/src/features/chat/components/ChatReactionIcon.tsx
@@ -1,0 +1,51 @@
+import { FontAwesome6 } from '@expo/vector-icons';
+import { memo } from 'react';
+import { colors } from '@/shared/theme/tokens';
+import type { AllowedReactionEmoji } from '../types';
+
+export const REACTION_ICON_NAMES = {
+  '❤️': 'heart',
+  '😂': 'face-laugh-squint',
+  '😮': 'face-surprise',
+  '😢': 'face-sad-tear',
+  '😡': 'face-angry',
+  '👍': 'thumbs-up',
+  '👎': 'thumbs-down',
+} as const satisfies Record<AllowedReactionEmoji, string>;
+
+const REACTION_ICON_COLORS = {
+  '❤️': colors.danger,
+  '😂': colors.warning,
+  '😮': colors.violet,
+  '😢': colors.primary,
+  '😡': colors.danger,
+  '👍': colors.primary,
+  '👎': colors.textMuted,
+} as const satisfies Record<AllowedReactionEmoji, string>;
+
+interface ChatReactionIconProps {
+  emoji: AllowedReactionEmoji;
+  size?: number;
+}
+
+/**
+ * App-bundled vector equivalents for the reaction protocol's Unicode values.
+ * The API value remains the exact emoji; only presentation avoids depending on
+ * the host OS emoji font, which is unreliable in some iOS Simulator runtimes.
+ */
+export const ChatReactionIcon = memo(function ChatReactionIcon({
+  emoji,
+  size = 20,
+}: ChatReactionIconProps) {
+  return (
+    <FontAwesome6
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      color={REACTION_ICON_COLORS[emoji]}
+      name={REACTION_ICON_NAMES[emoji]}
+      size={size}
+      solid
+      testID={`chat-reaction-icon-${emoji}`}
+    />
+  );
+});

--- a/mobile/src/features/chat/hooks/useTripChat.ts
+++ b/mobile/src/features/chat/hooks/useTripChat.ts
@@ -28,6 +28,17 @@ import {
   sendChatMessage,
   syncChangedChatMessages,
 } from '../api';
+import { parseAIActionDraft, type AIActionDraft } from '../ai/drafts';
+import {
+  createAIReconciliationCoordinator,
+  type AIReconciliationCoordinator,
+} from '../ai/reconciliation';
+import {
+  createAITypingVisualController,
+  EMPTY_AI_TYPING_STATE,
+  type AITypingState,
+  type AITypingVisualController,
+} from '../ai/typingState';
 import {
   createTranscriptState,
   hasConfirmedClientId,
@@ -39,6 +50,7 @@ import {
   selectTranscriptMessages,
   transcriptReducer,
   type ChatRoomStatus,
+  type TranscriptState,
   type TranscriptAction,
 } from '../application/transcriptReducer';
 import { canonicalizeChatTripId } from '../contracts';
@@ -61,6 +73,13 @@ const CHAT_MUTATION_INTERRUPTED_ERROR_CODE = 'CHAT_MUTATION_INTERRUPTED';
 const ACCESS_LOST_ERROR_CODES = new Set(['TRIP_NOT_FOUND', 'FORBIDDEN']);
 const EMPTY_ID_SET: ReadonlySet<string> = new Set();
 const EMPTY_FAILURE_MAP: ReadonlyMap<string, ChatApiFailure> = new Map();
+const AI_TYPING_TIMER_SCHEDULER = {
+  set: (callback: () => void, delayMs: number): unknown =>
+    globalThis.setTimeout(callback, delayMs),
+  clear: (handle: unknown): void => {
+    globalThis.clearTimeout(handle as ReturnType<typeof setTimeout>);
+  },
+};
 
 type ChatCurrentUser = Pick<
   AuthUser,
@@ -80,6 +99,11 @@ export type ChatRoomViewStatus = Exclude<ChatRoomStatus, 'idle'>;
 export interface ChatRoomError {
   readonly errorCode: string;
   readonly detail: string;
+}
+
+interface ResourceScopedChatRoomError {
+  readonly resourceKey: string;
+  readonly error: ChatRoomError;
 }
 
 export type ChatSendOutcome =
@@ -114,6 +138,13 @@ export interface UseTripChatOptions {
   readonly tripId: string | undefined;
 }
 
+export interface ApplyAIDraftSnapshotInput {
+  readonly messageId: string;
+  readonly draftId: string;
+  readonly expectedSourceIdentity: string;
+  readonly draft: AIActionDraft;
+}
+
 export interface UseTripChatResult {
   readonly currentUserId: string | null;
   readonly tripStatus: TripStatus | null;
@@ -136,8 +167,11 @@ export interface UseTripChatResult {
   readonly isHidingMessages: boolean;
   readonly isReadOnly: boolean;
   readonly mutationError: ChatMutationError | null;
+  readonly aiTypingState: AITypingState;
   readonly connectionStatus: RealtimeStatus;
   readonly connectionEpoch: number;
+  readonly aiReconciliationCoordinator: AIReconciliationCoordinator;
+  readonly ambiguousAIDraftIds: ReadonlySet<string>;
   readonly retryInitialLoad: () => Promise<void>;
   readonly loadOlder: () => Promise<void>;
   readonly sendMessage: (content: string) => Promise<ChatSendOutcome>;
@@ -153,6 +187,9 @@ export interface UseTripChatResult {
   readonly hideMessagesForMe: (
     messageIds: readonly string[],
   ) => Promise<ChatMutationOutcome>;
+  readonly applyAIDraftSnapshot: (
+    input: ApplyAIDraftSnapshotInput,
+  ) => Promise<void>;
 }
 
 interface CatchUpRun {
@@ -171,6 +208,25 @@ interface LiveReactionProof {
 interface LiveDeleteProof {
   readonly message: ChatMessage;
 }
+
+interface ActiveAITypingVisualController {
+  readonly controller: AITypingVisualController;
+  readonly resourceKey: string;
+  readonly focusGeneration: number;
+  readonly connectionEpoch: number;
+}
+
+interface AITypingPresentation {
+  readonly state: AITypingState;
+  readonly resourceKey: string | null;
+  readonly connectionEpoch: number | null;
+}
+
+const EMPTY_AI_TYPING_PRESENTATION: AITypingPresentation = {
+  state: EMPTY_AI_TYPING_STATE,
+  resourceKey: null,
+  connectionEpoch: null,
+};
 
 function localFailure(
   message: string,
@@ -212,6 +268,157 @@ function compareMessages(a: ChatMessage, b: ChatMessage): number {
     return a.created_at < b.created_at ? -1 : 1;
   }
   return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+interface AIDraftObservationIndex {
+  readonly resourceKey: string;
+  readonly byMessageId: Map<string, readonly AIActionDraft[]>;
+  readonly byDraftId: Map<
+    string,
+    Map<string, readonly AIActionDraft[]>
+  >;
+  readonly ambiguousDraftIds: Set<string>;
+  readonly ambiguitySnapshots: Map<'current', ReadonlySet<string>>;
+}
+
+interface AIDraftObservationChange {
+  readonly previousByDraftId: ReadonlyMap<
+    string,
+    readonly AIActionDraft[]
+  >;
+  readonly nextByDraftId: ReadonlyMap<
+    string,
+    readonly AIActionDraft[]
+  >;
+}
+
+function effectiveAIDraftsForMessage(
+  state: TranscriptState,
+  messageId: string,
+): readonly AIActionDraft[] {
+  const message = selectMessageById(state, messageId);
+  if (
+    message === null ||
+    message.sender_kind !== 'AI' ||
+    message.is_deleted_for_everyone ||
+    message.action_drafts.length === 0
+  ) {
+    return [];
+  }
+  const drafts: AIActionDraft[] = [];
+  for (const candidate of message.action_drafts) {
+    const parsed = parseAIActionDraft(candidate);
+    if (parsed !== null) {
+      drafts.push(parsed);
+    }
+  }
+  return drafts;
+}
+
+function indexedDraftOccurrences(
+  index: AIDraftObservationIndex,
+  draftId: string,
+): readonly AIActionDraft[] {
+  const occurrencesByMessage = index.byDraftId.get(draftId);
+  return occurrencesByMessage === undefined
+    ? []
+    : [...occurrencesByMessage.values()].flat();
+}
+
+function updateAIDraftObservationIndex(
+  index: AIDraftObservationIndex,
+  nextState: TranscriptState,
+  messageIds: readonly string[],
+): AIDraftObservationChange {
+  const affectedMessageIds = [...new Set(messageIds)];
+  const nextDraftsByMessage = new Map<string, readonly AIActionDraft[]>();
+  const affectedDraftIds = new Set<string>();
+  for (const messageId of affectedMessageIds) {
+    for (const draft of index.byMessageId.get(messageId) ?? []) {
+      affectedDraftIds.add(draft.id);
+    }
+    const nextDrafts = effectiveAIDraftsForMessage(nextState, messageId);
+    nextDraftsByMessage.set(messageId, nextDrafts);
+    for (const draft of nextDrafts) {
+      affectedDraftIds.add(draft.id);
+    }
+  }
+
+  const previousByDraftId = new Map<
+    string,
+    readonly AIActionDraft[]
+  >();
+  for (const draftId of affectedDraftIds) {
+    previousByDraftId.set(
+      draftId,
+      [...indexedDraftOccurrences(index, draftId)],
+    );
+  }
+
+  for (const messageId of affectedMessageIds) {
+    const priorDraftIds = new Set(
+      (index.byMessageId.get(messageId) ?? []).map((draft) => draft.id),
+    );
+    for (const draftId of priorDraftIds) {
+      const occurrencesByMessage = index.byDraftId.get(draftId);
+      occurrencesByMessage?.delete(messageId);
+      if (occurrencesByMessage?.size === 0) {
+        index.byDraftId.delete(draftId);
+      }
+    }
+    index.byMessageId.delete(messageId);
+  }
+
+  for (const [messageId, drafts] of nextDraftsByMessage) {
+    if (drafts.length === 0) {
+      continue;
+    }
+    index.byMessageId.set(messageId, drafts);
+    const draftsById = new Map<string, AIActionDraft[]>();
+    for (const draft of drafts) {
+      const occurrences = draftsById.get(draft.id) ?? [];
+      occurrences.push(draft);
+      draftsById.set(draft.id, occurrences);
+    }
+    for (const [draftId, occurrences] of draftsById) {
+      const occurrencesByMessage =
+        index.byDraftId.get(draftId) ??
+        new Map<string, readonly AIActionDraft[]>();
+      occurrencesByMessage.set(messageId, occurrences);
+      index.byDraftId.set(draftId, occurrencesByMessage);
+    }
+  }
+
+  const nextByDraftId = new Map<
+    string,
+    readonly AIActionDraft[]
+  >();
+  for (const draftId of affectedDraftIds) {
+    nextByDraftId.set(
+      draftId,
+      [...indexedDraftOccurrences(index, draftId)],
+    );
+  }
+  let ambiguityChanged = false;
+  for (const [draftId, occurrences] of nextByDraftId) {
+    const isAmbiguous = occurrences.length > 1;
+    if (index.ambiguousDraftIds.has(draftId) === isAmbiguous) {
+      continue;
+    }
+    ambiguityChanged = true;
+    if (isAmbiguous) {
+      index.ambiguousDraftIds.add(draftId);
+    } else {
+      index.ambiguousDraftIds.delete(draftId);
+    }
+  }
+  if (ambiguityChanged) {
+    index.ambiguitySnapshots.set(
+      'current',
+      new Set(index.ambiguousDraftIds),
+    );
+  }
+  return { previousByDraftId, nextByDraftId };
 }
 
 function latestChangeCursorFromMessages(
@@ -355,6 +562,10 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
     useState<ChatSubscriptionStatus>('inactive');
   const [currentRoomError, setCurrentRoomError] =
     useState<ChatRoomError | null>(null);
+  const [aiReconciliationError, setAIReconciliationError] =
+    useState<ResourceScopedChatRoomError | null>(null);
+  const [aiTypingPresentation, setAITypingPresentation] =
+    useState<AITypingPresentation>(EMPTY_AI_TYPING_PRESENTATION);
   const clearNonterminalRoomError = useCallback(() => {
     setCurrentRoomError((current) =>
       current?.errorCode === TERMINAL_ERROR_CODE ? current : null,
@@ -403,16 +614,135 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
   const liveDeleteProofsRef = useRef(new Map<string, LiveDeleteProof>());
   const deleteLocksRef = useRef(new Map<string, symbol>());
   const hideLockRef = useRef<symbol | null>(null);
+  const aiTypingControllerRef =
+    useRef<ActiveAITypingVisualController | null>(null);
+  const aiTypingDisposalGenerationRef = useRef(0);
+  const aiReconciliationCoordinator = useMemo(
+    () => createAIReconciliationCoordinator({ resourceKey, tripId }),
+    [resourceKey, tripId],
+  );
+  const aiDraftObservationIndex = useMemo<AIDraftObservationIndex>(
+    () => ({
+      resourceKey,
+      byMessageId: new Map(),
+      byDraftId: new Map(),
+      ambiguousDraftIds: new Set(),
+      ambiguitySnapshots: new Map([['current', EMPTY_ID_SET]]),
+    }),
+    [resourceKey],
+  );
 
   const dispatch = useCallback(
     (action: TranscriptAction) => {
       // Async reconciliation can dispatch several causally ordered results
       // before React publishes a render. Keep a write-through reducer mirror
       // so every later request captures the exact post-action version.
-      stateRef.current = transcriptReducer(stateRef.current, action);
+      const previousState = stateRef.current;
+      const nextState = transcriptReducer(previousState, action);
+      let reconciliation = Promise.resolve();
+      let observationMode: 'seed-new' | 'transition' | 'silent' | null = null;
+      let affectedMessageIds: readonly string[] = [];
+      switch (action.type) {
+        case 'INIT_RESOLVED':
+        case 'OLDER_RESOLVED':
+          observationMode = 'seed-new';
+          affectedMessageIds = action.messages.map((message) => message.id);
+          break;
+        case 'UPSERT':
+        case 'PATCH_KNOWN':
+          observationMode = 'transition';
+          affectedMessageIds = action.messages.map((message) => message.id);
+          break;
+        case 'AI_DRAFT_LOCAL_SNAPSHOT':
+          observationMode = 'transition';
+          affectedMessageIds = [action.messageId];
+          break;
+        case 'HIDE_MESSAGES':
+          observationMode = 'silent';
+          affectedMessageIds = action.messageIds;
+          break;
+        case 'DELETE_SUCCESS':
+          observationMode = 'silent';
+          affectedMessageIds = [action.message.id];
+          break;
+        case 'RESET':
+        case 'KICKED':
+          aiDraftObservationIndex.byMessageId.clear();
+          aiDraftObservationIndex.byDraftId.clear();
+          aiDraftObservationIndex.ambiguousDraftIds.clear();
+          aiDraftObservationIndex.ambiguitySnapshots.set(
+            'current',
+            EMPTY_ID_SET,
+          );
+          break;
+      }
+
+      if (
+        nextState !== previousState &&
+        observationMode !== null &&
+        affectedMessageIds.length > 0
+      ) {
+        const { previousByDraftId, nextByDraftId } =
+          updateAIDraftObservationIndex(
+            aiDraftObservationIndex,
+            nextState,
+            affectedMessageIds,
+          );
+        const claims: Promise<unknown>[] = [];
+        for (const [draftId, nextOccurrences] of nextByDraftId) {
+          if (
+            observationMode === 'silent' ||
+            nextOccurrences.length !== 1 ||
+            nextOccurrences[0].status !== 'CONFIRMED'
+          ) {
+            continue;
+          }
+          const previousOccurrences = previousByDraftId.get(draftId) ?? [];
+          if (previousOccurrences.length > 1) {
+            continue;
+          }
+          const nextDraft = nextOccurrences[0];
+          const previousDraft = previousOccurrences[0] ?? null;
+          if (previousDraft?.status === 'CONFIRMED') {
+            aiReconciliationCoordinator.seedConfirmedDrafts([nextDraft]);
+            continue;
+          }
+          if (observationMode === 'seed-new' && previousDraft === null) {
+            aiReconciliationCoordinator.seedConfirmedDrafts([nextDraft]);
+            continue;
+          }
+          claims.push(
+            aiReconciliationCoordinator.reconcile({
+              previousStatus: previousDraft?.status ?? null,
+              draft: nextDraft,
+            }),
+          );
+        }
+        reconciliation = Promise.all(claims).then(() => undefined);
+        if (claims.length > 0) {
+          void reconciliation.catch(() => {
+            if (activeResourceKeyRef.current === resourceKey) {
+              setAIReconciliationError({
+                resourceKey,
+                error: roomError(
+                  'AI_RECONCILIATION_FAILED',
+                  'The AI action was confirmed, but another trip screen could not refresh automatically.',
+                ),
+              });
+            }
+          });
+        }
+      }
+      stateRef.current = nextState;
       reactDispatch(action);
+      return reconciliation;
     },
-    [reactDispatch],
+    [
+      aiDraftObservationIndex,
+      aiReconciliationCoordinator,
+      reactDispatch,
+      resourceKey,
+    ],
   );
 
   useLayoutEffect(() => {
@@ -425,6 +755,111 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
     (expectedResourceKey: string) =>
       activeResourceKeyRef.current === expectedResourceKey,
     [],
+  );
+
+  const disposeAITypingVisual = useCallback(() => {
+    const disposalGeneration = aiTypingDisposalGenerationRef.current + 1;
+    aiTypingDisposalGenerationRef.current = disposalGeneration;
+    const active = aiTypingControllerRef.current;
+    aiTypingControllerRef.current = null;
+    active?.controller.dispose();
+    queueMicrotask(() => {
+      if (
+        aiTypingDisposalGenerationRef.current !== disposalGeneration ||
+        aiTypingControllerRef.current !== null
+      ) {
+        return;
+      }
+      setAITypingPresentation((current) =>
+        current === EMPTY_AI_TYPING_PRESENTATION ||
+        (current.state.active === null && current.resourceKey === null)
+          ? current
+          : EMPTY_AI_TYPING_PRESENTATION,
+      );
+    });
+  }, []);
+
+  const ensureAITypingVisual = useCallback(
+    (connectionEpoch: number) => {
+      const focusGeneration = focusGenerationRef.current;
+      const current = aiTypingControllerRef.current;
+      if (
+        current !== null &&
+        current.resourceKey === resourceKey &&
+        current.focusGeneration === focusGeneration &&
+        current.connectionEpoch === connectionEpoch
+      ) {
+        return current.controller;
+      }
+
+      disposeAITypingVisual();
+      let controller: AITypingVisualController;
+      controller = createAITypingVisualController({
+        scheduler: AI_TYPING_TIMER_SCHEDULER,
+        now: () => Date.now(),
+        onChange: (next) => {
+          const active = aiTypingControllerRef.current;
+          const snapshot = snapshotRef.current;
+          if (
+            active?.controller !== controller ||
+            active.resourceKey !== resourceKey ||
+            active.focusGeneration !== focusGeneration ||
+            active.connectionEpoch !== connectionEpoch ||
+            activeResourceKeyRef.current !== resourceKey ||
+            focusGenerationRef.current !== focusGeneration ||
+            !focusedRef.current ||
+            !accessGrantedRef.current ||
+            kickedRef.current ||
+            snapshot.status !== 'connected' ||
+            snapshot.connectionEpoch !== connectionEpoch ||
+            ackedEpochRef.current !== connectionEpoch
+          ) {
+            return;
+          }
+          setAITypingPresentation({
+            state: next,
+            resourceKey,
+            connectionEpoch,
+          });
+        },
+      });
+      aiTypingControllerRef.current = {
+        controller,
+        resourceKey,
+        focusGeneration,
+        connectionEpoch,
+      };
+      aiTypingDisposalGenerationRef.current += 1;
+      setAITypingPresentation({
+        state: EMPTY_AI_TYPING_STATE,
+        resourceKey,
+        connectionEpoch,
+      });
+      return controller;
+    },
+    [disposeAITypingVisual, resourceKey],
+  );
+
+  const applyAIDraftSnapshot = useCallback(
+    (input: ApplyAIDraftSnapshotInput): Promise<void> => {
+      if (
+        !isResourceCurrent(resourceKey) ||
+        stateRef.current.resourceKey !== resourceKey ||
+        !accessGrantedRef.current ||
+        kickedRef.current
+      ) {
+        return Promise.resolve();
+      }
+      return dispatch({
+        type: 'AI_DRAFT_LOCAL_SNAPSHOT',
+        resourceKey,
+        messageId: input.messageId,
+        draftId: input.draftId,
+        expectedSourceIdentity: input.expectedSourceIdentity,
+        draft: input.draft,
+      });
+    },
+    [dispatch, isResourceCurrent, resourceKey],
   );
 
   const registerController = useCallback(() => {
@@ -476,6 +911,7 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
     }
     abortAllRequests();
     invalidateMutationOwnership();
+    disposeAITypingVisual();
     sentEpochRef.current = null;
     ackedEpochRef.current = null;
     rejectedEpochRef.current = null;
@@ -498,6 +934,7 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
   }, [
     abortAllRequests,
     dispatch,
+    disposeAITypingVisual,
     invalidateMutationOwnership,
     realtime,
     resourceKey,
@@ -510,11 +947,18 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
       focusGenerationRef.current += 1;
       abortAllRequests();
       invalidateMutationOwnership();
+      disposeAITypingVisual();
       setSubscriptionStatus('inactive');
       setCurrentRoomError(roomError(errorCode, detail));
       dispatch({ type: 'KICKED', resourceKey });
     },
-    [abortAllRequests, dispatch, invalidateMutationOwnership, resourceKey],
+    [
+      abortAllRequests,
+      dispatch,
+      disposeAITypingVisual,
+      invalidateMutationOwnership,
+      resourceKey,
+    ],
   );
 
   const applyAuthoritativeFailure = useCallback(
@@ -544,6 +988,7 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
   useEffect(() => {
     let cancelled = false;
     invalidateMutationOwnership();
+    disposeAITypingVisual();
     kickedRef.current = false;
     sentEpochRef.current = null;
     ackedEpochRef.current = null;
@@ -553,6 +998,7 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
     queueMicrotask(() => {
       if (!cancelled) {
         setCurrentRoomError(null);
+        setAIReconciliationError(null);
       }
     });
     return () => {
@@ -560,8 +1006,15 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
       focusGenerationRef.current += 1;
       abortAllRequests();
       invalidateMutationOwnership();
+      disposeAITypingVisual();
     };
-  }, [abortAllRequests, dispatch, invalidateMutationOwnership, resourceKey]);
+  }, [
+    abortAllRequests,
+    dispatch,
+    disposeAITypingVisual,
+    invalidateMutationOwnership,
+    resourceKey,
+  ]);
 
   const loadInitialHistory = useCallback(async () => {
     if (
@@ -911,6 +1364,7 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
     useCallback(() => {
       focusedRef.current = true;
       focusGenerationRef.current += 1;
+      disposeAITypingVisual();
       setSubscriptionStatus(
         snapshotRef.current.status === 'connected' ? 'subscribing' : 'waiting',
       );
@@ -919,6 +1373,7 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
       return () => {
         focusedRef.current = false;
         focusGenerationRef.current += 1;
+        disposeAITypingVisual();
         const activeCatchUp = catchUpRunRef.current;
         activeCatchUp?.controller.abort();
         if (activeCatchUp !== null && catchUpRunRef.current === activeCatchUp) {
@@ -944,11 +1399,29 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
         catchUpRequestedEpochRef.current = null;
         setSubscriptionStatus('inactive');
       };
-    }, [attemptSubscribe, dispatch, isResourceCurrent, realtime, tripId]),
+    }, [
+      attemptSubscribe,
+      dispatch,
+      disposeAITypingVisual,
+      isResourceCurrent,
+      realtime,
+      tripId,
+    ]),
   );
 
   useEffect(() => {
     const activeCatchUp = catchUpRunRef.current;
+    const activeTyping = aiTypingControllerRef.current;
+    if (
+      activeTyping !== null &&
+      (realtimeSnapshot.status !== 'connected' ||
+        activeTyping.connectionEpoch !== realtimeSnapshot.connectionEpoch ||
+        activeTyping.resourceKey !== resourceKey ||
+        !focusedRef.current ||
+        !accessGranted)
+    ) {
+      disposeAITypingVisual();
+    }
     if (
       activeCatchUp !== null &&
       (realtimeSnapshot.status !== 'connected' ||
@@ -981,6 +1454,7 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
     accessGranted,
     attemptSubscribe,
     dispatch,
+    disposeAITypingVisual,
     realtimeSnapshot,
     resourceKey,
   ]);
@@ -1026,6 +1500,7 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
           catchUpRequestedEpochRef.current = snapshot.connectionEpoch;
           setSubscriptionStatus('subscribed');
           clearNonterminalRoomError();
+          ensureAITypingVisual(snapshot.connectionEpoch);
           if (stateRef.current.roomStatus === 'ready') {
             void runCatchUp(snapshot.connectionEpoch);
           }
@@ -1045,6 +1520,7 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
           }
           ackedEpochRef.current = null;
           catchUpRequestedEpochRef.current = null;
+          disposeAITypingVisual();
           if (focusedRef.current && !rejectedCurrentAttempt) {
             if (sentEpochRef.current === snapshot.connectionEpoch) {
               setSubscriptionStatus('subscribing');
@@ -1141,9 +1617,43 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
           }
           return;
         }
-        case 'chat.ai_typing_started':
-        case 'chat.ai_typing_stopped':
+        case 'chat.ai_typing_started': {
+          const active = aiTypingControllerRef.current;
+          const snapshot = snapshotRef.current;
+          if (
+            active === null ||
+            active.resourceKey !== resourceKey ||
+            active.focusGeneration !== focusGenerationRef.current ||
+            !focusedRef.current ||
+            snapshot.status !== 'connected' ||
+            active.connectionEpoch !== snapshot.connectionEpoch ||
+            ackedEpochRef.current !== snapshot.connectionEpoch
+          ) {
+            return;
+          }
+          active.controller.start(
+            event.interaction_id,
+            event.requested_by_user_id,
+          );
           return;
+        }
+        case 'chat.ai_typing_stopped': {
+          const active = aiTypingControllerRef.current;
+          const snapshot = snapshotRef.current;
+          if (
+            active === null ||
+            active.resourceKey !== resourceKey ||
+            active.focusGeneration !== focusGenerationRef.current ||
+            !focusedRef.current ||
+            snapshot.status !== 'connected' ||
+            active.connectionEpoch !== snapshot.connectionEpoch ||
+            ackedEpochRef.current !== snapshot.connectionEpoch
+          ) {
+            return;
+          }
+          active.controller.stop(event.interaction_id);
+          return;
+        }
       }
     });
   }, [
@@ -1151,6 +1661,8 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
     attemptSubscribe,
     clearNonterminalRoomError,
     dispatch,
+    disposeAITypingVisual,
+    ensureAITypingVisual,
     invalidateMutationOwnership,
     isResourceCurrent,
     kickRoom,
@@ -1874,6 +2386,10 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
         state.roomError.message,
       )
     : null;
+  const visibleAIReconciliationError =
+    aiReconciliationError?.resourceKey === resourceKey
+      ? aiReconciliationError.error
+      : null;
   const visibleSubscriptionStatus: ChatSubscriptionStatus =
     !visibleState
       ? 'inactive'
@@ -1882,6 +2398,14 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
       : realtimeSnapshot.status === 'connected'
         ? subscriptionStatus
         : 'waiting';
+  const visibleAITypingState =
+    securityAllowsTranscript &&
+    visibleSubscriptionStatus === 'subscribed' &&
+    realtimeSnapshot.status === 'connected' &&
+    aiTypingPresentation.resourceKey === resourceKey &&
+    aiTypingPresentation.connectionEpoch === realtimeSnapshot.connectionEpoch
+      ? aiTypingPresentation.state
+      : EMPTY_AI_TYPING_STATE;
 
   return {
     currentUserId: ownerUserId,
@@ -1897,7 +2421,10 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
             : state.roomStatus,
     subscriptionStatus: visibleSubscriptionStatus,
     roomError:
-      accessError ?? (visibleState ? currentRoomError : null) ?? transcriptRoomError,
+      accessError ??
+      (visibleState ? currentRoomError : null) ??
+      visibleAIReconciliationError ??
+      transcriptRoomError,
     messages,
     pendingClientIds: visibleState ? state.pendingClientIds : EMPTY_ID_SET,
     failedClientIds: visibleState ? state.failedClientIds : EMPTY_ID_SET,
@@ -1916,8 +2443,14 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
     isHidingMessages: visibleState && state.isHidingMessages,
     isReadOnly: readOnly,
     mutationError: visibleState ? state.mutationError : null,
+    aiTypingState: visibleAITypingState,
     connectionStatus: realtimeSnapshot.status,
     connectionEpoch: realtimeSnapshot.connectionEpoch,
+    aiReconciliationCoordinator,
+    ambiguousAIDraftIds: visibleState
+      ? (aiDraftObservationIndex.ambiguitySnapshots.get('current') ??
+        EMPTY_ID_SET)
+      : EMPTY_ID_SET,
     retryInitialLoad,
     loadOlder,
     sendMessage,
@@ -1925,5 +2458,6 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
     toggleReaction,
     deleteMessage,
     hideMessagesForMe,
+    applyAIDraftSnapshot,
   };
 }

--- a/mobile/src/features/chat/hooks/useTripChat.ts
+++ b/mobile/src/features/chat/hooks/useTripChat.ts
@@ -14,7 +14,10 @@ import {
   useRealtimeSnapshot,
   useRealtimeTransport,
 } from '@/features/realtime/application/RealtimeProvider';
-import type { RealtimeStatus } from '@/features/realtime/types';
+import type {
+  RealtimeDiagnostics,
+  RealtimeStatus,
+} from '@/features/realtime/types';
 import { useTripDetail } from '@/features/trips/hooks/useTripDetail';
 import type { TripStatus } from '@/features/trips/types';
 import {
@@ -47,9 +50,11 @@ import {
   selectMessageById,
   selectMessageVersion,
   selectPendingByClientId,
+  selectDeferredFullAuthorityForMaterialization,
   selectTranscriptMessages,
   transcriptReducer,
   type ChatRoomStatus,
+  type ChangeSyncCursor,
   type TranscriptState,
   type TranscriptAction,
 } from '../application/transcriptReducer';
@@ -66,6 +71,9 @@ import type {
 const HISTORY_PAGE_SIZE = 30;
 const RECONCILIATION_PAGE_SIZE = 100;
 const RECONCILIATION_MAX_PAGES = 50;
+export const CHAT_SUBSCRIPTION_ACK_TIMEOUT_MS = 4_000;
+export const CHAT_SUBSCRIPTION_RETRY_DELAY_MS = 500;
+export const CHAT_SUBSCRIPTION_MAX_ATTEMPTS = 3;
 const TERMINAL_ERROR_CODE = 'TRIP_TERMINAL';
 const SUBSCRIPTION_LIMIT_ERROR_CODE = 'SUBSCRIPTION_LIMIT_REACHED';
 const CHAT_ACCESS_UNCERTAIN_ERROR_CODE = 'CHAT_ACCESS_UNCERTAIN';
@@ -152,6 +160,10 @@ export interface UseTripChatResult {
   readonly roomStatus: ChatRoomViewStatus;
   readonly subscriptionStatus: ChatSubscriptionStatus;
   readonly roomError: ChatRoomError | null;
+  /** Recoverable read-plane synchronization failure, including read-only rooms. */
+  readonly readSyncError: ChatRoomError | null;
+  readonly initialLoadError: ChatApiFailure | null;
+  readonly isLoadingInitial: boolean;
   /** Ascending by `(created_at, id)`; reverse before feeding an inverted list. */
   readonly messages: readonly ChatMessage[];
   readonly pendingClientIds: ReadonlySet<string>;
@@ -169,10 +181,14 @@ export interface UseTripChatResult {
   readonly mutationError: ChatMutationError | null;
   readonly aiTypingState: AITypingState;
   readonly connectionStatus: RealtimeStatus;
+  readonly connectionDiagnostics: RealtimeDiagnostics | null;
   readonly connectionEpoch: number;
   readonly aiReconciliationCoordinator: AIReconciliationCoordinator;
   readonly ambiguousAIDraftIds: ReadonlySet<string>;
   readonly retryInitialLoad: () => Promise<void>;
+  readonly retryConnection: () => boolean;
+  readonly retrySubscription: () => void;
+  readonly retryCatchUp: () => void;
   readonly loadOlder: () => Promise<void>;
   readonly sendMessage: (content: string) => Promise<ChatSendOutcome>;
   readonly retryPending: (clientMessageId: string) => Promise<ChatSendOutcome>;
@@ -197,6 +213,20 @@ interface CatchUpRun {
   readonly focusGeneration: number;
   readonly connectionEpoch: number;
   readonly controller: AbortController;
+}
+
+interface CatchUpBaseline {
+  readonly latestMessageId: string | null;
+  readonly changeCursor: ChangeSyncCursor | null;
+}
+
+interface CatchUpRetryIntent {
+  readonly connectionEpoch: number;
+  readonly baseline: CatchUpBaseline;
+}
+
+interface SubscriptionRecoveryTimeout {
+  handle: ReturnType<typeof setTimeout> | null;
 }
 
 interface LiveReactionProof {
@@ -439,6 +469,23 @@ function latestChangeCursorFromMessages(
   return latest;
 }
 
+function catchUpBaselineFromMessages(
+  messages: readonly ChatMessage[],
+): CatchUpBaseline {
+  const latestMessage = [...messages].sort(compareMessages).at(-1) ?? null;
+  return {
+    latestMessageId: latestMessage?.id ?? null,
+    changeCursor: latestChangeCursorFromMessages(messages),
+  };
+}
+
+function catchUpBaselineFromState(state: TranscriptState): CatchUpBaseline {
+  return {
+    latestMessageId: selectLatestConfirmed(state)?.id ?? null,
+    changeCursor: selectLatestChangeCursor(state),
+  };
+}
+
 export function createChatClientMessageId(): string {
   if (typeof globalThis.crypto?.randomUUID === 'function') {
     return globalThis.crypto.randomUUID();
@@ -562,6 +609,8 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
     useState<ChatSubscriptionStatus>('inactive');
   const [currentRoomError, setCurrentRoomError] =
     useState<ChatRoomError | null>(null);
+  const [readSyncError, setReadSyncError] =
+    useState<ResourceScopedChatRoomError | null>(null);
   const [aiReconciliationError, setAIReconciliationError] =
     useState<ResourceScopedChatRoomError | null>(null);
   const [aiTypingPresentation, setAITypingPresentation] =
@@ -571,10 +620,17 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
       current?.errorCode === TERMINAL_ERROR_CODE ? current : null,
     );
   }, []);
-
   const activeResourceKeyRef = useRef(resourceKey);
   const stateRef = useRef(state);
   const snapshotRef = useRef(realtimeSnapshot);
+  const setNonterminalRoomError = useCallback((error: ChatRoomError) => {
+    if (stateRef.current.terminalLocked) {
+      return;
+    }
+    setCurrentRoomError((current) =>
+      current?.errorCode === TERMINAL_ERROR_CODE ? current : error,
+    );
+  }, []);
   const accessGranted = Boolean(
     tripId &&
     sessionStatus === 'signedIn' &&
@@ -603,8 +659,22 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
   const sentEpochRef = useRef<number | null>(null);
   const ackedEpochRef = useRef<number | null>(null);
   const rejectedEpochRef = useRef<number | null>(null);
+  const subscriptionAttemptEpochRef = useRef<number | null>(null);
+  const subscriptionAttemptCountRef = useRef(0);
+  const subscriptionRecoveryTimerRef =
+    useRef<SubscriptionRecoveryTimeout | null>(null);
+  const attemptSubscribeRef = useRef<() => void>(() => undefined);
   const catchUpRequestedEpochRef = useRef<number | null>(null);
+  const catchUpRetryIntentRef = useRef<CatchUpRetryIntent | null>(null);
+  const runCatchUpRef = useRef<(connectionEpoch: number) => void>(
+    () => undefined,
+  );
+  // A partial or interrupted reconcile must resume from the exact transcript
+  // floor that existed before gap-fill began. Live/high-sequence rows may have
+  // arrived meanwhile and are never authority to advance this watermark.
+  const unresolvedCatchUpBaselineRef = useRef<CatchUpBaseline | null>(null);
   const catchUpRunRef = useRef<CatchUpRun | null>(null);
+  const initialHistoryLoadedRef = useRef(false);
   const initialLoadControllerRef = useRef<AbortController | null>(null);
   const olderLoadControllerRef = useRef<AbortController | null>(null);
   const requestControllersRef = useRef(new Set<AbortController>());
@@ -643,11 +713,40 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
       let reconciliation = Promise.resolve();
       let observationMode: 'seed-new' | 'transition' | 'silent' | null = null;
       let affectedMessageIds: readonly string[] = [];
+      const deferredTransitionDraftIds = new Set<string>();
       switch (action.type) {
         case 'INIT_RESOLVED':
         case 'OLDER_RESOLVED':
           observationMode = 'seed-new';
           affectedMessageIds = action.messages.map((message) => message.id);
+          for (const message of action.messages) {
+            const deferredFullMessage =
+              selectDeferredFullAuthorityForMaterialization(
+                previousState,
+                message,
+              );
+            if (deferredFullMessage === null) {
+              continue;
+            }
+            const rawStatusByDraftId = new Map<
+              string,
+              AIActionDraft['status']
+            >();
+            for (const candidate of message.action_drafts) {
+              const parsed = parseAIActionDraft(candidate);
+              if (parsed !== null) {
+                rawStatusByDraftId.set(parsed.id, parsed.status);
+              }
+            }
+            for (const draft of effectiveAIDraftsForMessage(
+              nextState,
+              message.id,
+            )) {
+              if (rawStatusByDraftId.get(draft.id) !== 'CONFIRMED') {
+                deferredTransitionDraftIds.add(draft.id);
+              }
+            }
+          }
           break;
         case 'UPSERT':
         case 'PATCH_KNOWN':
@@ -708,7 +807,11 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
             aiReconciliationCoordinator.seedConfirmedDrafts([nextDraft]);
             continue;
           }
-          if (observationMode === 'seed-new' && previousDraft === null) {
+          if (
+            observationMode === 'seed-new' &&
+            previousDraft === null &&
+            !deferredTransitionDraftIds.has(draftId)
+          ) {
             aiReconciliationCoordinator.seedConfirmedDrafts([nextDraft]);
             continue;
           }
@@ -757,6 +860,40 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
       activeResourceKeyRef.current === expectedResourceKey,
     [],
   );
+
+  const scheduleRequestedCatchUp = useCallback(() => {
+    const connectionEpoch = catchUpRequestedEpochRef.current;
+    const snapshot = snapshotRef.current;
+    if (
+      connectionEpoch === null ||
+      initialLoadControllerRef.current !== null ||
+      !initialHistoryLoadedRef.current ||
+      activeResourceKeyRef.current !== resourceKey ||
+      stateRef.current.resourceKey !== resourceKey ||
+      stateRef.current.roomStatus !== 'ready' ||
+      !focusedRef.current ||
+      !accessGrantedRef.current ||
+      kickedRef.current ||
+      snapshot.status !== 'connected' ||
+      snapshot.connectionEpoch !== connectionEpoch ||
+      ackedEpochRef.current !== connectionEpoch
+    ) {
+      return;
+    }
+    runCatchUpRef.current(connectionEpoch);
+  }, [resourceKey]);
+
+  const requestCurrentReadCatchUp = useCallback(() => {
+    const snapshot = snapshotRef.current;
+    if (
+      snapshot.status !== 'connected' ||
+      ackedEpochRef.current !== snapshot.connectionEpoch
+    ) {
+      return;
+    }
+    catchUpRequestedEpochRef.current = snapshot.connectionEpoch;
+    queueMicrotask(scheduleRequestedCatchUp);
+  }, [scheduleRequestedCatchUp]);
 
   const disposeAITypingVisual = useCallback(() => {
     const disposalGeneration = aiTypingDisposalGenerationRef.current + 1;
@@ -885,6 +1022,7 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
     }
     requestControllersRef.current.clear();
     catchUpRunRef.current = null;
+    catchUpRetryIntentRef.current = null;
   }, []);
 
   const invalidateMutationOwnership = useCallback(() => {
@@ -900,23 +1038,48 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
     liveDeleteProofsRef.current.clear();
   }, []);
 
-  const resetTransientSubscriptionOwnership = useCallback(() => {
-    const snapshot = snapshotRef.current;
-    focusGenerationRef.current += 1;
-    if (
-      focusedRef.current &&
-      snapshot.status === 'connected' &&
-      sentEpochRef.current === snapshot.connectionEpoch
-    ) {
-      realtime.send({ type: 'chat.unsubscribe', trip_id: tripId });
+  const clearSubscriptionRecoveryTimer = useCallback(() => {
+    const timeout = subscriptionRecoveryTimerRef.current;
+    subscriptionRecoveryTimerRef.current = null;
+    if (timeout !== null && timeout.handle !== null) {
+      clearTimeout(timeout.handle);
     }
+  }, []);
+
+  const resetSubscriptionAttemptTracking = useCallback(() => {
+    clearSubscriptionRecoveryTimer();
+    subscriptionAttemptEpochRef.current = null;
+    subscriptionAttemptCountRef.current = 0;
+  }, [clearSubscriptionRecoveryTimer]);
+
+  const leaveOwnedSubscription = useCallback(() => {
+    const snapshot = snapshotRef.current;
+    if (
+      snapshot.status !== 'connected' ||
+      sentEpochRef.current !== snapshot.connectionEpoch
+    ) {
+      return false;
+    }
+
+    // Claim the leave before sending so repeated cleanup paths are idempotent,
+    // including if the transport synchronously publishes another event.
+    sentEpochRef.current = null;
+    realtime.send({ type: 'chat.unsubscribe', trip_id: tripId });
+    return true;
+  }, [realtime, tripId]);
+
+  const resetTransientSubscriptionOwnership = useCallback(() => {
+    focusGenerationRef.current += 1;
+    leaveOwnedSubscription();
     abortAllRequests();
     invalidateMutationOwnership();
     disposeAITypingVisual();
+    resetSubscriptionAttemptTracking();
     sentEpochRef.current = null;
     ackedEpochRef.current = null;
     rejectedEpochRef.current = null;
     catchUpRequestedEpochRef.current = null;
+    catchUpRetryIntentRef.current = null;
     setSubscriptionStatus('inactive');
     if (stateRef.current.resourceKey === resourceKey) {
       dispatch({
@@ -937,20 +1100,29 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
     dispatch,
     disposeAITypingVisual,
     invalidateMutationOwnership,
-    realtime,
+    leaveOwnedSubscription,
+    resetSubscriptionAttemptTracking,
     resourceKey,
-    tripId,
   ]);
 
   const kickRoom = useCallback(
     (detail: string, errorCode = 'FORBIDDEN') => {
+      leaveOwnedSubscription();
       kickedRef.current = true;
       focusGenerationRef.current += 1;
       abortAllRequests();
       invalidateMutationOwnership();
       disposeAITypingVisual();
+      resetSubscriptionAttemptTracking();
+      sentEpochRef.current = null;
+      ackedEpochRef.current = null;
+      rejectedEpochRef.current = null;
+      catchUpRequestedEpochRef.current = null;
+      catchUpRetryIntentRef.current = null;
+      unresolvedCatchUpBaselineRef.current = null;
       setSubscriptionStatus('inactive');
       setCurrentRoomError(roomError(errorCode, detail));
+      setReadSyncError(null);
       dispatch({ type: 'KICKED', resourceKey });
     },
     [
@@ -958,12 +1130,18 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
       dispatch,
       disposeAITypingVisual,
       invalidateMutationOwnership,
+      leaveOwnedSubscription,
+      resetSubscriptionAttemptTracking,
       resourceKey,
     ],
   );
 
   const applyAuthoritativeFailure = useCallback(
-    (error: ChatApiFailure, messageId: string | null = null) => {
+    (
+      error: ChatApiFailure,
+      messageId: string | null = null,
+      requestReadCatchUp = true,
+    ) => {
       if (error.errorCode === TERMINAL_ERROR_CODE) {
         invalidateMutationOwnership();
         dispatch({
@@ -973,8 +1151,13 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
           requestVersion: stateRef.current.version,
         });
         setCurrentRoomError(roomError(TERMINAL_ERROR_CODE, error.message));
+        if (requestReadCatchUp) {
+          requestCurrentReadCatchUp();
+        }
+        return;
       } else if (isAccessLost(error)) {
         kickRoom(error.message, error.errorCode ?? 'FORBIDDEN');
+        return;
       }
       dispatch({
         type: 'SET_MUTATION_ERROR',
@@ -983,22 +1166,52 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
         error,
       });
     },
-    [dispatch, invalidateMutationOwnership, kickRoom, resourceKey],
+    [
+      dispatch,
+      invalidateMutationOwnership,
+      kickRoom,
+      requestCurrentReadCatchUp,
+      resourceKey,
+    ],
   );
+
+  useLayoutEffect(() => {
+    const reportAuthoritativeFailure = (failure: ChatApiFailure) => {
+      if (
+        activeResourceKeyRef.current !== resourceKey ||
+        stateRef.current.resourceKey !== resourceKey ||
+        kickedRef.current
+      ) {
+        return;
+      }
+      applyAuthoritativeFailure(failure);
+    };
+    aiReconciliationCoordinator.setAuthoritativeFailureReporter(
+      reportAuthoritativeFailure,
+    );
+    return () => {
+      aiReconciliationCoordinator.setAuthoritativeFailureReporter(null);
+    };
+  }, [aiReconciliationCoordinator, applyAuthoritativeFailure, resourceKey]);
 
   useEffect(() => {
     let cancelled = false;
     invalidateMutationOwnership();
     disposeAITypingVisual();
+    resetSubscriptionAttemptTracking();
     kickedRef.current = false;
     sentEpochRef.current = null;
     ackedEpochRef.current = null;
     rejectedEpochRef.current = null;
     catchUpRequestedEpochRef.current = null;
+    catchUpRetryIntentRef.current = null;
+    unresolvedCatchUpBaselineRef.current = null;
+    initialHistoryLoadedRef.current = false;
     dispatch({ type: 'RESET', resourceKey });
     queueMicrotask(() => {
       if (!cancelled) {
         setCurrentRoomError(null);
+        setReadSyncError(null);
         setAIReconciliationError(null);
       }
     });
@@ -1008,19 +1221,21 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
       abortAllRequests();
       invalidateMutationOwnership();
       disposeAITypingVisual();
+      resetSubscriptionAttemptTracking();
     };
   }, [
     abortAllRequests,
     dispatch,
     disposeAITypingVisual,
     invalidateMutationOwnership,
+    resetSubscriptionAttemptTracking,
     resourceKey,
   ]);
 
   const loadInitialHistory = useCallback(async () => {
     if (
       initialLoadControllerRef.current !== null ||
-      stateRef.current.roomStatus === 'ready' ||
+      initialHistoryLoadedRef.current ||
       kickedRef.current ||
       !tripId
     ) {
@@ -1028,11 +1243,11 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
     }
     const controller = registerController();
     initialLoadControllerRef.current = controller;
+    dispatch({ type: 'INIT_START', resourceKey });
     const requestVersion =
       stateRef.current.resourceKey === resourceKey
         ? stateRef.current.version
         : 0;
-    dispatch({ type: 'INIT_START', resourceKey });
     try {
       const response = await listChatHistory(
         tripId,
@@ -1046,6 +1261,10 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
       ) {
         return;
       }
+      unresolvedCatchUpBaselineRef.current = catchUpBaselineFromMessages(
+        response.results,
+      );
+      initialHistoryLoadedRef.current = true;
       dispatch({
         type: 'INIT_RESOLVED',
         resourceKey,
@@ -1054,6 +1273,7 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
         requestVersion,
       });
       clearNonterminalRoomError();
+      queueMicrotask(scheduleRequestedCatchUp);
     } catch (caught: unknown) {
       if (controller.signal.aborted || !isResourceCurrent(resourceKey)) {
         return;
@@ -1063,9 +1283,15 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
         kickRoom(error.message, error.errorCode ?? 'FORBIDDEN');
         return;
       }
-      setCurrentRoomError(
-        roomError(error.errorCode ?? 'CHAT_INITIAL_LOAD_FAILED', error.message),
-      );
+      const terminalAlreadyKnown = stateRef.current.terminalLocked;
+      if (!terminalAlreadyKnown) {
+        setNonterminalRoomError(
+          roomError(
+            error.errorCode ?? 'CHAT_INITIAL_LOAD_FAILED',
+            error.message,
+          ),
+        );
+      }
       dispatch({
         type: 'INIT_FAILED',
         resourceKey,
@@ -1086,6 +1312,8 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
     registerController,
     releaseController,
     resourceKey,
+    scheduleRequestedCatchUp,
+    setNonterminalRoomError,
     tripId,
   ]);
 
@@ -1161,9 +1389,11 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
       ),
       requestVersion: state.version,
     });
+    requestCurrentReadCatchUp();
   }, [
     dispatch,
     invalidateMutationOwnership,
+    requestCurrentReadCatchUp,
     resourceKey,
     state.resourceKey,
     state.roomStatus,
@@ -1174,6 +1404,7 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
 
   const isCatchUpCurrent = useCallback(
     (run: CatchUpRun) =>
+      catchUpRunRef.current === run &&
       !run.controller.signal.aborted &&
       isResourceCurrent(run.resourceKey) &&
       focusedRef.current &&
@@ -1186,11 +1417,20 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
   );
 
   const runCatchUp = useCallback(
-    async (connectionEpoch: number) => {
+    async (
+      connectionEpoch: number,
+      baselineOverride?: CatchUpBaseline,
+    ) => {
       if (
         catchUpRunRef.current !== null ||
         stateRef.current.resourceKey !== resourceKey ||
-        stateRef.current.roomStatus !== 'ready'
+        stateRef.current.roomStatus !== 'ready' ||
+        !focusedRef.current ||
+        !accessGrantedRef.current ||
+        kickedRef.current ||
+        snapshotRef.current.status !== 'connected' ||
+        snapshotRef.current.connectionEpoch !== connectionEpoch ||
+        ackedEpochRef.current !== connectionEpoch
       ) {
         return;
       }
@@ -1203,13 +1443,36 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
       };
       catchUpRunRef.current = run;
       catchUpRequestedEpochRef.current = null;
-      let changeCursor = selectLatestChangeCursor(stateRef.current);
+      const baseline =
+        baselineOverride ??
+        unresolvedCatchUpBaselineRef.current ??
+        catchUpBaselineFromState(stateRef.current);
+      unresolvedCatchUpBaselineRef.current = baseline;
+      let changeCursor = baseline.changeCursor;
+      let reconciledChangeCursor = baseline.changeCursor;
       let firstUpdateRequestVersionFloor: number | null = null;
-      let latest = selectLatestConfirmed(stateRef.current);
+      let latestMessageId = baseline.latestMessageId;
+      let reconciledLatestMessageId = baseline.latestMessageId;
+      let retryBaseline = baseline;
+      const armCatchUpRetry = (
+        errorCode:
+          | 'CHAT_SYNC_FAILED'
+          | 'GAP_FILL_INCOMPLETE'
+          | 'CHANGE_SYNC_INCOMPLETE',
+        detail: string,
+      ) => {
+        catchUpRetryIntentRef.current = {
+          connectionEpoch: run.connectionEpoch,
+          baseline: retryBaseline,
+        };
+        const error = roomError(errorCode, detail);
+        setReadSyncError({ resourceKey, error });
+        setNonterminalRoomError(error);
+      };
       dispatch({ type: 'CATCHUP_PHASE', resourceKey, phase: 'gap' });
 
       try {
-        if (latest === null) {
+        if (latestMessageId === null) {
           const requestVersion = stateRef.current.version;
           const history = await listChatHistory(
             tripId,
@@ -1224,13 +1487,21 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
             nextCursor: history.next_cursor,
             requestVersion,
           });
-          latest = [...history.results].sort(compareMessages).at(-1) ?? null;
-          changeCursor ??= latestChangeCursorFromMessages(history.results);
+          const historyBaseline = catchUpBaselineFromMessages(history.results);
+          latestMessageId = historyBaseline.latestMessageId;
+          changeCursor ??= historyBaseline.changeCursor;
+          reconciledLatestMessageId = latestMessageId;
+          reconciledChangeCursor = changeCursor;
+          retryBaseline = {
+            latestMessageId: reconciledLatestMessageId,
+            changeCursor: reconciledChangeCursor,
+          };
+          unresolvedCatchUpBaselineRef.current = retryBaseline;
           if (history.results.length > 0) {
             firstUpdateRequestVersionFloor = stateRef.current.version;
           }
         } else {
-          let since = latest.id;
+          let since = latestMessageId;
           let completed = false;
           for (let page = 0; page < RECONCILIATION_MAX_PAGES; page += 1) {
             const requestVersion = stateRef.current.version;
@@ -1247,19 +1518,29 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
               requestVersion,
             });
             const last = response.results.at(-1);
-            if (!response.has_more || last === undefined) {
+            if (last !== undefined) {
+              since = last.id;
+              reconciledLatestMessageId = last.id;
+              retryBaseline = {
+                latestMessageId: reconciledLatestMessageId,
+                changeCursor: baseline.changeCursor,
+              };
+              unresolvedCatchUpBaselineRef.current = retryBaseline;
+            }
+            if (!response.has_more) {
               completed = true;
               break;
             }
-            since = last.id;
+            if (last === undefined) {
+              break;
+            }
           }
           if (!completed) {
-            setCurrentRoomError(
-              roomError(
-                'GAP_FILL_INCOMPLETE',
-                'Chat recovery reached its safety limit. Reopen chat to retry.',
-              ),
+            armCatchUpRetry(
+              'GAP_FILL_INCOMPLETE',
+              'Chat recovery reached its safety limit. Tap Retry catching up to continue.',
             );
+            return;
           }
         }
 
@@ -1291,31 +1572,60 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
               requestVersion,
             });
             const last = response.results.at(-1);
-            if (!response.has_more || last === undefined) {
+            if (last !== undefined) {
+              changedSince = last.change_sequence;
+              changedSinceId = last.id;
+              reconciledChangeCursor = {
+                changeSequence: last.change_sequence,
+                id: last.id,
+              };
+              retryBaseline = {
+                latestMessageId: reconciledLatestMessageId,
+                changeCursor: reconciledChangeCursor,
+              };
+              unresolvedCatchUpBaselineRef.current = retryBaseline;
+            }
+            if (!response.has_more) {
               completed = true;
               break;
             }
-            changedSince = last.change_sequence;
-            changedSinceId = last.id;
+            if (last === undefined) {
+              break;
+            }
           }
           if (!completed) {
-            setCurrentRoomError(
-              roomError(
-                'CHANGE_SYNC_INCOMPLETE',
-                'Chat updates could not be fully synchronized. Reopen chat to retry.',
-              ),
+            armCatchUpRetry(
+              'CHANGE_SYNC_INCOMPLETE',
+              'Chat updates could not be fully synchronized. Tap Retry catching up to continue.',
             );
+            return;
           }
         }
+        unresolvedCatchUpBaselineRef.current = {
+          latestMessageId: reconciledLatestMessageId,
+          changeCursor: reconciledChangeCursor,
+        };
+        catchUpRetryIntentRef.current = null;
+        setReadSyncError((current) =>
+          current?.resourceKey === resourceKey ? null : current,
+        );
+        setCurrentRoomError((current) =>
+          current?.errorCode === 'CHAT_SYNC_FAILED' ||
+          current?.errorCode === 'GAP_FILL_INCOMPLETE' ||
+          current?.errorCode === 'CHANGE_SYNC_INCOMPLETE'
+            ? null
+            : current,
+        );
       } catch (caught: unknown) {
         if (!isCatchUpCurrent(run)) return;
         const error = normalizeChatApiError(caught);
         if (isAccessLost(error)) {
           kickRoom(error.message, error.errorCode ?? 'FORBIDDEN');
+        } else if (error.errorCode === TERMINAL_ERROR_CODE) {
+          applyAuthoritativeFailure(error, null, false);
+          armCatchUpRetry('CHAT_SYNC_FAILED', error.message);
         } else {
-          setCurrentRoomError(
-            roomError(error.errorCode ?? 'CHAT_SYNC_FAILED', error.message),
-          );
+          armCatchUpRetry('CHAT_SYNC_FAILED', error.message);
         }
       } finally {
         releaseController(run.controller);
@@ -1326,9 +1636,13 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
         if (stillOwnsCatchUp && isResourceCurrent(resourceKey)) {
           dispatch({ type: 'CATCHUP_PHASE', resourceKey, phase: null });
         }
+        if (stillOwnsCatchUp) {
+          queueMicrotask(scheduleRequestedCatchUp);
+        }
       }
     },
     [
+      applyAuthoritativeFailure,
       dispatch,
       isCatchUpCurrent,
       isResourceCurrent,
@@ -1336,8 +1650,103 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
       registerController,
       releaseController,
       resourceKey,
+      scheduleRequestedCatchUp,
+      setNonterminalRoomError,
       tripId,
     ],
+  );
+
+  useLayoutEffect(() => {
+    runCatchUpRef.current = (connectionEpoch) => {
+      void runCatchUp(connectionEpoch);
+    };
+  }, [runCatchUp]);
+
+  const retryCatchUp = useCallback(() => {
+    const retryIntent = catchUpRetryIntentRef.current;
+    const snapshot = snapshotRef.current;
+    if (
+      retryIntent === null ||
+      catchUpRunRef.current !== null ||
+      !focusedRef.current ||
+      !accessGrantedRef.current ||
+      kickedRef.current ||
+      snapshot.status !== 'connected' ||
+      snapshot.connectionEpoch !== retryIntent.connectionEpoch ||
+      ackedEpochRef.current !== retryIntent.connectionEpoch ||
+      stateRef.current.resourceKey !== resourceKey ||
+      stateRef.current.roomStatus !== 'ready'
+    ) {
+      return;
+    }
+
+    catchUpRetryIntentRef.current = null;
+    setReadSyncError((current) =>
+      current?.resourceKey === resourceKey ? null : current,
+    );
+    setCurrentRoomError((current) =>
+      current?.errorCode === 'CHAT_SYNC_FAILED' ||
+      current?.errorCode === 'GAP_FILL_INCOMPLETE' ||
+      current?.errorCode === 'CHANGE_SYNC_INCOMPLETE'
+        ? null
+        : current,
+    );
+    void runCatchUp(retryIntent.connectionEpoch, retryIntent.baseline);
+  }, [resourceKey, runCatchUp]);
+
+  const scheduleSubscriptionRecovery = useCallback(
+    (
+      connectionEpoch: number,
+      focusGeneration: number,
+      delayMs: number,
+    ) => {
+      clearSubscriptionRecoveryTimer();
+      const timeout: SubscriptionRecoveryTimeout = { handle: null };
+      subscriptionRecoveryTimerRef.current = timeout;
+      timeout.handle = setTimeout(() => {
+        if (subscriptionRecoveryTimerRef.current !== timeout) {
+          return;
+        }
+        subscriptionRecoveryTimerRef.current = null;
+        const snapshot = snapshotRef.current;
+        if (
+          activeResourceKeyRef.current !== resourceKey ||
+          !focusedRef.current ||
+          focusGenerationRef.current !== focusGeneration ||
+          !accessGrantedRef.current ||
+          kickedRef.current ||
+          snapshot.status !== 'connected' ||
+          snapshot.connectionEpoch !== connectionEpoch ||
+          subscriptionAttemptEpochRef.current !== connectionEpoch ||
+          ackedEpochRef.current === connectionEpoch ||
+          rejectedEpochRef.current === connectionEpoch
+        ) {
+          return;
+        }
+
+        if (
+          subscriptionAttemptCountRef.current >=
+          CHAT_SUBSCRIPTION_MAX_ATTEMPTS
+        ) {
+          rejectedEpochRef.current = connectionEpoch;
+          setSubscriptionStatus('rejected');
+          setCurrentRoomError((current) =>
+            current?.errorCode === TERMINAL_ERROR_CODE
+              ? current
+              : roomError(
+                  'CHAT_SUBSCRIPTION_TIMEOUT',
+                  'Live chat could not confirm this room after several attempts. Tap Retry live chat or reopen chat.',
+                ),
+          );
+          return;
+        }
+
+        sentEpochRef.current = null;
+        setSubscriptionStatus('waiting');
+        attemptSubscribeRef.current();
+      }, delayMs);
+    },
+    [clearSubscriptionRecoveryTimer, resourceKey],
   );
 
   const attemptSubscribe = useCallback(() => {
@@ -1348,26 +1757,105 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
       kickedRef.current ||
       snapshot.status !== 'connected' ||
       sentEpochRef.current === snapshot.connectionEpoch ||
+      ackedEpochRef.current === snapshot.connectionEpoch ||
       rejectedEpochRef.current === snapshot.connectionEpoch
     ) {
       return;
     }
+
+    if (subscriptionAttemptEpochRef.current !== snapshot.connectionEpoch) {
+      clearSubscriptionRecoveryTimer();
+      subscriptionAttemptEpochRef.current = snapshot.connectionEpoch;
+      subscriptionAttemptCountRef.current = 0;
+      sentEpochRef.current = null;
+      ackedEpochRef.current = null;
+      rejectedEpochRef.current = null;
+    }
+    if (
+      subscriptionAttemptCountRef.current >= CHAT_SUBSCRIPTION_MAX_ATTEMPTS
+    ) {
+      return;
+    }
+
+    const focusGeneration = focusGenerationRef.current;
+    subscriptionAttemptCountRef.current += 1;
     const sent = realtime.send({ type: 'chat.subscribe', trip_id: tripId });
     if (sent) {
       sentEpochRef.current = snapshot.connectionEpoch;
       setSubscriptionStatus('subscribing');
+      scheduleSubscriptionRecovery(
+        snapshot.connectionEpoch,
+        focusGeneration,
+        CHAT_SUBSCRIPTION_ACK_TIMEOUT_MS,
+      );
     } else {
+      sentEpochRef.current = null;
       setSubscriptionStatus('waiting');
+      scheduleSubscriptionRecovery(
+        snapshot.connectionEpoch,
+        focusGeneration,
+        CHAT_SUBSCRIPTION_RETRY_DELAY_MS,
+      );
     }
-  }, [realtime, tripId]);
+  }, [
+    clearSubscriptionRecoveryTimer,
+    realtime,
+    scheduleSubscriptionRecovery,
+    tripId,
+  ]);
+
+  useLayoutEffect(() => {
+    attemptSubscribeRef.current = attemptSubscribe;
+  }, [attemptSubscribe]);
+
+  const retrySubscription = useCallback(() => {
+    if (
+      !focusedRef.current ||
+      !accessGrantedRef.current ||
+      kickedRef.current
+    ) {
+      return;
+    }
+
+    resetSubscriptionAttemptTracking();
+    sentEpochRef.current = null;
+    ackedEpochRef.current = null;
+    rejectedEpochRef.current = null;
+    catchUpRequestedEpochRef.current = null;
+    catchUpRetryIntentRef.current = null;
+    setReadSyncError((current) =>
+      current?.resourceKey === resourceKey ? null : current,
+    );
+    clearNonterminalRoomError();
+    setSubscriptionStatus('waiting');
+    attemptSubscribe();
+  }, [
+    attemptSubscribe,
+    clearNonterminalRoomError,
+    resetSubscriptionAttemptTracking,
+    resourceKey,
+  ]);
+
+  const retryConnection = useCallback(
+    () => realtime.retryConnection(),
+    [realtime],
+  );
 
   useFocusEffect(
     useCallback(() => {
       focusedRef.current = true;
       focusGenerationRef.current += 1;
       disposeAITypingVisual();
+      resetSubscriptionAttemptTracking();
+      sentEpochRef.current = null;
+      ackedEpochRef.current = null;
+      rejectedEpochRef.current = null;
+      catchUpRequestedEpochRef.current = null;
+      catchUpRetryIntentRef.current = null;
       setSubscriptionStatus(
-        snapshotRef.current.status === 'connected' ? 'subscribing' : 'waiting',
+        snapshotRef.current.status === 'connected'
+          ? 'subscribing'
+          : 'waiting',
       );
       attemptSubscribe();
 
@@ -1375,6 +1863,7 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
         focusedRef.current = false;
         focusGenerationRef.current += 1;
         disposeAITypingVisual();
+        clearSubscriptionRecoveryTimer();
         const activeCatchUp = catchUpRunRef.current;
         activeCatchUp?.controller.abort();
         if (activeCatchUp !== null && catchUpRunRef.current === activeCatchUp) {
@@ -1387,26 +1876,24 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
             });
           }
         }
-        const snapshot = snapshotRef.current;
-        if (
-          snapshot.status === 'connected' &&
-          sentEpochRef.current === snapshot.connectionEpoch
-        ) {
-          realtime.send({ type: 'chat.unsubscribe', trip_id: tripId });
-        }
+        leaveOwnedSubscription();
         sentEpochRef.current = null;
         ackedEpochRef.current = null;
         rejectedEpochRef.current = null;
+        subscriptionAttemptEpochRef.current = null;
+        subscriptionAttemptCountRef.current = 0;
         catchUpRequestedEpochRef.current = null;
+        catchUpRetryIntentRef.current = null;
         setSubscriptionStatus('inactive');
       };
     }, [
       attemptSubscribe,
+      clearSubscriptionRecoveryTimer,
       dispatch,
       disposeAITypingVisual,
       isResourceCurrent,
-      realtime,
-      tripId,
+      leaveOwnedSubscription,
+      resetSubscriptionAttemptTracking,
     ]),
   );
 
@@ -1435,12 +1922,35 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
       }
     }
 
-    if (!focusedRef.current || kickedRef.current || !accessGranted) {
+    if (
+      !focusedRef.current ||
+      kickedRef.current ||
+      !accessGranted
+    ) {
       return;
     }
     if (realtimeSnapshot.status !== 'connected') {
+      clearSubscriptionRecoveryTimer();
+      sentEpochRef.current = null;
       ackedEpochRef.current = null;
-      return;
+      rejectedEpochRef.current = null;
+      subscriptionAttemptEpochRef.current = null;
+      subscriptionAttemptCountRef.current = 0;
+      catchUpRequestedEpochRef.current = null;
+      catchUpRetryIntentRef.current = null;
+      let cancelled = false;
+      queueMicrotask(() => {
+        if (
+          !cancelled &&
+          focusedRef.current &&
+          snapshotRef.current.status !== 'connected'
+        ) {
+          setSubscriptionStatus('waiting');
+        }
+      });
+      return () => {
+        cancelled = true;
+      };
     }
     let cancelled = false;
     void Promise.resolve().then(() => {
@@ -1454,6 +1964,7 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
   }, [
     accessGranted,
     attemptSubscribe,
+    clearSubscriptionRecoveryTimer,
     dispatch,
     disposeAITypingVisual,
     realtimeSnapshot,
@@ -1467,9 +1978,9 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
       ackedEpochRef.current !== null &&
       catchUpRequestedEpochRef.current === ackedEpochRef.current
     ) {
-      void runCatchUp(ackedEpochRef.current);
+      scheduleRequestedCatchUp();
     }
-  }, [runCatchUp, state.roomStatus, subscriptionStatus]);
+  }, [scheduleRequestedCatchUp, state.roomStatus, subscriptionStatus]);
 
   useEffect(() => {
     if (!accessGranted) {
@@ -1492,25 +2003,33 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
           if (
             !focusedRef.current ||
             snapshot.status !== 'connected' ||
-            sentEpochRef.current !== snapshot.connectionEpoch
+            subscriptionAttemptEpochRef.current !==
+              snapshot.connectionEpoch ||
+            subscriptionAttemptCountRef.current === 0
           ) {
             return;
           }
+          clearSubscriptionRecoveryTimer();
+          const alreadyAcknowledged =
+            ackedEpochRef.current === snapshot.connectionEpoch;
           ackedEpochRef.current = snapshot.connectionEpoch;
           rejectedEpochRef.current = null;
-          catchUpRequestedEpochRef.current = snapshot.connectionEpoch;
           setSubscriptionStatus('subscribed');
-          clearNonterminalRoomError();
-          ensureAITypingVisual(snapshot.connectionEpoch);
-          if (stateRef.current.roomStatus === 'ready') {
-            void runCatchUp(snapshot.connectionEpoch);
+          if (alreadyAcknowledged) {
+            return;
           }
+          clearNonterminalRoomError();
+          catchUpRequestedEpochRef.current = snapshot.connectionEpoch;
+          catchUpRetryIntentRef.current = null;
+          ensureAITypingVisual(snapshot.connectionEpoch);
+          scheduleRequestedCatchUp();
           return;
         }
         case 'chat.unsubscribed': {
           const snapshot = snapshotRef.current;
           const rejectedCurrentAttempt =
             rejectedEpochRef.current === snapshot.connectionEpoch;
+          clearSubscriptionRecoveryTimer();
           const activeCatchUp = catchUpRunRef.current;
           if (activeCatchUp !== null) {
             activeCatchUp.controller.abort();
@@ -1521,14 +2040,17 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
           }
           ackedEpochRef.current = null;
           catchUpRequestedEpochRef.current = null;
+          catchUpRetryIntentRef.current = null;
           disposeAITypingVisual();
-          if (focusedRef.current && !rejectedCurrentAttempt) {
-            if (sentEpochRef.current === snapshot.connectionEpoch) {
-              setSubscriptionStatus('subscribing');
-            } else {
-              setSubscriptionStatus('waiting');
-              attemptSubscribe();
-            }
+          if (
+            focusedRef.current &&
+            !rejectedCurrentAttempt
+          ) {
+            sentEpochRef.current = null;
+            subscriptionAttemptEpochRef.current = null;
+            subscriptionAttemptCountRef.current = 0;
+            setSubscriptionStatus('waiting');
+            attemptSubscribe();
           }
           return;
         }
@@ -1597,24 +2119,34 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
               TERMINAL_ERROR_CODE,
               409,
             );
-            invalidateMutationOwnership();
-            dispatch({
-              type: 'TERMINAL_LOCK',
-              resourceKey,
-              error,
-              requestVersion: stateRef.current.version,
-            });
+            applyAuthoritativeFailure(error);
+            return;
           }
-          setCurrentRoomError(roomError(event.error_code, event.detail));
+          setNonterminalRoomError(
+            roomError(event.error_code, event.detail),
+          );
           const snapshot = snapshotRef.current;
           const pendingCurrentAttempt =
             focusedRef.current &&
             snapshot.status === 'connected' &&
-            sentEpochRef.current === snapshot.connectionEpoch &&
+            subscriptionAttemptEpochRef.current ===
+              snapshot.connectionEpoch &&
+            subscriptionAttemptCountRef.current > 0 &&
             ackedEpochRef.current !== snapshot.connectionEpoch;
           if (pendingCurrentAttempt) {
-            rejectedEpochRef.current = snapshot.connectionEpoch;
-            setSubscriptionStatus('rejected');
+            if (event.error_code === SUBSCRIPTION_LIMIT_ERROR_CODE) {
+              clearSubscriptionRecoveryTimer();
+              rejectedEpochRef.current = snapshot.connectionEpoch;
+              setSubscriptionStatus('rejected');
+            } else {
+              sentEpochRef.current = null;
+              setSubscriptionStatus('waiting');
+              scheduleSubscriptionRecovery(
+                snapshot.connectionEpoch,
+                focusGenerationRef.current,
+                CHAT_SUBSCRIPTION_RETRY_DELAY_MS,
+              );
+            }
           }
           return;
         }
@@ -1659,7 +2191,9 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
     });
   }, [
     accessGranted,
+    applyAuthoritativeFailure,
     attemptSubscribe,
+    clearSubscriptionRecoveryTimer,
     clearNonterminalRoomError,
     dispatch,
     disposeAITypingVisual,
@@ -1670,57 +2204,76 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
     realtime,
     resourceKey,
     runCatchUp,
+    scheduleRequestedCatchUp,
+    scheduleSubscriptionRecovery,
+    setNonterminalRoomError,
     tripId,
   ]);
 
   const mutationBlockedFailure = useCallback((): ChatApiFailure | null => {
+    const current = stateRef.current;
     if (
       activeResourceKeyRef.current !== resourceKey ||
-      stateRef.current.resourceKey !== resourceKey
+      current.resourceKey !== resourceKey
     ) {
       return localFailure(
         'Chat is switching trips. Wait for the new conversation to load.',
         'CHAT_NOT_READY',
       );
     }
-    if (accessStatus !== 'granted' || state.roomStatus === 'kicked') {
+    if (
+      !accessGrantedRef.current ||
+      kickedRef.current ||
+      current.roomStatus === 'kicked'
+    ) {
       return localFailure(
         'You no longer have access to this trip chat.',
         'FORBIDDEN',
         403,
       );
     }
-    if (subscriptionStatus === 'rejected') {
-      return localFailure(
-        currentRoomError?.detail ?? 'This chat room is not subscribed.',
-        currentRoomError?.errorCode ?? SUBSCRIPTION_LIMIT_ERROR_CODE,
-      );
-    }
-    if (state.roomStatus !== 'ready') {
-      return localFailure(
-        'Chat is not ready yet.',
-        'CHAT_NOT_READY',
-      );
-    }
     if (
-      state.terminalLocked ||
+      current.terminalLocked ||
       tripDetail.detail?.trip.status === 'COMPLETED' ||
       tripDetail.detail?.trip.status === 'CANCELLED'
     ) {
       return localFailure('This trip chat is read-only.', TERMINAL_ERROR_CODE, 409);
     }
+    const snapshot = snapshotRef.current;
+    const currentEpochRejected =
+      snapshot.status === 'connected' &&
+      rejectedEpochRef.current === snapshot.connectionEpoch;
+    if (subscriptionStatus === 'rejected' || currentEpochRejected) {
+      return localFailure(
+        currentRoomError?.detail ?? 'This chat room is not subscribed.',
+        currentRoomError?.errorCode ?? SUBSCRIPTION_LIMIT_ERROR_CODE,
+      );
+    }
+    if (current.roomStatus !== 'ready') {
+      return localFailure(
+        'Chat is not ready yet.',
+        'CHAT_NOT_READY',
+      );
+    }
     return null;
   }, [
-    accessStatus,
     currentRoomError,
     resourceKey,
-    state.roomStatus,
-    state.terminalLocked,
     subscriptionStatus,
     tripDetail.detail?.trip.status,
   ]);
 
   const retryInitialLoad = useCallback(async () => {
+    if (
+      (stateRef.current.terminalLocked ||
+        tripStatus === 'COMPLETED' ||
+        tripStatus === 'CANCELLED') &&
+      accessStatus === 'granted' &&
+      !initialHistoryLoadedRef.current
+    ) {
+      await loadInitialHistory();
+      return;
+    }
     if (accessStatus === 'error') {
       clearNonterminalRoomError();
       await refreshTripDetail('initial');
@@ -1737,6 +2290,7 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
     clearNonterminalRoomError,
     loadInitialHistory,
     refreshTripDetail,
+    tripStatus,
   ]);
 
   const loadOlder = useCallback(async () => {
@@ -2426,6 +2980,10 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
       (visibleState ? currentRoomError : null) ??
       visibleAIReconciliationError ??
       transcriptRoomError,
+    readSyncError:
+      readSyncError?.resourceKey === resourceKey ? readSyncError.error : null,
+    initialLoadError: visibleState ? state.roomError : null,
+    isLoadingInitial: visibleState && state.isLoadingInitial,
     messages,
     pendingClientIds: visibleState ? state.pendingClientIds : EMPTY_ID_SET,
     failedClientIds: visibleState ? state.failedClientIds : EMPTY_ID_SET,
@@ -2446,6 +3004,7 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
     mutationError: visibleState ? state.mutationError : null,
     aiTypingState: visibleAITypingState,
     connectionStatus: realtimeSnapshot.status,
+    connectionDiagnostics: realtimeSnapshot.diagnostics ?? null,
     connectionEpoch: realtimeSnapshot.connectionEpoch,
     aiReconciliationCoordinator,
     ambiguousAIDraftIds: visibleState
@@ -2453,6 +3012,9 @@ export function useTripChat({ tripId: rawTripId }: UseTripChatOptions): UseTripC
         EMPTY_ID_SET)
       : EMPTY_ID_SET,
     retryInitialLoad,
+    retryConnection,
+    retrySubscription,
+    retryCatchUp,
     loadOlder,
     sendMessage,
     retryPending,

--- a/mobile/src/features/chat/screens/ChatScreen.tsx
+++ b/mobile/src/features/chat/screens/ChatScreen.tsx
@@ -1,14 +1,20 @@
 import { useLocalSearchParams } from 'expo-router';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  KeyboardAvoidingView,
+  Dimensions,
+  Keyboard,
   Platform,
   Pressable,
   StyleSheet,
   Text,
+  useWindowDimensions,
   View,
+  type KeyboardEvent,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
 import { colors, spacing, typography } from '@/shared/theme/tokens';
 import { LoadingScreen } from '@/shared/ui/LoadingScreen';
 import { goPlanAISendFailureMessage } from '../ai/mention';
@@ -28,7 +34,117 @@ import type {
 
 const CHAT_SAFE_AREA_EDGES = ['left', 'right', 'bottom'] as const;
 const EMPTY_DRAFT_ID_SET: ReadonlySet<string> = new Set();
-export const CHAT_KEYBOARD_BEHAVIOR = Platform.OS === 'ios' ? 'padding' : undefined;
+
+export interface ChatKeyboardFrame {
+  readonly height: number;
+  readonly screenY: number;
+}
+
+export function chatKeyboardBottomInset(
+  viewportHeight: number,
+  keyboardFrame: ChatKeyboardFrame | null,
+  safeAreaBottom: number,
+): number {
+  if (
+    !Number.isFinite(viewportHeight) ||
+    viewportHeight <= 0 ||
+    keyboardFrame === null ||
+    !Number.isFinite(keyboardFrame.height) ||
+    keyboardFrame.height <= 0 ||
+    !Number.isFinite(keyboardFrame.screenY) ||
+    keyboardFrame.screenY <= 0
+  ) {
+    return 0;
+  }
+  const safeBottom =
+    Number.isFinite(safeAreaBottom) && safeAreaBottom > 0 ? safeAreaBottom : 0;
+  const overlapEnd = Math.min(
+    viewportHeight,
+    keyboardFrame.screenY + keyboardFrame.height,
+  );
+  const overlapStart = Math.max(0, keyboardFrame.screenY);
+  return Math.max(0, overlapEnd - overlapStart - safeBottom);
+}
+
+export function stableChatKeyboardFrame(
+  current: ChatKeyboardFrame | null,
+  candidate: ChatKeyboardFrame | null | undefined,
+): ChatKeyboardFrame | null {
+  if (candidate === null || candidate === undefined) {
+    return current;
+  }
+  if (!Number.isFinite(candidate.height) || candidate.height <= 0) {
+    return null;
+  }
+  if (!Number.isFinite(candidate.screenY) || candidate.screenY <= 0) {
+    // iOS briefly reports screenY=0 while cross-fading keyboard variants.
+    // Retaining the last stable frame prevents the composer from jumping.
+    return current;
+  }
+  return { height: candidate.height, screenY: candidate.screenY };
+}
+
+function useChatKeyboardBottomInset(): number {
+  const { bottom: safeAreaBottom } = useSafeAreaInsets();
+  const viewport = useWindowDimensions();
+  const [keyboardFrame, setKeyboardFrame] = useState<ChatKeyboardFrame | null>(
+    () =>
+      Platform.OS === 'ios'
+        ? stableChatKeyboardFrame(null, Keyboard.metrics())
+        : null,
+  );
+
+  useEffect(() => {
+    if (Platform.OS !== 'ios') {
+      return undefined;
+    }
+    const viewportSubscription = Dimensions.addEventListener(
+      'change',
+      () => {
+        setKeyboardFrame((current) =>
+          stableChatKeyboardFrame(current, Keyboard.metrics()),
+        );
+      },
+    );
+    return () => viewportSubscription.remove();
+  }, []);
+
+  useEffect(() => {
+    if (Platform.OS !== 'ios') {
+      return undefined;
+    }
+
+    const updateKeyboardFrame = (event: KeyboardEvent): void => {
+      Keyboard.scheduleLayoutAnimation(event);
+      setKeyboardFrame((current) =>
+        stableChatKeyboardFrame(current, event.endCoordinates),
+      );
+    };
+    const hideKeyboard = (event: KeyboardEvent): void => {
+      Keyboard.scheduleLayoutAnimation(event);
+      setKeyboardFrame(null);
+    };
+    const frameSubscription = Keyboard.addListener(
+      'keyboardWillChangeFrame',
+      updateKeyboardFrame,
+    );
+    const hideSubscription = Keyboard.addListener(
+      'keyboardWillHide',
+      hideKeyboard,
+    );
+
+    return () => {
+      frameSubscription.remove();
+      hideSubscription.remove();
+    };
+  }, []);
+
+  return chatKeyboardBottomInset(
+    viewport.height,
+    keyboardFrame,
+    safeAreaBottom,
+  );
+}
 
 function routeTripId(value: string | string[] | undefined): string | undefined {
   const candidate = Array.isArray(value) ? value[0] : value;
@@ -137,6 +253,11 @@ export function ChatScreen() {
   const params = useLocalSearchParams<{ tripId?: string | string[] }>();
   const tripId = routeTripId(params.tripId);
   const chat = useTripChat({ tripId });
+  const keyboardBottomInset = useChatKeyboardBottomInset();
+  const keyboardLayoutStyle = useMemo(
+    () => [styles.fill, { paddingBottom: keyboardBottomInset }],
+    [keyboardBottomInset],
+  );
   const {
     deleteMessage: deleteChatMessage,
     hideMessagesForMe,
@@ -294,9 +415,8 @@ export function ChatScreen() {
       style={styles.safe}
       testID="chat-safe-area"
     >
-      <KeyboardAvoidingView
-        behavior={CHAT_KEYBOARD_BEHAVIOR}
-        style={styles.fill}
+      <View
+        style={keyboardLayoutStyle}
         testID="chat-keyboard-layout"
       >
         <ChatConnectionBanner
@@ -359,7 +479,7 @@ export function ChatScreen() {
             onApplyAIDraftSnapshot={chat.applyAIDraftSnapshot}
           />
         </AIReconciliationCoordinatorProvider>
-      </KeyboardAvoidingView>
+      </View>
     </SafeAreaView>
   );
 }

--- a/mobile/src/features/chat/screens/ChatScreen.tsx
+++ b/mobile/src/features/chat/screens/ChatScreen.tsx
@@ -216,13 +216,53 @@ function BlockingState({
 
 function StatusNotice({
   children,
+  actionLabel,
+  onAction,
   tone = 'neutral',
   testID,
 }: {
   children: string;
+  actionLabel?: string;
+  onAction?: () => void;
   tone?: 'neutral' | 'warning' | 'error';
   testID: string;
 }) {
+  if (onAction && actionLabel) {
+    return (
+      <View
+        style={[
+          styles.actionNotice,
+          tone === 'warning' ? styles.warningNoticeBackground : null,
+          tone === 'error' ? styles.errorNoticeBackground : null,
+        ]}
+        testID={testID}
+      >
+        <Text
+          accessibilityLiveRegion="polite"
+          accessibilityRole="alert"
+          style={[
+            styles.actionNoticeText,
+            tone === 'warning' ? styles.warningNoticeText : null,
+            tone === 'error' ? styles.errorNoticeText : null,
+          ]}
+        >
+          {children}
+        </Text>
+        <Pressable
+          accessibilityLabel={actionLabel}
+          accessibilityRole="button"
+          onPress={onAction}
+          style={({ pressed }) => [
+            styles.noticeActionButton,
+            pressed ? styles.retryButtonPressed : null,
+          ]}
+        >
+          <Text style={styles.noticeActionButtonText}>{actionLabel}</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
   return (
     <Text
       accessibilityLiveRegion="polite"
@@ -262,7 +302,10 @@ export function ChatScreen() {
     deleteMessage: deleteChatMessage,
     hideMessagesForMe,
     loadOlder: loadOlderMessages,
+    retryCatchUp,
+    retryConnection,
     retryInitialLoad,
+    retrySubscription,
     retryPending,
     sendMessage,
     toggleReaction: toggleChatReaction,
@@ -282,12 +325,17 @@ export function ChatScreen() {
   }, [chat.roomError, chat.tripStatus]);
 
   const subscriptionRejected = chat.subscriptionStatus === 'rejected';
+  const terminalActive = terminalMessage !== null;
   const roomResourceKey =
     chat.aiReconciliationCoordinator?.resourceKey ?? tripId;
-  const actionsEnabled = !chat.isReadOnly;
-  const readOnlyMessage = subscriptionRejected
-    ? 'Realtime is unavailable for this room. Chat actions are disabled.'
-    : terminalMessage ?? 'This chat is read-only.';
+  const actionsEnabled = !chat.isReadOnly && !terminalActive;
+  const canRetryReadSync =
+    chat.connectionStatus === 'connected' &&
+    chat.subscriptionStatus === 'subscribed';
+  const readOnlyMessage = terminalMessage ??
+    (subscriptionRejected
+      ? 'Realtime is unavailable for this room. Chat actions are disabled.'
+      : 'This chat is read-only.');
 
   const submitMessage = useCallback(
     async (content: string): Promise<ChatComposerSubmitResult> => {
@@ -396,10 +444,14 @@ export function ChatScreen() {
     !subscriptionRejected &&
     chat.roomError &&
     chat.roomError.errorCode !== 'SUBSCRIPTION_LIMIT_REACHED' &&
-    chat.roomError.errorCode !== 'TRIP_TERMINAL'
+    chat.roomError.errorCode !== 'TRIP_TERMINAL' &&
+    chat.roomError.errorCode !== 'CHAT_SYNC_FAILED' &&
+    chat.roomError.errorCode !== 'GAP_FILL_INCOMPLETE' &&
+    chat.roomError.errorCode !== 'CHANGE_SYNC_INCOMPLETE'
       ? chat.roomError
       : null;
   const visibleMutationError =
+    !terminalActive &&
     chat.mutationError &&
     chat.mutationError.error.errorCode !== 'TRIP_TERMINAL' &&
     !(
@@ -420,26 +472,80 @@ export function ChatScreen() {
         testID="chat-keyboard-layout"
       >
         <ChatConnectionBanner
+          diagnostics={chat.connectionDiagnostics ?? undefined}
+          onRetry={retryConnection}
           status={chat.connectionStatus}
           subscriptionStatus={chat.subscriptionStatus}
         />
         {subscriptionRejected ? (
-          <StatusNotice tone="warning" testID="chat-subscription-rejected">
-            {chat.roomError?.detail ??
-              'Realtime is unavailable for this room. Chat actions are disabled.'}
+          <StatusNotice
+            actionLabel={terminalActive ? 'Retry live updates' : 'Retry live chat'}
+            onAction={retrySubscription}
+            tone="warning"
+            testID="chat-subscription-rejected"
+          >
+            {terminalActive
+              ? 'Live updates could not confirm this room. Retry to receive late messages.'
+              : chat.roomError?.detail ??
+                'Realtime is unavailable for this room. Chat actions are disabled.'}
           </StatusNotice>
         ) : null}
         {terminalMessage ? (
           <StatusNotice testID="chat-terminal-notice">{terminalMessage}</StatusNotice>
         ) : null}
-        {genericRoomError ? (
-          <StatusNotice tone="error" testID="chat-room-error">
-            {genericRoomError.detail}
+        {terminalActive && chat.isLoadingInitial ? (
+          <StatusNotice testID="chat-terminal-history-loading">
+            Loading chat history…
           </StatusNotice>
+        ) : terminalActive && chat.initialLoadError ? (
+          <StatusNotice
+            actionLabel="Retry chat history"
+            onAction={retryInitial}
+            tone="error"
+            testID="chat-terminal-history-error"
+          >
+            {chat.initialLoadError.message}
+          </StatusNotice>
+        ) : null}
+        {chat.readSyncError ? (
+          <StatusNotice
+            actionLabel={
+              canRetryReadSync
+                ? terminalActive
+                  ? 'Retry live updates'
+                  : 'Retry catching up'
+                : undefined
+            }
+            onAction={canRetryReadSync ? retryCatchUp : undefined}
+            tone="error"
+            testID="chat-read-sync-error"
+          >
+            {chat.readSyncError.detail}
+          </StatusNotice>
+        ) : null}
+        {genericRoomError ? (
+          genericRoomError.errorCode === 'CHAT_SYNC_FAILED' ||
+          genericRoomError.errorCode === 'GAP_FILL_INCOMPLETE' ||
+          genericRoomError.errorCode === 'CHANGE_SYNC_INCOMPLETE' ? (
+            <StatusNotice
+              actionLabel="Retry catching up"
+              onAction={retryCatchUp}
+              tone="error"
+              testID="chat-room-error"
+            >
+              {genericRoomError.detail}
+            </StatusNotice>
+          ) : (
+            <StatusNotice tone="error" testID="chat-room-error">
+              {genericRoomError.detail}
+            </StatusNotice>
+          )
         ) : null}
         {chat.isGapFilling || chat.isUpdating ? (
           <StatusNotice testID="chat-catch-up-status">
-            Catching up on messages…
+            {terminalActive
+              ? 'Updating read-only chat history…'
+              : 'Catching up on messages…'}
           </StatusNotice>
         ) : null}
         {visibleMutationError ? (
@@ -514,6 +620,30 @@ const styles = StyleSheet.create({
   },
   warningNotice: { color: colors.warning, backgroundColor: colors.warningSoft },
   errorNotice: { color: colors.danger, backgroundColor: colors.dangerSoft },
+  actionNotice: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingLeft: spacing.md,
+    backgroundColor: colors.completedSoft,
+  },
+  actionNoticeText: {
+    ...typography.caption,
+    flex: 1,
+    color: colors.textMuted,
+  },
+  warningNoticeBackground: { backgroundColor: colors.warningSoft },
+  warningNoticeText: { color: colors.warning },
+  errorNoticeBackground: { backgroundColor: colors.dangerSoft },
+  errorNoticeText: { color: colors.danger },
+  noticeActionButton: {
+    minHeight: 44,
+    minWidth: 88,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.md,
+  },
+  noticeActionButtonText: { ...typography.label, color: colors.primary },
   readOnlyFooter: {
     minHeight: 52,
     alignItems: 'center',

--- a/mobile/src/features/chat/screens/ChatScreen.tsx
+++ b/mobile/src/features/chat/screens/ChatScreen.tsx
@@ -11,6 +11,8 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { colors, spacing, typography } from '@/shared/theme/tokens';
 import { LoadingScreen } from '@/shared/ui/LoadingScreen';
+import { goPlanAISendFailureMessage } from '../ai/mention';
+import { AIReconciliationCoordinatorProvider } from '../ai/reconciliationContext';
 import { ChatComposer, type ChatComposerSubmitResult } from '../components/ChatComposer';
 import { ChatConnectionBanner } from '../components/ChatConnectionBanner';
 import {
@@ -25,6 +27,7 @@ import type {
 } from '../types';
 
 const CHAT_SAFE_AREA_EDGES = ['left', 'right', 'bottom'] as const;
+const EMPTY_DRAFT_ID_SET: ReadonlySet<string> = new Set();
 export const CHAT_KEYBOARD_BEHAVIOR = Platform.OS === 'ios' ? 'padding' : undefined;
 
 function routeTripId(value: string | string[] | undefined): string | undefined {
@@ -34,12 +37,29 @@ function routeTripId(value: string | string[] | undefined): string | undefined {
 }
 
 function failureMessage(failure: ChatApiFailure): string {
-  const message = failure.message.trim() || 'Something went wrong.';
+  return failureMessageWithDetail(failure, failure.message);
+}
+
+function failureMessageWithDetail(
+  failure: ChatApiFailure,
+  detail: string,
+): string {
+  const message = detail.trim() || 'Something went wrong.';
   if (failure.retryAfterMs === null || failure.retryAfterMs <= 0) {
     return message;
   }
   const seconds = Math.max(1, Math.ceil(failure.retryAfterMs / 1000));
   return `${message} Try again in ${seconds} ${seconds === 1 ? 'second' : 'seconds'}.`;
+}
+
+function composerFailureMessage(
+  content: string,
+  failure: ChatApiFailure,
+): string {
+  return failureMessageWithDetail(
+    failure,
+    goPlanAISendFailureMessage(content, failure),
+  );
 }
 
 function BlockingState({
@@ -141,7 +161,8 @@ export function ChatScreen() {
   }, [chat.roomError, chat.tripStatus]);
 
   const subscriptionRejected = chat.subscriptionStatus === 'rejected';
-  const roomResourceKey = `${chat.currentUserId ?? 'no-session'}:${tripId ?? 'no-trip'}`;
+  const roomResourceKey =
+    chat.aiReconciliationCoordinator?.resourceKey ?? tripId;
   const actionsEnabled = !chat.isReadOnly;
   const readOnlyMessage = subscriptionRejected
     ? 'Realtime is unavailable for this room. Chat actions are disabled.'
@@ -158,7 +179,7 @@ export function ChatScreen() {
       }
       return {
         draftDisposition: 'preserve',
-        feedback: failureMessage(outcome.error),
+        feedback: composerFailureMessage(content, outcome.error),
       };
     },
     [sendMessage],
@@ -306,9 +327,13 @@ export function ChatScreen() {
             {failureMessage(visibleMutationError.error)}
           </StatusNotice>
         ) : null}
-        <ChatMessageList
-          key={roomResourceKey}
-          messages={chat.messages}
+        <AIReconciliationCoordinatorProvider
+          value={chat.aiReconciliationCoordinator ?? null}
+        >
+          <ChatMessageList
+            key={roomResourceKey}
+            messages={chat.messages}
+          ambiguousAIDraftIds={chat.ambiguousAIDraftIds ?? EMPTY_DRAFT_ID_SET}
           currentUserId={chat.currentUserId}
           pendingClientIds={chat.pendingClientIds}
           failedClientIds={chat.failedClientIds}
@@ -321,6 +346,9 @@ export function ChatScreen() {
             chat.olderLoadError ? failureMessage(chat.olderLoadError) : null
           }
           actionsEnabled={actionsEnabled}
+          aiTypingInteractionId={
+            chat.aiTypingState.active?.interactionId ?? null
+          }
           isHidingMessages={chat.isHidingMessages}
           bottomAccessory={bottomAccessory}
           onLoadOlder={loadOlder}
@@ -328,7 +356,9 @@ export function ChatScreen() {
           onToggleReaction={toggleReaction}
           onDeleteMessage={deleteMessage}
           onHideMessagesForMe={hideMessages}
-        />
+            onApplyAIDraftSnapshot={chat.applyAIDraftSnapshot}
+          />
+        </AIReconciliationCoordinatorProvider>
       </KeyboardAvoidingView>
     </SafeAreaView>
   );

--- a/mobile/src/features/realtime/__tests__/RealtimeProvider.test.tsx
+++ b/mobile/src/features/realtime/__tests__/RealtimeProvider.test.tsx
@@ -66,6 +66,8 @@ describe('RealtimeProvider', () => {
     });
 
     expect(transports).toHaveLength(1);
+    expect(transports[0]?.retryConnection()).toBe(true);
+    expect(manager.retryConnectionCalls).toBe(1);
     await waitFor(() => {
       expect(snapshots.at(-1)).toEqual({ status: 'connected', connectionEpoch: 1 });
     });

--- a/mobile/src/features/realtime/__tests__/RealtimeRuntimeController.test.ts
+++ b/mobile/src/features/realtime/__tests__/RealtimeRuntimeController.test.ts
@@ -127,6 +127,22 @@ describe('RealtimeRuntimeController', () => {
     ]);
   });
 
+  it('does not recycle the socket for indeterminate type noise around a known online path', async () => {
+    const value = makeHarness(ACTIVE_AUTH, 'active', {
+      availability: 'online',
+      type: 'WIFI',
+    });
+    value.controller.start();
+    await flushPromises();
+
+    value.network.emit({ availability: 'unknown', type: null });
+    value.network.emit({ availability: 'online', type: null });
+    value.network.emit({ availability: 'online', type: 'WIFI' });
+
+    expect(value.manager.restartCalls).toHaveLength(0);
+    expect(value.manager.disconnectCalls).not.toContain('offline');
+  });
+
   it('ignores a stale initial network read after a newer listener event', async () => {
     const value = makeHarness();
     const initial = deferred<ConnectivitySnapshot>();

--- a/mobile/src/features/realtime/__tests__/WebSocketManager.test.ts
+++ b/mobile/src/features/realtime/__tests__/WebSocketManager.test.ts
@@ -1,4 +1,4 @@
-import type { RealtimeOwner } from '../types';
+import type { RealtimeEnvelope, RealtimeOwner } from '../types';
 import { TicketRequestError } from '../infrastructure/ticket-api';
 import {
   REALTIME_TIMING,
@@ -98,6 +98,17 @@ describe('WebSocketManager', () => {
 
     expect(value.tickets.issueCalls).toBe(0);
     expect(value.manager.getSnapshot().status).toBe('disconnected');
+    expect(value.manager.getSnapshot().diagnostics).toMatchObject({
+      phase: 'stopped',
+      reason: 'invalid_configuration',
+      category: 'configuration',
+      terminal: true,
+    });
+    expect(jest.getTimerCount()).toBe(0);
+    expect(value.manager.retryConnection()).toBe(false);
+    value.manager.connect(OWNER_A);
+    await flushPromises();
+    expect(value.tickets.issueCalls).toBe(0);
     expect(jest.getTimerCount()).toBe(0);
   });
 
@@ -117,20 +128,28 @@ describe('WebSocketManager', () => {
         protocols: ['goplan.realtime.v1', 'ticket-1'],
       },
     ]);
-    expect(value.manager.getSnapshot()).toEqual({
+    expect(value.manager.getSnapshot()).toMatchObject({
       status: 'connecting',
       connectionEpoch: 0,
+      diagnostics: {
+        phase: 'opening_socket',
+        ticketPhase: null,
+      },
     });
 
     value.sockets.sockets[0].open();
-    expect(value.manager.getSnapshot()).toEqual({
+    expect(value.manager.getSnapshot()).toMatchObject({
       status: 'connected',
       connectionEpoch: 1,
+      diagnostics: {
+        phase: 'open',
+        heartbeat: 'scheduled',
+      },
     });
-    expect(snapshots).toHaveBeenLastCalledWith({
+    expect(snapshots).toHaveBeenLastCalledWith(expect.objectContaining({
       status: 'connected',
       connectionEpoch: 1,
-    });
+    }));
   });
 
   it('bounds a stuck opening socket and enters bootstrap then backoff recovery', async () => {
@@ -193,13 +212,50 @@ describe('WebSocketManager', () => {
 
     replacement.open();
     openTimeoutCallbacks[1]?.();
-    expect(value.manager.getSnapshot()).toEqual({
+    expect(value.manager.getSnapshot()).toMatchObject({
       status: 'connected',
       connectionEpoch: 1,
     });
     expect(replacement.closeCalls).toHaveLength(0);
     expect(value.tickets.issueCalls).toBe(2);
     expect(stale.closeCalls).toHaveLength(1);
+  });
+
+  it('does not let a cleared stale reconnect callback replace the active retry', async () => {
+    const reconnectCallbacks: (() => void)[] = [];
+    const value = harness({
+      scheduler: {
+        ...jestScheduler,
+        setTimeout: (callback, delayMs) => {
+          if (delayMs === 1_000) {
+            reconnectCallbacks.push(callback);
+          }
+          return jestScheduler.setTimeout(callback, delayMs);
+        },
+      },
+    });
+    value.tickets.defaultIssue = () =>
+      Promise.reject(new TicketRequestError('transient'));
+
+    value.manager.connect(OWNER_A);
+    await flushPromises();
+    expect(reconnectCallbacks).toHaveLength(1);
+    expect(value.tickets.issueCalls).toBe(1);
+
+    value.manager.restart(OWNER_A);
+    await flushPromises();
+    expect(reconnectCallbacks).toHaveLength(2);
+    expect(value.tickets.issueCalls).toBe(2);
+
+    reconnectCallbacks[0]?.();
+    await flushPromises();
+    expect(value.tickets.issueCalls).toBe(2);
+
+    await jest.advanceTimersByTimeAsync(999);
+    expect(value.tickets.issueCalls).toBe(2);
+    await jest.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    expect(value.tickets.issueCalls).toBe(3);
   });
 
   it.each(['disconnect', 'destroy'] as const)(
@@ -332,6 +388,55 @@ describe('WebSocketManager', () => {
     ]);
   });
 
+  it('rejects an unserializable payload without recycling a healthy socket', async () => {
+    const value = harness();
+    const socket = await connectOpen(value);
+    const cyclic: RealtimeEnvelope = { type: 'notification.read_all' };
+    cyclic.self = cyclic;
+
+    expect(value.manager.send(cyclic)).toBe(false);
+
+    expect(socket.sent).toHaveLength(0);
+    expect(socket.closeCalls).toHaveLength(0);
+    expect(value.tickets.issueCalls).toBe(1);
+    expect(value.manager.getSnapshot()).toMatchObject({
+      status: 'connected',
+      connectionEpoch: 1,
+      diagnostics: { phase: 'open' },
+    });
+  });
+
+  it('recovers when an open socket throws while sending', async () => {
+    const sockets = new FakeSocketFactory();
+    const value = harness({
+      socketFactory: (url, protocols) => {
+        const socket = sockets.create(url, protocols);
+        socket.send = () => {
+          throw new Error('native send failure');
+        };
+        return socket;
+      },
+    });
+    value.manager.connect(OWNER_A);
+    await flushPromises();
+    const socket = sockets.sockets[0];
+    socket.open();
+
+    expect(value.manager.send({ type: 'notification.read_all' })).toBe(false);
+    await flushPromises();
+
+    expect(socket.closeCalls).toHaveLength(1);
+    expect(value.tickets.issueCalls).toBe(2);
+    expect(value.manager.getSnapshot()).toMatchObject({
+      status: 'reconnecting',
+      diagnostics: {
+        reason: 'send_failed',
+        category: 'transport',
+        terminal: false,
+      },
+    });
+  });
+
   it('waits for pong without resetting the timeout on the next heartbeat tick', async () => {
     const value = harness();
     const socket = await connectOpen(value);
@@ -360,6 +465,42 @@ describe('WebSocketManager', () => {
     expect(socket.sent).toHaveLength(2);
   });
 
+  it('does not let a cleared stale heartbeat timeout invalidate a new socket timeout', async () => {
+    const timeoutCallbacks: (() => void)[] = [];
+    const value = harness({
+      scheduler: {
+        ...jestScheduler,
+        setTimeout: (callback, delayMs) => {
+          if (delayMs === REALTIME_TIMING.heartbeatTimeoutMs) {
+            timeoutCallbacks.push(callback);
+          }
+          return jestScheduler.setTimeout(callback, delayMs);
+        },
+      },
+    });
+    const first = await connectOpen(value);
+    await jest.advanceTimersByTimeAsync(REALTIME_TIMING.heartbeatIntervalMs);
+    expect(timeoutCallbacks).toHaveLength(2);
+
+    first.serverClose();
+    await flushPromises();
+    const replacement = value.sockets.sockets[1];
+    replacement.open();
+    await jest.advanceTimersByTimeAsync(REALTIME_TIMING.heartbeatIntervalMs);
+    expect(timeoutCallbacks).toHaveLength(4);
+
+    timeoutCallbacks[1]?.();
+    replacement.message(JSON.stringify({ type: 'pong' }));
+    await jest.advanceTimersByTimeAsync(REALTIME_TIMING.heartbeatTimeoutMs);
+    await flushPromises();
+
+    expect(value.manager.getSnapshot()).toMatchObject({
+      status: 'connected',
+      connectionEpoch: 2,
+    });
+    expect(replacement.closeCalls).toHaveLength(0);
+  });
+
   it('uses one immediate network-close bootstrap before exponential backoff', async () => {
     const value = harness();
     const first = await connectOpen(value);
@@ -376,6 +517,284 @@ describe('WebSocketManager', () => {
     expect(value.tickets.issueCalls).toBe(3);
   });
 
+  it('keeps backoff state across sockets that open then close before a valid pong', async () => {
+    const value = harness();
+    const first = await connectOpen(value);
+
+    first.serverClose();
+    await flushPromises();
+    expect(value.tickets.issueCalls).toBe(2);
+
+    let unstableSocket = value.sockets.sockets[1];
+    for (
+      let attemptIndex = 0;
+      attemptIndex < REALTIME_TIMING.maxReconnectAttempts;
+      attemptIndex += 1
+    ) {
+      unstableSocket.open();
+      unstableSocket.serverClose();
+
+      const delay = Math.min(
+        1_000 * 2 ** attemptIndex,
+        REALTIME_TIMING.maxBackoffMs,
+      );
+      await jest.advanceTimersByTimeAsync(delay - 1);
+      expect(value.tickets.issueCalls).toBe(attemptIndex + 2);
+      await jest.advanceTimersByTimeAsync(1);
+      await flushPromises();
+      expect(value.tickets.issueCalls).toBe(attemptIndex + 3);
+      unstableSocket = value.sockets.sockets[attemptIndex + 2];
+    }
+
+    unstableSocket.open();
+    unstableSocket.serverClose();
+
+    expect(value.manager.getSnapshot()).toMatchObject({
+      status: 'disconnected',
+      diagnostics: {
+        phase: 'stopped',
+        reason: 'retry_exhausted',
+        category: 'retry',
+        terminal: true,
+        reconnectAttempt: REALTIME_TIMING.maxReconnectAttempts,
+      },
+    });
+    expect(jest.getTimerCount()).toBe(0);
+
+    const issueCallsBeforeManualRetry = value.tickets.issueCalls;
+    value.manager.connect(OWNER_A);
+    await flushPromises();
+    expect(value.tickets.issueCalls).toBe(issueCallsBeforeManualRetry);
+    expect(jest.getTimerCount()).toBe(0);
+
+    value.tickets.defaultIssue = () => Promise.resolve('manual-retry-ticket');
+    expect(value.manager.retryConnection()).toBe(true);
+    expect(value.manager.retryConnection()).toBe(false);
+    await flushPromises();
+    expect(value.tickets.issueCalls).toBe(issueCallsBeforeManualRetry + 1);
+    expect(value.sockets.calls.at(-1)?.protocols[1]).toBe(
+      'manual-retry-ticket',
+    );
+    value.sockets.sockets.at(-1)?.open();
+    expect(value.manager.getSnapshot()).toMatchObject({
+      status: 'connected',
+      diagnostics: { terminal: false, phase: 'open' },
+    });
+  });
+
+  it('restores a fresh immediate bootstrap only after the socket answers a heartbeat', async () => {
+    const value = harness();
+    const first = await connectOpen(value);
+
+    first.serverClose();
+    await flushPromises();
+    const bootstrapSocket = value.sockets.sockets[1];
+    bootstrapSocket.open();
+    bootstrapSocket.serverClose();
+    await jest.advanceTimersByTimeAsync(1_000);
+    await flushPromises();
+
+    const recoveredSocket = value.sockets.sockets[2];
+    recoveredSocket.open();
+    recoveredSocket.message(JSON.stringify({ type: 'pong' }));
+    expect(value.manager.getSnapshot().diagnostics?.reconnectAttempt).toBe(1);
+
+    await jest.advanceTimersByTimeAsync(REALTIME_TIMING.heartbeatIntervalMs);
+    expect(recoveredSocket.sent).toContain(JSON.stringify({ type: 'ping' }));
+    recoveredSocket.message(JSON.stringify({ type: 'pong' }));
+    expect(value.manager.getSnapshot().diagnostics?.reconnectAttempt).toBe(0);
+
+    recoveredSocket.serverClose();
+    await flushPromises();
+
+    expect(value.tickets.issueCalls).toBe(4);
+    expect(value.manager.getSnapshot()).toMatchObject({
+      status: 'reconnecting',
+      diagnostics: {
+        phase: 'opening_socket',
+        reconnectAttempt: 0,
+        retryDelayMs: null,
+      },
+    });
+  });
+
+  it('leaves connected immediately on socket error and recovers if native close never arrives', async () => {
+    const value = harness();
+    const socket = await connectOpen(value);
+
+    socket.error();
+
+    expect(value.manager.getSnapshot()).toMatchObject({
+      status: 'reconnecting',
+      diagnostics: {
+        phase: 'awaiting_close',
+        reason: 'socket_error',
+        category: 'transport',
+        terminal: false,
+      },
+    });
+    expect(value.manager.send({ type: 'notification.read_all' })).toBe(false);
+    expect(value.tickets.issueCalls).toBe(1);
+
+    await jest.advanceTimersByTimeAsync(REALTIME_TIMING.errorCloseGraceMs - 1);
+    expect(value.tickets.issueCalls).toBe(1);
+    await jest.advanceTimersByTimeAsync(1);
+    await flushPromises();
+
+    expect(socket.closeCalls).toHaveLength(1);
+    expect(value.tickets.issueCalls).toBe(2);
+    expect(value.manager.getSnapshot()).toMatchObject({
+      status: 'reconnecting',
+      diagnostics: {
+        reason: 'socket_error_without_close',
+        category: 'transport',
+      },
+    });
+  });
+
+  it('ignores a late pong after socket error without corrupting diagnostics', async () => {
+    const value = harness();
+    const socket = await connectOpen(value);
+    await jest.advanceTimersByTimeAsync(REALTIME_TIMING.heartbeatIntervalMs);
+
+    socket.error();
+    socket.message(JSON.stringify({ type: 'pong' }));
+
+    expect(value.manager.getSnapshot()).toMatchObject({
+      status: 'reconnecting',
+      diagnostics: {
+        phase: 'awaiting_close',
+        reason: 'socket_error',
+        category: 'transport',
+        heartbeat: 'inactive',
+      },
+    });
+  });
+
+  it('does not let a cleared stale heartbeat interval steal an authoritative close', async () => {
+    const intervalCallbacks: (() => void)[] = [];
+    const value = harness({
+      scheduler: {
+        ...jestScheduler,
+        setInterval: (callback, delayMs) => {
+          if (delayMs === REALTIME_TIMING.heartbeatIntervalMs) {
+            intervalCallbacks.push(callback);
+          }
+          return jestScheduler.setInterval(callback, delayMs);
+        },
+      },
+    });
+    const socket = await connectOpen(value);
+    expect(intervalCallbacks).toHaveLength(1);
+
+    socket.error();
+    const sendAfterError = jest.fn(() => {
+      throw new Error('socket is already failing');
+    });
+    socket.send = sendAfterError;
+    intervalCallbacks[0]?.();
+
+    expect(sendAfterError).not.toHaveBeenCalled();
+    expect(value.tickets.issueCalls).toBe(1);
+    expect(value.manager.getSnapshot()).toMatchObject({
+      status: 'reconnecting',
+      diagnostics: {
+        phase: 'awaiting_close',
+        reason: 'socket_error',
+        heartbeat: 'inactive',
+      },
+    });
+
+    socket.serverClose(4001);
+    await jest.advanceTimersByTimeAsync(REALTIME_TIMING.errorCloseGraceMs);
+    await flushPromises();
+
+    expect(value.tickets.issueCalls).toBe(1);
+    expect(value.manager.getSnapshot()).toMatchObject({
+      status: 'disconnected',
+      diagnostics: {
+        phase: 'stopped',
+        reason: 'authentication_failed',
+        category: 'authentication',
+        terminal: true,
+        closeCode: 4001,
+      },
+    });
+  });
+
+  it('cancels the socket-error fallback if the same opening socket succeeds', async () => {
+    const value = harness();
+    value.manager.connect(OWNER_A);
+    await flushPromises();
+    const socket = value.sockets.sockets[0];
+
+    socket.error();
+    socket.open();
+    await jest.advanceTimersByTimeAsync(REALTIME_TIMING.errorCloseGraceMs);
+    await flushPromises();
+
+    expect(socket.closeCalls).toHaveLength(0);
+    expect(value.tickets.issueCalls).toBe(1);
+    expect(value.manager.getSnapshot()).toMatchObject({
+      status: 'connected',
+      connectionEpoch: 1,
+      diagnostics: {
+        phase: 'open',
+        reason: null,
+        heartbeat: 'scheduled',
+      },
+    });
+  });
+
+  it('lets a close code win over the socket-error fallback and cancels its timer', async () => {
+    const value = harness();
+    const socket = await connectOpen(value);
+
+    socket.error();
+    socket.serverClose(4001);
+    value.manager.connect(OWNER_A);
+    await jest.advanceTimersByTimeAsync(REALTIME_TIMING.errorCloseGraceMs);
+    await flushPromises();
+
+    expect(value.tickets.issueCalls).toBe(1);
+    expect(value.manager.getSnapshot()).toMatchObject({
+      status: 'disconnected',
+      diagnostics: {
+        phase: 'stopped',
+        reason: 'authentication_failed',
+        category: 'authentication',
+        terminal: true,
+        closeCode: 4001,
+      },
+    });
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it.each(['disconnect', 'restart', 'destroy'] as const)(
+    'cancels a socket-error fallback on %s',
+    async (action) => {
+      const value = harness();
+      const socket = await connectOpen(value);
+      socket.error();
+      expect(jest.getTimerCount()).toBe(1);
+
+      if (action === 'disconnect') {
+        value.manager.disconnect('background');
+      } else if (action === 'restart') {
+        value.manager.restart(OWNER_A);
+      } else {
+        value.manager.destroy();
+      }
+      await flushPromises();
+
+      const expectedTicketCalls = action === 'restart' ? 2 : 1;
+      expect(value.tickets.issueCalls).toBe(expectedTicketCalls);
+      await jest.advanceTimersByTimeAsync(REALTIME_TIMING.errorCloseGraceMs);
+      await flushPromises();
+      expect(value.tickets.issueCalls).toBe(expectedTicketCalls);
+    },
+  );
+
   it('caps exponential backoff and stops after ten attempts', async () => {
     const value = harness();
     value.tickets.defaultIssue = () =>
@@ -391,6 +810,14 @@ describe('WebSocketManager', () => {
     }
 
     expect(value.manager.getSnapshot().status).toBe('disconnected');
+    expect(value.manager.getSnapshot().diagnostics).toMatchObject({
+      phase: 'stopped',
+      reason: 'retry_exhausted',
+      category: 'retry',
+      terminal: true,
+      reconnectAttempt: REALTIME_TIMING.maxReconnectAttempts,
+      retryDelayMs: null,
+    });
     expect(jest.getTimerCount()).toBe(0);
   });
 
@@ -444,6 +871,63 @@ describe('WebSocketManager', () => {
     expect(value.tickets.refreshCalls).toBe(1);
     expect(value.sockets.calls[1]?.protocols[1]).toBe('refresh-1');
   });
+
+  it.each([
+    ['envelope', (socket: { message(data: unknown): void }) => socket.message(JSON.stringify({ type: 'auth_error', code: 'token_expired' })), null],
+    ['close code', (socket: { serverClose(code: number): void }) => socket.serverClose(4002), 4002],
+  ])(
+    'backs off and stops repeated pre-pong token expiry via %s',
+    async (_label, expire, expectedCloseCode) => {
+      const value = harness();
+      const first = await connectOpen(value);
+
+      expire(first);
+      await flushPromises();
+      expect(value.tickets.issueCalls).toBe(1);
+      expect(value.tickets.refreshCalls).toBe(1);
+
+      let unstableSocket = value.sockets.sockets[1];
+      for (
+        let attemptIndex = 0;
+        attemptIndex < REALTIME_TIMING.maxReconnectAttempts;
+        attemptIndex += 1
+      ) {
+        unstableSocket.open();
+        expire(unstableSocket);
+
+        const delay = Math.min(
+          1_000 * 2 ** attemptIndex,
+          REALTIME_TIMING.maxBackoffMs,
+        );
+        await jest.advanceTimersByTimeAsync(delay - 1);
+        expect(value.tickets.refreshCalls).toBe(attemptIndex + 1);
+        await jest.advanceTimersByTimeAsync(1);
+        await flushPromises();
+        expect(value.tickets.refreshCalls).toBe(attemptIndex + 2);
+        unstableSocket = value.sockets.sockets[attemptIndex + 2];
+      }
+
+      unstableSocket.open();
+      expire(unstableSocket);
+
+      expect(value.tickets.issueCalls).toBe(1);
+      expect(value.tickets.refreshCalls).toBe(
+        REALTIME_TIMING.maxReconnectAttempts + 1,
+      );
+      expect(value.manager.getSnapshot()).toMatchObject({
+        status: 'disconnected',
+        diagnostics: {
+          phase: 'stopped',
+          reason: 'retry_exhausted',
+          category: 'retry',
+          terminal: true,
+          closeCode: expectedCloseCode,
+          reconnectAttempt: REALTIME_TIMING.maxReconnectAttempts,
+        },
+      });
+      expect(jest.getTimerCount()).toBe(0);
+    },
+  );
 
   it('retries a throttled refreshed-ticket request through the refresh endpoint', async () => {
     const value = harness();
@@ -522,9 +1006,42 @@ describe('WebSocketManager', () => {
     await flushPromises();
 
     expect(value.manager.getSnapshot().status).toBe('disconnected');
+    expect(value.manager.getSnapshot().diagnostics).toMatchObject({
+      reason: 'authentication_failed',
+      category: 'authentication',
+      terminal: true,
+    });
     expect(value.tickets.issueCalls).toBe(1);
     expect(jest.getTimerCount()).toBe(0);
+    expect(value.manager.retryConnection()).toBe(false);
   });
+
+  it.each(['background', 'offline'] as const)(
+    'preserves authentication hard-stop diagnostics across %s lifecycle transitions',
+    async (reason) => {
+      const value = harness();
+      const socket = await connectOpen(value);
+
+      socket.serverClose(4001);
+      value.manager.disconnect(reason);
+      value.manager.connect(OWNER_A);
+      await flushPromises();
+
+      expect(value.tickets.issueCalls).toBe(1);
+      expect(value.manager.getSnapshot()).toMatchObject({
+        status: 'disconnected',
+        diagnostics: {
+          phase: 'stopped',
+          reason: 'authentication_failed',
+          category: 'authentication',
+          terminal: true,
+          closeCode: 4001,
+          heartbeat: 'inactive',
+        },
+      });
+      expect(jest.getTimerCount()).toBe(0);
+    },
+  );
 
   it('disconnect cancels timers and destroy clears listeners', async () => {
     const value = harness();

--- a/mobile/src/features/realtime/application/RealtimeProvider.tsx
+++ b/mobile/src/features/realtime/application/RealtimeProvider.tsx
@@ -82,6 +82,7 @@ export function RealtimeProvider({
   const transport = useMemo<RealtimeTransport>(
     () => ({
       send: (message) => manager.send(message),
+      retryConnection: () => manager.retryConnection(),
       subscribe: (type, listener) => manager.subscribe(type, listener),
       subscribeAll: (listener) => manager.subscribeAll(listener),
     }),

--- a/mobile/src/features/realtime/infrastructure/WebSocketManager.ts
+++ b/mobile/src/features/realtime/infrastructure/WebSocketManager.ts
@@ -1,5 +1,9 @@
 import { isAuthTicketCurrent } from '@/shared/api/authSessionLifecycle';
 import {
+  type RealtimeDiagnosticCategory,
+  type RealtimeDiagnosticReason,
+  type RealtimeDiagnostics,
+  type RealtimeDisconnectReason,
   type RealtimeEnvelope,
   type RealtimeManager,
   type RealtimeMessageListener,
@@ -16,6 +20,7 @@ const SOCKET_OPEN = 1;
 
 export const REALTIME_TIMING = {
   openTimeoutMs: 30_000,
+  errorCloseGraceMs: 500,
   heartbeatIntervalMs: 25_000,
   heartbeatTimeoutMs: 30_000,
   maxReconnectAttempts: 10,
@@ -28,6 +33,29 @@ export const REALTIME_TIMING = {
 interface SocketOpenTimeout {
   handle: TimerHandle | null;
   socket: RealtimeSocket;
+}
+
+interface SocketErrorCloseTimeout {
+  handle: TimerHandle | null;
+  socket: RealtimeSocket;
+}
+
+interface ReconnectTimeout {
+  handle: TimerHandle | null;
+}
+
+interface HeartbeatTimeout {
+  handle: TimerHandle | null;
+}
+
+interface HeartbeatInterval {
+  handle: TimerHandle | null;
+}
+
+interface ReconnectCause {
+  reason: RealtimeDiagnosticReason;
+  category: RealtimeDiagnosticCategory;
+  closeCode?: number | null;
 }
 
 export interface RealtimeSocket {
@@ -47,6 +75,18 @@ export type RealtimeSocketFactory = (
 
 type TimerHandle = ReturnType<typeof setTimeout>;
 type TicketRequestKind = 'issue' | 'refresh';
+
+const INITIAL_DIAGNOSTICS: RealtimeDiagnostics = {
+  phase: 'idle',
+  reason: null,
+  category: null,
+  terminal: false,
+  closeCode: null,
+  reconnectAttempt: 0,
+  retryDelayMs: null,
+  ticketPhase: null,
+  heartbeat: 'inactive',
+};
 
 export interface RealtimeScheduler {
   setTimeout(callback: () => void, delayMs: number): TimerHandle;
@@ -135,6 +175,7 @@ export class WebSocketManager implements RealtimeManager {
   private snapshot: RealtimeSnapshot = {
     status: 'disconnected',
     connectionEpoch: 0,
+    diagnostics: { ...INITIAL_DIAGNOSTICS },
   };
   private currentOwner: RealtimeOwner | null = null;
   private hardStoppedOwner: RealtimeOwner | null = null;
@@ -142,10 +183,11 @@ export class WebSocketManager implements RealtimeManager {
   private isConnecting = false;
   private reconnectAttempt = 0;
   private reconnectBootstrapUsed = false;
-  private reconnectTimer: TimerHandle | null = null;
+  private reconnectTimer: ReconnectTimeout | null = null;
   private openTimeout: SocketOpenTimeout | null = null;
-  private heartbeatTimer: TimerHandle | null = null;
-  private heartbeatTimeoutTimer: TimerHandle | null = null;
+  private errorCloseTimeout: SocketErrorCloseTimeout | null = null;
+  private heartbeatTimer: HeartbeatInterval | null = null;
+  private heartbeatTimeoutTimer: HeartbeatTimeout | null = null;
   private awaitingPong = false;
   private destroyed = false;
 
@@ -157,6 +199,12 @@ export class WebSocketManager implements RealtimeManager {
 
   connect(owner: RealtimeOwner): void {
     if (!this.canUseOwner(owner)) return;
+    if (
+      sameOwner(this.currentOwner, owner) &&
+      this.snapshot.diagnostics?.terminal === true
+    ) {
+      return;
+    }
     if (!sameOwner(this.currentOwner, owner)) {
       this.invalidateWork(true);
       this.currentOwner = copyOwner(owner);
@@ -172,6 +220,16 @@ export class WebSocketManager implements RealtimeManager {
     }
 
     const status = this.snapshot.connectionEpoch > 0 ? 'reconnecting' : 'connecting';
+    if (status === 'connecting') {
+      this.updateSnapshot(status, {
+        reason: null,
+        category: null,
+        terminal: false,
+        closeCode: null,
+        reconnectAttempt: 0,
+        retryDelayMs: null,
+      });
+    }
     this.beginTicketRequest(owner, 'issue', status);
   }
 
@@ -180,24 +238,90 @@ export class WebSocketManager implements RealtimeManager {
     this.invalidateWork(true);
     this.currentOwner = copyOwner(owner);
     this.hardStoppedOwner = null;
+    this.updateSnapshot('reconnecting', {
+      phase: 'idle',
+      reason: 'runtime_restart',
+      category: 'lifecycle',
+      terminal: false,
+      closeCode: null,
+      reconnectAttempt: 0,
+      retryDelayMs: null,
+      ticketPhase: null,
+      heartbeat: 'inactive',
+    });
     this.beginTicketRequest(owner, 'issue', 'reconnecting');
   }
 
-  disconnect(_reason: 'auth' | 'background' | 'offline' | 'unmount'): void {
+  disconnect(reason: RealtimeDisconnectReason): void {
     if (this.destroyed) return;
+    const preserveAuthenticationFailure =
+      (reason === 'background' || reason === 'offline') &&
+      this.snapshot.diagnostics?.reason === 'authentication_failed' &&
+      this.snapshot.diagnostics.terminal === true &&
+      this.currentOwner !== null &&
+      sameOwner(this.hardStoppedOwner, this.currentOwner);
     this.invalidateWork(true);
     this.currentOwner = null;
-    this.setStatus('disconnected');
+    if (preserveAuthenticationFailure) return;
+    this.updateSnapshot('disconnected', {
+      phase: 'stopped',
+      reason: this.disconnectDiagnosticReason(reason),
+      category: 'lifecycle',
+      terminal: reason === 'unmount',
+      closeCode: null,
+      reconnectAttempt: 0,
+      retryDelayMs: null,
+      ticketPhase: null,
+      heartbeat: 'inactive',
+    });
   }
 
   send(message: RealtimeEnvelope): boolean {
-    if (this.socket?.readyState !== SOCKET_OPEN) return false;
+    const socket = this.socket;
+    const owner = this.currentOwner;
+    const requestId = this.connectRequestId;
+    if (
+      this.snapshot.status !== 'connected' ||
+      socket?.readyState !== SOCKET_OPEN ||
+      owner === null
+    ) {
+      return false;
+    }
+
+    let serialized: string;
     try {
-      this.socket.send(JSON.stringify(message));
-      return true;
+      const encoded = JSON.stringify(message);
+      if (encoded === undefined) return false;
+      serialized = encoded;
     } catch {
       return false;
     }
+
+    try {
+      socket.send(serialized);
+      return true;
+    } catch {
+      this.failActiveSocket(socket, owner, requestId, {
+        reason: 'send_failed',
+        category: 'transport',
+      });
+      return false;
+    }
+  }
+
+  retryConnection(): boolean {
+    const owner = this.currentOwner;
+    if (
+      this.destroyed ||
+      owner === null ||
+      this.snapshot.diagnostics?.terminal !== true ||
+      this.snapshot.diagnostics.reason !== 'retry_exhausted'
+    ) {
+      return false;
+    }
+
+    this.restart(owner);
+    return this.snapshot.status === 'reconnecting';
   }
 
   subscribe(type: string, listener: RealtimeMessageListener): () => void {
@@ -261,14 +385,31 @@ export class WebSocketManager implements RealtimeManager {
     } catch {
       this.invalidateWork(true);
       this.currentOwner = copyOwner(owner);
-      this.setStatus('disconnected');
+      this.updateSnapshot('disconnected', {
+        phase: 'stopped',
+        reason: 'invalid_configuration',
+        category: 'configuration',
+        terminal: true,
+        closeCode: null,
+        reconnectAttempt: 0,
+        retryDelayMs: null,
+        ticketPhase: null,
+        heartbeat: 'inactive',
+      });
       return;
     }
 
     this.clearReconnectTimer();
     const requestId = ++this.connectRequestId;
     this.isConnecting = true;
-    this.setStatus(status);
+    this.updateSnapshot(status, {
+      phase: 'requesting_ticket',
+      terminal: false,
+      reconnectAttempt: this.reconnectAttempt,
+      retryDelayMs: null,
+      ticketPhase: requestKind,
+      heartbeat: 'inactive',
+    });
     void this.fetchTicket(url, owner, requestId, requestKind);
   }
 
@@ -305,26 +446,36 @@ export class WebSocketManager implements RealtimeManager {
       socket = this.dependencies.socketFactory(url, [WS_SUBPROTOCOL, ticket]);
     } catch {
       this.isConnecting = false;
-      this.scheduleReconnect(owner, 'issue');
+      this.scheduleReconnect(owner, 'issue', {
+        reason: 'socket_factory_failed',
+        category: 'transport',
+      });
       return;
     }
 
     this.socket = socket;
     let authHandled = false;
+    // An open handshake alone is not evidence of a healthy connection. Keep
+    // the retry budget across short-lived sockets until this socket answers a
+    // heartbeat that the client actually sent.
+    let stabilityConfirmed = false;
+    this.updateSnapshot(this.snapshot.status, {
+      phase: 'opening_socket',
+      ticketPhase: null,
+    });
     this.startOpenTimeout(socket, owner, requestId);
 
     socket.onopen = () => {
       this.clearOpenTimeout(socket);
+      this.clearErrorCloseTimeout(socket);
       if (!this.isActiveSocket(socket, owner, requestId)) {
         this.detachSocket(socket, true);
         return;
       }
       this.isConnecting = false;
       this.clearReconnectTimer();
-      this.reconnectAttempt = 0;
-      this.reconnectBootstrapUsed = false;
-      this.markConnected();
       this.startHeartbeat(socket, owner, requestId);
+      this.markConnected();
     };
 
     socket.onmessage = (event) => {
@@ -338,7 +489,7 @@ export class WebSocketManager implements RealtimeManager {
         this.detachSocket(socket, true);
         this.stopHeartbeat();
         if (authErrorCode(message) === 'token_expired') {
-          this.beginTicketRequest(owner, 'refresh', 'reconnecting');
+          this.handleTokenExpiry(owner);
         } else {
           this.hardStop(owner);
         }
@@ -346,7 +497,21 @@ export class WebSocketManager implements RealtimeManager {
       }
 
       if (message.type === 'pong') {
+        if (this.snapshot.status !== 'connected') return;
+        const answeredHeartbeat = this.awaitingPong;
         this.clearHeartbeatTimeout();
+        if (!stabilityConfirmed && answeredHeartbeat) {
+          stabilityConfirmed = true;
+          this.reconnectAttempt = 0;
+          this.reconnectBootstrapUsed = false;
+          this.updateDiagnostics({
+            reconnectAttempt: 0,
+            retryDelayMs: null,
+            heartbeat: 'scheduled',
+          });
+        } else {
+          this.updateDiagnostics({ heartbeat: 'scheduled' });
+        }
         return;
       }
 
@@ -355,22 +520,47 @@ export class WebSocketManager implements RealtimeManager {
 
     socket.onclose = (event) => {
       this.clearOpenTimeout(socket);
+      this.clearErrorCloseTimeout(socket);
       if (authHandled || !this.isActiveSocket(socket, owner, requestId)) return;
       this.detachSocket(socket, false);
       this.isConnecting = false;
       this.stopHeartbeat();
 
       if (event.code === 4002) {
-        this.beginTicketRequest(owner, 'refresh', 'reconnecting');
+        this.handleTokenExpiry(owner, event.code);
       } else if (event.code === 4001) {
-        this.hardStop(owner);
+        this.hardStop(owner, event.code);
       } else {
-        this.handleNetworkClose(owner);
+        this.handleNetworkClose(owner, {
+          reason: 'socket_closed',
+          category: 'transport',
+          closeCode: event.code,
+        });
       }
     };
 
     socket.onerror = () => {
-      // React Native reports a close after an error. The close code owns recovery.
+      if (!this.isActiveSocket(socket, owner, requestId)) return;
+
+      // Native implementations normally publish a close after an error, but
+      // React Native does not guarantee it. Leave the handlers attached briefly
+      // so an authoritative close code can win, while immediately leaving the
+      // falsely-connected UI state and bounding the no-close path.
+      this.clearOpenTimeout(socket);
+      this.stopHeartbeat();
+      this.updateSnapshot(
+        this.snapshot.connectionEpoch > 0 ? 'reconnecting' : 'connecting',
+        {
+          phase: 'awaiting_close',
+          reason: 'socket_error',
+          category: 'transport',
+          terminal: false,
+          retryDelayMs: null,
+          ticketPhase: null,
+          heartbeat: 'inactive',
+        },
+      );
+      this.startErrorCloseTimeout(socket, owner, requestId);
     };
   }
 
@@ -395,7 +585,10 @@ export class WebSocketManager implements RealtimeManager {
       this.detachSocket(socket, true);
       this.isConnecting = false;
       this.stopHeartbeat();
-      this.handleNetworkClose(owner);
+      this.handleNetworkClose(owner, {
+        reason: 'socket_open_timeout',
+        category: 'transport',
+      });
     }, REALTIME_TIMING.openTimeoutMs);
   }
 
@@ -403,6 +596,39 @@ export class WebSocketManager implements RealtimeManager {
     const timeout = this.openTimeout;
     if (timeout === null || (socket && timeout.socket !== socket)) return;
     this.openTimeout = null;
+    if (timeout.handle !== null) {
+      this.dependencies.scheduler.clearTimeout(timeout.handle);
+    }
+  }
+
+  private startErrorCloseTimeout(
+    socket: RealtimeSocket,
+    owner: RealtimeOwner,
+    requestId: number,
+  ): void {
+    if (this.errorCloseTimeout?.socket === socket) return;
+    this.clearErrorCloseTimeout();
+    const timeout: SocketErrorCloseTimeout = { handle: null, socket };
+    this.errorCloseTimeout = timeout;
+    timeout.handle = this.dependencies.scheduler.setTimeout(() => {
+      if (this.errorCloseTimeout !== timeout) return;
+      this.errorCloseTimeout = null;
+      if (!this.isActiveSocket(socket, owner, requestId)) return;
+
+      this.detachSocket(socket, true);
+      this.isConnecting = false;
+      this.stopHeartbeat();
+      this.handleNetworkClose(owner, {
+        reason: 'socket_error_without_close',
+        category: 'transport',
+      });
+    }, REALTIME_TIMING.errorCloseGraceMs);
+  }
+
+  private clearErrorCloseTimeout(socket?: RealtimeSocket): void {
+    const timeout = this.errorCloseTimeout;
+    if (timeout === null || (socket && timeout.socket !== socket)) return;
+    this.errorCloseTimeout = null;
     if (timeout.handle !== null) {
       this.dependencies.scheduler.clearTimeout(timeout.handle);
     }
@@ -433,26 +659,73 @@ export class WebSocketManager implements RealtimeManager {
         return;
       }
     }
-    this.scheduleReconnect(owner, requestKind);
+    this.scheduleReconnect(owner, requestKind, {
+      reason: 'ticket_request_failed',
+      category: 'ticket',
+    });
   }
 
-  private handleNetworkClose(owner: RealtimeOwner): void {
+  private handleTokenExpiry(
+    owner: RealtimeOwner,
+    closeCode: number | null = null,
+  ): void {
+    const cause: ReconnectCause = {
+      reason: 'token_expired',
+      category: 'authentication',
+      closeCode,
+    };
+    this.updateSnapshot('reconnecting', {
+      reason: cause.reason,
+      category: cause.category,
+      terminal: false,
+      closeCode,
+      retryDelayMs: null,
+      ticketPhase: null,
+      heartbeat: 'inactive',
+    });
+    if (!this.reconnectBootstrapUsed) {
+      this.reconnectBootstrapUsed = true;
+      this.beginTicketRequest(owner, 'refresh', 'reconnecting');
+      return;
+    }
+    this.scheduleReconnect(owner, 'refresh', cause);
+  }
+
+  private handleNetworkClose(owner: RealtimeOwner, cause: ReconnectCause): void {
+    this.updateSnapshot('reconnecting', {
+      reason: cause.reason,
+      category: cause.category,
+      terminal: false,
+      closeCode: cause.closeCode ?? null,
+      ticketPhase: null,
+      heartbeat: 'inactive',
+    });
     if (!this.reconnectBootstrapUsed) {
       this.reconnectBootstrapUsed = true;
       this.beginTicketRequest(owner, 'issue', 'reconnecting');
       return;
     }
-    this.scheduleReconnect(owner, 'issue');
+    this.scheduleReconnect(owner, 'issue', cause);
   }
 
   private scheduleReconnect(
     owner: RealtimeOwner,
     requestKind: TicketRequestKind,
+    cause: ReconnectCause,
   ): void {
     if (!this.canUseOwner(owner) || !sameOwner(this.currentOwner, owner)) return;
     if (this.reconnectAttempt >= REALTIME_TIMING.maxReconnectAttempts) {
       this.isConnecting = false;
-      this.setStatus('disconnected');
+      this.updateSnapshot('disconnected', {
+        phase: 'stopped',
+        reason: 'retry_exhausted',
+        category: 'retry',
+        terminal: true,
+        reconnectAttempt: this.reconnectAttempt,
+        retryDelayMs: null,
+        ticketPhase: null,
+        heartbeat: 'inactive',
+      });
       return;
     }
 
@@ -461,7 +734,12 @@ export class WebSocketManager implements RealtimeManager {
       REALTIME_TIMING.maxBackoffMs,
     );
     this.reconnectAttempt += 1;
-    this.scheduleRetry(owner, requestKind, baseDelay + this.jitterMs());
+    this.scheduleRetry(
+      owner,
+      requestKind,
+      baseDelay + this.jitterMs(),
+      cause,
+    );
   }
 
   private scheduleThrottledReconnect(
@@ -474,19 +752,39 @@ export class WebSocketManager implements RealtimeManager {
       requestedDelay + this.jitterMs(),
       REALTIME_TIMING.throttleMaxMs,
     );
-    this.scheduleRetry(owner, requestKind, delay);
+    this.scheduleRetry(owner, requestKind, delay, {
+      reason: 'ticket_throttled',
+      category: 'ticket',
+    });
   }
 
   private scheduleRetry(
     owner: RealtimeOwner,
     requestKind: TicketRequestKind,
     delayMs: number,
+    cause: ReconnectCause,
   ): void {
     if (!this.canUseOwner(owner) || !sameOwner(this.currentOwner, owner)) return;
     this.clearReconnectTimer();
     this.isConnecting = false;
-    this.setStatus('reconnecting');
-    this.reconnectTimer = this.dependencies.scheduler.setTimeout(() => {
+    this.updateSnapshot('reconnecting', {
+      phase: 'waiting_retry',
+      reason: cause.reason,
+      category: cause.category,
+      terminal: false,
+      closeCode:
+        cause.closeCode === undefined
+          ? this.snapshot.diagnostics?.closeCode ?? null
+          : cause.closeCode,
+      reconnectAttempt: this.reconnectAttempt,
+      retryDelayMs: delayMs,
+      ticketPhase: null,
+      heartbeat: 'inactive',
+    });
+    const timeout: ReconnectTimeout = { handle: null };
+    this.reconnectTimer = timeout;
+    timeout.handle = this.dependencies.scheduler.setTimeout(() => {
+      if (this.reconnectTimer !== timeout) return;
       this.reconnectTimer = null;
       this.beginTicketRequest(owner, requestKind, 'reconnecting');
     }, delayMs);
@@ -502,8 +800,12 @@ export class WebSocketManager implements RealtimeManager {
     requestId: number,
   ): void {
     this.stopHeartbeat();
-    this.heartbeatTimer = this.dependencies.scheduler.setInterval(() => {
+    const interval: HeartbeatInterval = { handle: null };
+    this.heartbeatTimer = interval;
+    interval.handle = this.dependencies.scheduler.setInterval(() => {
       if (
+        this.heartbeatTimer !== interval ||
+        this.snapshot.status !== 'connected' ||
         this.awaitingPong ||
         !this.isActiveSocket(socket, owner, requestId) ||
         socket.readyState !== SOCKET_OPEN
@@ -513,13 +815,23 @@ export class WebSocketManager implements RealtimeManager {
       try {
         socket.send(JSON.stringify({ type: 'ping' }));
       } catch {
-        this.failActiveSocket(socket, owner, requestId);
+        this.failActiveSocket(socket, owner, requestId, {
+          reason: 'heartbeat_send_failed',
+          category: 'heartbeat',
+        });
         return;
       }
       this.awaitingPong = true;
-      this.heartbeatTimeoutTimer = this.dependencies.scheduler.setTimeout(() => {
+      this.updateDiagnostics({ heartbeat: 'awaiting_pong' });
+      const timeout: HeartbeatTimeout = { handle: null };
+      this.heartbeatTimeoutTimer = timeout;
+      timeout.handle = this.dependencies.scheduler.setTimeout(() => {
+        if (this.heartbeatTimeoutTimer !== timeout) return;
         this.heartbeatTimeoutTimer = null;
-        this.failActiveSocket(socket, owner, requestId);
+        this.failActiveSocket(socket, owner, requestId, {
+          reason: 'heartbeat_timeout',
+          category: 'heartbeat',
+        });
       }, REALTIME_TIMING.heartbeatTimeoutMs);
     }, REALTIME_TIMING.heartbeatIntervalMs);
   }
@@ -528,35 +840,48 @@ export class WebSocketManager implements RealtimeManager {
     socket: RealtimeSocket,
     owner: RealtimeOwner,
     requestId: number,
+    cause: ReconnectCause,
   ): void {
     if (!this.isActiveSocket(socket, owner, requestId)) return;
     this.detachSocket(socket, true);
     this.isConnecting = false;
     this.stopHeartbeat();
-    this.handleNetworkClose(owner);
+    this.handleNetworkClose(owner, cause);
   }
 
   private stopHeartbeat(): void {
-    if (this.heartbeatTimer !== null) {
-      this.dependencies.scheduler.clearInterval(this.heartbeatTimer);
-      this.heartbeatTimer = null;
+    const interval = this.heartbeatTimer;
+    this.heartbeatTimer = null;
+    if (interval !== null && interval.handle !== null) {
+      this.dependencies.scheduler.clearInterval(interval.handle);
     }
     this.clearHeartbeatTimeout();
   }
 
   private clearHeartbeatTimeout(): void {
-    if (this.heartbeatTimeoutTimer !== null) {
-      this.dependencies.scheduler.clearTimeout(this.heartbeatTimeoutTimer);
-      this.heartbeatTimeoutTimer = null;
+    const timeout = this.heartbeatTimeoutTimer;
+    this.heartbeatTimeoutTimer = null;
+    if (timeout !== null && timeout.handle !== null) {
+      this.dependencies.scheduler.clearTimeout(timeout.handle);
     }
     this.awaitingPong = false;
   }
 
-  private hardStop(owner: RealtimeOwner): void {
+  private hardStop(owner: RealtimeOwner, closeCode: number | null = null): void {
     this.hardStoppedOwner = copyOwner(owner);
     this.invalidateWork(true);
     this.currentOwner = copyOwner(owner);
-    this.setStatus('disconnected');
+    this.updateSnapshot('disconnected', {
+      phase: 'stopped',
+      reason: 'authentication_failed',
+      category: 'authentication',
+      terminal: true,
+      closeCode,
+      reconnectAttempt: 0,
+      retryDelayMs: null,
+      ticketPhase: null,
+      heartbeat: 'inactive',
+    });
   }
 
   private invalidateWork(resetAttempts: boolean): void {
@@ -564,6 +889,7 @@ export class WebSocketManager implements RealtimeManager {
     this.isConnecting = false;
     this.clearReconnectTimer();
     this.clearOpenTimeout();
+    this.clearErrorCloseTimeout();
     this.stopHeartbeat();
     if (this.socket !== null) {
       this.detachSocket(this.socket, true);
@@ -575,14 +901,16 @@ export class WebSocketManager implements RealtimeManager {
   }
 
   private clearReconnectTimer(): void {
-    if (this.reconnectTimer !== null) {
-      this.dependencies.scheduler.clearTimeout(this.reconnectTimer);
-      this.reconnectTimer = null;
+    const timeout = this.reconnectTimer;
+    this.reconnectTimer = null;
+    if (timeout !== null && timeout.handle !== null) {
+      this.dependencies.scheduler.clearTimeout(timeout.handle);
     }
   }
 
   private detachSocket(socket: RealtimeSocket, shouldClose: boolean): void {
     this.clearOpenTimeout(socket);
+    this.clearErrorCloseTimeout(socket);
     if (this.socket === socket) {
       this.socket = null;
     }
@@ -622,14 +950,42 @@ export class WebSocketManager implements RealtimeManager {
     this.snapshot = {
       status: 'connected',
       connectionEpoch: this.snapshot.connectionEpoch + 1,
+      diagnostics: {
+        ...INITIAL_DIAGNOSTICS,
+        phase: 'open',
+        reconnectAttempt: this.reconnectAttempt,
+        heartbeat: 'scheduled',
+      },
     };
     this.emitSnapshot();
   }
 
-  private setStatus(status: RealtimeSnapshot['status']): void {
-    if (this.snapshot.status === status) return;
-    this.snapshot = { ...this.snapshot, status };
+  private updateSnapshot(
+    status: RealtimeSnapshot['status'],
+    diagnosticsPatch: Partial<RealtimeDiagnostics>,
+  ): void {
+    const currentDiagnostics = this.snapshot.diagnostics ?? INITIAL_DIAGNOSTICS;
+    const diagnostics = { ...currentDiagnostics, ...diagnosticsPatch };
+    const diagnosticsChanged = (
+      Object.keys(diagnosticsPatch) as (keyof RealtimeDiagnostics)[]
+    ).some((key) => currentDiagnostics[key] !== diagnostics[key]);
+    if (this.snapshot.status === status && !diagnosticsChanged) return;
+    this.snapshot = { ...this.snapshot, status, diagnostics };
     this.emitSnapshot();
+  }
+
+  private updateDiagnostics(
+    diagnosticsPatch: Partial<RealtimeDiagnostics>,
+  ): void {
+    this.updateSnapshot(this.snapshot.status, diagnosticsPatch);
+  }
+
+  private disconnectDiagnosticReason(
+    reason: RealtimeDisconnectReason,
+  ): RealtimeDiagnosticReason {
+    if (reason === 'auth') return 'auth_unavailable';
+    if (reason === 'unmount') return 'unmounted';
+    return reason;
   }
 
   private emitSnapshot(): void {

--- a/mobile/src/features/realtime/testing/fakes.ts
+++ b/mobile/src/features/realtime/testing/fakes.ts
@@ -89,6 +89,10 @@ export class FakeSocket implements RealtimeSocket {
     this.onclose?.({ code });
   }
 
+  error(): void {
+    this.onerror?.();
+  }
+
   send(data: string): void {
     this.sent.push(data);
   }
@@ -122,6 +126,7 @@ export class FakeManager implements RealtimeManager {
   readonly connectCalls: RealtimeOwner[] = [];
   readonly restartCalls: RealtimeOwner[] = [];
   readonly disconnectCalls: RealtimeDisconnectReason[] = [];
+  retryConnectionCalls = 0;
   readonly events: string[] = [];
   private snapshot: RealtimeSnapshot = {
     status: 'disconnected',
@@ -146,6 +151,12 @@ export class FakeManager implements RealtimeManager {
 
   send(_message: RealtimeEnvelope): boolean {
     return false;
+  }
+
+  retryConnection(): boolean {
+    this.retryConnectionCalls += 1;
+    this.events.push('retryConnection');
+    return true;
   }
 
   subscribe(_type: string, _listener: RealtimeMessageListener): () => void {

--- a/mobile/src/features/realtime/types.ts
+++ b/mobile/src/features/realtime/types.ts
@@ -19,6 +19,67 @@ export type RealtimeOwner = AuthTicket;
 export interface RealtimeSnapshot {
   status: RealtimeStatus;
   connectionEpoch: number;
+  /**
+   * Safe transport diagnostics. The production manager always publishes this
+   * object; it remains optional so injected test transports can keep a minimal
+   * snapshot contract. It must never contain credentials, ticket values,
+   * message payloads, URLs, or user identifiers.
+   */
+  diagnostics?: RealtimeDiagnostics;
+}
+
+export type RealtimeDiagnosticPhase =
+  | 'idle'
+  | 'requesting_ticket'
+  | 'opening_socket'
+  | 'open'
+  | 'awaiting_close'
+  | 'waiting_retry'
+  | 'stopped';
+
+export type RealtimeDiagnosticCategory =
+  | 'lifecycle'
+  | 'configuration'
+  | 'authentication'
+  | 'ticket'
+  | 'transport'
+  | 'heartbeat'
+  | 'retry';
+
+export type RealtimeDiagnosticReason =
+  | 'auth_unavailable'
+  | 'background'
+  | 'offline'
+  | 'unmounted'
+  | 'runtime_restart'
+  | 'invalid_configuration'
+  | 'authentication_failed'
+  | 'token_expired'
+  | 'ticket_request_failed'
+  | 'ticket_throttled'
+  | 'socket_factory_failed'
+  | 'socket_open_timeout'
+  | 'socket_error'
+  | 'socket_error_without_close'
+  | 'socket_closed'
+  | 'heartbeat_send_failed'
+  | 'heartbeat_timeout'
+  | 'send_failed'
+  | 'retry_exhausted';
+
+export interface RealtimeDiagnostics {
+  phase: RealtimeDiagnosticPhase;
+  reason: RealtimeDiagnosticReason | null;
+  category: RealtimeDiagnosticCategory | null;
+  /** No automatic recovery work remains for the current lifecycle state. */
+  terminal: boolean;
+  /** Last native close code only; close reasons are intentionally excluded. */
+  closeCode: number | null;
+  reconnectAttempt: number;
+  retryDelayMs: number | null;
+  /** Endpoint kind only. The single-use ticket value is never exposed. */
+  ticketPhase: 'issue' | 'refresh' | null;
+  heartbeat: 'inactive' | 'scheduled' | 'awaiting_pong';
 }
 
 export interface PublishedAuthLifecycleSnapshot extends AuthLifecycleSnapshot {
@@ -30,6 +91,12 @@ export type RealtimeSnapshotListener = (snapshot: RealtimeSnapshot) => void;
 
 export interface RealtimeTransport {
   send(message: RealtimeEnvelope): boolean;
+  /**
+   * Restarts a transport that exhausted its automatic retry budget.
+   * Returns false when no safe manual retry is currently available (for
+   * example, authentication or configuration hard stops).
+   */
+  retryConnection(): boolean;
   subscribe(type: string, listener: RealtimeMessageListener): () => void;
   subscribeAll(listener: RealtimeMessageListener): () => void;
 }


### PR DESCRIPTION
## Summary

Implements #67, GoPlanAI inside mobile trip chat. PR #73 has merged, and this branch is synchronized with and based on `main`.

The post-stack update is complete: the branch includes the reviewed #73 fixes, all three merge conflicts were resolved semantically, the final backend/mobile contracts were hardened, and the full automated and two-simulator gates were rerun.

### Mention and AI conversation UX

- Ports the exact case-insensitive `@GoPlanAI` parser and trailing-`@` command affordance.
- Shows a distinct inert mention token and AI-quota intent before sending.
- Blocks a bare mention locally so it cannot consume the 20/hour AI prompt throttle.
- Preserves chat's outer-whitespace trim contract while leaving internal prompt spacing for the server to normalize.
- Distinguishes AI 429, `AI_BUSY`, and `INVALID_AI_PROMPT` feedback while preserving the local draft.
- Renders AI success/error text as inert constrained content and correlates typing by interaction id with a visual-only 120-second fallback.

### Action drafts and confirmation security

- Runtime-validates all six statuses and preserves open confirmation/action strings and opaque future fields.
- Renders all twelve shipped action types through timeline, expense, settlement, and transfer views, with a safe generic fallback.
- Drives every control strictly from server `can_confirm`, `can_cancel`, and `can_edit` authority.
- Supports NEEDS_INFO editing with exact `{payload}` bodies, authoritative trip currency, nested timeline validation, legacy normalization, field errors, expiry retention, and no silent loss across FlatList virtualization.
- Uses an explicit native confirmation restatement before every real write.
- Never automatically retries an ambiguous confirmation; one POST is followed only by GET reconciliation and a fail-closed **Check status** state.
- Keeps unknown outcome, Retry-After deadlines, editor values, and in-flight ownership in a room-scoped session store keyed by user and trip.
- Enforces terminal-trip authority under the locked backend Trip row for PATCH/CANCEL/CONFIRM while preserving idempotent replay of already-final drafts.
- Aborts and fences mobile draft mutations when room authority changes, and promotes exact terminal/access failures to the room controller.

### Realtime, reactions, and reconciliation

- Uses two distinct planes for terminal trips: writes are locked, while history, subscription, catch-up, pagination, and late accepted AI replies remain readable and convergent.
- Adds bounded subscribe ACK recovery, durable gap/change watermarks, explicit catch-up retry, unknown-row patch deferral, and same-tick authority fences.
- Hardens socket retry/backoff, token-expiry loops, heartbeat/error timer ownership, native send failures, and terminal diagnostic reasons.
- Gives terminal retry exhaustion a real reconnect action and keeps auth/config hard stops honest.
- Replaces runtime-dependent emoji glyph rendering with app-bundled vector reaction icons while preserving the exact seven Unicode values in the API contract.
- Adds discoverable 44pt reaction affordances, selected checkmarks/hints, deterministic focus restoration, destructive-alert handoff, and long-text/selection layout guards.
- Projects successful draft mutations immediately without fabricating `change_sequence`; higher-sequence full rows reconcile or replace the projection.
- Reconciles every newly observed CONFIRMED transition exactly once at room scope, including offscreen WS-first and deferred history/catch-up races.

## Security decisions

- AI text is untrusted inert text: no links, navigation, HTML, evaluation, or agent-driven actions.
- Confirmation is per action, explicit, and never remembered or batched.
- Viewer permissions are refreshed before mutation; stale/revoked authority cannot issue a write.
- Draft/message/trip UUIDs are canonical and resource-bound at direct mobile API boundaries.
- Wrong-id responses, stale async results, resource switches, duplicate IDs, and virtualized row detach all fail closed.
- Access prechecks return generic `TRIP_NOT_FOUND`; an inaccessible trip and a missing trip remain indistinguishable, while a missing draft in an accessible trip remains `AI_DRAFT_NOT_FOUND`.

## Verification

- Full mobile: **163 suites / 2,365 tests passing**.
- Focused final chat/realtime/AI integration: **7 suites / 289 tests passing**.
- Focused transport lifecycle: **5 suites / 96 tests passing**.
- Full backend: **1,333 tests passing**.
- Focused backend AI draft/executor/chat consumer integration: **138/138 passing**.
- Django system check passing; migration dry-run reports no changes.
- `pnpm lint`: passing with 0 warnings.
- `pnpm typecheck`: passing.
- `git diff --check`: passing.
- Independent locked state/security, realtime/race, cross-layer contract, and UI/accessibility reviews: no remaining P0/P1/P2 findings.
- GitHub diff is scoped to backend/mobile only: no frontend, docs, or migration files.

## Two-simulator E2E / visual QA

Final smoke used two independent iOS app containers, two different active users, and one guarded disposable trip fixture:

- Alice → Bob and Bob → Alice messages converged without refresh, duplication, or ordering drift.
- Sender/recipient bubble alignment, sender identity, avatar, timestamp, composer, keyboard, and transcript layout were visually checked.
- Reaction sheet showed all seven app-bundled vector icons in canonical order; two users reacting with ❤️ converged to count 2 on both clients with correct selected/accessibility state.
- Empty-chat layout was caught upside-down by Simulator, fixed by forwarding React Native's platform inversion style, and visually rechecked upright on both simulators.
- A controlled backend outage displayed the debounced reconnect warning while preserving readable history; after restore, the banner cleared automatically and the transcript/reactions remained converged.
- Background/foreground catch-up, missed messages/reactions, idle heartbeat, and reconnect recovery were exercised during the two-device QA session.
- The disposable trip and cascaded chat data were deleted with an ID/name/captain guard after QA; reusable test accounts contain no fixture trip data.

## Residual manual boundary

A physical iPhone is **not** required for normal feature development or for validating two-user realtime, layout, reaction icons, reconnect behavior, and accessibility metadata. The only remaining device-specific boundary is real VoiceOver gesture/audio/focus behavior: iOS Simulator does not run VoiceOver itself. Accessibility labels, roles, hints, custom actions, focus fencing, and modal order are covered by automated tests and Accessibility Inspector; one physical-device VoiceOver pass remains recommended before release.

The full mobile suite still prints pre-existing React `act()` warnings from unrelated EditName/ForgotPassword tests; all 163 suites pass and this PR does not touch those screens.

Closes #67
